### PR TITLE
fix: resolve ruff lint/format errors and fix failing tests

### DIFF
--- a/.claude/coordination/parallel-state.json
+++ b/.claude/coordination/parallel-state.json
@@ -1404,8 +1404,85 @@
         "components",
         "api"
       ]
+    },
+    {
+      "taskId": "task_1771732131883_ik1ldf",
+      "subagentType": "Explore",
+      "description": "Explore backend implementation",
+      "startTime": 1771732131883,
+      "status": "running",
+      "targetAreas": [
+        "components",
+        "services",
+        "api"
+      ]
+    },
+    {
+      "taskId": "task_1771732134441_2cicx6",
+      "subagentType": "Explore",
+      "description": "Explore dashboard implementation",
+      "startTime": 1771732134441,
+      "status": "running",
+      "targetAreas": [
+        "components",
+        "hooks"
+      ]
+    },
+    {
+      "taskId": "task_1771732136932_lak6qc",
+      "subagentType": "Explore",
+      "description": "Read all documentation files",
+      "startTime": 1771732136932,
+      "status": "running",
+      "targetAreas": [
+        "api"
+      ]
+    },
+    {
+      "taskId": "task_1771732758270_049l1p",
+      "subagentType": "Explore",
+      "description": "Verify updated docs accuracy",
+      "startTime": 1771732758270,
+      "status": "running",
+      "targetAreas": [
+        "components",
+        "hooks",
+        "services",
+        "api"
+      ]
+    },
+    {
+      "taskId": "task_1771733020623_b8ajoi",
+      "subagentType": "general-purpose",
+      "description": "Fix lint unused vars batch 1",
+      "startTime": 1771733020623,
+      "status": "running",
+      "targetAreas": [
+        "components",
+        "hooks",
+        "screens"
+      ]
+    },
+    {
+      "taskId": "task_1771733032227_ncfek4",
+      "subagentType": "general-purpose",
+      "description": "Fix lint unused vars batch 2",
+      "startTime": 1771733032227,
+      "status": "running",
+      "targetAreas": [
+        "components",
+        "hooks"
+      ]
+    },
+    {
+      "taskId": "task_1771733037199_9yl7go",
+      "subagentType": "general-purpose",
+      "description": "Fix agents.test.ts no-explicit-any",
+      "startTime": 1771733037199,
+      "status": "running",
+      "targetAreas": []
     }
   ],
-  "lastUpdated": "2026-02-21T17:27:40.804Z",
+  "lastUpdated": "2026-02-22T04:07:36.191Z",
   "sessionId": "session_1770950296910_bp60yfrgy"
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,6 +35,7 @@ AOS Backend API 엔드포인트 문서입니다.
 | GET | `/api/sessions/{id}/permissions` | 세션 권한 조회 |
 | PUT | `/api/sessions/{id}/permissions` | 권한 업데이트 |
 | POST | `/api/sessions/{id}/permissions/toggle/{permission}` | 권한 토글 |
+| POST | `/api/sessions/{id}/permissions/agents/{agent_id}/toggle` | 에이전트 토글 |
 
 ---
 
@@ -55,36 +56,54 @@ AOS Backend API 엔드포인트 문서입니다.
 
 ---
 
-## Agents & MCP
+## Agents
 
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/agents` | 에이전트 목록 조회 |
 | GET | `/api/agents/stats` | 레지스트리 통계 |
+| GET | `/api/agents/{agent_id}` | 에이전트 상세 조회 |
 | POST | `/api/agents/search` | 능력 기반 검색 |
-| POST | `/api/agents/orchestrate/analyze` | 태스크 분석 |
-| GET | `/api/agents/mcp/servers` | MCP 서버 목록 |
-| POST | `/api/agents/mcp/servers/{id}/start` | MCP 서버 시작 |
-| POST | `/api/agents/mcp/servers/{id}/stop` | MCP 서버 중지 |
-| POST | `/api/agents/mcp/tools/call` | MCP 도구 호출 |
+| POST | `/api/agents/{agent_id}/status` | 에이전트 상태 업데이트 |
 | POST | `/api/agents/ocr` | 이미지 OCR 텍스트 추출 (Vision LLM) |
 
----
-
-## MCP (Model Context Protocol)
+### Task Analysis & Orchestration
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/mcp/servers` | MCP 서버 목록 조회 |
-| POST | `/api/mcp/servers` | MCP 서버 추가 |
-| GET | `/api/mcp/servers/{id}` | MCP 서버 상세 |
-| PUT | `/api/mcp/servers/{id}` | MCP 서버 수정 |
-| DELETE | `/api/mcp/servers/{id}` | MCP 서버 삭제 |
-| POST | `/api/mcp/servers/{id}/start` | 서버 시작 |
-| POST | `/api/mcp/servers/{id}/stop` | 서버 중지 |
-| GET | `/api/mcp/servers/{id}/tools` | 도구 목록 조회 |
-| POST | `/api/mcp/servers/{id}/tools/{tool}/call` | 도구 호출 |
-| GET | `/api/mcp/stats` | MCP 통계 |
+| POST | `/api/agents/orchestrate/analyze` | 태스크 분석 |
+| POST | `/api/agents/orchestrate/analyze-with-images` | 이미지 포함 태스크 분석 |
+| GET | `/api/agents/orchestrate/analyses` | 분석 이력 조회 |
+| GET | `/api/agents/orchestrate/analyses/{analysis_id}` | 분석 상세 조회 |
+| DELETE | `/api/agents/orchestrate/analyses/{analysis_id}` | 분석 삭제 |
+| POST | `/api/agents/orchestrate/execute-analysis` | 분석 실행 |
+| GET | `/api/agents/orchestrate/strategies` | 실행 전략 목록 |
+| GET | `/api/agents/orchestrate/claude-auth-status` | Claude 인증 상태 |
+
+### Tmux Session Management
+
+| Method | Path | 설명 |
+|--------|------|------|
+| POST | `/api/agents/orchestrate/execute-with-tmux` | Tmux 세션으로 실행 |
+| GET | `/api/agents/orchestrate/tmux-sessions` | Tmux 세션 목록 |
+| GET | `/api/agents/orchestrate/tmux-sessions/{name}/status` | 세션 상태 조회 |
+| GET | `/api/agents/orchestrate/tmux-sessions/{name}/stream` | 세션 출력 스트리밍 |
+| POST | `/api/agents/orchestrate/tmux-sessions/{name}/stop` | 세션 중지 |
+
+### MCP Server Management
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/agents/mcp/servers` | MCP 서버 목록 |
+| GET | `/api/agents/mcp/servers/{id}` | MCP 서버 상세 |
+| POST | `/api/agents/mcp/servers/{id}/start` | MCP 서버 시작 |
+| POST | `/api/agents/mcp/servers/{id}/stop` | MCP 서버 중지 |
+| POST | `/api/agents/mcp/servers/{id}/restart` | MCP 서버 재시작 |
+| GET | `/api/agents/mcp/servers/{id}/tools` | 서버 도구 목록 |
+| POST | `/api/agents/mcp/tools/call` | MCP 도구 호출 |
+| POST | `/api/agents/mcp/tools/batch-call` | MCP 도구 일괄 호출 |
+| GET | `/api/agents/mcp/tools` | 전체 도구 목록 |
+| GET | `/api/agents/mcp/stats` | MCP 통계 |
 
 ---
 
@@ -199,6 +218,28 @@ AOS Backend API 엔드포인트 문서입니다.
 **응답**: `ProjectResponse` (id, name, slug, description, path, is_active, settings, created_at, updated_at)
 
 > **Note**: 기존 `/api/projects` 경로는 오케스트레이션 세션 프로젝트용이며, 이 API는 DB 기반 프로젝트 레지스트리 관리 전용입니다.
+
+---
+
+## Projects (오케스트레이션)
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/projects` | 프로젝트 목록 (접근 제어 적용) |
+| POST | `/api/projects` | 프로젝트 등록 |
+| POST | `/api/projects/create` | 템플릿에서 프로젝트 생성 |
+| POST | `/api/projects/link` | 외부 프로젝트 심볼릭 링크 |
+| POST | `/api/projects/reorder` | 프로젝트 순서 변경 |
+| GET | `/api/projects/templates` | 프로젝트 템플릿 목록 |
+| GET | `/api/projects/{id}` | 프로젝트 상세 조회 |
+| PUT | `/api/projects/{id}` | 프로젝트 수정 |
+| DELETE | `/api/projects/{id}` | 프로젝트 삭제 (cascade) |
+| GET | `/api/projects/{id}/health` | 프로젝트 헬스 상태 |
+| GET | `/api/projects/{id}/checks/run-all` | 전체 체크 실행 (SSE) |
+| GET | `/api/projects/{id}/checks/{check_type}` | 특정 체크 실행 (SSE) |
+| GET | `/api/projects/{id}/deletion-preview` | 삭제 미리보기 |
+| GET | `/api/projects/{id}/context` | 프로젝트 컨텍스트 (CLAUDE.md, dev docs) |
+| GET | `/api/projects/{id}/claude-md` | CLAUDE.md 내용 조회 |
 
 ---
 
@@ -334,7 +375,11 @@ AOS Backend API 엔드포인트 문서입니다.
 | GET | `/api/audit/resource-types` | 가능한 리소스 타입 목록 |
 | POST | `/api/audit/cleanup` | 오래된 로그 정리 |
 | POST | `/api/audit/seed` | 테스트용 샘플 데이터 생성 |
-| POST | `/api/audit/verify-integrity` | 무결성 검증 |
+| GET | `/api/audit/integrity/verify` | 무결성 검증 |
+| GET | `/api/audit/compliance/report` | 컴플라이언스 보고서 |
+| POST | `/api/audit/retention/apply` | 보존 정책 적용 |
+| GET | `/api/audit/retention-policies` | 보존 정책 목록 |
+| GET | `/api/audit/data-classifications` | 데이터 분류 목록 |
 
 **쿼리 파라미터** (`GET /api/audit`):
 - `session_id`, `user_id`: 필터
@@ -850,14 +895,16 @@ AOS Backend API 엔드포인트 문서입니다.
 
 ---
 
-## MCP Protocol
+## MCP Protocol (Warp Terminal Integration)
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/mcp/sse` | MCP SSE 스트림 |
+| GET | `/api/mcp/sse` | MCP SSE 스트림 (Warp 클라이언트 연결) |
 | POST | `/api/mcp/messages` | MCP 메시지 전송 |
 | GET | `/api/mcp/health` | MCP 헬스체크 |
 | GET | `/api/mcp/tools` | MCP 도구 목록 |
+
+> **Note**: 이 API는 Warp 터미널 MCP 클라이언트와의 통신용입니다. MCP 서버 관리는 `/api/agents/mcp/` 엔드포인트를 사용합니다.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,20 @@ src/backend/
 │   ├── project_access_service.py  # RBAC 접근제어 서비스
 │   ├── quota_service.py           # 사용량 쿼터 서비스
 │   ├── template_service.py        # 프로젝트/워크플로우 템플릿
+│   ├── llm_router_service.py      # LLM 라우팅/Failover
+│   ├── session_service.py         # 세션 생명주기 관리
+│   ├── task_service.py            # 태스크 CRUD/상태 관리
+│   ├── merge_service.py           # Git 머지/충돌 해결
+│   ├── mcp_manager.py             # MCP 서버 생명주기 관리
+│   ├── project_config_monitor.py  # 프로젝트 설정 파일 모니터링
+│   ├── tmux_service.py            # Tmux 세션 관리
+│   ├── playground_service.py      # 에이전트 플레이그라운드
+│   ├── credential_service.py      # 자격증명 암호화/저장
+│   ├── secret_service.py          # 시크릿 관리
+│   ├── webhook_service.py         # Webhook 딜리버리
+│   ├── external_usage_service.py  # 외부 LLM 사용량 추적
+│   ├── task_analysis_service.py   # 태스크 분석
+│   ├── project_cleanup_service.py # 프로젝트 삭제/정리
 │   └── ...
 ├── api/                     # FastAPI 라우터
 ├── db/                      # SQLAlchemy ORM
@@ -233,6 +247,24 @@ USE_DATABASE=false
 | `rate_limits` | API 속도 제한 |
 | `workflow_definitions` | 워크플로우 정의 |
 | `workflow_runs` | 워크플로우 실행 이력 |
+| `workflow_jobs` | 워크플로우 잡 |
+| `workflow_steps` | 워크플로우 스텝 |
+| `workflow_secrets` | 워크플로우 시크릿 |
+| `workflow_webhooks` | 워크플로우 웹훅 |
+| `workflow_artifacts` | 워크플로우 아티팩트 |
+| `workflow_templates` | 워크플로우 템플릿 |
+| `merge_requests` | 머지 요청 |
+| `branch_protection_rules` | 브랜치 보호 규칙 |
+| `cost_centers` | 비용 센터 |
+| `cost_allocations` | 비용 할당 |
+| `llm_model_configs` | LLM 모델 설정 |
+| `user_llm_credentials` | 사용자 LLM 자격증명 |
+| `project_access` | 프로젝트 접근 제어 |
+| `project_invitations` | 프로젝트 초대 |
+| `menu_visibility` | UI 메뉴 가시성 |
+| `task_evaluations` | 태스크 평가 |
+| `session_activities` | 세션 활동 |
+| `task_analyses` | 태스크 분석 |
 
 ### Database Migration (Alembic)
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -137,6 +137,7 @@ import { cn } from '@/lib/utils';
 | `HookEditModal` | Hook 편집 모달 |
 | `CommandsTab` | 커맨드 목록 탭 |
 | `CommandEditModal` | 커맨드 편집 모달 |
+| `ConfirmDeleteModal` | 삭제 확인 범용 모달 |
 | `DeleteProjectModal` | 프로젝트 삭제 확인 모달 |
 | `ProjectClaudeConfigPanel` | 프로젝트 Claude 설정 패널 |
 
@@ -218,6 +219,7 @@ import { cn } from '@/lib/utils';
 | 컴포넌트 | 설명 |
 |----------|------|
 | `ProjectMembersPanel` | 프로젝트 멤버 관리 (목록, 추가, 역할 변경, 제거) |
+| `ProjectMembersContent` | 프로젝트 멤버 관리 콘텐츠 (멤버십 목록, 관리) |
 
 ### Monitor Components
 
@@ -229,6 +231,9 @@ import { cn } from '@/lib/utils';
 | `ContextPanel` | 컨텍스트 정보 패널 |
 | `OutputLog` | 실시간 출력 로그 |
 | `ResizablePanel` | 리사이즈 가능 패널 |
+| `AgentMonitorPanel` | 에이전트 모니터링 패널 |
+| `MetricsChart` | 메트릭 차트 시각화 |
+| `WorkflowCheckCard` | 워크플로우 체크 카드 |
 
 ### RAG Components
 
@@ -276,6 +281,9 @@ import { cn } from '@/lib/utils';
 | `CostMonitor` | 비용 모니터링 패널 |
 | `UsageProgressBar` | 사용량 진행바 |
 | `ClaudeUsageDashboard` | Claude 사용량 대시보드 |
+| `DailyCostTrend` | 일간 비용 추이 차트 |
+| `LLMAccountsSettings` | LLM 계정/API 키 설정 |
+| `MemberUsageTable` | 멤버별 사용량 테이블 |
 
 ### Admin Components
 
@@ -351,6 +359,8 @@ import { cn } from '@/lib/utils';
 | `useMenuVisibilityStore` | `menuVisibility.ts` | 메뉴 가시성 및 순서 |
 | `useProjectAccess` | `projectAccess.ts` | 프로젝트별 멤버/역할 관리 |
 | `useWorkflowStore` | `workflows.ts` | 워크플로우 CRUD, 실행, 시크릿, 스케줄 |
+| `useExternalUsage` | `externalUsage.ts` | 외부 LLM 프로바이더 사용량 추적 |
+| `useLLMCredentials` | `llmCredentials.ts` | LLM 프로바이더 자격증명/API 키 관리 |
 
 ### Store Pattern
 
@@ -396,7 +406,7 @@ export const useStore = create<State>((set, get) => ({
 ```
 src/dashboard/
 ├── src/
-│   ├── pages/                  # 페이지 컴포넌트 (22개)
+│   ├── pages/                  # 페이지 컴포넌트 (23개)
 │   │   ├── DashboardPage.tsx
 │   │   ├── ProjectsPage.tsx
 │   │   ├── ProjectConfigsPage.tsx
@@ -413,6 +423,7 @@ src/dashboard/
 │   │   ├── OrganizationsPage.tsx
 │   │   ├── ProjectManagementPage.tsx
 │   │   ├── WorkflowsPage.tsx
+│   │   ├── ExternalUsagePage.tsx
 │   │   ├── AdminPage.tsx
 │   │   ├── SettingsPage.tsx
 │   │   ├── LoginPage.tsx
@@ -450,6 +461,7 @@ src/dashboard/
 │   │   │   ├── HookEditModal.tsx
 │   │   │   ├── CommandsTab.tsx
 │   │   │   ├── CommandEditModal.tsx
+│   │   │   ├── ConfirmDeleteModal.tsx
 │   │   │   └── CopyToProjectModal.tsx
 │   │   ├── workflows/          # 워크플로우
 │   │   │   ├── WorkflowList.tsx
@@ -493,7 +505,10 @@ src/dashboard/
 │   │   │   ├── CheckCard.tsx
 │   │   │   ├── ContextPanel.tsx
 │   │   │   ├── OutputLog.tsx
-│   │   │   └── ResizablePanel.tsx
+│   │   │   ├── ResizablePanel.tsx
+│   │   │   ├── AgentMonitorPanel.tsx
+│   │   │   ├── MetricsChart.tsx
+│   │   │   └── WorkflowCheckCard.tsx
 │   │   ├── rag/                # RAG 검색
 │   │   │   └── RAGQueryPanel.tsx
 │   │   ├── admin/              # 관리자 설정
@@ -505,7 +520,7 @@ src/dashboard/
 │   │   └── analytics/          # Analytics
 │   │       └── ProjectMultiSelect.tsx
 │   ├── services/               # API 서비스 레이어
-│   ├── stores/                 # Zustand 스토어 (27개)
+│   ├── stores/                 # Zustand 스토어 (29개)
 │   │   ├── orchestration.ts
 │   │   ├── projects.ts
 │   │   ├── projectConfigs.ts
@@ -531,11 +546,15 @@ src/dashboard/
 │   │   ├── audit.ts
 │   │   ├── menuVisibility.ts
 │   │   ├── projectAccess.ts
+│   │   ├── externalUsage.ts
+│   │   ├── llmCredentials.ts
 │   │   └── workflows.ts
 │   ├── hooks/                  # 커스텀 훅
+│   │   ├── useErrorHandler.ts
+│   │   └── useRealtimeMonitor.ts
 │   ├── lib/                    # 유틸리티
 │   │   ├── utils.ts            # cn() 등 헬퍼 함수
-│   │   └── api.ts              # API 클라이언트
+│   │   └── cookieStorage.ts    # 쿠키 기반 스토리지
 │   └── types/                  # TypeScript 타입
 ├── public/
 ├── index.html
@@ -544,6 +563,15 @@ src/dashboard/
 ├── tsconfig.json
 └── package.json
 ```
+
+---
+
+## Custom Hooks
+
+| Hook | 파일 | 설명 |
+|------|------|------|
+| `useErrorHandler` | `useErrorHandler.ts` | 에러 핸들링 유틸리티 훅 |
+| `useRealtimeMonitor` | `useRealtimeMonitor.ts` | 실시간 모니터링 WebSocket 훅 |
 
 ---
 

--- a/src/backend/alembic/versions/f3a8b2c1d4e5_add_project_invitations.py
+++ b/src/backend/alembic/versions/f3a8b2c1d4e5_add_project_invitations.py
@@ -8,8 +8,6 @@ Create Date: 2026-02-18
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
-
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/backend/api/auth.py
+++ b/src/backend/api/auth.py
@@ -422,6 +422,7 @@ async def get_current_user_info(
     """Get current authenticated user info."""
     # 조직 admin 여부 계산 (circular import 방지를 위해 인라인 구현)
     import os
+
     admin_org_ids: list[str] = []
 
     if os.getenv("USE_DATABASE", "false").lower() == "true":
@@ -449,6 +450,7 @@ async def get_current_user_info(
 
             # JSON fallback
             from services.organization_service import OrganizationService
+
             all_orgs = OrganizationService.list_organizations()
             for org in all_orgs:
                 mem = OrganizationService.get_member_by_user(org.id, current_user.id)
@@ -460,6 +462,7 @@ async def get_current_user_info(
             admin_org_ids = db_org_ids
         except Exception as e:
             import logging
+
             logging.getLogger(__name__).warning(
                 "Failed to fetch org admin info for user %s: %s", current_user.id, e
             )

--- a/src/backend/api/auth.py
+++ b/src/backend/api/auth.py
@@ -429,9 +429,10 @@ async def get_current_user_info(
         # circular import 방지를 위해 인라인으로 구현
         # DB에서 조직 admin 역할 조회
         try:
+            from sqlalchemy import and_, select
+
             from db.database import async_session_factory
             from db.models import OrganizationMemberModel
-            from sqlalchemy import and_, select
 
             admin_roles = {"owner", "admin"}
             async with async_session_factory() as session:

--- a/src/backend/api/claude_sessions.py
+++ b/src/backend/api/claude_sessions.py
@@ -305,7 +305,7 @@ async def list_projects(
 
     if use_database and current_user:
         try:
-            from sqlalchemy import select, or_
+            from sqlalchemy import or_, select
 
             from db.database import async_session_factory
             from db.models import ProjectAccessModel, ProjectModel

--- a/src/backend/api/external_usage.py
+++ b/src/backend/api/external_usage.py
@@ -84,9 +84,7 @@ if AUTH_AVAILABLE:
 
         # Merge: if user has a DB credential, mark provider as enabled
         return [
-            cfg.model_copy(update={"enabled": True})
-            if cfg.provider.value in db_providers
-            else cfg
+            cfg.model_copy(update={"enabled": True}) if cfg.provider.value in db_providers else cfg
             for cfg in configs
         ]
 

--- a/src/backend/api/external_usage.py
+++ b/src/backend/api/external_usage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, select
@@ -31,11 +31,11 @@ router = APIRouter(prefix="/external-usage", tags=["external-usage"])
 
 
 def _default_start() -> datetime:
-    return datetime.now(tz=timezone.utc) - timedelta(days=30)
+    return datetime.now(tz=UTC) - timedelta(days=30)
 
 
 def _default_end() -> datetime:
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)
 
 
 @router.get("/summary", response_model=ExternalUsageSummaryResponse)

--- a/src/backend/api/llm.py
+++ b/src/backend/api/llm.py
@@ -170,9 +170,7 @@ async def update_model(
 
     from db.models import LLMModelConfigModel
 
-    result = await db.execute(
-        select(LLMModelConfigModel).where(LLMModelConfigModel.id == model_id)
-    )
+    result = await db.execute(select(LLMModelConfigModel).where(LLMModelConfigModel.id == model_id))
     db_model = result.scalar_one_or_none()
 
     if not db_model:

--- a/src/backend/api/llm_proxy.py
+++ b/src/backend/api/llm_proxy.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -154,7 +154,7 @@ if AUTH_AVAILABLE:
             svc.add_record(
                 UnifiedUsageRecord(
                     provider=provider_enum,
-                    timestamp=datetime.now(tz=timezone.utc),
+                    timestamp=datetime.now(tz=UTC),
                     bucket_width="realtime",
                     input_tokens=input_tok,
                     output_tokens=output_tok,

--- a/src/backend/api/project_configs.py
+++ b/src/backend/api/project_configs.py
@@ -12,7 +12,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from api.deps import get_current_user_optional
-
 from models.project_config import (
     AgentConfig,
     AgentContentResponse,
@@ -100,7 +99,7 @@ async def _get_db_filtered_projects(monitor, current_user=None) -> list:
     """
     from pathlib import Path as PathLib
 
-    from sqlalchemy import select, or_
+    from sqlalchemy import or_, select
 
     from db.database import async_session_factory
     from db.models import ProjectAccessModel, ProjectModel

--- a/src/backend/api/projects.py
+++ b/src/backend/api/projects.py
@@ -43,9 +43,10 @@ async def _get_admin_org_ids(user) -> list[str]:
     if os.getenv("USE_DATABASE", "false").lower() != "true":
         return []
 
+    from sqlalchemy import and_, select
+
     from db.database import async_session_factory
     from db.models import OrganizationMemberModel
-    from sqlalchemy import and_, select
 
     admin_roles = {"owner", "admin"}
 
@@ -206,6 +207,7 @@ async def list_active_projects(
     - 일반 유저/member: ProjectAccess에 명시된 프로젝트만
     """
     import os
+
     from sqlalchemy import or_
 
     use_database = os.getenv("USE_DATABASE", "false").lower() == "true"
@@ -609,6 +611,7 @@ async def add_project_member(
         proj_org = proj_org_result.scalar_one_or_none()
         if proj_org and proj_org.organization_id:
             from sqlalchemy import and_
+
             from db.models import OrganizationMemberModel
             org_mem_result = await session.execute(
                 select(OrganizationMemberModel).where(
@@ -782,10 +785,11 @@ async def list_available_org_members(
     if os.getenv("USE_DATABASE", "false").lower() != "true":
         raise HTTPException(status_code=503, detail="Database mode is not enabled")
 
+    from sqlalchemy import and_, select
+
     from db.database import async_session_factory
     from db.models import OrganizationMemberModel, ProjectAccessModel, ProjectModel
     from db.models import UserModel as UserModelDB
-    from sqlalchemy import and_, select
 
     is_system_admin = current_user.role == "admin" or current_user.is_admin
 

--- a/src/backend/api/projects.py
+++ b/src/backend/api/projects.py
@@ -64,6 +64,7 @@ async def _get_admin_org_ids(user) -> list[str]:
 
     # JSON fallback
     from services.organization_service import OrganizationService
+
     all_orgs = OrganizationService.list_organizations()
     json_org_ids = []
     for org in all_orgs:
@@ -500,9 +501,7 @@ async def restore_project(project_id: str) -> DBProjectResponse:
 VALID_ROLES = {"owner", "editor", "viewer"}
 
 
-async def _check_project_manage_permission(
-    project_id: str, current_user, session
-) -> None:
+async def _check_project_manage_permission(project_id: str, current_user, session) -> None:
     """Admin 또는 project owner만 멤버 관리 가능."""
     from db.models import ProjectAccessModel
 
@@ -537,9 +536,7 @@ async def list_project_members(
     from db.models import UserModel as UserModelDB
 
     async with async_session_factory() as session:
-        proj = await session.execute(
-            select(ProjectModel).where(ProjectModel.id == project_id)
-        )
+        proj = await session.execute(select(ProjectModel).where(ProjectModel.id == project_id))
         if not proj.scalar_one_or_none():
             raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
 
@@ -589,9 +586,7 @@ async def add_project_member(
     from db.models import UserModel as UserModelDB
 
     async with async_session_factory() as session:
-        proj = await session.execute(
-            select(ProjectModel).where(ProjectModel.id == project_id)
-        )
+        proj = await session.execute(select(ProjectModel).where(ProjectModel.id == project_id))
         if not proj.scalar_one_or_none():
             raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
 
@@ -613,6 +608,7 @@ async def add_project_member(
             from sqlalchemy import and_
 
             from db.models import OrganizationMemberModel
+
             org_mem_result = await session.execute(
                 select(OrganizationMemberModel).where(
                     and_(
@@ -626,6 +622,7 @@ async def add_project_member(
 
             if not is_org_member:
                 from services.organization_service import OrganizationService
+
                 json_mem = OrganizationService.get_member_by_user(
                     proj_org.organization_id, request.user_id
                 )
@@ -706,9 +703,7 @@ async def update_project_member_role(
         await session.commit()
         await session.refresh(access)
 
-        user_result = await session.execute(
-            select(UserModelDB).where(UserModelDB.id == user_id)
-        )
+        user_result = await session.execute(select(UserModelDB).where(UserModelDB.id == user_id))
         user = user_result.scalar_one_or_none()
 
         return ProjectMemberResponse(
@@ -810,9 +805,7 @@ async def list_available_org_members(
 
         # 이미 프로젝트에 속한 user_id 집합
         existing_result = await session.execute(
-            select(ProjectAccessModel.user_id).where(
-                ProjectAccessModel.project_id == project_id
-            )
+            select(ProjectAccessModel.user_id).where(ProjectAccessModel.project_id == project_id)
         )
         existing_user_ids = {row[0] for row in existing_result.all()}
 
@@ -853,6 +846,7 @@ async def list_available_org_members(
 
         # JSON fallback
         from services.organization_service import OrganizationService
+
         json_members = OrganizationService.get_members(org_id) or []
         for jmem in json_members:
             uid = jmem.user_id if hasattr(jmem, "user_id") else ""

--- a/src/backend/api/routes.py
+++ b/src/backend/api/routes.py
@@ -637,9 +637,7 @@ async def _get_accessible_paths_for_user(
 
         # 2. 이 user가 접근 가능한 project_id (UUID) 집합
         access_result = await db.execute(
-            select(ProjectAccessModel.project_id).where(
-                ProjectAccessModel.user_id == user_id
-            )
+            select(ProjectAccessModel.project_id).where(ProjectAccessModel.user_id == user_id)
         )
         user_accessible_uuids: set[str] = {row[0] for row in access_result.all()}
 
@@ -697,9 +695,7 @@ async def get_projects(
                 from db.models import ProjectModel
 
                 path_result = await db.execute(select(ProjectModel.path))
-                db_registered_paths: set[str] = {
-                    row[0] for row in path_result.all() if row[0]
-                }
+                db_registered_paths: set[str] = {row[0] for row in path_result.all() if row[0]}
 
                 filtered = []
                 for p in projects:

--- a/src/backend/api/routes.py
+++ b/src/backend/api/routes.py
@@ -580,8 +580,9 @@ async def get_inactive_project_paths(db: AsyncSession) -> set[str]:
         return set()
 
     try:
-        from db.models import ProjectModel
         from sqlalchemy import select
+
+        from db.models import ProjectModel
 
         result = await db.execute(
             select(ProjectModel.path).where(

--- a/src/backend/db/models.py
+++ b/src/backend/db/models.py
@@ -1166,7 +1166,7 @@ class LLMModelConfigModel(Base):
     display_name = Column(String(255), nullable=False)
     provider = Column(String(50), nullable=False, index=True)  # "google" | "anthropic" | ...
     context_window = Column(Integer, nullable=False, default=128000)
-    input_price = Column(Float, nullable=False, default=0.001)   # USD per 1K tokens
+    input_price = Column(Float, nullable=False, default=0.001)  # USD per 1K tokens
     output_price = Column(Float, nullable=False, default=0.002)  # USD per 1K tokens
     is_default = Column(Boolean, default=False, nullable=False)
     is_enabled = Column(Boolean, default=True, nullable=False, index=True)
@@ -1175,9 +1175,7 @@ class LLMModelConfigModel(Base):
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
-    __table_args__ = (
-        Index("ix_llm_model_provider_enabled", "provider", "is_enabled"),
-    )
+    __table_args__ = (Index("ix_llm_model_provider_enabled", "provider", "is_enabled"),)
 
 
 class UserLLMCredentialModel(Base):
@@ -1187,8 +1185,8 @@ class UserLLMCredentialModel(Base):
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     user_id = Column(String(255), nullable=False, index=True)
-    provider = Column(String(50), nullable=False)          # "openai" | "google_gemini" | "anthropic"
-    key_name = Column(String(255), nullable=False)         # 사용자 표시용 이름
+    provider = Column(String(50), nullable=False)  # "openai" | "google_gemini" | "anthropic"
+    key_name = Column(String(255), nullable=False)  # 사용자 표시용 이름
     api_key = Column(EncryptedString(1024), nullable=False)  # Fernet 자동 암호화
     is_active = Column(Boolean, default=True, nullable=False)
     last_verified_at = Column(DateTime, nullable=True)

--- a/src/backend/models/external_usage.py
+++ b/src/backend/models/external_usage.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 class ExternalProvider(str, Enum):
     """Supported external LLM providers."""
+
     OPENAI = "openai"
     GITHUB_COPILOT = "github_copilot"
     GOOGLE_GEMINI = "google_gemini"
@@ -19,6 +20,7 @@ class ExternalProvider(str, Enum):
 
 class ProviderHealthStatus(BaseModel):
     """Health check result for a provider."""
+
     provider: ExternalProvider
     is_healthy: bool
     last_checked: datetime = Field(default_factory=datetime.utcnow)
@@ -28,6 +30,7 @@ class ProviderHealthStatus(BaseModel):
 
 class UnifiedUsageRecord(BaseModel):
     """Normalized usage record across providers."""
+
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     provider: ExternalProvider
     timestamp: datetime
@@ -58,6 +61,7 @@ class UnifiedUsageRecord(BaseModel):
 
 class UsageSummary(BaseModel):
     """Aggregated usage summary for a provider."""
+
     provider: ExternalProvider
     period_start: datetime
     period_end: datetime
@@ -71,6 +75,7 @@ class UsageSummary(BaseModel):
 
 class ExternalUsageSummaryResponse(BaseModel):
     """Combined external usage response."""
+
     providers: list[UsageSummary] = Field(default_factory=list)
     total_cost_usd: float = 0.0
     records: list[UnifiedUsageRecord] = Field(default_factory=list)
@@ -80,6 +85,7 @@ class ExternalUsageSummaryResponse(BaseModel):
 
 class ProviderConfig(BaseModel):
     """Provider configuration status."""
+
     provider: ExternalProvider
     enabled: bool
     api_key_masked: str | None = None
@@ -90,12 +96,14 @@ class ProviderConfig(BaseModel):
 
 class ProviderConfigRequest(BaseModel):
     """Request to configure a provider."""
+
     api_key: str
     org_id: str | None = None
 
 
 class SyncRequest(BaseModel):
     """Request to sync usage data."""
+
     provider: ExternalProvider | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
@@ -103,8 +111,10 @@ class SyncRequest(BaseModel):
 
 # ── LLM Credential 관련 스키마 ────────────────────────────────────
 
+
 class LLMCredentialCreate(BaseModel):
     """사용자가 API Key 등록 시 전달하는 요청 바디."""
+
     provider: ExternalProvider
     key_name: str = Field(min_length=1, max_length=100)
     api_key: str = Field(min_length=10)
@@ -112,6 +122,7 @@ class LLMCredentialCreate(BaseModel):
 
 class LLMCredentialResponse(BaseModel):
     """API 응답 — api_key는 마스킹 처리."""
+
     id: str
     provider: ExternalProvider
     key_name: str
@@ -123,6 +134,7 @@ class LLMCredentialResponse(BaseModel):
 
 class LLMCredentialVerifyResponse(BaseModel):
     """API Key 유효성 검증 결과."""
+
     is_valid: bool
     provider: ExternalProvider
     error_message: str | None = None

--- a/src/backend/scripts/migrate_project_owners.py
+++ b/src/backend/scripts/migrate_project_owners.py
@@ -45,9 +45,7 @@ async def main():
         for proj in projects:
             # 이미 ACL이 있는지 확인
             acl_result = await session.execute(
-                select(ProjectAccessModel)
-                .where(ProjectAccessModel.project_id == proj.id)
-                .limit(1)
+                select(ProjectAccessModel).where(ProjectAccessModel.project_id == proj.id).limit(1)
             )
             existing = acl_result.scalar_one_or_none()
             if existing:

--- a/src/backend/scripts/migrate_project_owners.py
+++ b/src/backend/scripts/migrate_project_owners.py
@@ -15,9 +15,10 @@ async def main():
 
     os.environ.setdefault("USE_DATABASE", "true")
 
+    from sqlalchemy import select
+
     from db.database import async_session_factory
     from db.models import ProjectAccessModel, ProjectModel, UserModel
-    from sqlalchemy import select
 
     async with async_session_factory() as session:
         # 어드민 유저 조회

--- a/src/backend/scripts/seed_projects_to_db.py
+++ b/src/backend/scripts/seed_projects_to_db.py
@@ -7,9 +7,9 @@
 """
 
 import asyncio
+import re
 import sys
 import uuid
-import re
 from pathlib import Path
 
 # src/backend를 sys.path에 추가
@@ -30,10 +30,11 @@ async def main(dry_run: bool = False):
 
     os.environ.setdefault("USE_DATABASE", "true")
 
+    from sqlalchemy import select
+
     from db.database import async_session_factory
     from db.models import ProjectAccessModel, ProjectModel, UserModel
     from models.project import init_projects, list_projects
-    from sqlalchemy import select
 
     # projects/ 디렉토리에서 프로젝트 로드
     base_path = Path(__file__).parent.parent.parent.parent

--- a/src/backend/services/credential_service.py
+++ b/src/backend/services/credential_service.py
@@ -25,9 +25,7 @@ def _mask_key(key: str) -> str:
     return key[:6] + "..." + key[-4:]
 
 
-async def list_user_credentials(
-    db: AsyncSession, user_id: str
-) -> list[LLMCredentialResponse]:
+async def list_user_credentials(db: AsyncSession, user_id: str) -> list[LLMCredentialResponse]:
     """Return all active credentials for a user (keys masked)."""
     result = await db.execute(
         select(UserLLMCredentialModel)
@@ -78,9 +76,7 @@ async def create_credential(
     )
 
 
-async def delete_credential(
-    db: AsyncSession, user_id: str, credential_id: str
-) -> bool:
+async def delete_credential(db: AsyncSession, user_id: str, credential_id: str) -> bool:
     """Soft-delete (deactivate) a credential. Returns False if not found/owned."""
     result = await db.execute(
         select(UserLLMCredentialModel).where(
@@ -177,9 +173,7 @@ async def _test_key(provider: ExternalProvider, api_key: str) -> tuple[bool, str
     return False, f"Unsupported provider: {provider}"
 
 
-async def get_raw_key(
-    db: AsyncSession, user_id: str, provider: ExternalProvider
-) -> str | None:
+async def get_raw_key(db: AsyncSession, user_id: str, provider: ExternalProvider) -> str | None:
     """Return decrypted API key for a user+provider (for proxy use). None if not found."""
     result = await db.execute(
         select(UserLLMCredentialModel)

--- a/src/backend/services/external_usage_service.py
+++ b/src/backend/services/external_usage_service.py
@@ -22,9 +22,7 @@ class BaseUsageCollector(ABC):
     """Abstract base for external LLM usage collectors."""
 
     @abstractmethod
-    async def collect(
-        self, start_time: datetime, end_time: datetime
-    ) -> list[UnifiedUsageRecord]:
+    async def collect(self, start_time: datetime, end_time: datetime) -> list[UnifiedUsageRecord]:
         """Collect usage records for the given period."""
         ...
 
@@ -34,8 +32,7 @@ class BaseUsageCollector(ABC):
         ...
 
     @abstractmethod
-    def get_provider(self) -> ExternalProvider:
-        ...
+    def get_provider(self) -> ExternalProvider: ...
 
 
 class OpenAIUsageCollector(BaseUsageCollector):
@@ -78,9 +75,7 @@ class OpenAIUsageCollector(BaseUsageCollector):
                 error_message=str(e),
             )
 
-    async def collect(
-        self, start_time: datetime, end_time: datetime
-    ) -> list[UnifiedUsageRecord]:
+    async def collect(self, start_time: datetime, end_time: datetime) -> list[UnifiedUsageRecord]:
         records: list[UnifiedUsageRecord] = []
         try:
             start_ts = int(start_time.timestamp())
@@ -174,9 +169,7 @@ class GitHubCopilotCollector(BaseUsageCollector):
                 error_message=str(e),
             )
 
-    async def collect(
-        self, start_time: datetime, end_time: datetime
-    ) -> list[UnifiedUsageRecord]:
+    async def collect(self, start_time: datetime, end_time: datetime) -> list[UnifiedUsageRecord]:
         records: list[UnifiedUsageRecord] = []
         try:
             async with httpx.AsyncClient(timeout=30) as client:
@@ -371,9 +364,7 @@ class ExternalUsageService:
         summaries: list[UsageSummary] = []
 
         target_collectors = {
-            p: c
-            for p, c in self._collectors.items()
-            if providers is None or p in providers
+            p: c for p, c in self._collectors.items() if providers is None or p in providers
         }
 
         for provider, collector in target_collectors.items():
@@ -404,9 +395,7 @@ class ExternalUsageService:
                 continue
 
         # Merge proxy-collected records within the requested period
-        filtered_proxy = [
-            r for r in self._proxy_records if start_time <= r.timestamp <= end_time
-        ]
+        filtered_proxy = [r for r in self._proxy_records if start_time <= r.timestamp <= end_time]
         all_records.extend(filtered_proxy)
 
         total_cost = sum(s.total_cost_usd for s in summaries)

--- a/src/backend/services/external_usage_service.py
+++ b/src/backend/services/external_usage_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime
 
 import httpx
 
@@ -103,7 +103,7 @@ class OpenAIUsageCollector(BaseUsageCollector):
 
                 data = resp.json()
                 for bucket in data.get("data", []):
-                    ts = datetime.fromtimestamp(bucket.get("start_time", 0), tz=timezone.utc)
+                    ts = datetime.fromtimestamp(bucket.get("start_time", 0), tz=UTC)
                     for result in bucket.get("results", []):
                         input_tok = result.get("input_tokens", 0) or 0
                         output_tok = result.get("output_tokens", 0) or 0
@@ -194,7 +194,7 @@ class GitHubCopilotCollector(BaseUsageCollector):
                 for day_data in resp.json():
                     date_str = day_data.get("date", "")
                     try:
-                        ts = datetime.fromisoformat(date_str).replace(tzinfo=timezone.utc)
+                        ts = datetime.fromisoformat(date_str).replace(tzinfo=UTC)
                     except ValueError:
                         continue
 
@@ -267,7 +267,7 @@ class AnthropicUsageCollector(BaseUsageCollector):
         """Collect from Anthropic Usage Report API."""
         records: list[UnifiedUsageRecord] = []
 
-        COSTS: dict[str, tuple[float, float]] = {
+        costs: dict[str, tuple[float, float]] = {
             "claude-opus-4": (0.015, 0.075),
             "claude-sonnet-4": (0.003, 0.015),
             "claude-haiku-4": (0.00025, 0.00125),
@@ -305,7 +305,7 @@ class AnthropicUsageCollector(BaseUsageCollector):
                     input_tok = item.get("input_tokens", 0)
                     output_tok = item.get("output_tokens", 0)
                     cost = 0.0
-                    for prefix, (ci, co) in COSTS.items():
+                    for prefix, (ci, co) in costs.items():
                         if model.startswith(prefix):
                             cost = (input_tok / 1000) * ci + (output_tok / 1000) * co
                             break

--- a/src/backend/services/organization_service.py
+++ b/src/backend/services/organization_service.py
@@ -556,8 +556,7 @@ class OrganizationService:
         return [
             _organizations[oid]
             for oid in org_ids
-            if oid in _organizations
-            and _organizations[oid].status != OrganizationStatus.DELETED
+            if oid in _organizations and _organizations[oid].status != OrganizationStatus.DELETED
         ]
 
     @staticmethod

--- a/src/backend/services/project_invitation_service.py
+++ b/src/backend/services/project_invitation_service.py
@@ -63,9 +63,7 @@ class ProjectInvitationService:
     ) -> ProjectInvitationModel | None:
         """토큰으로 초대 조회."""
         result = await db.execute(
-            select(ProjectInvitationModel).where(
-                ProjectInvitationModel.token == token
-            )
+            select(ProjectInvitationModel).where(ProjectInvitationModel.token == token)
         )
         return result.scalar_one_or_none()
 
@@ -90,6 +88,7 @@ class ProjectInvitationService:
             raise ValueError("이메일이 일치하지 않습니다")
 
         from services.project_access_service import ProjectAccessService
+
         try:
             access = await ProjectAccessService.grant_access(
                 db=db,
@@ -120,12 +119,14 @@ class ProjectInvitationService:
     ) -> list[ProjectInvitationModel]:
         """프로젝트의 pending 초대 목록 조회."""
         result = await db.execute(
-            select(ProjectInvitationModel).where(
+            select(ProjectInvitationModel)
+            .where(
                 and_(
                     ProjectInvitationModel.project_id == project_id,
                     ProjectInvitationModel.status == "pending",
                 )
-            ).order_by(ProjectInvitationModel.created_at.desc())
+            )
+            .order_by(ProjectInvitationModel.created_at.desc())
         )
         return list(result.scalars().all())
 

--- a/src/dashboard/src/components/__tests__/ProcessMonitorWidget.test.tsx
+++ b/src/dashboard/src/components/__tests__/ProcessMonitorWidget.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import { ProcessMonitorWidget } from '../ProcessMonitorWidget'

--- a/src/dashboard/src/components/claude-sessions/__tests__/ProcessCleanupPanel.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/ProcessCleanupPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { ProcessCleanupPanel } from '../ProcessCleanupPanel'
 

--- a/src/dashboard/src/components/claude-sessions/__tests__/SessionList.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/SessionList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 // Mock lucide-react icons

--- a/src/dashboard/src/components/mcp/__tests__/MCPToolCaller.test.tsx
+++ b/src/dashboard/src/components/mcp/__tests__/MCPToolCaller.test.tsx
@@ -925,7 +925,7 @@ describe('MCPToolCaller', () => {
 
       // The close button is next to "Batch Result" text, it contains an X icon.
       // Find all X icons and click the one in the batch result area.
-      const xIcons = screen.getAllByTestId('icon-x')
+      const _xIcons = screen.getAllByTestId('icon-x')
       // The batch result close button's X icon - find the one whose parent button
       // is inside the batch result summary header
       const batchResultEl = screen.getByText('Batch Result').closest('.rounded-lg')!

--- a/src/dashboard/src/components/monitor/__tests__/HealthOverview.test.tsx
+++ b/src/dashboard/src/components/monitor/__tests__/HealthOverview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { HealthOverview } from '../HealthOverview'
 import type { ProjectHealth, CheckType, WorkflowCheck } from '../../../types/monitoring'
 

--- a/src/dashboard/src/components/notifications/__tests__/NotificationRuleEditor.test.tsx
+++ b/src/dashboard/src/components/notifications/__tests__/NotificationRuleEditor.test.tsx
@@ -437,7 +437,7 @@ describe('NotificationRuleEditor', () => {
       // There should be 4 channel buttons in the new rule form
       // The channel icons in the form section (slack, discord, email, webhook buttons)
       const newRuleSection = screen.getByText('New Rule').closest('div')!
-      const channelButtons = newRuleSection.querySelectorAll('button')
+      const _channelButtons = newRuleSection.querySelectorAll('button')
       // Filter to just the channel toggle buttons (they contain icon elements)
       const slackButtons = newRuleSection.querySelectorAll('[data-testid="slack-icon"]')
       expect(slackButtons.length).toBeGreaterThan(0)

--- a/src/dashboard/src/components/permissions/__tests__/PermissionTogglePanel.test.tsx
+++ b/src/dashboard/src/components/permissions/__tests__/PermissionTogglePanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
-import type { PermissionInfo, AgentPermission } from '../../../stores/permissions'
+import type { PermissionInfo } from '../../../stores/permissions'
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({

--- a/src/dashboard/src/components/project-configs/__tests__/CopyToProjectModal.test.tsx
+++ b/src/dashboard/src/components/project-configs/__tests__/CopyToProjectModal.test.tsx
@@ -105,7 +105,6 @@ describe('CopyToProjectModal', () => {
 
   it('shows empty state when no other projects available', () => {
     // Source project is proj-1, and we only have proj-1 in the list
-    vi.mocked
     render(
       <CopyToProjectModal
         {...defaultProps}

--- a/src/dashboard/src/components/project-configs/__tests__/HooksTab.test.tsx
+++ b/src/dashboard/src/components/project-configs/__tests__/HooksTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { HooksTab } from '../HooksTab'
 

--- a/src/dashboard/src/components/project-management/__tests__/ProjectMembersContent.test.tsx
+++ b/src/dashboard/src/components/project-management/__tests__/ProjectMembersContent.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ProjectMembersContent } from '../ProjectMembersContent'
 
 // Mock lucide-react

--- a/src/dashboard/src/components/rag/__tests__/RAGQueryPanel.test.tsx
+++ b/src/dashboard/src/components/rag/__tests__/RAGQueryPanel.test.tsx
@@ -154,13 +154,13 @@ describe('RAGQueryPanel', () => {
   })
 
   it('performs search on button click', async () => {
-    let callCount = 0
+    let _callCount = 0
     vi.mocked(global.fetch).mockImplementation(async (url) => {
       const u = String(url)
       if (u.includes('/query')) {
         return { ok: true, json: async () => mockQueryResult } as Response
       }
-      callCount++
+      _callCount++
       return { ok: true, json: async () => mockStats } as Response
     })
 

--- a/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import { ClaudeUsageDashboard } from '../ClaudeUsageDashboard'
 import type { ClaudeUsageResponse } from '../../../types/claudeUsage'
 

--- a/src/dashboard/src/components/usage/__tests__/LLMAccountsSettings.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/LLMAccountsSettings.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { LLMAccountsSettings } from '../LLMAccountsSettings'
 
 // Mock lucide-react

--- a/src/dashboard/src/components/usage/__tests__/UsageProgressBar.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/UsageProgressBar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { UsageProgressBar } from '../UsageProgressBar'
 

--- a/src/dashboard/src/pages/AnalyticsPage.test.tsx
+++ b/src/dashboard/src/pages/AnalyticsPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 // Mock lucide-react icons

--- a/src/dashboard/src/pages/ExternalUsagePage.test.tsx
+++ b/src/dashboard/src/pages/ExternalUsagePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 // Mock lucide-react icons

--- a/src/dashboard/src/pages/ExternalUsagePage.tsx
+++ b/src/dashboard/src/pages/ExternalUsagePage.tsx
@@ -67,7 +67,7 @@ export function ExternalUsagePage() {
     const startTime = new Date(Date.now() - selectedPeriod * 86_400_000).toISOString()
     fetchSummary(startTime, endTime)
     fetchProviders()
-  }, [selectedPeriod])
+  }, [selectedPeriod, fetchSummary, fetchProviders])
 
   const handleSync = async () => {
     setIsSyncing(true)

--- a/src/dashboard/src/pages/GitPage.test.tsx
+++ b/src/dashboard/src/pages/GitPage.test.tsx
@@ -39,8 +39,8 @@ const mockCreatePRReview = vi.fn()
 let lastBranchListProps: Record<string, unknown> = {}
 let lastMergeRequestListProps: Record<string, unknown> = {}
 let lastPullRequestListProps: Record<string, unknown> = {}
-let lastMergePreviewPanelProps: Record<string, unknown> = {}
-let lastPRReviewPanelProps: Record<string, unknown> = {}
+let _lastMergePreviewPanelProps: Record<string, unknown> = {}
+let _lastPRReviewPanelProps: Record<string, unknown> = {}
 let lastGitSetupProps: Record<string, unknown> = {}
 let lastWorkingDirectoryProps: Record<string, unknown> = {}
 let lastCommitHistoryProps: Record<string, unknown> = {}
@@ -160,7 +160,7 @@ vi.mock('../components/git', () => ({
     return <div data-testid="merge-request-list">MergeRequestList</div>
   },
   MergePreviewPanel: (props: Record<string, unknown>) => {
-    lastMergePreviewPanelProps = props
+    _lastMergePreviewPanelProps = props
     return <div data-testid="merge-preview">MergePreviewPanel</div>
   },
   PullRequestList: (props: Record<string, unknown>) => {
@@ -168,7 +168,7 @@ vi.mock('../components/git', () => ({
     return <div data-testid="pull-request-list">PullRequestList</div>
   },
   PRReviewPanel: (props: Record<string, unknown>) => {
-    lastPRReviewPanelProps = props
+    _lastPRReviewPanelProps = props
     return <div data-testid="pr-review-panel">PRReviewPanel</div>
   },
   CommitHistory: (props: Record<string, unknown>) => {
@@ -803,7 +803,7 @@ describe('GitPage', () => {
   it('applies animate-spin class to Fetch icon when loading', () => {
     setValidRepoTab('changes', { isLoading: true })
 
-    const { container } = render(<GitPage />)
+    render(<GitPage />)
 
     // The RefreshCw icon (mocked as <span>) should have animate-spin
     const fetchBtn = screen.getByTitle('Fetch from remote')

--- a/src/dashboard/src/pages/PlaygroundPage.test.tsx
+++ b/src/dashboard/src/pages/PlaygroundPage.test.tsx
@@ -279,10 +279,8 @@ describe('PlaygroundPage', () => {
     // Make fetch hang to keep loading state
     mockAuthFetch.mockImplementation(() => new Promise(() => {}))
 
-    let container: HTMLElement
     await act(async () => {
-      const result = render(<PlaygroundPage />)
-      container = result.container
+      render(<PlaygroundPage />)
     })
 
     // The loading state should show RefreshCw spinner (rendered as <span> via mock)

--- a/src/dashboard/src/stores/__tests__/agents.test.ts
+++ b/src/dashboard/src/stores/__tests__/agents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { useAgentsStore, Agent, AgentRegistryStats } from '../agents'
+import { useAgentsStore, Agent, AgentRegistryStats, TaskAnalysisHistory, TaskAnalysisResult } from '../agents'
 
 const mockAgent: Agent = {
   id: 'agent-1',
@@ -420,7 +420,7 @@ describe('agents store', () => {
     })
 
     it('resets history when reset=true', async () => {
-      useAgentsStore.setState({ analysisHistory: [{ id: 'old' } as any] })
+      useAgentsStore.setState({ analysisHistory: [{ id: 'old' } as unknown as TaskAnalysisHistory] })
       vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(mockHistoryData)))
       await useAgentsStore.getState().fetchAnalysisHistory(undefined, true)
       expect(useAgentsStore.getState().analysisHistory).toHaveLength(1)
@@ -461,7 +461,7 @@ describe('agents store', () => {
       useAgentsStore.setState({
         historyHasMore: true,
         historyLoading: false,
-        analysisHistory: [{ id: 'h1' } as any],
+        analysisHistory: [{ id: 'h1' } as unknown as TaskAnalysisHistory],
         historyProjectFilter: null,
       })
       vi.spyOn(global, 'fetch').mockResolvedValue(
@@ -476,7 +476,7 @@ describe('agents store', () => {
   describe('deleteAnalysis', () => {
     it('removes item from history on success', async () => {
       useAgentsStore.setState({
-        analysisHistory: [{ id: 'h1' } as any, { id: 'h2' } as any],
+        analysisHistory: [{ id: 'h1' } as unknown as TaskAnalysisHistory, { id: 'h2' } as unknown as TaskAnalysisHistory],
         historyTotal: 2,
         selectedHistoryId: null,
       })
@@ -489,10 +489,10 @@ describe('agents store', () => {
 
     it('clears selection if deleted item was selected', async () => {
       useAgentsStore.setState({
-        analysisHistory: [{ id: 'h1' } as any],
+        analysisHistory: [{ id: 'h1' } as unknown as TaskAnalysisHistory],
         historyTotal: 1,
         selectedHistoryId: 'h1',
-        lastAnalysis: { success: true } as any,
+        lastAnalysis: { success: true } as unknown as TaskAnalysisResult,
       })
       vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
       await useAgentsStore.getState().deleteAnalysis('h1')
@@ -509,7 +509,7 @@ describe('agents store', () => {
 
   describe('selectHistoryItem', () => {
     it('clears selection when null is passed', () => {
-      useAgentsStore.setState({ selectedHistoryId: 'h1', lastAnalysis: { success: true } as any })
+      useAgentsStore.setState({ selectedHistoryId: 'h1', lastAnalysis: { success: true } as unknown as TaskAnalysisResult })
       useAgentsStore.getState().selectHistoryItem(null)
       expect(useAgentsStore.getState().selectedHistoryId).toBeNull()
       expect(useAgentsStore.getState().lastAnalysis).toBeNull()
@@ -529,7 +529,7 @@ describe('agents store', () => {
         strategy: 'sequential',
         project_id: 'proj-1',
       }
-      useAgentsStore.getState().selectHistoryItem(historyItem as any)
+      useAgentsStore.getState().selectHistoryItem(historyItem as unknown as TaskAnalysisHistory)
       expect(useAgentsStore.getState().selectedHistoryId).toBe('h1')
       expect(useAgentsStore.getState().lastAnalysis).toMatchObject({
         success: true,
@@ -1208,7 +1208,7 @@ describe('agents store', () => {
         ...mockAnalysisData,
         analysis: {
           ...mockAnalysisData.analysis,
-          execution_plan: null as any,
+          execution_plan: null as unknown,
         },
       }
       vi.spyOn(global, 'fetch')
@@ -1282,7 +1282,7 @@ describe('agents store', () => {
 
     it('resets history when project filter changes', async () => {
       useAgentsStore.setState({
-        analysisHistory: [{ id: 'old' } as any],
+        analysisHistory: [{ id: 'old' } as unknown as TaskAnalysisHistory],
         historyTotal: 5,
         historyProjectFilter: 'proj-old',
       })
@@ -1298,7 +1298,7 @@ describe('agents store', () => {
 
     it('does not reset when same project filter is used', async () => {
       useAgentsStore.setState({
-        analysisHistory: [{ id: 'existing' } as any],
+        analysisHistory: [{ id: 'existing' } as unknown as TaskAnalysisHistory],
         historyProjectFilter: 'proj-1',
         historyTotal: 1,
         historyHasMore: false,
@@ -1343,7 +1343,7 @@ describe('agents store', () => {
       useAgentsStore.setState({
         historyHasMore: true,
         historyLoading: false,
-        analysisHistory: [{ id: 'h1' } as any],
+        analysisHistory: [{ id: 'h1' } as unknown as TaskAnalysisHistory],
         historyProjectFilter: 'proj-filter',
       })
       const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
@@ -1359,7 +1359,7 @@ describe('agents store', () => {
       useAgentsStore.setState({
         historyHasMore: true,
         historyLoading: false,
-        analysisHistory: [{ id: 'h1' } as any, { id: 'h2' } as any, { id: 'h3' } as any],
+        analysisHistory: [{ id: 'h1' } as unknown as TaskAnalysisHistory, { id: 'h2' } as unknown as TaskAnalysisHistory, { id: 'h3' } as unknown as TaskAnalysisHistory],
         historyProjectFilter: null,
       })
       const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
@@ -1409,10 +1409,10 @@ describe('agents store', () => {
   describe('deleteAnalysis - additional branches', () => {
     it('preserves selection when deleted item was not selected', async () => {
       useAgentsStore.setState({
-        analysisHistory: [{ id: 'h1' } as any, { id: 'h2' } as any],
+        analysisHistory: [{ id: 'h1' } as unknown as TaskAnalysisHistory, { id: 'h2' } as unknown as TaskAnalysisHistory],
         historyTotal: 2,
         selectedHistoryId: 'h2',
-        lastAnalysis: { success: true } as any,
+        lastAnalysis: { success: true } as unknown as TaskAnalysisResult,
       })
       vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
 
@@ -1453,7 +1453,7 @@ describe('agents store', () => {
         image_paths: null,
         created_at: '2025-01-01T00:00:00Z',
       }
-      useAgentsStore.getState().selectHistoryItem(historyItem as any)
+      useAgentsStore.getState().selectHistoryItem(historyItem as unknown as TaskAnalysisHistory)
 
       const lastAnalysis = useAgentsStore.getState().lastAnalysis
       expect(lastAnalysis).not.toBeNull()

--- a/tests/backend/test_project_active_filter.py
+++ b/tests/backend/test_project_active_filter.py
@@ -2,6 +2,9 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+# USE_DATABASE=true로 설정해야 get_inactive_project_paths가 DB 조회를 수행함
+_USE_DB_ENV = {"USE_DATABASE": "true"}
+
 
 @pytest.fixture
 def mock_projects():
@@ -37,14 +40,15 @@ async def test_regular_user_cannot_see_inactive_project(mock_projects):
     mock_result.all.return_value = [("/projects/inactive",)]
     mock_db.execute = AsyncMock(return_value=mock_result)
 
-    inactive_paths = await get_inactive_project_paths(mock_db)
-    assert "/projects/inactive" in inactive_paths
-    assert "/projects/active" not in inactive_paths
+    with patch.dict("os.environ", _USE_DB_ENV):
+        inactive_paths = await get_inactive_project_paths(mock_db)
+        assert "/projects/inactive" in inactive_paths
+        assert "/projects/active" not in inactive_paths
 
-    # 필터링 적용
-    filtered = [p for p in mock_projects if p.path not in inactive_paths]
-    assert len(filtered) == 1
-    assert filtered[0].name == "Active Project"
+        # 필터링 적용
+        filtered = [p for p in mock_projects if p.path not in inactive_paths]
+        assert len(filtered) == 1
+        assert filtered[0].name == "Active Project"
 
 
 @pytest.mark.asyncio
@@ -67,7 +71,8 @@ async def test_no_inactive_registry_shows_all(mock_projects):
     mock_result.all.return_value = []
     mock_db.execute = AsyncMock(return_value=mock_result)
 
-    inactive_paths = await get_inactive_project_paths(mock_db)
+    with patch.dict("os.environ", _USE_DB_ENV):
+        inactive_paths = await get_inactive_project_paths(mock_db)
     assert len(inactive_paths) == 0
 
     filtered = [p for p in mock_projects if p.path not in inactive_paths]
@@ -85,7 +90,8 @@ async def test_unregistered_project_always_visible(mock_projects):
     mock_result.all.return_value = [("/projects/other",)]
     mock_db.execute = AsyncMock(return_value=mock_result)
 
-    inactive_paths = await get_inactive_project_paths(mock_db)
+    with patch.dict("os.environ", _USE_DB_ENV):
+        inactive_paths = await get_inactive_project_paths(mock_db)
     assert "/projects/other" in inactive_paths
     assert "/projects/active" not in inactive_paths
     assert "/projects/inactive" not in inactive_paths


### PR DESCRIPTION
## Summary
- Resolve all ruff lint errors (I001, F401, UP017, N806) across 11 backend files
- Apply ruff format to 12 files
- Fix 2 failing tests in `test_project_active_filter.py` (missing `USE_DATABASE=true` env)
- Update docs (api-reference, architecture, dashboard) and fix dashboard test imports

## Changes
- **Backend lint (I001)**: Sort import blocks in api/, scripts/, alembic/
- **Backend lint (F401)**: Remove unused `sqlalchemy`, `datetime.timedelta` imports
- **Backend lint (UP017)**: Use `datetime.UTC` alias instead of `datetime.timezone.utc`
- **Backend lint (N806)**: Rename `COSTS` to `costs` (local variable in function)
- **Backend format**: Auto-format 12 files with `ruff format`
- **Test fix**: Add `USE_DATABASE=true` env patch to `test_project_active_filter.py`
- **Docs**: Update api-reference, architecture, dashboard documentation
- **Dashboard**: Fix test imports and patterns

## Test Plan
- [x] `ruff check .` - All checks passed
- [x] `ruff format .` - All files formatted
- [x] `pytest` - 428 passed (0 failed)
- [x] Frontend: eslint, tsc, vitest, build all passing

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)