### PR TITLE
fix(backend): CORS_ORIGINS 환경변수 파싱 강건화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,9 @@ LOG_LEVEL=INFO
 # Frontend URL (for OAuth callbacks)
 FRONTEND_URL=http://localhost:5173
 
-# CORS (comma-separated)
+# CORS - 아래 두 형식 모두 지원:
+#   쉼표 구분: http://localhost:3000,http://localhost:5173
+#   JSON 배열: '["http://localhost:3000","http://localhost:5173"]'  (shell source 시 single-quote 필수)
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # =============================================================================

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -83,7 +83,8 @@ DATABASE_URL=postgresql+asyncpg://aos:aos@localhost:5432/aos
 
 1. **연결 안됨**: Backend 서버 실행 확인
 2. **API 에러**: `.env` 파일의 LLM API 키 확인 (GOOGLE_API_KEY 또는 ANTHROPIC_API_KEY)
-3. **UI 에러**: `npm install` 후 재시작
-4. **DB 에러**: `USE_DATABASE=false`로 설정하거나 `./infra/scripts/dev.sh` 실행
+3. **CORS 에러**: `CORS_ORIGINS` 형식 확인 (쉼표 구분: `a.com,b.com` 또는 JSON 배열)
+4. **UI 에러**: `npm install` 후 재시작
+5. **DB 에러**: `USE_DATABASE=false`로 설정하거나 `./infra/scripts/dev.sh` 실행
 
 자세한 내용은 [USER_GUIDE.md](./USER_GUIDE.md) 참조

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -776,7 +776,7 @@ ws.onmessage = (event) => {
 해결:
 1. Backend 서버가 실행 중인지 확인
 2. 포트 8000이 사용 중인지 확인
-3. CORS 설정 확인
+3. CORS 설정 확인 (CORS_ORIGINS 환경변수 형식: 쉼표 구분 또는 JSON 배열)
 ```
 
 #### 2. API Key 에러

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -170,7 +170,7 @@ GOOGLE_API_KEY=<your-api-key>
 | `GOOGLE_CLIENT_SECRET` | Google OAuth 시크릿 | - |
 | `GITHUB_CLIENT_ID` | GitHub OAuth 클라이언트 ID | - |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth 시크릿 | - |
-| `CORS_ORIGINS` | 추가 CORS 허용 오리진 | - |
+| `CORS_ORIGINS` | 추가 CORS 허용 오리진 (쉼표 구분 또는 JSON 배열) | - |
 | `LOG_LEVEL` | 로그 레벨 | `INFO` |
 | `ENV` | 환경 (production/staging) | `production` |
 
@@ -315,7 +315,8 @@ CORS policy: No 'Access-Control-Allow-Origin'
 
 **해결책**:
 - `FRONTEND_URL` 설정 확인
-- `CORS_ORIGINS`에 추가 도메인 설정
+- `CORS_ORIGINS`에 추가 도메인 설정 (쉼표 구분: `http://a.com,http://b.com` 또는 JSON 배열: `'["http://a.com","http://b.com"]'`)
+- `source .env` 사용 시 JSON 배열 값은 반드시 single-quote로 감싸야 셸이 내부 따옴표를 보존함
 
 ### 로그 확인
 

--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -274,8 +274,14 @@ else:
             lifespan=lifespan,
         )
 
-        # Configure CORS
-        cors_origins = [
+        # Configure CORS - use Settings for robust parsing (JSON array, comma-separated)
+        from config import get_settings
+
+        settings = get_settings()
+        cors_origins = list(settings.cors_origins)
+
+        # Ensure common dev origins are included
+        dev_origins = [
             "http://localhost:3000",
             "http://localhost:5173",
             "http://localhost:5174",
@@ -283,16 +289,14 @@ else:
             "http://127.0.0.1:5173",
             "http://127.0.0.1:5174",
         ]
+        for origin in dev_origins:
+            if origin not in cors_origins:
+                cors_origins.append(origin)
 
         # Add frontend URL from environment (for production)
         frontend_url = os.getenv("FRONTEND_URL")
-        if frontend_url:
+        if frontend_url and frontend_url not in cors_origins:
             cors_origins.append(frontend_url)
-
-        # Add extra origins from environment
-        extra_origins = os.getenv("CORS_ORIGINS", "")
-        if extra_origins:
-            cors_origins.extend([o.strip() for o in extra_origins.split(",") if o.strip()])
 
         app.add_middleware(
             CORSMiddleware,

--- a/src/backend/api/app_railway.py
+++ b/src/backend/api/app_railway.py
@@ -47,13 +47,28 @@ app = FastAPI(
     version="0.1.0",
 )
 
+# CORS - parse CORS_ORIGINS env var (JSON array or comma-separated)
+import json
+
+_cors_origins = [
+    "http://localhost:3000",
+    "http://localhost:5173",
+    FRONTEND_URL,
+]
+_extra = os.getenv("CORS_ORIGINS", "")
+if _extra:
+    _extra = _extra.strip()
+    if _extra.startswith("["):
+        try:
+            _cors_origins.extend(json.loads(_extra))
+        except json.JSONDecodeError:
+            _cors_origins.extend(o.strip().strip("'\"") for o in _extra.strip("[]").split(",") if o.strip())
+    else:
+        _cors_origins.extend(o.strip() for o in _extra.split(",") if o.strip())
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",
-        "http://localhost:5173",
-        FRONTEND_URL,
-    ],
+    allow_origins=list(set(_cors_origins)),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/backend/api/app_railway.py
+++ b/src/backend/api/app_railway.py
@@ -62,7 +62,9 @@ if _extra:
         try:
             _cors_origins.extend(json.loads(_extra))
         except json.JSONDecodeError:
-            _cors_origins.extend(o.strip().strip("'\"") for o in _extra.strip("[]").split(",") if o.strip())
+            _cors_origins.extend(
+                o.strip().strip("'\"") for o in _extra.strip("[]").split(",") if o.strip()
+            )
     else:
         _cors_origins.extend(o.strip() for o in _extra.split(",") if o.strip())
 

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -2,7 +2,7 @@
 
 import json
 from functools import lru_cache
-from typing import Annotated, TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,9 +1,11 @@
 """Application configuration."""
 
+import json
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import Annotated, TYPE_CHECKING
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 if TYPE_CHECKING:
     pass
@@ -43,11 +45,27 @@ class Settings(BaseSettings):
     max_iterations: int = 100
     default_model: str = ""  # If empty, uses LLMModelRegistry.get_default()
 
-    # CORS
-    cors_origins: list[str] = [
+    # CORS - NoDecode prevents EnvSettingsSource from JSON-parsing before validator runs
+    cors_origins: Annotated[list[str], NoDecode] = [
         "http://localhost:3000",
         "http://localhost:5173",
     ]
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, v: object) -> list[str] | object:
+        """Handle JSON array, bracket-wrapped, comma-separated string, or list."""
+        if isinstance(v, str):
+            v = v.strip()
+            if v.startswith("["):
+                try:
+                    return json.loads(v)
+                except json.JSONDecodeError:
+                    # Shell source strips inner quotes: ["a","b"] → [a,b]
+                    inner = v.strip("[]")
+                    return [o.strip().strip("'\"") for o in inner.split(",") if o.strip()]
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
 
     # OAuth/JWT Settings
     session_secret_key: str = ""  # JWT signing key


### PR DESCRIPTION
## Summary
- `source .env` 시 JSON 배열 형식 `CORS_ORIGINS`가 pydantic `SettingsError`를 유발하는 문제 수정
- `config.py`, `app.py`, `app_railway.py` 모두 일관된 CORS 파싱 로직으로 통일
- 관련 문서 (deployment, QUICK_START, USER_GUIDE, .env.example) 업데이트

## Changes
- **`config.py`**: `NoDecode` 어노테이션 + `field_validator`로 JSON 배열, 쉼표 구분, 셸 맹글링 형식 모두 처리
- **`app.py`**: 수동 CORS 파싱 제거, `Settings.cors_origins` 사용으로 통일
- **`app_railway.py`**: `CORS_ORIGINS` 환경변수 지원 추가 (JSON 배열/쉼표 구분)
- **docs**: CORS 포맷 설명 및 트러블슈팅 보강

## Test Plan
- [x] `source .env`로 환경변수 로드 후 Backend 정상 시작 확인
- [x] JSON 배열, 쉼표 구분, 셸 맹글링 브래킷, 리스트 4가지 형식 파싱 테스트 통과
- [x] ruff lint/format 통과
- [x] pytest 통과

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)