### PR TITLE
fix(ui): LoadingSkeleton 스피너 중앙 배치

### DIFF
--- a/src/dashboard/src/components/ErrorBoundary.tsx
+++ b/src/dashboard/src/components/ErrorBoundary.tsx
@@ -71,7 +71,7 @@ function DefaultFallback({ error, resetError }: FallbackProps) {
 
 export function LoadingSkeleton() {
   return (
-    <div className="flex items-center justify-center min-h-[200px] p-8">
+    <div className="flex items-center justify-center flex-1 min-h-[200px] p-8">
       <div className="flex flex-col items-center gap-3">
         <div className="w-8 h-8 border-4 border-gray-200 dark:border-gray-700 border-t-primary-500 rounded-full animate-spin" />
         <p className="text-sm text-gray-500 dark:text-gray-400">Loading...</p>


### PR DESCRIPTION
## Summary
- Suspense fallback의 `LoadingSkeleton` 스피너가 좌하단에 표시되던 문제 수정
- `flex-1` 추가로 콘텐츠 영역 전체 중앙에 배치

## Changes
- `src/dashboard/src/components/ErrorBoundary.tsx`: `LoadingSkeleton`에 `flex-1` 클래스 추가

## Test Plan
- [x] 페이지 로딩 시 스피너가 콘텐츠 영역 중앙에 표시되는지 확인
- [x] 다크모드에서도 정상 표시 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)