### PR TITLE
feat(hooks): 하네스 v2.0 — 경고→차단 전환 및 신규 가드 추가

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -20,19 +20,59 @@
             "command": "python3 -c \"import json,sys; p=json.load(sys.stdin).get('tool_input',{}).get('file_path',''); blocked=['.env','secrets','.git/','/prod/','credentials','private_key','id_rsa','.pem']; sys.exit(2 if any(b in p for b in blocked) else 0)\"",
             "timeout": 5,
             "statusMessage": "Path protection..."
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/hardGateGuard.js",
+            "timeout": 3,
+            "statusMessage": "HARD-GATE check..."
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/tddGuard.js",
+            "timeout": 3,
+            "statusMessage": "TDD check..."
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/skillGateGuard.js",
+            "timeout": 3,
+            "statusMessage": "Skill gate check..."
           }
         ]
       }
     ],
     "PostToolUse": [
       {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/skillGateGuard.js",
+            "timeout": 3,
+            "statusMessage": "Recording skill invocation..."
+          }
+        ]
+      },
+      {
         "matcher": "Write",
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/verificationGuard.js 2>/dev/null || true",
-            "timeout": 10,
+            "command": "node .claude/hooks/verificationGuard.js",
+            "timeout": 15,
             "statusMessage": "Verification check..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/componentPatternChecker.js",
+            "timeout": 5,
+            "statusMessage": "Component pattern check..."
           }
         ]
       }
@@ -62,9 +102,9 @@
           },
           {
             "type": "command",
-            "command": "rm -rf /tmp/gemini-review-retries 2>/dev/null; true",
+            "command": "node -e \"const fs=require('fs');['/tmp/gemini-review-retries','/tmp/claude-hard-gate','/tmp/claude-tdd-guard','/tmp/claude-skill-gate','/tmp/claude-skill-gate-cooldown'].forEach(d=>{try{fs.rmSync(d,{recursive:true})}catch{}})\"",
             "timeout": 3,
-            "statusMessage": "Resetting Gemini review state..."
+            "statusMessage": "Resetting session state..."
           }
         ]
       }

--- a/.claude/hooks/componentPatternChecker.js
+++ b/.claude/hooks/componentPatternChecker.js
@@ -1,0 +1,113 @@
+/**
+ * PostToolUse:Write|Edit Hook - React Component Pattern Checker
+ *
+ * .tsx 컴포넌트 파일 수정 후 필수 패턴을 검사합니다:
+ *   1) React.memo() 래핑 여부
+ *   2) displayName 설정 여부
+ *   3) dark: Tailwind 변형 존재 여부
+ *   4) 인터랙티브 요소의 aria-label 존재 여부
+ *
+ * type: "prompt" (자기감시) → type: "command" (외부 검증) 전환
+ *
+ * 위반 2개 이상 시 exit 2 (차단), 1개는 경고만
+ *
+ * @version 1.0.0
+ * @hook-config
+ * {"event": "PostToolUse", "matcher": "Write|Edit", "command": "node .claude/hooks/componentPatternChecker.js", "timeout": 5}
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const VIOLATION_THRESHOLD = 1;
+
+function main() {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { input += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const event = JSON.parse(input);
+      const filePath = event.tool_input?.file_path || '';
+
+      // .tsx 컴포넌트 파일만 대상
+      if (!filePath.endsWith('.tsx')) return process.exit(0);
+      if (!filePath.includes('src/dashboard/src/')) return process.exit(0);
+
+      // 제외 대상
+      if (filePath.includes('.test.') || filePath.includes('.spec.')) return process.exit(0);
+      if (filePath.endsWith('index.tsx')) return process.exit(0);
+      if (filePath.includes('/types/') || filePath.includes('/styles/')) return process.exit(0);
+      if (filePath.includes('.config.') || filePath.includes('vite')) return process.exit(0);
+      if (filePath.endsWith('main.tsx') || filePath.endsWith('App.tsx')) return process.exit(0);
+
+      if (!fs.existsSync(filePath)) return process.exit(0);
+
+      const content = fs.readFileSync(filePath, 'utf8');
+      const fileName = path.basename(filePath, '.tsx');
+      const violations = [];
+
+      // 1) React.memo() 래핑 확인
+      const hasDefaultExport = /export\s+default/.test(content);
+      const hasMemo = /React\.memo\(|memo\(/.test(content);
+      if (hasDefaultExport && !hasMemo) {
+        violations.push(`memo() 미사용 — export default를 React.memo()로 래핑하세요`);
+      }
+
+      // 2) displayName 확인
+      const hasDisplayName = /\.displayName\s*=/.test(content) || /displayName:/.test(content);
+      if (hasDefaultExport && !hasDisplayName) {
+        violations.push(`displayName 미설정 — Component.displayName = '${fileName}' 추가하세요`);
+      }
+
+      // 3) dark: Tailwind 변형 확인
+      // bg-, text-, border- 클래스가 있는데 대응하는 dark: 변형이 없는 경우
+      const bgClasses = content.match(/(?<!\w)bg-\w+/g) || [];
+      const hasDarkBg = /dark:bg-/.test(content);
+      const textClasses = content.match(/(?<!\w)text-(?:white|black|gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+/g) || [];
+      const hasDarkText = /dark:text-/.test(content);
+
+      if (bgClasses.length > 0 && !hasDarkBg) {
+        violations.push(`dark: 변형 누락 — bg- 클래스에 대응하는 dark:bg- 추가하세요`);
+      }
+      if (textClasses.length > 0 && !hasDarkText) {
+        violations.push(`dark: 변형 누락 — text- 컬러에 대응하는 dark:text- 추가하세요`);
+      }
+
+      // 4) aria-label 확인 (인터랙티브 요소)
+      const interactiveElements = content.match(/<(button|input|select|textarea|a)\b[^>]*>/g) || [];
+      const missingAria = interactiveElements.filter(el => {
+        return !el.includes('aria-label') && !el.includes('aria-labelledby') && !el.includes('aria-describedby');
+      });
+      if (missingAria.length > 0) {
+        violations.push(`aria-label 누락 — ${missingAria.length}개 인터랙티브 요소에 aria-label 추가하세요`);
+      }
+
+      if (violations.length === 0) {
+        return process.exit(0);
+      }
+
+      const violationList = violations.map((v, i) => `  ${i + 1}. ${v}`).join('\n');
+
+      if (violations.length >= VIOLATION_THRESHOLD) {
+        console.log(
+          `\n[BLOCKED] Component Pattern: ${fileName}.tsx — ${violations.length}개 위반 (threshold: ${VIOLATION_THRESHOLD})\n` +
+          `${violationList}\n` +
+          `ACTION: 위반 사항을 수정한 후 다시 저장하세요.\n`
+        );
+        process.exit(2);
+      } else {
+        console.log(
+          `\n[WARNING] Component Pattern: ${fileName}.tsx — ${violations.length}개 위반\n` +
+          `${violationList}\n`
+        );
+        process.exit(0);
+      }
+    } catch {
+      process.exit(0);
+    }
+  });
+  setTimeout(() => process.exit(0), 5000);
+}
+
+main();

--- a/.claude/hooks/hardGateGuard.js
+++ b/.claude/hooks/hardGateGuard.js
@@ -1,0 +1,112 @@
+/**
+ * PreToolUse:Edit|Write Hook - HARD-GATE 차단
+ *
+ * 세션 내 3개 이상 고유 파일을 편집하면 plan 파일 없이는
+ * 추가 편집을 차단(exit 2)합니다.
+ *
+ * v2.0: WARN → BLOCK 전환
+ *   - plan 없이 3+ 파일 수정 시 → exit 2 (차단)
+ *   - plan 존재 시 또는 3개 미만 → exit 0 (통과)
+ *
+ * Exit codes:
+ *   0 = 통과
+ *   2 = 차단 (plan 먼저 필요)
+ *
+ * @version 2.0.0
+ * @hook-config
+ * {"event": "PreToolUse", "matcher": "Edit|Write", "command": "node .claude/hooks/hardGateGuard.js", "timeout": 3}
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TRACKER_DIR = '/tmp/claude-hard-gate';
+const TRACKER_FILE = path.join(TRACKER_DIR, 'edited-files.json');
+const FILE_THRESHOLD = 3;
+
+function hasPlanFile(projectDir) {
+  const devActive = path.join(projectDir, 'dev', 'active');
+  if (fs.existsSync(devActive)) {
+    try {
+      const tasks = fs.readdirSync(devActive, { withFileTypes: true });
+      for (const task of tasks) {
+        if (!task.isDirectory()) continue;
+        const planPath = path.join(devActive, task.name, `${task.name}-plan.md`);
+        if (fs.existsSync(planPath)) return true;
+      }
+    } catch { /* ignore */ }
+  }
+  return false;
+}
+
+function hasClaudePlan(projectDir) {
+  const plansDir = path.join(projectDir, '.claude', 'plans');
+  if (!fs.existsSync(plansDir)) return false;
+  try {
+    return fs.readdirSync(plansDir).some(f => f.endsWith('.md'));
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { input += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const event = JSON.parse(input);
+      const filePath = (event.tool_input && event.tool_input.file_path) || '';
+      if (!filePath) return process.exit(0);
+
+      // hooks, settings, config, plan 파일은 카운트에서 제외
+      if (filePath.includes('.claude/hooks/') ||
+          filePath.includes('.claude/settings') ||
+          filePath.includes('.claude/plans/') ||
+          filePath.includes('.claude/rules/') ||
+          filePath.includes('node_modules/') ||
+          filePath.endsWith('.json') && filePath.includes('package')) {
+        return process.exit(0);
+      }
+
+      fs.mkdirSync(TRACKER_DIR, { recursive: true });
+
+      let editedFiles = [];
+      if (fs.existsSync(TRACKER_FILE)) {
+        try {
+          editedFiles = JSON.parse(fs.readFileSync(TRACKER_FILE, 'utf8'));
+        } catch {
+          editedFiles = [];
+        }
+      }
+
+      if (!editedFiles.includes(filePath)) {
+        editedFiles.push(filePath);
+        fs.writeFileSync(TRACKER_FILE, JSON.stringify(editedFiles, null, 2));
+      }
+
+      if (editedFiles.length <= FILE_THRESHOLD) {
+        return process.exit(0);
+      }
+
+      const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+      if (hasPlanFile(projectDir) || hasClaudePlan(projectDir)) {
+        return process.exit(0);
+      }
+
+      // BLOCK: plan 없이 3+ 파일 수정 시도
+      const fileList = editedFiles.map(f => `  - ${path.basename(f)}`).join('\n');
+      console.log(
+        `\n[BLOCKED] HARD-GATE: ${editedFiles.length}개 파일을 plan 없이 수정 중 (임계값: ${FILE_THRESHOLD})\n` +
+        `수정 파일:\n${fileList}\n` +
+        `ACTION: /plan을 먼저 실행하세요. plan 파일이 생성되면 자동으로 통과됩니다.\n`
+      );
+      process.exit(2);
+    } catch {
+      process.exit(0);
+    }
+  });
+  setTimeout(() => process.exit(0), 3000);
+}
+
+main();

--- a/.claude/hooks/skillGateGuard.js
+++ b/.claude/hooks/skillGateGuard.js
@@ -1,0 +1,138 @@
+/**
+ * Skill Gate Guard — 스킬 라우팅 강제
+ *
+ * 두 가지 역할을 하나의 스크립트로 수행:
+ *
+ * 1) PostToolUse:Skill — 호출된 스킬명을 마커 파일에 기록
+ *    매칭: Skill 도구 사용 후
+ *
+ * 2) PreToolUse:Edit|Write — 파일 타입에 맞는 스킬이 호출되었는지 확인
+ *    매칭: Edit|Write 도구 사용 전
+ *
+ * 스킬 요구사항 (aos-workflow.md 기반):
+ *   - .tsx/.ts 파일 편집 → react-web-development 스킬 필요
+ *   - .test.tsx/.spec.tsx 작성 → test-automation 스킬 필요
+ *
+ * 차단 조건: 필수 스킬이 세션 내에서 한 번도 호출되지 않은 경우
+ * 쿨다운: 파일 타입별 1회 경고 후 5분간 재차단 안 함
+ *
+ * @version 1.0.0
+ * @hook-config (2개 훅에서 공유)
+ * PostToolUse:Skill → node .claude/hooks/skillGateGuard.js
+ * PreToolUse:Edit|Write → node .claude/hooks/skillGateGuard.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MARKER_DIR = '/tmp/claude-skill-gate';
+const COOLDOWN_DIR = '/tmp/claude-skill-gate-cooldown';
+const COOLDOWN_SECONDS = 300;
+
+// 파일 패턴 → 필수 스킬 매핑
+const SKILL_REQUIREMENTS = [
+  {
+    pattern: /src\/dashboard\/src\/.*\.tsx$/,
+    exclude: /\.(test|spec)\.tsx$/,
+    skill: 'react-web-development',
+    label: 'React 컴포넌트',
+  },
+  {
+    pattern: /\.(test|spec)\.(tsx|ts)$/,
+    exclude: null,
+    skill: 'test-automation',
+    label: '테스트 파일',
+  },
+];
+
+function ensureDir(dir) {
+  try { fs.mkdirSync(dir, { recursive: true }); } catch { /* ignore */ }
+}
+
+function isSkillInvoked(skillName) {
+  const markerFile = path.join(MARKER_DIR, skillName);
+  return fs.existsSync(markerFile);
+}
+
+function recordSkill(skillName) {
+  ensureDir(MARKER_DIR);
+  fs.writeFileSync(
+    path.join(MARKER_DIR, skillName),
+    String(Math.floor(Date.now() / 1000))
+  );
+}
+
+function isInCooldown(key) {
+  const hash = Buffer.from(key).toString('base64url').slice(0, 32);
+  const file = path.join(COOLDOWN_DIR, hash);
+  if (fs.existsSync(file)) {
+    try {
+      const ts = parseInt(fs.readFileSync(file, 'utf8'), 10);
+      if (Date.now() / 1000 - ts < COOLDOWN_SECONDS) return true;
+    } catch { /* ignore */ }
+  }
+  return false;
+}
+
+function setCooldown(key) {
+  ensureDir(COOLDOWN_DIR);
+  const hash = Buffer.from(key).toString('base64url').slice(0, 32);
+  fs.writeFileSync(
+    path.join(COOLDOWN_DIR, hash),
+    String(Math.floor(Date.now() / 1000))
+  );
+}
+
+function main() {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { input += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const event = JSON.parse(input);
+      const toolName = event.tool_name || '';
+
+      // ── 모드 1: Skill 호출 기록 (PostToolUse:Skill) ──
+      if (toolName === 'Skill') {
+        const skillName = event.tool_input?.skill || '';
+        if (skillName) {
+          recordSkill(skillName);
+        }
+        return process.exit(0);
+      }
+
+      // ── 모드 2: 스킬 게이트 (PreToolUse:Edit|Write) ──
+      const filePath = event.tool_input?.file_path || '';
+      if (!filePath) return process.exit(0);
+
+      for (const req of SKILL_REQUIREMENTS) {
+        if (!req.pattern.test(filePath)) continue;
+        if (req.exclude && req.exclude.test(filePath)) continue;
+
+        // 이미 스킬이 호출되었으면 통과
+        if (isSkillInvoked(req.skill)) continue;
+
+        // 쿨다운 체크
+        const cooldownKey = `${req.skill}:${req.label}`;
+        if (isInCooldown(cooldownKey)) continue;
+
+        // BLOCK: 필수 스킬 미호출
+        setCooldown(cooldownKey);
+        const basename = path.basename(filePath);
+        console.log(
+          `\n[BLOCKED] Skill Gate: ${req.label} 편집에 '${req.skill}' 스킬이 필요합니다.\n` +
+          `파일: ${basename}\n` +
+          `ACTION: Skill('${req.skill}') 을 먼저 호출하세요.\n`
+        );
+        return process.exit(2);
+      }
+
+      process.exit(0);
+    } catch {
+      process.exit(0);
+    }
+  });
+  setTimeout(() => process.exit(0), 3000);
+}
+
+main();

--- a/.claude/hooks/tddGuard.js
+++ b/.claude/hooks/tddGuard.js
@@ -1,0 +1,117 @@
+/**
+ * PreToolUse:Edit|Write Hook - TDD Guard 차단
+ *
+ * src/dashboard/src/ 내 컴포넌트 파일(.tsx, 비테스트) 편집 시
+ * 같은 디렉토리에 테스트 파일(.test.tsx)이 존재하지 않으면
+ * 편집을 차단(exit 2)합니다.
+ *
+ * v2.0: WARN → BLOCK 전환
+ *   - 테스트 파일 없이 구현 코드 수정 → exit 2 (차단)
+ *   - 테스트 파일 존재 또는 스킵 대상 → exit 0 (통과)
+ *
+ * Exit codes:
+ *   0 = 통과
+ *   2 = 차단 (테스트 먼저 필요)
+ *
+ * @version 2.0.0
+ * @hook-config
+ * {"event": "PreToolUse", "matcher": "Edit|Write", "command": "node .claude/hooks/tddGuard.js", "timeout": 3}
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SKIP_PATTERNS = [
+  /\/pages\//,
+  /\/types\//,
+  /\/styles\//,
+  /index\.tsx?$/,
+  /main\.tsx$/,
+  /App\.tsx$/,
+  /vite/,
+  /\.config\./,
+  /\.d\.ts$/,
+  /\/hooks\/use[A-Z]/, // 커스텀 훅 (테스트 작성 복잡)
+  /\/lib\//,           // 유틸리티 라이브러리
+  /\/providers\//,     // Context providers
+];
+
+const COOLDOWN_DIR = '/tmp/claude-tdd-guard';
+const COOLDOWN_SECONDS = 300;
+
+function isInCooldown(filePath) {
+  const hash = Buffer.from(filePath).toString('base64url').slice(0, 32);
+  const cooldownFile = path.join(COOLDOWN_DIR, hash);
+  if (fs.existsSync(cooldownFile)) {
+    try {
+      const lastWarn = parseInt(fs.readFileSync(cooldownFile, 'utf8'), 10);
+      if (Date.now() / 1000 - lastWarn < COOLDOWN_SECONDS) return true;
+    } catch { /* ignore */ }
+  }
+  return false;
+}
+
+function setCooldown(filePath) {
+  fs.mkdirSync(COOLDOWN_DIR, { recursive: true });
+  const hash = Buffer.from(filePath).toString('base64url').slice(0, 32);
+  fs.writeFileSync(path.join(COOLDOWN_DIR, hash), String(Math.floor(Date.now() / 1000)));
+}
+
+function main() {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { input += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const event = JSON.parse(input);
+      const filePath = (event.tool_input && event.tool_input.file_path) || '';
+      if (!filePath) return process.exit(0);
+
+      // dashboard src 내 .tsx 파일만 대상
+      if (!filePath.includes('src/dashboard/src/') || !filePath.endsWith('.tsx')) {
+        return process.exit(0);
+      }
+
+      // 테스트 파일 자체는 건너뜀
+      if (filePath.includes('.test.') || filePath.includes('.spec.')) {
+        return process.exit(0);
+      }
+
+      // 스킵 패턴 확인
+      if (SKIP_PATTERNS.some(pattern => pattern.test(filePath))) {
+        return process.exit(0);
+      }
+
+      // 쿨다운 확인 (같은 파일 반복 차단 방지)
+      if (isInCooldown(filePath)) {
+        return process.exit(0);
+      }
+
+      // 테스트 파일 존재 확인
+      const dir = path.dirname(filePath);
+      const basename = path.basename(filePath, '.tsx');
+      const testFile = path.join(dir, `${basename}.test.tsx`);
+      const specFile = path.join(dir, `${basename}.spec.tsx`);
+      const testsDir = path.join(dir, '__tests__');
+      const testInDir = path.join(testsDir, `${basename}.test.tsx`);
+
+      if (fs.existsSync(testFile) || fs.existsSync(specFile) || fs.existsSync(testInDir)) {
+        return process.exit(0);
+      }
+
+      // BLOCK: 테스트 없이 구현 코드 수정 시도
+      setCooldown(filePath);
+      console.log(
+        `\n[BLOCKED] TDD Guard: 테스트 파일이 없습니다 — ${basename}.tsx\n` +
+        `예상 테스트 파일: ${basename}.test.tsx\n` +
+        `ACTION: 테스트를 먼저 작성하세요. /tdd 명령 사용 권장.\n`
+      );
+      process.exit(2);
+    } catch {
+      process.exit(0);
+    }
+  });
+  setTimeout(() => process.exit(0), 3000);
+}
+
+main();

--- a/.claude/hooks/verificationGuard.js
+++ b/.claude/hooks/verificationGuard.js
@@ -1,18 +1,23 @@
 /**
- * Verification Guard
+ * Verification Guard v2.0
  *
  * PostToolUse:Write 시 src/ 디렉토리의 TypeScript/Python 파일 변경을 감지하고
- * 경량 검증(tsc --noEmit, ruff check)을 실행하여 빌드 깨짐을 조기 경고합니다.
+ * 경량 검증(tsc --noEmit, ruff check)을 실행합니다.
  *
- * 차단(exit 2)하지 않고 경고만 출력 — 개발 흐름을 방해하지 않으면서
- * 빌드 깨짐을 즉시 인지하도록 합니다.
+ * v2.0: 임계값 기반 차단 (BLOCK)
+ *   - TypeScript 에러 5개 이상 → exit 2 (차단)
+ *   - Python 에러 3개 이상 → exit 2 (차단)
+ *   - 임계값 미만 → exit 0 (경고만)
  *
- * @version 1.0.0
+ * @version 2.0.0
  * @hook-config
- * {"event": "PostToolUse", "matcher": "Write", "command": "node .claude/hooks/verificationGuard.js 2>/dev/null || true", "timeout": 10}
+ * {"event": "PostToolUse", "matcher": "Write", "command": "node .claude/hooks/verificationGuard.js", "timeout": 15}
  */
 
 const { execSync } = require('child_process');
+
+const TS_ERROR_THRESHOLD = 3;
+const PY_ERROR_THRESHOLD = 2;
 
 function main() {
   let input = '';
@@ -23,19 +28,18 @@ function main() {
       const event = JSON.parse(input);
       const filePath = event.tool_input?.file_path || '';
 
-      // src/ 디렉토리 파일만 대상
       if (!filePath.includes('src/')) {
         process.exit(0);
         return;
       }
 
-      const warnings = [];
+      let shouldBlock = false;
 
       // TypeScript 파일 → tsc 경량 체크
       if (/\.(ts|tsx)$/.test(filePath) && filePath.includes('src/dashboard')) {
         try {
-          execSync('cd src/dashboard && npx tsc --noEmit --pretty false 2>&1 | head -5', {
-            timeout: 8000,
+          execSync('cd src/dashboard && npx tsc --noEmit --pretty false 2>&1 | head -20', {
+            timeout: 12000,
             stdio: ['pipe', 'pipe', 'pipe'],
             cwd: process.cwd()
           });
@@ -43,8 +47,15 @@ function main() {
           const output = (err.stdout || '').toString().trim();
           if (output) {
             const errorCount = (output.match(/error TS/g) || []).length;
-            if (errorCount > 0) {
-              warnings.push(`[Verification] TypeScript: ${errorCount} error(s) detected`);
+            if (errorCount >= TS_ERROR_THRESHOLD) {
+              console.log(
+                `\n[BLOCKED] TypeScript: ${errorCount} error(s) detected (threshold: ${TS_ERROR_THRESHOLD})\n` +
+                `${output.split('\n').slice(0, 5).join('\n')}\n` +
+                `ACTION: 타입 에러를 먼저 수정하세요. /build-fix 사용 권장.\n`
+              );
+              shouldBlock = true;
+            } else if (errorCount > 0) {
+              console.log(`[Verification] TypeScript: ${errorCount} error(s) — threshold(${TS_ERROR_THRESHOLD}) 미만, 경고`);
             }
           }
         }
@@ -53,26 +64,35 @@ function main() {
       // Python 파일 → ruff 경량 체크
       if (/\.py$/.test(filePath) && filePath.includes('src/backend')) {
         try {
-          execSync(`ruff check "${filePath}" --select E,F --no-fix --quiet 2>&1 | head -5`, {
+          execSync(`ruff check "${filePath}" --select E,F --no-fix --quiet 2>&1 | head -10`, {
             timeout: 5000,
             stdio: ['pipe', 'pipe', 'pipe']
           });
         } catch (err) {
           const output = (err.stdout || '').toString().trim();
           if (output) {
-            const lines = output.split('\n').length;
-            warnings.push(`[Verification] Python lint: ${lines} issue(s) in ${filePath.split('/').pop()}`);
+            const errorCount = output.split('\n').filter(l => l.trim()).length;
+            if (errorCount >= PY_ERROR_THRESHOLD) {
+              console.log(
+                `\n[BLOCKED] Python lint: ${errorCount} issue(s) in ${filePath.split('/').pop()} (threshold: ${PY_ERROR_THRESHOLD})\n` +
+                `${output.split('\n').slice(0, 5).join('\n')}\n` +
+                `ACTION: lint 에러를 먼저 수정하세요.\n`
+              );
+              shouldBlock = true;
+            } else {
+              console.log(`[Verification] Python lint: ${errorCount} issue(s) — threshold(${PY_ERROR_THRESHOLD}) 미만, 경고`);
+            }
           }
         }
       }
 
-      if (warnings.length > 0) {
-        console.log(warnings.join('\n'));
-      }
-    } catch { /* silent */ }
-    process.exit(0);
+      process.exit(shouldBlock ? 2 : 0);
+    } catch {
+      // 파싱 실패 시 차단하지 않음
+      process.exit(0);
+    }
   });
-  setTimeout(() => process.exit(0), 10000);
+  setTimeout(() => process.exit(0), 15000);
 }
 
 main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,7 @@ jobs:
           uv pip install --system -e ".[dev]"
 
       - name: MyPy type check
-        run: mypy . --ignore-missing-imports --no-error-summary || true
-        # Note: '|| true' to allow warnings without failing the build
-        # Remove when type coverage improves
+        run: mypy . --ignore-missing-imports --no-error-summary
 
   backend-test:
     name: Backend Tests

--- a/infra/scripts/gemini-review.sh
+++ b/infra/scripts/gemini-review.sh
@@ -150,12 +150,15 @@ if [[ -z "$CLEAN" ]]; then
     CLEAN=$(echo "$REVIEW" | tail -15)
 fi
 
-# VERDICT 파싱하여 리트라이 카운터 갱신
+# VERDICT 파싱하여 리트라이 카운터 갱신 + BLOCK 판정
 VERDICT=$(echo "$CLEAN" | grep -i '^VERDICT:' | head -1 | tr '[:upper:]' '[:lower:]')
+SHOULD_BLOCK=false
+
 if echo "$VERDICT" | grep -q 'needs-attention'; then
     # needs-attention: 카운터 증가
     CURRENT=$(cat "$RETRY_FILE" 2>/dev/null || echo "0")
     echo $(( CURRENT + 1 )) > "$RETRY_FILE" 2>/dev/null || true
+    SHOULD_BLOCK=true
 elif echo "$VERDICT" | grep -q 'approve'; then
     # approve: 카운터 리셋
     rm -f "$RETRY_FILE" 2>/dev/null || true
@@ -164,3 +167,11 @@ fi
 echo ""
 echo "Gemini Checker [$BASENAME]"
 echo "$CLEAN"
+
+# v2.0: needs-attention 시 exit 2로 차단 신호 전송
+# (PostToolUse이므로 edit 자체는 완료되었지만, Claude에게 수정 필요 신호)
+if [[ "$SHOULD_BLOCK" == "true" ]]; then
+    echo ""
+    echo "[BLOCKED] Gemini가 문제를 발견했습니다. 위 이슈를 먼저 수정하세요."
+    exit 2
+fi


### PR DESCRIPTION
## Summary
- 기존 경고 전용(exit 0) 훅들을 **임계값 초과 시 차단(exit 2)** 모드로 전환
- 코드 품질을 기계적으로 강제하는 **4개 신규 PreToolUse/PostToolUse 가드** 추가
- CI 파이프라인의 mypy 타입 체크를 엄격 모드로 전환

## Changes

### 신규 가드 (4개)
| 가드 | 이벤트 | 역할 |
|------|--------|------|
| `hardGateGuard.js` | PreToolUse:Edit\|Write | plan 없이 3+ 파일 수정 차단 |
| `tddGuard.js` | PreToolUse:Edit\|Write | 테스트 없이 .tsx 컴포넌트 수정 차단 |
| `skillGateGuard.js` | Pre/PostToolUse | 필수 스킬 미호출 시 편집 차단 |
| `componentPatternChecker.js` | PostToolUse:Write\|Edit | memo/displayName/dark/aria 패턴 위반 차단 |

### 기존 훅 업그레이드
- **verificationGuard v2.0**: TS 에러 3+, Python 에러 2+ 시 차단 (기존: 경고만)
- **gemini-review**: needs-attention verdict 시 exit 2 차단 신호

### CI 강화
- `mypy . --ignore-missing-imports` 에서 `|| true` 제거 → 타입 에러 시 CI 실패

### 세션 관리
- SessionEnd에서 신규 가드의 `/tmp/` 마커 파일 정리 추가

## Architecture

```
PreToolUse (편집 전)
├── Path Protection (기존)
├── HARD-GATE Guard ← NEW
├── TDD Guard ← NEW
└── Skill Gate Guard ← NEW

PostToolUse (편집 후)
├── Skill Recording ← NEW
├── Verification Guard v2.0 ← UPGRADED
├── Component Pattern Checker ← NEW
└── Gemini Review ← UPGRADED
```

## Test Plan
- [x] 3+ 파일 편집 시 hardGateGuard 차단 확인
- [x] 테스트 없는 .tsx 편집 시 tddGuard 차단 확인
- [x] react-web-development 스킬 미호출 시 skillGateGuard 차단 확인
- [x] memo/displayName 누락 .tsx에서 componentPatternChecker 차단 확인
- [x] TS 에러 3+ 파일에서 verificationGuard 차단 확인
- [x] 쿨다운 메커니즘 정상 동작 확인 (5분간 재차단 안 함)
- [x] SessionEnd 시 /tmp/ 마커 파일 정리 확인
- [x] CI mypy 엄격 모드에서 기존 코드 통과 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)