### PR TITLE
chore(deps): lucide-react 0.468 → 1.8 + 브랜드 아이콘 대체

### DIFF
--- a/src/dashboard/package-lock.json
+++ b/src/dashboard/package-lock.json
@@ -16,7 +16,7 @@
         "clsx": "^2.1.1",
         "diff": "^9.0.0",
         "js-yaml": "^4.1.1",
-        "lucide-react": "^0.468.0",
+        "lucide-react": "^1.8.0",
         "posthog-js": "^1.369.1",
         "react": "^18.3.1",
         "react-diff-view": "^3.3.3",
@@ -5988,12 +5988,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.468.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
-      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -23,7 +23,7 @@
     "clsx": "^2.1.1",
     "diff": "^9.0.0",
     "js-yaml": "^4.1.1",
-    "lucide-react": "^0.468.0",
+    "lucide-react": "^1.8.0",
     "posthog-js": "^1.369.1",
     "react": "^18.3.1",
     "react-diff-view": "^3.3.3",

--- a/src/dashboard/src/components/mcp/MCPServerCard.tsx
+++ b/src/dashboard/src/components/mcp/MCPServerCard.tsx
@@ -13,7 +13,7 @@ import {
   Square,
   RotateCw,
   FolderOpen,
-  Github,
+  Code2,
   Globe,
   Database,
   Settings,
@@ -27,7 +27,7 @@ import {
 // 서버 타입별 아이콘
 const serverTypeIcons: Record<MCPServerType, typeof Server> = {
   filesystem: FolderOpen,
-  github: Github,
+  github: Code2,
   playwright: Globe,
   sqlite: Database,
   custom: Settings,

--- a/src/dashboard/src/components/mcp/MCPStatsPanel.tsx
+++ b/src/dashboard/src/components/mcp/MCPStatsPanel.tsx
@@ -6,12 +6,12 @@
 
 import { cn } from '../../lib/utils'
 import { MCPManagerStats, MCPServerType } from '../../stores/mcp'
-import { Server, Play, Wrench, FolderOpen, Github, Globe, Database, Settings } from 'lucide-react'
+import { Server, Play, Wrench, FolderOpen, Code2, Globe, Database, Settings } from 'lucide-react'
 
 // 서버 타입별 아이콘
 const serverTypeIcons: Record<MCPServerType, typeof Server> = {
   filesystem: FolderOpen,
-  github: Github,
+  github: Code2,
   playwright: Globe,
   sqlite: Database,
   custom: Settings,

--- a/src/dashboard/src/components/mcp/__tests__/MCPServerCard.test.tsx
+++ b/src/dashboard/src/components/mcp/__tests__/MCPServerCard.test.tsx
@@ -10,7 +10,7 @@ vi.mock('lucide-react', () => ({
   Square: (props: Record<string, unknown>) => <svg data-testid="icon-square" {...props} />,
   RotateCw: (props: Record<string, unknown>) => <svg data-testid="icon-rotate" {...props} />,
   FolderOpen: (props: Record<string, unknown>) => <svg data-testid="icon-folder" {...props} />,
-  Github: (props: Record<string, unknown>) => <svg data-testid="icon-github" {...props} />,
+  Code2: (props: Record<string, unknown>) => <svg data-testid="icon-github" {...props} />,
   Globe: (props: Record<string, unknown>) => <svg data-testid="icon-globe" {...props} />,
   Database: (props: Record<string, unknown>) => <svg data-testid="icon-database" {...props} />,
   Settings: (props: Record<string, unknown>) => <svg data-testid="icon-settings" {...props} />,

--- a/src/dashboard/src/components/mcp/__tests__/MCPStatsPanel.test.tsx
+++ b/src/dashboard/src/components/mcp/__tests__/MCPStatsPanel.test.tsx
@@ -9,7 +9,7 @@ vi.mock('lucide-react', () => ({
   Play: (props: Record<string, unknown>) => <svg data-testid="icon-play" {...props} />,
   Wrench: (props: Record<string, unknown>) => <svg data-testid="icon-wrench" {...props} />,
   FolderOpen: (props: Record<string, unknown>) => <svg data-testid="icon-folder" {...props} />,
-  Github: (props: Record<string, unknown>) => <svg data-testid="icon-github" {...props} />,
+  Code2: (props: Record<string, unknown>) => <svg data-testid="icon-github" {...props} />,
   Globe: (props: Record<string, unknown>) => <svg data-testid="icon-globe" {...props} />,
   Database: (props: Record<string, unknown>) => <svg data-testid="icon-database" {...props} />,
   Settings: (props: Record<string, unknown>) => <svg data-testid="icon-settings" {...props} />,

--- a/src/dashboard/src/components/notifications/NotificationRuleEditor.tsx
+++ b/src/dashboard/src/components/notifications/NotificationRuleEditor.tsx
@@ -12,7 +12,7 @@ import {
   TestTube,
   Check,
   X,
-  Slack,
+  MessageSquare,
   MessageCircle,
   Mail,
   Webhook,
@@ -93,8 +93,8 @@ interface NotificationRuleEditorProps {
 // Channel Icons
 // ─────────────────────────────────────────────────────────────
 
-const CHANNEL_ICONS: Record<NotificationChannel, typeof Slack> = {
-  slack: Slack,
+const CHANNEL_ICONS: Record<NotificationChannel, typeof MessageSquare> = {
+  slack: MessageSquare,
   discord: MessageCircle,
   email: Mail,
   webhook: Webhook,

--- a/src/dashboard/src/components/notifications/__tests__/NotificationRuleEditor.test.tsx
+++ b/src/dashboard/src/components/notifications/__tests__/NotificationRuleEditor.test.tsx
@@ -10,7 +10,7 @@ vi.mock('lucide-react', () => ({
   TestTube: (props: Record<string, unknown>) => <div data-testid="test-tube" {...props} />,
   Check: (props: Record<string, unknown>) => <div data-testid="check" {...props} />,
   X: (props: Record<string, unknown>) => <div data-testid="x-icon" {...props} />,
-  Slack: (props: Record<string, unknown>) => <div data-testid="slack-icon" {...props} />,
+  MessageSquare: (props: Record<string, unknown>) => <div data-testid="slack-icon" {...props} />,
   MessageCircle: (props: Record<string, unknown>) => <div data-testid="discord-icon" {...props} />,
   Mail: (props: Record<string, unknown>) => <div data-testid="mail-icon" {...props} />,
   Webhook: (props: Record<string, unknown>) => <div data-testid="webhook-icon" {...props} />,


### PR DESCRIPTION
## Summary
- lucide-react v1 메이저 업그레이드 (0.468 → 1.8)
- v1에서 제거된 브랜드 아이콘(Github, Slack)을 의미가 가까운 일반 아이콘으로 교체
  - `Github` → `Code2` (MCP github provider)
  - `Slack` → `MessageSquare` (알림 채널)
- 3개 컴포넌트 + 3개 테스트 파일의 vi.mock 갱신

Dependabot PR #40을 대체합니다 (#40은 close 예정).

## 위험도
- 🟢 **낮음** — 아이콘 3곳 시각적 변경만 존재, 나머지 140여 파일은 변경 없음
- lucide-react v1은 tree-shaking 개선 + API 안정화, 호환성 영향 최소

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `npm run lint` 0 errors
- [x] `npm run build` 성공
- [x] `vitest run` 181 files / 4153 tests 전체 통과
- [x] CI Green 확인 후 머지