### PR TITLE
chore(ci): dependabot ecosystem grouping (peer-dep 충돌 예방)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,29 @@ updates:
       - "dependencies"
       - "npm"
     groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@vitejs/plugin-react"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "eslint-plugin-*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+      testing:
+        patterns:
+          - "@testing-library/*"
+          - "vitest"
+          - "@vitest/*"
+          - "jsdom"
       minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
@@ -24,6 +46,30 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    groups:
+      langchain:
+        patterns:
+          - "langchain*"
+          - "langgraph*"
+          - "langsmith"
+      fastapi:
+        patterns:
+          - "fastapi"
+          - "starlette"
+          - "uvicorn*"
+          - "pydantic*"
+      sqlalchemy:
+        patterns:
+          - "sqlalchemy*"
+          - "alembic"
+          - "asyncpg"
+          - "psycopg*"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -34,3 +80,7 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why
이번주 React 19 / ESLint 10 Dependabot PR 4개가 모두 **peer-dep ERESOLVE**로 실패했습니다 (#33, #34, #36, #39 → #47, #48로 통합 처리). 근본 원인은 Dependabot이 의존 관계가 있는 패키지들을 **각각 독립 PR**로 만들기 때문. 구조적으로 예방합니다.

## Changes

### npm (`/src/dashboard`)
- `react`: `react`, `react-dom`, `@types/react(-dom)`, `@vitejs/plugin-react`
- `eslint`: `eslint`, `@eslint/*`, `eslint-plugin-*`, `typescript-eslint`, `@typescript-eslint/*`
- `testing`: `@testing-library/*`, `vitest`, `@vitest/*`, `jsdom`
- `minor-and-patch`: 나머지 minor/patch (기존 유지)

### pip (`/src/backend`)
- `langchain`: `langchain*`, `langgraph*`, `langsmith`
- `fastapi`: `fastapi`, `starlette`, `uvicorn*`, `pydantic*`
- `sqlalchemy`: `sqlalchemy*`, `alembic`, `asyncpg`, `psycopg*`
- `minor-and-patch`: 나머지

### github-actions
- `actions`: 전체 하나로 묶음

## Semantics
- 패턴 우선순위는 **specific → general** 순. Dependabot은 첫 매칭 그룹 사용.
- specific 그룹은 `update-types` 미지정 → major 포함 전체가 한 PR로 묶임.
- `minor-and-patch`는 `*` + minor/patch 제한 → specific에 못 잡힌 잔여 패키지의 minor/patch만 수집.
- **결과**: peer-dep 종속 패키지들이 항상 함께 bump되어 install 단계 ERESOLVE가 구조적으로 발생 불가.

## Test plan
- [x] YAML 파싱 검증 (python3 yaml.safe_load 통과)
- [ ] 다음 월요일 자동 실행 시 그룹화 PR 1-2개로 수렴 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)
