### PR TITLE
chore(deps): typescript 5.6 → 6.0 + baseUrl ignoreDeprecations (Wave 6)

### DIFF
--- a/src/dashboard/package-lock.json
+++ b/src/dashboard/package-lock.json
@@ -43,7 +43,7 @@
         "jsdom": "^29.0.2",
         "postcss": "^8.5.10",
         "tailwindcss": "^4.2.2",
-        "typescript": "^5.6.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.8",
         "vitest": "^4.0.18"
@@ -5102,9 +5102,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -50,7 +50,7 @@
     "jsdom": "^29.0.2",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.6.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.8",
     "vitest": "^4.0.18"

--- a/src/dashboard/tsconfig.json
+++ b/src/dashboard/tsconfig.json
@@ -18,7 +18,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"]


### PR DESCRIPTION
## Summary
- `typescript`: `^5.6.0` → `^6.0.3`
- `tsconfig.json`: `"ignoreDeprecations": "6.0"` 추가
- Dependabot #53 대체

## Breaking change 대응
TS 6은 `baseUrl`을 deprecated로 **에러 처리** (TS 7.0에서 완전 제거). 원본 CI 에러:
```
tsconfig.json(18,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

**왜 baseUrl을 제거하지 않는가?**
- `paths: { "@/*": ["./src/*"] }` 맵핑이 여전히 baseUrl 기준 동작
- TS 5.x부터 baseUrl 없이 paths가 tsconfig 파일 기준으로도 동작하지만, vite.config.ts의 resolve.alias와 일관성을 유지하기 위해 현재는 유지
- TS 7 시점에 별도 PR로 paths 상대경로 재작성 + baseUrl 제거 예정 (기한 여유 있음)

## Test plan
- [x] `tsc --noEmit` PASS
- [x] `eslint .` 0 errors
- [x] `vite build` ✓ built in 3.10s
- [x] `vitest run` — 181 files / 4153 tests PASS
- [x] `npm audit` 0 vulnerabilities

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
