### PR TITLE
fix(projects): sync filesystem projects to DB registry at startup

### DIFF
--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -212,6 +212,17 @@ else:
             project_root = backend_dir.parent.parent
             init_projects(str(project_root))
 
+            if USE_DATABASE:
+                try:
+                    from services.project_sync_service import sync_all_projects_to_db
+
+                    synced = await sync_all_projects_to_db()
+                    if logger:
+                        logger.info("startup_project_sync_done", count=synced)
+                except Exception as e:
+                    if logger:
+                        logger.warning("startup_project_sync_failed", error=str(e))
+
         if ORCHESTRATOR_ENABLED:
             set_engine(OrchestrationEngine())
 

--- a/src/backend/api/routes.py
+++ b/src/backend/api/routes.py
@@ -72,56 +72,7 @@ router.include_router(permission_toggles_router)
 # ─────────────────────────────────────────────────────────────
 
 
-async def _sync_project_to_db(
-    project_id: str, name: str, path: str, description: str | None = None
-) -> None:
-    """Sync a project to the DB projects table (upsert by name).
-
-    Ensures projects created/linked via the Projects page also appear
-    in Project Configs and Project Registry.
-    """
-    import logging
-    import re
-
-    use_database = os.getenv("USE_DATABASE", "false").lower() == "true"
-    if not use_database:
-        return
-
-    try:
-        from sqlalchemy import select
-
-        from db.database import async_session_factory
-        from db.models import ProjectModel
-
-        # Generate slug from name
-        slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
-
-        async with async_session_factory() as session:
-            # Check if already exists by name
-            result = await session.execute(select(ProjectModel).where(ProjectModel.name == name))
-            existing = result.scalar_one_or_none()
-
-            if existing:
-                # Update path if changed
-                if path and existing.path != path:
-                    existing.path = path
-                if not existing.is_active:
-                    existing.is_active = True
-                await session.commit()
-            else:
-                new_project = ProjectModel(
-                    id=project_id,
-                    name=name,
-                    slug=slug,
-                    description=description or "",
-                    path=path,
-                    is_active=True,
-                )
-                session.add(new_project)
-                await session.commit()
-    except Exception as e:
-        logging.getLogger(__name__).warning(f"Failed to sync project to DB: {e}")
-
+from services.project_sync_service import sync_project_to_db as _sync_project_to_db
 
 # ─────────────────────────────────────────────────────────────
 # Project API — Request models

--- a/src/backend/services/project_sync_service.py
+++ b/src/backend/services/project_sync_service.py
@@ -1,0 +1,99 @@
+"""Project sync service — keeps in-memory PROJECTS_REGISTRY and DB ProjectModel aligned.
+
+파일시스템 기반 PROJECTS_REGISTRY(메모리)와 DB ProjectModel이
+따로 진화하지 않도록 동기화 헬퍼를 제공한다.
+
+- sync_project_to_db: 단일 프로젝트 upsert (이름 기준)
+- sync_all_projects_to_db: PROJECTS_REGISTRY 전체를 일괄 upsert
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+
+def _use_database() -> bool:
+    return os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+async def sync_project_to_db(
+    project_id: str,
+    name: str,
+    path: str,
+    description: str | None = None,
+) -> None:
+    """Upsert a single project into the DB projects table (match by name).
+
+    기존 `api.routes._sync_project_to_db`를 서비스로 추출한 함수.
+    DB 미사용 모드에서는 no-op. 예외 발생 시 warning 로그만 남기고 호출자에게 전파하지 않는다.
+    """
+    if not _use_database():
+        return
+
+    try:
+        from sqlalchemy import select
+
+        from db.database import async_session_factory
+        from db.models import ProjectModel
+
+        slug = _slugify(name)
+
+        async with async_session_factory() as session:
+            result = await session.execute(select(ProjectModel).where(ProjectModel.name == name))
+            existing = result.scalar_one_or_none()
+
+            if existing:
+                if path and existing.path != path:
+                    existing.path = path
+                if not existing.is_active:
+                    existing.is_active = True
+                await session.commit()
+            else:
+                new_project = ProjectModel(
+                    id=project_id,
+                    name=name,
+                    slug=slug,
+                    description=description or "",
+                    path=path,
+                    is_active=True,
+                )
+                session.add(new_project)
+                await session.commit()
+    except Exception as e:
+        logger.warning("project_sync_failed", extra={"project": name, "error": str(e)})
+
+
+async def sync_all_projects_to_db() -> int:
+    """Sync every PROJECTS_REGISTRY entry to DB at startup.
+
+    Returns:
+        시도한 프로젝트 수 (성공/실패 관계없이). 호출자는 로그로 결과 확인.
+    """
+    if not _use_database():
+        return 0
+
+    try:
+        from models.project import list_projects
+    except Exception as e:
+        logger.warning("project_sync_bulk_import_failed", extra={"error": str(e)})
+        return 0
+
+    projects = list_projects()
+    for project in projects:
+        await sync_project_to_db(
+            project_id=project.id,
+            name=project.name,
+            path=project.path,
+            description=project.description,
+        )
+
+    logger.info("project_sync_bulk_completed", extra={"count": len(projects)})
+    return len(projects)


### PR DESCRIPTION
## Summary
- 서버 시작 시 `PROJECTS_REGISTRY`(메모리)와 DB `ProjectModel`을 자동 동기화하여, **Projects / Project Configs / Project Registry** 세 UI의 프로젝트 목록이 서로 일치하지 않던 버그를 수정합니다.
- 기존에는 UI `POST /projects/link`, `POST /projects/create` 경로에서만 DB sync가 발생해, `projects/` 심링크로 등록된 프로젝트는 Registry/Configs에 나타나지 않았습니다.
- 기존 7개의 로컬 프로젝트는 `scripts/seed_projects_to_db.py`로 일회성 백필 완료 (Phase 1). 이 PR은 재발 방지를 위한 자동화 (Phase 2).

## Changes

### New — `src/backend/services/project_sync_service.py`
- `sync_project_to_db(project_id, name, path, description)`: 기존 `routes.py`의 `_sync_project_to_db`를 서비스 레이어로 추출 (name 기준 upsert).
- `sync_all_projects_to_db()`: `PROJECTS_REGISTRY` 전체를 순회하며 DB에 일괄 sync. 서버 startup에서 호출.
- `USE_DATABASE=false` 환경에서는 no-op. 예외 발생 시 warning만 로깅하고 호출자에게 전파하지 않음.

### Modified — `src/backend/api/routes.py`
- 로컬 `_sync_project_to_db` 50줄 함수 제거.
- `from services.project_sync_service import sync_project_to_db as _sync_project_to_db`로 교체 → 기존 두 call site(`routes.py:373, 434`) **무수정 유지** (최소 blast radius).

### Modified — `src/backend/api/app.py`
- FastAPI `lifespan` 훅에서 `init_projects()` 직후 `await sync_all_projects_to_db()` 호출 추가.
- `USE_DATABASE=true`일 때만 실행, 실패 시 `startup_project_sync_failed` warning 후 startup 계속.

## Test Plan
- [x] `python -c "from services.project_sync_service import ..."` import OK
- [x] `python -c "from api import routes, app"` 모듈 import OK
- [x] 서버 재시작 후 `logs/backend.log`에 `startup_project_sync_done count=7` 확인
- [x] `/api/health` → 200 OK
- [x] Idempotent 검증: 재시작 후 `SELECT COUNT(*) FROM projects` = 7 (중복 생성 없음)
- [x] ruff lint/format pre-commit 통과

## Verification (Live)
\`\`\`
logs: startup_project_sync_done count=7
DB:   7 projects, 7 owner ACL records
UI:   Projects / Project Configs / Project Registry 세 페이지 모두 동일 목록 표시
\`\`\`

## Notes
- RAG/Playground는 여전히 `PROJECTS_REGISTRY`(메모리) 기반으로 동작 — DB 등록 여부와 무관하게 기존 기능 그대로 작동함을 코드 검증 완료 (`api/rag.py`, `api/playground.py`에 DB 조회 없음).
- 향후 개선 여지: 수동으로 `is_active=false` 처리한 프로젝트가 startup sync로 재활성화되는 현재 동작은 의도적(startup=truth). 보존이 필요해지면 `existing.is_active` 조건 추가로 조정 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)