### PR TITLE
fix(test): align test_embedding_model_consistency with BAAI/bge-m3 default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,9 @@ RAG_CANDIDATE_MULTIPLIER=3
 #               intfloat/multilingual-e5-large (1024d)
 EMBEDDING_PROVIDER=huggingface
 RAG_EMBEDDING_MODEL=BAAI/bge-m3
+# Device for HuggingFace embeddings: cpu | mps | cuda
+# macOS PyTorch MPS deadlocks with uvloop on long indexing runs — keep cpu
+RAG_EMBEDDING_DEVICE=cpu
 
 # =============================================================================
 # Web Search Tool (Playground)

--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,37 @@ CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 CLAUDE_CODE_TEAMMATE_MODE=tmux
 
 # =============================================================================
+# RAG Configuration (Playground + project context retrieval)
+# =============================================================================
+
+# Hybrid search: BM25 + semantic with RRF fusion (requires rank_bm25)
+RAG_ENABLE_HYBRID=true
+# CrossEncoder reranking of fused candidates (requires sentence-transformers)
+RAG_ENABLE_RERANK=true
+RAG_RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+
+# Chunking: files under threshold kept as single chunk
+RAG_FULL_CONTEXT_THRESHOLD=8000
+RAG_CHUNK_SIZE=1500
+RAG_CHUNK_OVERLAP=300
+# Semantic candidate pool multiplier before fusion (k * multiplier)
+RAG_CANDIDATE_MULTIPLIER=3
+
+# Embedding model — multilingual + code aware
+# Alternatives: sentence-transformers/all-MiniLM-L6-v2 (en only, 384d),
+#               intfloat/multilingual-e5-large (1024d)
+EMBEDDING_PROVIDER=huggingface
+RAG_EMBEDDING_MODEL=BAAI/bge-m3
+
+# =============================================================================
+# Web Search Tool (Playground)
+# =============================================================================
+
+# Tavily search API key — get one at https://tavily.com
+# Falls back to DuckDuckGo Instant Answer when empty
+TAVILY_API_KEY=
+
+# =============================================================================
 # Docker Port Overrides (optional - use when default ports conflict)
 # =============================================================================
 

--- a/src/backend/alembic/versions/b7e4f9d2c8a1_add_rag_k_and_overrides_to_playground_sessions.py
+++ b/src/backend/alembic/versions/b7e4f9d2c8a1_add_rag_k_and_overrides_to_playground_sessions.py
@@ -1,0 +1,52 @@
+"""add rag_k and hybrid/rerank overrides to playground_sessions
+
+Revision ID: b7e4f9d2c8a1
+Revises: f3a8b2c1d4e5
+Create Date: 2026-04-18
+
+Adds per-session RAG controls so the Playground UI can override the
+global env flags on a session-by-session basis.
+
+- rag_k: INTEGER DEFAULT 5 NOT NULL (how many chunks to retrieve)
+- rag_hybrid_override: BOOLEAN NULLABLE (NULL = follow RAG_ENABLE_HYBRID env)
+- rag_rerank_override: BOOLEAN NULLABLE (NULL = follow RAG_ENABLE_RERANK env)
+
+Idempotent: uses ADD COLUMN IF NOT EXISTS so re-runs are safe when the
+columns were created outside Alembic.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "b7e4f9d2c8a1"
+down_revision: str | Sequence[str] | None = "f3a8b2c1d4e5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE playground_sessions
+            ADD COLUMN IF NOT EXISTS rag_k INTEGER NOT NULL DEFAULT 5
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE playground_sessions
+            ADD COLUMN IF NOT EXISTS rag_hybrid_override BOOLEAN
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE playground_sessions
+            ADD COLUMN IF NOT EXISTS rag_rerank_override BOOLEAN
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE playground_sessions DROP COLUMN IF EXISTS rag_rerank_override")
+    op.execute("ALTER TABLE playground_sessions DROP COLUMN IF EXISTS rag_hybrid_override")
+    op.execute("ALTER TABLE playground_sessions DROP COLUMN IF EXISTS rag_k")

--- a/src/backend/alembic/versions/c9f1e52a3b7c_add_rag_include_shared_to_playground_sessions.py
+++ b/src/backend/alembic/versions/c9f1e52a3b7c_add_rag_include_shared_to_playground_sessions.py
@@ -1,0 +1,34 @@
+"""add rag_include_shared to playground_sessions
+
+Revision ID: c9f1e52a3b7c
+Revises: b7e4f9d2c8a1
+Create Date: 2026-04-18
+
+Adds the per-session flag that enables cross-project RAG retrieval — the
+search fuses results from other projects' Qdrant collections (with a rank
+boost for the current project) when True.
+
+Idempotent ADD COLUMN IF NOT EXISTS for safe re-runs.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "c9f1e52a3b7c"
+down_revision: str | Sequence[str] | None = "b7e4f9d2c8a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE playground_sessions
+            ADD COLUMN IF NOT EXISTS rag_include_shared BOOLEAN NOT NULL DEFAULT false
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE playground_sessions DROP COLUMN IF EXISTS rag_include_shared")

--- a/src/backend/api/playground.py
+++ b/src/backend/api/playground.py
@@ -85,6 +85,7 @@ class SessionSettingsUpdate(BaseModel):
     rag_k: int | None = None
     rag_hybrid_override: bool | None = None
     rag_rerank_override: bool | None = None
+    rag_include_shared: bool | None = None
 
 
 @router.patch("/sessions/{session_id}/settings", response_model=PlaygroundSession)
@@ -109,6 +110,7 @@ async def update_session_settings(
         rag_k=data.rag_k,
         rag_hybrid_override=data.rag_hybrid_override,
         rag_rerank_override=data.rag_rerank_override,
+        rag_include_shared=data.rag_include_shared,
     )
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/src/backend/api/playground.py
+++ b/src/backend/api/playground.py
@@ -82,6 +82,9 @@ class SessionSettingsUpdate(BaseModel):
     project_id: str | None = None
     working_directory: str | None = None
     rag_enabled: bool | None = None
+    rag_k: int | None = None
+    rag_hybrid_override: bool | None = None
+    rag_rerank_override: bool | None = None
 
 
 @router.patch("/sessions/{session_id}/settings", response_model=PlaygroundSession)
@@ -103,6 +106,9 @@ async def update_session_settings(
         project_id=data.project_id,
         working_directory=data.working_directory,
         rag_enabled=data.rag_enabled,
+        rag_k=data.rag_k,
+        rag_hybrid_override=data.rag_hybrid_override,
+        rag_rerank_override=data.rag_rerank_override,
     )
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/src/backend/db/models/playground.py
+++ b/src/backend/db/models/playground.py
@@ -38,6 +38,11 @@ class PlaygroundSessionModel(Base):
     max_tokens = Column(Integer, default=4096)
     system_prompt = Column(Text, nullable=True)
     rag_enabled = Column(Boolean, default=False)
+    # How many chunks to retrieve per RAG query (UI slider 1-20)
+    rag_k = Column(Integer, default=5, nullable=False, server_default="5")
+    # Per-session overrides for env flags (NULL = follow env)
+    rag_hybrid_override = Column(Boolean, nullable=True)
+    rag_rerank_override = Column(Boolean, nullable=True)
 
     # Tools
     available_tools = Column(JSONB, default=list)

--- a/src/backend/db/models/playground.py
+++ b/src/backend/db/models/playground.py
@@ -43,6 +43,8 @@ class PlaygroundSessionModel(Base):
     # Per-session overrides for env flags (NULL = follow env)
     rag_hybrid_override = Column(Boolean, nullable=True)
     rag_rerank_override = Column(Boolean, nullable=True)
+    # Include results from OTHER project collections (cross-project RAG)
+    rag_include_shared = Column(Boolean, default=False, nullable=False, server_default="false")
 
     # Tools
     available_tools = Column(JSONB, default=list)

--- a/src/backend/models/playground.py
+++ b/src/backend/models/playground.py
@@ -96,6 +96,11 @@ class PlaygroundSession(BaseModel):
 
     # RAG
     rag_enabled: bool = False
+    # How many chunks to retrieve per query
+    rag_k: int = Field(default=5, ge=1, le=20)
+    # Per-session overrides for env flags (None = follow env)
+    rag_hybrid_override: bool | None = None
+    rag_rerank_override: bool | None = None
 
     # Tools
     available_tools: list[str] = Field(default_factory=list)
@@ -138,6 +143,11 @@ class PlaygroundExecuteRequest(BaseModel):
     max_tokens: int | None = None
     tools: list[str] | None = None
     stream: bool = False
+
+    # Per-request RAG overrides (fall back to session defaults when None)
+    rag_k: int | None = Field(default=None, ge=1, le=20)
+    rag_hybrid_override: bool | None = None
+    rag_rerank_override: bool | None = None
 
 
 class PlaygroundToolTest(BaseModel):

--- a/src/backend/models/playground.py
+++ b/src/backend/models/playground.py
@@ -101,6 +101,11 @@ class PlaygroundSession(BaseModel):
     # Per-session overrides for env flags (None = follow env)
     rag_hybrid_override: bool | None = None
     rag_rerank_override: bool | None = None
+    # Also pull relevant chunks from OTHER projects' collections (current
+    # project still gets a rank boost via RRF double-insertion). Useful when
+    # project_id is code, but background notes live in a separate project
+    # (e.g. Obsidian).
+    rag_include_shared: bool = False
 
     # Tools
     available_tools: list[str] = Field(default_factory=list)
@@ -148,6 +153,7 @@ class PlaygroundExecuteRequest(BaseModel):
     rag_k: int | None = Field(default=None, ge=1, le=20)
     rag_hybrid_override: bool | None = None
     rag_rerank_override: bool | None = None
+    rag_include_shared: bool | None = None
 
 
 class PlaygroundToolTest(BaseModel):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "sentence-transformers>=2.2.0",
     "langchain-huggingface>=0.1.0",
     "rank_bm25>=0.2.2",
+    # Web search tool backend
+    "tavily-python>=0.5.0",
     # Docker (for sandbox)
     "docker>=6.0.0",
     # Git integration

--- a/src/backend/services/llm_service.py
+++ b/src/backend/services/llm_service.py
@@ -6,7 +6,12 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any
 
-from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 
 from models.llm_models import LLMModelRegistry, get_model_configs
 
@@ -45,6 +50,53 @@ class LLMResponse:
         input_cost = (self.input_tokens / 1000) * pricing["input"]
         output_cost = (self.output_tokens / 1000) * pricing["output"]
         return round(input_cost + output_cost, 6)
+
+
+def _build_messages(
+    system_prompt: str | None,
+    history: list[BaseMessage] | None,
+    prompt: str,
+    rag_context: str | None = None,
+    extra_context: dict[str, Any] | None = None,
+) -> list[BaseMessage]:
+    """
+    Build a LangChain message sequence for LLM invocation.
+
+    Layout:
+        1. SystemMessage: base system prompt (persona, rules)
+        2. SystemMessage: RAG / project context (separated so the model treats
+           it as authoritative context, not user input)
+        3. <history>: previous HumanMessage / AIMessage / ToolMessage turns
+        4. HumanMessage: current user prompt (with optional inline extra_context)
+    """
+    messages: list[BaseMessage] = []
+
+    if system_prompt:
+        messages.append(SystemMessage(content=system_prompt))
+
+    if rag_context:
+        messages.append(
+            SystemMessage(
+                content=(
+                    "## Relevant project context\n"
+                    "Use the following retrieved context as the source of truth "
+                    "for any project-specific facts. If the answer isn't in the "
+                    "context, say so explicitly instead of guessing.\n\n"
+                    f"{rag_context}"
+                )
+            )
+        )
+
+    if history:
+        messages.extend(history)
+
+    if extra_context:
+        ctx_str = "\n".join(f"- {k}: {v}" for k, v in extra_context.items())
+        messages.append(HumanMessage(content=f"Additional context:\n{ctx_str}\n\nUser: {prompt}"))
+    else:
+        messages.append(HumanMessage(content=prompt))
+
+    return messages
 
 
 class LLMService:
@@ -128,20 +180,22 @@ class LLMService:
         temperature: float = 0.7,
         max_tokens: int = 4096,
         context: dict[str, Any] | None = None,
+        history: list[BaseMessage] | None = None,
+        rag_context: str | None = None,
     ) -> LLMResponse:
         """
         Invoke an LLM with the given prompt.
 
         Args:
-            prompt: The user's prompt
-            model_id: Model identifier (e.g., "gemini-3-flash-preview", "claude-sonnet-4-6")
-            system_prompt: Optional system prompt
-            temperature: Sampling temperature
-            max_tokens: Maximum output tokens
-            context: Optional context dict to include
-
-        Returns:
-            LLMResponse with content and metrics
+            prompt: The user's prompt (current turn).
+            model_id: Model identifier (e.g., "gemini-3-flash-preview").
+            system_prompt: Optional system prompt.
+            temperature: Sampling temperature.
+            max_tokens: Maximum output tokens.
+            context: Optional extra-context dict inlined above the user prompt.
+            history: Prior turns as LangChain messages (enables multi-turn).
+            rag_context: Retrieved project context injected as a separate
+                SystemMessage so the model treats it as authoritative.
         """
         config = MODEL_CONFIGS.get(model_id, {})
         provider = config.get("provider", "unknown")
@@ -151,19 +205,13 @@ class LLMService:
         try:
             llm = cls._get_llm(model_id, temperature, max_tokens)
 
-            # Build messages
-            messages = []
-            if system_prompt:
-                messages.append(SystemMessage(content=system_prompt))
-
-            # Add context if provided
-            if context:
-                context_str = "\n".join(f"- {k}: {v}" for k, v in context.items())
-                full_prompt = f"Context:\n{context_str}\n\nUser: {prompt}"
-            else:
-                full_prompt = prompt
-
-            messages.append(HumanMessage(content=full_prompt))
+            messages = _build_messages(
+                system_prompt=system_prompt,
+                history=history,
+                prompt=prompt,
+                rag_context=rag_context,
+                extra_context=context,
+            )
 
             # Invoke LLM
             response = await llm.ainvoke(messages)
@@ -184,11 +232,13 @@ class LLMService:
                     input_tokens = usage.get("input_tokens", usage.get("prompt_tokens", 0))
                     output_tokens = usage.get("output_tokens", usage.get("completion_tokens", 0))
 
-            # Estimate if not available
+            # Estimate if not available (sum across all messages — history +
+            # rag + current turn — to reflect what the model actually saw)
             if input_tokens == 0:
-                input_tokens = len(full_prompt.split()) * 2
+                approx = sum(len(str(m.content).split()) for m in messages if hasattr(m, "content"))
+                input_tokens = approx * 2
             if output_tokens == 0:
-                output_tokens = len(response.content.split()) * 2
+                output_tokens = len(str(response.content).split()) * 2
 
             return LLMResponse(
                 content=response.content,
@@ -212,29 +262,21 @@ class LLMService:
         temperature: float = 0.7,
         max_tokens: int = 4096,
         context: dict[str, Any] | None = None,
+        history: list[BaseMessage] | None = None,
+        rag_context: str | None = None,
     ) -> AsyncIterator[str]:
-        """
-        Stream response from LLM.
-
-        Yields chunks of text as they arrive.
-        """
+        """Stream response from LLM. See ``invoke`` for argument semantics."""
         try:
             llm = cls._get_llm(model_id, temperature, max_tokens)
 
-            # Build messages
-            messages = []
-            if system_prompt:
-                messages.append(SystemMessage(content=system_prompt))
+            messages = _build_messages(
+                system_prompt=system_prompt,
+                history=history,
+                prompt=prompt,
+                rag_context=rag_context,
+                extra_context=context,
+            )
 
-            if context:
-                context_str = "\n".join(f"- {k}: {v}" for k, v in context.items())
-                full_prompt = f"Context:\n{context_str}\n\nUser: {prompt}"
-            else:
-                full_prompt = prompt
-
-            messages.append(HumanMessage(content=full_prompt))
-
-            # Stream response
             async for chunk in llm.astream(messages):
                 if hasattr(chunk, "content") and chunk.content:
                     yield chunk.content
@@ -251,6 +293,8 @@ class LLMService:
         temperature: float = 0.7,
         max_tokens: int = 4096,
         context: dict[str, Any] | None = None,
+        history: list[BaseMessage] | None = None,
+        rag_context: str | None = None,
     ) -> AsyncIterator[tuple[str, dict | None]]:
         """
         Stream response from LLM with token information.
@@ -259,24 +303,21 @@ class LLMService:
 
         Yields:
             Tuple of (chunk_text, token_info).
-            token_info is None for intermediate chunks, and contains
-            token usage data in the final yield.
+            ``token_info`` is None for intermediate chunks; the final yield
+            carries usage data, or ``{"error": True, "message": ...}`` on
+            failure so callers can distinguish error payloads from streamed
+            content.
         """
         try:
             llm = cls._get_llm(model_id, temperature, max_tokens)
 
-            # Build messages
-            messages = []
-            if system_prompt:
-                messages.append(SystemMessage(content=system_prompt))
-
-            if context:
-                context_str = "\n".join(f"- {k}: {v}" for k, v in context.items())
-                full_prompt = f"Context:\n{context_str}\n\nUser: {prompt}"
-            else:
-                full_prompt = prompt
-
-            messages.append(HumanMessage(content=full_prompt))
+            messages = _build_messages(
+                system_prompt=system_prompt,
+                history=history,
+                prompt=prompt,
+                rag_context=rag_context,
+                extra_context=context,
+            )
 
             token_info = None
 
@@ -324,7 +365,9 @@ class LLMService:
                 yield "", token_info
 
         except Exception as e:
-            yield f"\n\n[Error: {str(e)}]", None
+            # Emit error with structured sentinel so callers can distinguish
+            # an error payload from a streamed content chunk.
+            yield f"\n\n[Error: {str(e)}]", {"error": True, "message": str(e)}
 
     @classmethod
     def get_available_models(cls) -> list[dict[str, Any]]:
@@ -354,26 +397,18 @@ class LLMService:
         context: dict[str, Any] | None = None,
         max_tool_iterations: int = 15,
         working_directory: str | None = None,
+        history: list[BaseMessage] | None = None,
+        rag_context: str | None = None,
     ) -> LLMResponse:
         """
         Invoke an LLM with tool support.
 
         The LLM can call tools, and this method will execute them
-        and return the final response.
+        and return the final response. When the iteration budget is exhausted
+        a single forced-final round is performed (without tools) so callers
+        always receive a real answer instead of a sentinel string.
 
-        Args:
-            prompt: The user's prompt
-            tools: List of enabled tool names
-            model_id: Model identifier
-            system_prompt: Optional system prompt
-            temperature: Sampling temperature
-            max_tokens: Maximum output tokens
-            context: Optional context dict
-            max_tool_iterations: Max number of tool call rounds
-            working_directory: Working directory for file/code tools
-
-        Returns:
-            LLMResponse with content, tool calls, and metrics
+        See ``invoke`` for ``history`` / ``rag_context`` semantics.
         """
         from services.playground_tools import TOOL_DEFINITIONS, execute_tool
 
@@ -383,8 +418,15 @@ class LLMService:
         start_time = time.time()
         total_input_tokens = 0
         total_output_tokens = 0
-        all_tool_calls = []
-        all_tool_results = []
+        all_tool_calls: list[dict[str, Any]] = []
+        all_tool_results: list[dict[str, Any]] = []
+
+        default_tool_sys = (
+            "You are a helpful AI assistant. You have access to tools that you can use "
+            "to help answer questions. Use tools when they would help provide accurate "
+            "and current information. After using tools, synthesize the results into a "
+            "helpful response."
+        )
 
         try:
             llm = cls._get_llm(model_id, temperature, max_tokens)
@@ -398,29 +440,13 @@ class LLMService:
             else:
                 llm_with_tools = llm
 
-            # Build initial messages
-            messages = []
-            if system_prompt:
-                messages.append(SystemMessage(content=system_prompt))
-            else:
-                # Default system prompt for tool usage
-                messages.append(
-                    SystemMessage(
-                        content="You are a helpful AI assistant. "
-                        "You have access to tools that you can use to help answer questions. "
-                        "Use tools when they would help provide accurate and current information. "
-                        "After using tools, synthesize the results into a helpful response."
-                    )
-                )
-
-            # Add context if provided
-            if context:
-                context_str = "\n".join(f"- {k}: {v}" for k, v in context.items())
-                full_prompt = f"Context:\n{context_str}\n\nUser: {prompt}"
-            else:
-                full_prompt = prompt
-
-            messages.append(HumanMessage(content=full_prompt))
+            messages = _build_messages(
+                system_prompt=system_prompt or default_tool_sys,
+                history=history,
+                prompt=prompt,
+                rag_context=rag_context,
+                extra_context=context,
+            )
 
             # Iterate until we get a final response or hit max iterations
             for _iteration in range(max_tool_iterations):
@@ -439,11 +465,14 @@ class LLMService:
                     # No more tool calls - return final response
                     latency_ms = int((time.time() - start_time) * 1000)
 
-                    # Estimate tokens if not available
+                    # Estimate tokens if not available — sum across all messages
                     if total_input_tokens == 0:
-                        total_input_tokens = len(full_prompt.split()) * 2
+                        approx = sum(
+                            len(str(m.content).split()) for m in messages if hasattr(m, "content")
+                        )
+                        total_input_tokens = approx * 2
                     if total_output_tokens == 0:
-                        total_output_tokens = len(response.content.split()) * 2
+                        total_output_tokens = len(str(response.content).split()) * 2
 
                     return LLMResponse(
                         content=response.content,
@@ -498,11 +527,34 @@ class LLMService:
                         )
                     )
 
-            # Max iterations reached
+            # Tool iteration budget exhausted — force a final-answer round
+            # using the raw (non-tool-bound) LLM so we never return the
+            # "[Max tool iterations reached]" sentinel to users.
+            messages.append(
+                SystemMessage(
+                    content=(
+                        "Tool budget exhausted. Based on the tool results gathered "
+                        "so far, produce your best final answer to the user now. "
+                        "Do NOT call any more tools."
+                    )
+                )
+            )
+            final_response = await llm.ainvoke(messages)
+
+            if hasattr(final_response, "usage_metadata") and final_response.usage_metadata:
+                total_input_tokens += final_response.usage_metadata.get("input_tokens", 0)
+                total_output_tokens += final_response.usage_metadata.get("output_tokens", 0)
+
             latency_ms = int((time.time() - start_time) * 1000)
 
+            if total_input_tokens == 0:
+                approx = sum(len(str(m.content).split()) for m in messages if hasattr(m, "content"))
+                total_input_tokens = approx * 2
+            if total_output_tokens == 0:
+                total_output_tokens = len(str(final_response.content).split()) * 2
+
             return LLMResponse(
-                content="[Max tool iterations reached]",
+                content=final_response.content,
                 input_tokens=total_input_tokens,
                 output_tokens=total_output_tokens,
                 latency_ms=latency_ms,

--- a/src/backend/services/playground_service.py
+++ b/src/backend/services/playground_service.py
@@ -339,6 +339,7 @@ class PlaygroundService:
         rag_k: int | None = None,
         rag_hybrid_override: bool | None = None,
         rag_rerank_override: bool | None = None,
+        rag_include_shared: bool | None = None,
     ) -> PlaygroundSession | None:
         """Update session settings."""
         _load_sessions()  # Ensure sessions are loaded
@@ -372,6 +373,8 @@ class PlaygroundService:
             session.rag_hybrid_override = rag_hybrid_override
         if rag_rerank_override is not None:
             session.rag_rerank_override = rag_rerank_override
+        if rag_include_shared is not None:
+            session.rag_include_shared = rag_include_shared
 
         session.updated_at = utcnow()
         _save_sessions()  # Persist to file
@@ -441,10 +444,16 @@ class PlaygroundService:
                         if getattr(request, "rag_rerank_override", None) is not None
                         else getattr(session, "rag_rerank_override", None)
                     )
+                    include_shared = (
+                        request.rag_include_shared
+                        if getattr(request, "rag_include_shared", None) is not None
+                        else bool(getattr(session, "rag_include_shared", False))
+                    )
                     rag_context_str, rag_sources = await get_project_context_with_sources(
                         project_id=session.project_id,
                         query=request.prompt,
                         k=k,
+                        include_shared=include_shared,
                         force_hybrid=force_hybrid,
                         force_rerank=force_rerank,
                     )
@@ -594,10 +603,16 @@ class PlaygroundService:
                     if getattr(request, "rag_rerank_override", None) is not None
                     else getattr(session, "rag_rerank_override", None)
                 )
+                include_shared = (
+                    request.rag_include_shared
+                    if getattr(request, "rag_include_shared", None) is not None
+                    else bool(getattr(session, "rag_include_shared", False))
+                )
                 rag_context_str, rag_sources = await get_project_context_with_sources(
                     project_id=session.project_id,
                     query=request.prompt,
                     k=k,
+                    include_shared=include_shared,
                     force_hybrid=force_hybrid,
                     force_rerank=force_rerank,
                 )
@@ -858,6 +873,7 @@ class PlaygroundService:
             rag_k=getattr(model, "rag_k", None) or 5,
             rag_hybrid_override=getattr(model, "rag_hybrid_override", None),
             rag_rerank_override=getattr(model, "rag_rerank_override", None),
+            rag_include_shared=bool(getattr(model, "rag_include_shared", False)),
             available_tools=model.available_tools or [],
             enabled_tools=model.enabled_tools or [],
             messages=[PlaygroundMessage(**m) for m in (model.messages or [])],
@@ -887,6 +903,7 @@ class PlaygroundService:
             "rag_k": session.rag_k,
             "rag_hybrid_override": session.rag_hybrid_override,
             "rag_rerank_override": session.rag_rerank_override,
+            "rag_include_shared": session.rag_include_shared,
             "available_tools": session.available_tools,
             "enabled_tools": session.enabled_tools,
             "messages": [m.model_dump(mode="json") for m in session.messages],

--- a/src/backend/services/playground_service.py
+++ b/src/backend/services/playground_service.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
 from models.cost import calculate_cost, estimate_tokens
 from models.playground import (
     PlaygroundCompareRequest,
@@ -53,9 +55,66 @@ SESSIONS_FILE = STORAGE_DIR / "playground_sessions.json"
 _sessions: dict[str, PlaygroundSession] = {}
 _initialized = False
 
-# Default system prompt for playground
-DEFAULT_SYSTEM_PROMPT = """당신은 도움이 되는 AI 어시스턴트입니다.
-항상 한국어로 답변해주세요. 명확하고 친절하게 응답하며, 필요한 경우 단계별로 설명해주세요."""
+# Default system prompt for playground — Gemini 특화 가이드
+DEFAULT_SYSTEM_PROMPT = """당신은 AOS 플랫폼의 AI 어시스턴트입니다.
+
+- 한국어로 답변하고, 코드/명령어/경로는 원문을 그대로 유지합니다.
+- project context가 제공되면 그것을 사실의 단일 출처로 삼고,
+  컨텍스트에 없는 사실은 추측 대신 "제공된 컨텍스트에 없습니다"라고 명시합니다.
+- 답하기 전에 의도와 필요한 정보를 1~2문장으로 정리한 뒤 답변합니다.
+- 외부/최신 정보가 필요하면 사용 가능한 도구를 우선 호출합니다.
+- 여러 단계가 필요한 작업은 단계별로 명확히 설명합니다."""
+
+
+def _to_lc_messages(msgs: list[PlaygroundMessage]) -> list[BaseMessage]:
+    """
+    Convert persisted ``PlaygroundMessage`` history into LangChain messages.
+
+    - ``user`` → ``HumanMessage``
+    - ``assistant`` → ``AIMessage``
+    - ``tool`` → ``SystemMessage(content="[previous tool call] ...")``
+      (Legacy sessions don't carry ``tool_call_id`` required by LangChain
+      ``ToolMessage``; absorbing as SystemMessage preserves the information
+      without tripping strict tool-call validation on the next turn.)
+    - ``system`` role is omitted (handled via explicit ``system_prompt`` arg)
+    """
+    out: list[BaseMessage] = []
+    for m in msgs:
+        role = m.role
+        content = m.content or ""
+        if role == "user":
+            out.append(HumanMessage(content=content))
+        elif role == "assistant":
+            out.append(AIMessage(content=content))
+        elif role == "tool":
+            out.append(SystemMessage(content=f"[previous tool call] {content}"))
+        # other roles (system, etc.) are intentionally dropped
+    return out
+
+
+def _coerce_llm_content(content: Any) -> str:
+    """
+    Flatten LLM content into a plain string.
+
+    Gemini's multi-part responses can arrive as ``[{type: "text", text: ...},
+    {type: "tool_use", ...}]``. We extract only the textual parts so the
+    ``tool_use`` blocks don't leak into persisted transcripts as ``str(dict)``.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                # Only collect text parts; skip tool_use/tool_result blocks
+                if item.get("type") in (None, "text"):
+                    text = item.get("text")
+                    if text:
+                        parts.append(str(text))
+            else:
+                parts.append(str(item))
+        return " ".join(parts)
+    return str(content)
 
 
 def _ensure_storage_dir():
@@ -276,6 +335,9 @@ class PlaygroundService:
         project_id: str | None = None,
         working_directory: str | None = None,
         rag_enabled: bool | None = None,
+        rag_k: int | None = None,
+        rag_hybrid_override: bool | None = None,
+        rag_rerank_override: bool | None = None,
     ) -> PlaygroundSession | None:
         """Update session settings."""
         _load_sessions()  # Ensure sessions are loaded
@@ -303,6 +365,12 @@ class PlaygroundService:
             session.working_directory = working_directory
         if rag_enabled is not None:
             session.rag_enabled = rag_enabled
+        if rag_k is not None:
+            session.rag_k = rag_k
+        if rag_hybrid_override is not None:
+            session.rag_hybrid_override = rag_hybrid_override
+        if rag_rerank_override is not None:
+            session.rag_rerank_override = rag_rerank_override
 
         session.updated_at = utcnow()
         _save_sessions()  # Persist to file
@@ -346,35 +414,41 @@ class PlaygroundService:
         session.messages.append(user_msg)
 
         try:
-            # Build conversation history for context
-            conversation_context = None
-            if len(session.messages) > 1:
-                # Include recent conversation history
-                history = []
-                for msg in session.messages[-10:-1]:  # Last 10 messages excluding current
-                    history.append(f"{msg.role}: {msg.content}")
-                if history:
-                    conversation_context = {"conversation_history": "\n".join(history)}
-                    if request.context:
-                        conversation_context.update(request.context)
+            # Convert prior turns (excluding the one we just appended) into
+            # LangChain messages so the LLM sees a real multi-turn dialogue.
+            history = _to_lc_messages(session.messages[-11:-1])
 
             # Inject RAG context if enabled
-            rag_sources = None
+            rag_sources: list[dict] | None = None
+            rag_context_str: str | None = None
             if session.rag_enabled and session.project_id:
                 try:
                     from services.rag_service import get_project_context_with_sources
 
-                    rag_context, rag_sources = await get_project_context_with_sources(
+                    k = (
+                        request.rag_k
+                        if getattr(request, "rag_k", None)
+                        else getattr(session, "rag_k", None) or 5
+                    )
+                    force_hybrid = (
+                        request.rag_hybrid_override
+                        if getattr(request, "rag_hybrid_override", None) is not None
+                        else getattr(session, "rag_hybrid_override", None)
+                    )
+                    force_rerank = (
+                        request.rag_rerank_override
+                        if getattr(request, "rag_rerank_override", None) is not None
+                        else getattr(session, "rag_rerank_override", None)
+                    )
+                    rag_context_str, rag_sources = await get_project_context_with_sources(
                         project_id=session.project_id,
                         query=request.prompt,
-                        k=5,
+                        k=k,
+                        force_hybrid=force_hybrid,
+                        force_rerank=force_rerank,
                     )
-                    if rag_context:
-                        if conversation_context is None:
-                            conversation_context = request.context.copy() if request.context else {}
-                        conversation_context["project_context"] = rag_context
                 except Exception as e:
-                    print(f"Warning: RAG context retrieval failed: {e}")
+                    logger.warning("RAG context retrieval failed: %s", e)
 
             # Check if tools are enabled
             enabled_tools = execution.tools_enabled or []
@@ -388,7 +462,9 @@ class PlaygroundService:
                     system_prompt=session.system_prompt,
                     temperature=execution.temperature,
                     max_tokens=execution.max_tokens,
-                    context=conversation_context or request.context or None,
+                    context=request.context or None,
+                    history=history,
+                    rag_context=rag_context_str,
                     working_directory=session.working_directory,
                 )
 
@@ -407,26 +483,19 @@ class PlaygroundService:
                     session.messages.append(tool_msg)
             else:
                 # Regular LLM invocation without tools
-                llm_response: LLMResponse = await LLMService.invoke(
+                llm_response = await LLMService.invoke(
                     prompt=request.prompt,
                     model_id=session.model,
                     system_prompt=session.system_prompt,
                     temperature=execution.temperature,
                     max_tokens=execution.max_tokens,
-                    context=conversation_context or request.context or None,
+                    context=request.context or None,
+                    history=history,
+                    rag_context=rag_context_str,
                 )
 
-            # Add assistant message
-            # Handle content that might be a list (e.g., [{'type': 'text', 'text': '...'}])
-            content = llm_response.content
-            if isinstance(content, list):
-                # Extract text from list format
-                content = " ".join(
-                    item.get("text", str(item)) if isinstance(item, dict) else str(item)
-                    for item in content
-                )
-            elif not isinstance(content, str):
-                content = str(content)
+            # Flatten multi-part content (Gemini) into a persistable string
+            content = _coerce_llm_content(llm_response.content)
 
             assistant_msg = PlaygroundMessage(
                 role="assistant",
@@ -479,7 +548,14 @@ class PlaygroundService:
         session_id: str,
         request: PlaygroundExecuteRequest,
     ) -> AsyncIterator[str]:
-        """Execute with streaming response."""
+        """Execute with streaming response.
+
+        When ``request.tools`` (or session.enabled_tools) are active this
+        path routes through ``invoke_with_tools`` (non-streaming at the
+        provider level) and yields the final synthesized answer as a single
+        chunk, because Gemini's tool-calling protocol requires a complete
+        round-trip before a final textual response is produced.
+        """
         _load_sessions()  # Ensure sessions are loaded
         session = _sessions.get(session_id)
         if not session:
@@ -492,68 +568,106 @@ class PlaygroundService:
         )
         session.messages.append(user_msg)
 
-        # Build conversation context
-        conversation_context = None
-        if len(session.messages) > 1:
-            history = []
-            for msg in session.messages[-10:-1]:
-                history.append(f"{msg.role}: {msg.content}")
-            if history:
-                conversation_context = {"conversation_history": "\n".join(history)}
-                if request.context:
-                    conversation_context.update(request.context)
+        # Multi-turn history as LangChain messages (excl. the just-appended user)
+        history = _to_lc_messages(session.messages[-11:-1])
 
         # Inject RAG context if enabled
-        rag_sources = None
+        rag_sources: list[dict] | None = None
+        rag_context_str: str | None = None
         if session.rag_enabled and session.project_id:
             try:
                 from services.rag_service import get_project_context_with_sources
 
-                rag_context, rag_sources = await get_project_context_with_sources(
+                k = (
+                    request.rag_k
+                    if getattr(request, "rag_k", None)
+                    else getattr(session, "rag_k", None) or 5
+                )
+                force_hybrid = (
+                    request.rag_hybrid_override
+                    if getattr(request, "rag_hybrid_override", None) is not None
+                    else getattr(session, "rag_hybrid_override", None)
+                )
+                force_rerank = (
+                    request.rag_rerank_override
+                    if getattr(request, "rag_rerank_override", None) is not None
+                    else getattr(session, "rag_rerank_override", None)
+                )
+                rag_context_str, rag_sources = await get_project_context_with_sources(
                     project_id=session.project_id,
                     query=request.prompt,
-                    k=5,
+                    k=k,
+                    force_hybrid=force_hybrid,
+                    force_rerank=force_rerank,
                 )
-                if rag_context:
-                    if conversation_context is None:
-                        conversation_context = request.context.copy() if request.context else {}
-                    conversation_context["project_context"] = rag_context
             except Exception as e:
-                print(f"Warning: RAG context retrieval failed: {e}")
+                logger.warning("RAG context retrieval failed: %s", e)
 
-        # Stream from LLM with token tracking
+        # Choose streaming path vs tool-enabled path
+        enabled_tools = request.tools or session.enabled_tools or []
+        temperature = request.temperature or session.temperature
+        max_tokens = request.max_tokens or session.max_tokens
+
         full_response = ""
-        token_info = None
+        token_info: dict | None = None
 
         try:
-            async for chunk, info in LLMService.stream_with_tokens(
-                prompt=request.prompt,
-                model_id=session.model,
-                system_prompt=session.system_prompt,
-                temperature=request.temperature or session.temperature,
-                max_tokens=request.max_tokens or session.max_tokens,
-                context=conversation_context or request.context or None,
-            ):
-                if info:
-                    # Final chunk with token info
-                    token_info = info
-                elif chunk:
-                    full_response += chunk
-                    yield chunk
+            if enabled_tools:
+                # Tool-enabled: single-shot invoke_with_tools, yield final answer.
+                resp = await LLMService.invoke_with_tools(
+                    prompt=request.prompt,
+                    tools=enabled_tools,
+                    model_id=session.model,
+                    system_prompt=session.system_prompt,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    context=request.context or None,
+                    history=history,
+                    rag_context=rag_context_str,
+                    working_directory=session.working_directory,
+                )
+                full_response = _coerce_llm_content(resp.content)
+                yield full_response
+                token_info = {
+                    "input_tokens": resp.input_tokens,
+                    "output_tokens": resp.output_tokens,
+                }
+                # Emit tool call/result sentinels so clients can surface them.
+                for tc, tr in zip(resp.tool_calls, resp.tool_results, strict=False):
+                    yield f"\n\n__TOOL_CALL__{json.dumps({'call': tc, 'result': tr}, ensure_ascii=False)}"
+            else:
+                async for chunk, info in LLMService.stream_with_tokens(
+                    prompt=request.prompt,
+                    model_id=session.model,
+                    system_prompt=session.system_prompt,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    context=request.context or None,
+                    history=history,
+                    rag_context=rag_context_str,
+                ):
+                    if info:
+                        if info.get("error"):
+                            # Structured error — surface plain text to user
+                            yield chunk
+                            return
+                        token_info = info
+                    elif chunk:
+                        full_response += chunk
+                        yield chunk
 
-            # Calculate token usage - use actual values if available, else estimate
+            # Calculate token usage
             if token_info:
                 input_tokens = token_info.get("input_tokens", 0)
                 output_tokens = token_info.get("output_tokens", 0)
             else:
-                # Fallback: 추정값 사용
                 input_tokens = estimate_tokens(request.prompt, session.model)
                 output_tokens = estimate_tokens(full_response, session.model)
 
             total_tokens = input_tokens + output_tokens
             cost = calculate_cost(input_tokens, output_tokens, session.model)
 
-            # Add assistant message after streaming completes
+            # Persist assistant message
             assistant_msg = PlaygroundMessage(
                 role="assistant",
                 content=full_response,
@@ -565,14 +679,11 @@ class PlaygroundService:
             session.total_tokens += total_tokens
             session.total_cost += cost
             session.updated_at = utcnow()
-            _save_sessions()  # Persist to file
+            _save_sessions()
             _fire_and_forget(PlaygroundService.save_session_to_db(session))
 
-            # Send RAG sources as final metadata event
             if rag_sources:
-                import json
-
-                yield f"\n\n__RAG_SOURCES__{json.dumps(rag_sources)}"
+                yield f"\n\n__RAG_SOURCES__{json.dumps(rag_sources, ensure_ascii=False)}"
 
         except Exception as e:
             yield f"\n\n[Error: {str(e)}]"
@@ -743,6 +854,9 @@ class PlaygroundService:
             max_tokens=model.max_tokens or 4096,
             system_prompt=model.system_prompt,
             rag_enabled=model.rag_enabled or False,
+            rag_k=getattr(model, "rag_k", None) or 5,
+            rag_hybrid_override=getattr(model, "rag_hybrid_override", None),
+            rag_rerank_override=getattr(model, "rag_rerank_override", None),
             available_tools=model.available_tools or [],
             enabled_tools=model.enabled_tools or [],
             messages=[PlaygroundMessage(**m) for m in (model.messages or [])],
@@ -769,6 +883,9 @@ class PlaygroundService:
             "max_tokens": session.max_tokens,
             "system_prompt": session.system_prompt,
             "rag_enabled": session.rag_enabled,
+            "rag_k": session.rag_k,
+            "rag_hybrid_override": session.rag_hybrid_override,
+            "rag_rerank_override": session.rag_rerank_override,
             "available_tools": session.available_tools,
             "enabled_tools": session.enabled_tools,
             "messages": [m.model_dump(mode="json") for m in session.messages],

--- a/src/backend/services/playground_service.py
+++ b/src/backend/services/playground_service.py
@@ -284,6 +284,7 @@ class PlaygroundService:
             agent_id=data.agent_id,
             model=data.model,
             system_prompt=data.system_prompt or DEFAULT_SYSTEM_PROMPT,
+            rag_enabled=data.rag_enabled,
             available_tools=list(PLAYGROUND_TOOLS.keys()),
         )
         _sessions[session.id] = session

--- a/src/backend/services/playground_tools.py
+++ b/src/backend/services/playground_tools.py
@@ -1,12 +1,15 @@
 """Playground Tools - Real implementations for playground tool execution."""
 
 import asyncio
+import logging
 import os
 import re
 from datetime import datetime
 from typing import Any
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class PlaygroundTools:
@@ -19,17 +22,63 @@ class PlaygroundTools:
     @staticmethod
     async def web_search(query: str, max_results: int = 5) -> dict[str, Any]:
         """
-        Search the web using DuckDuckGo Instant Answer API.
+        Search the web. Uses Tavily (advanced search + synthesized answer)
+        when ``TAVILY_API_KEY`` is set, otherwise falls back to DuckDuckGo
+        Instant Answer (which only returns Wikipedia-style answer cards, not
+        general web results).
 
-        Args:
-            query: Search query string
-            max_results: Maximum number of results to return
-
-        Returns:
-            Search results with titles, URLs, and snippets
+        Returns a dict with ``success``, ``query``, ``results`` (list of
+        {title, url, snippet[, score]}), ``total``, and optionally ``answer``
+        (Tavily's synthesized answer) and ``provider``.
         """
+        api_key = os.getenv("TAVILY_API_KEY", "").strip()
+        if api_key:
+            try:
+                return await PlaygroundTools._web_search_tavily(query, max_results, api_key)
+            except Exception as e:
+                logger.warning("Tavily search failed, falling back to DuckDuckGo: %s", e)
+        return await PlaygroundTools._web_search_ddg(query, max_results)
+
+    @staticmethod
+    async def _web_search_tavily(
+        query: str,
+        max_results: int,
+        api_key: str,
+    ) -> dict[str, Any]:
+        """Tavily-backed search — returns real web results with LLM-ready answer."""
+        from tavily import AsyncTavilyClient
+
+        client = AsyncTavilyClient(api_key=api_key)
+        response = await client.search(
+            query=query,
+            max_results=max_results,
+            search_depth="advanced",
+            include_answer=True,
+        )
+
+        results = [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "snippet": r.get("content", ""),
+                "score": r.get("score", 0.0),
+            }
+            for r in response.get("results", [])
+        ]
+
+        return {
+            "success": True,
+            "query": query,
+            "answer": response.get("answer"),
+            "results": results,
+            "total": len(results),
+            "provider": "tavily",
+        }
+
+    @staticmethod
+    async def _web_search_ddg(query: str, max_results: int = 5) -> dict[str, Any]:
+        """Legacy DuckDuckGo Instant Answer fallback (no API key required)."""
         try:
-            # Use DuckDuckGo Instant Answer API (free, no API key needed)
             async with httpx.AsyncClient(timeout=10.0) as client:
                 # DuckDuckGo Instant Answer API
                 response = await client.get(
@@ -92,7 +141,12 @@ class PlaygroundTools:
                         "success": True,
                         "query": query,
                         "results": [],
-                        "message": f"No instant answers found for '{query}'. Try a more specific query or rephrase.",
+                        "provider": "duckduckgo",
+                        "message": (
+                            f"No instant answers found for '{query}'. DuckDuckGo "
+                            "Instant Answer only returns Wikipedia-style cards — "
+                            "set TAVILY_API_KEY for general web search."
+                        ),
                     }
 
                 return {
@@ -100,6 +154,7 @@ class PlaygroundTools:
                     "query": query,
                     "results": results[:max_results],
                     "total": len(results),
+                    "provider": "duckduckgo",
                 }
 
         except httpx.TimeoutException:
@@ -107,12 +162,14 @@ class PlaygroundTools:
                 "success": False,
                 "error": "Search request timed out",
                 "results": [],
+                "provider": "duckduckgo",
             }
         except Exception as e:
             return {
                 "success": False,
                 "error": f"Search failed: {str(e)}",
                 "results": [],
+                "provider": "duckduckgo",
             }
 
     @staticmethod
@@ -566,7 +623,12 @@ class PlaygroundTools:
 TOOL_DEFINITIONS = [
     {
         "name": "web_search",
-        "description": "Search the web for information. Use this when you need to find current information, facts, or answers to questions.",
+        "description": (
+            "Search the web for current information using Tavily (advanced search). "
+            "Returns up to N results with title, URL, snippet, and a synthesized "
+            "answer. Use this whenever you need recent or external information not "
+            "covered in the project context."
+        ),
         "parameters": {
             "type": "object",
             "properties": {

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -94,6 +94,12 @@ else:
 RAG_CHUNK_SIZE = int(os.getenv("RAG_CHUNK_SIZE", "1500"))
 RAG_CHUNK_OVERLAP = int(os.getenv("RAG_CHUNK_OVERLAP", "300"))
 
+# HuggingFace embedding device. macOS PyTorch MPS + asyncio/uvloop has a
+# known deadlock pattern (metal gpu stream + idle callback livelock) on
+# longer indexing runs, so default to CPU. Override with mps/cuda when
+# running outside an event loop or when the indexer is run as a CLI script.
+RAG_EMBEDDING_DEVICE = os.getenv("RAG_EMBEDDING_DEVICE", "cpu").strip().lower()
+
 # ── File extension → Language mapping ─────────────────────────────────────────
 _EXTENSION_LANGUAGE_MAP: dict[str, Any] = {}
 if SPLITTER_AVAILABLE:
@@ -239,8 +245,11 @@ class ProjectVectorStore:
             try:
                 from langchain_huggingface import HuggingFaceEmbeddings
 
-                print(f"[RAG] Using HuggingFace embeddings: {model}")
-                return HuggingFaceEmbeddings(model_name=model)
+                model_kwargs: dict[str, Any] = {"device": RAG_EMBEDDING_DEVICE}
+                print(
+                    f"[RAG] Using HuggingFace embeddings: {model} (device={RAG_EMBEDDING_DEVICE})"
+                )
+                return HuggingFaceEmbeddings(model_name=model, model_kwargs=model_kwargs)
             except ImportError:
                 print("[RAG] langchain-huggingface not installed, trying alternatives...")
 

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -99,6 +99,10 @@ RAG_CHUNK_OVERLAP = int(os.getenv("RAG_CHUNK_OVERLAP", "300"))
 # longer indexing runs, so default to CPU. Override with mps/cuda when
 # running outside an event loop or when the indexer is run as a CLI script.
 RAG_EMBEDDING_DEVICE = os.getenv("RAG_EMBEDDING_DEVICE", "cpu").strip().lower()
+# Batch size for sentence-transformers encode(). Larger = faster but more
+# memory. bge-m3 default 32 is conservative; 64 roughly halves wallclock
+# at ~2x peak memory.
+RAG_EMBEDDING_BATCH_SIZE = int(os.getenv("RAG_EMBEDDING_BATCH_SIZE", "64"))
 
 # ── File extension → Language mapping ─────────────────────────────────────────
 _EXTENSION_LANGUAGE_MAP: dict[str, Any] = {}
@@ -246,10 +250,19 @@ class ProjectVectorStore:
                 from langchain_huggingface import HuggingFaceEmbeddings
 
                 model_kwargs: dict[str, Any] = {"device": RAG_EMBEDDING_DEVICE}
+                encode_kwargs: dict[str, Any] = {
+                    "batch_size": RAG_EMBEDDING_BATCH_SIZE,
+                    "normalize_embeddings": True,
+                }
                 print(
-                    f"[RAG] Using HuggingFace embeddings: {model} (device={RAG_EMBEDDING_DEVICE})"
+                    f"[RAG] Using HuggingFace embeddings: {model} "
+                    f"(device={RAG_EMBEDDING_DEVICE}, batch={RAG_EMBEDDING_BATCH_SIZE})"
                 )
-                return HuggingFaceEmbeddings(model_name=model, model_kwargs=model_kwargs)
+                return HuggingFaceEmbeddings(
+                    model_name=model,
+                    model_kwargs=model_kwargs,
+                    encode_kwargs=encode_kwargs,
+                )
             except ImportError:
                 print("[RAG] langchain-huggingface not installed, trying alternatives...")
 
@@ -923,25 +936,29 @@ class ProjectVectorStore:
             return local_result
 
         # ── Cross-project search: merge results from other collections ────
+        # Strategy: fair RRF across every project, then (when rerank is on)
+        # CrossEncoder-score the fused pool against the query. This replaces
+        # the prior "insert local twice" boost, which mathematically locked
+        # every slot to the current project when k <= len(local_result).
         other_collections = self._get_all_project_collections(exclude_ids=[project_id])
 
         all_ranked_lists: list[list[tuple[str, dict[str, Any]]]] = []
 
-        # Add local results as a ranked list (with boost via double insertion)
         local_ranked: list[tuple[str, dict[str, Any]]] = [
             (d["content"], {**d, "project_id": d.get("project_id", project_id)})
             for d in local_result.documents
         ]
-        # Insert local list twice to give it a boost in RRF fusion
-        all_ranked_lists.append(local_ranked)
         all_ranked_lists.append(local_ranked)
 
+        # Pull a wider candidate pool from each other project so the reranker
+        # has a real chance to surface them in the final top-k.
+        other_k = max(k, k * 2)
         for coll_name in other_collections:
             try:
                 other_pid = self._extract_project_id_from_collection(coll_name)
                 other_vs = self._get_or_create_collection(other_pid)
                 other_results = other_vs.similarity_search_with_score(
-                    query=query, k=k, filter=qdrant_filter
+                    query=query, k=other_k, filter=qdrant_filter
                 )
                 other_ranked: list[tuple[str, dict[str, Any]]] = [
                     (
@@ -959,9 +976,18 @@ class ProjectVectorStore:
             except Exception as e:
                 logger.warning("Cross-project search failed for %s: %s", coll_name, e)
 
-        fused = self._rrf_fusion(all_ranked_lists)[:k]
+        fused = self._rrf_fusion(all_ranked_lists)
 
-        return QueryResult(query=query, documents=fused, total_found=len(fused))
+        # Final reranking on the fused pool when enabled — CrossEncoder
+        # compares the query directly against each candidate, giving a fair
+        # cross-project ranking regardless of per-collection score scales.
+        if use_rerank and RERANK_AVAILABLE:
+            rerank_pool = fused[: max(k * 3, 30)]
+            final = self._rerank(query, rerank_pool, top_k=k)
+        else:
+            final = fused[:k]
+
+        return QueryResult(query=query, documents=final, total_found=len(final))
 
     async def query_cross_project(
         self,

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -76,12 +76,23 @@ except ImportError:
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "google")
 EMBEDDING_PROVIDER = os.getenv("EMBEDDING_PROVIDER", "huggingface")
 
-if EMBEDDING_PROVIDER == "openai":
+# Explicit override (per provider default is only used when this is empty)
+_RAG_EMBEDDING_MODEL_OVERRIDE = os.getenv("RAG_EMBEDDING_MODEL", "").strip()
+
+if _RAG_EMBEDDING_MODEL_OVERRIDE:
+    DEFAULT_EMBEDDING_MODEL = _RAG_EMBEDDING_MODEL_OVERRIDE
+elif EMBEDDING_PROVIDER == "openai":
     DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 elif EMBEDDING_PROVIDER == "google":
     DEFAULT_EMBEDDING_MODEL = "models/text-embedding-004"
 else:
-    DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+    # Multilingual + code aware; Korean/English/code quality far better than
+    # all-MiniLM-L6-v2. 1024 dim, ~2.3 GB on first load.
+    DEFAULT_EMBEDDING_MODEL = "BAAI/bge-m3"
+
+# Chunking defaults — larger chunks to exploit Gemini 1M context window
+RAG_CHUNK_SIZE = int(os.getenv("RAG_CHUNK_SIZE", "1500"))
+RAG_CHUNK_OVERLAP = int(os.getenv("RAG_CHUNK_OVERLAP", "300"))
 
 # ── File extension → Language mapping ─────────────────────────────────────────
 _EXTENSION_LANGUAGE_MAP: dict[str, Any] = {}
@@ -220,21 +231,16 @@ class ProjectVectorStore:
         """Create embeddings instance based on EMBEDDING_PROVIDER."""
         model = model_name or DEFAULT_EMBEDDING_MODEL
 
-        if (
-            EMBEDDING_PROVIDER == "huggingface"
-            or "sentence-transformers" in model
-            or "all-MiniLM" in model
-        ):
+        # HuggingFace route: explicit provider, OR model name matches a known
+        # HF repo pattern. Previously this clamped non-"sentence-transformers"
+        # names back to all-MiniLM, which silently discarded BAAI/bge-m3 etc.
+        _looks_like_hf = "/" in model or "sentence-transformers" in model or "all-MiniLM" in model
+        if EMBEDDING_PROVIDER == "huggingface" or _looks_like_hf:
             try:
                 from langchain_huggingface import HuggingFaceEmbeddings
 
-                hf_model = (
-                    model
-                    if "sentence-transformers" in model
-                    else "sentence-transformers/all-MiniLM-L6-v2"
-                )
-                print(f"[RAG] Using HuggingFace embeddings: {hf_model}")
-                return HuggingFaceEmbeddings(model_name=hf_model)
+                print(f"[RAG] Using HuggingFace embeddings: {model}")
+                return HuggingFaceEmbeddings(model_name=model)
             except ImportError:
                 print("[RAG] langchain-huggingface not installed, trying alternatives...")
 
@@ -387,9 +393,14 @@ class ProjectVectorStore:
         self,
         content: str,
         file_path: str,
-        chunk_size: int = 1000,
-        chunk_overlap: int = 200,
+        chunk_size: int | None = None,
+        chunk_overlap: int | None = None,
     ) -> list[Document]:
+        # Use env-driven defaults when caller doesn't specify
+        if chunk_size is None:
+            chunk_size = RAG_CHUNK_SIZE
+        if chunk_overlap is None:
+            chunk_overlap = RAG_CHUNK_OVERLAP
         """
         Split a document into chunks for indexing.
 
@@ -830,15 +841,18 @@ class ProjectVectorStore:
         k: int = 5,
         filter_priority: str | None = None,
         include_shared: bool = False,
+        force_hybrid: bool | None = None,
+        force_rerank: bool | None = None,
     ) -> QueryResult:
         """
         Query the vector store for relevant documents.
 
-        When RAG_ENABLE_HYBRID is True:
+        When hybrid is active (env ``RAG_ENABLE_HYBRID`` or ``force_hybrid=True``):
           1. Semantic search (k * CANDIDATE_MULTIPLIER candidates)
           2. BM25 keyword search (k * 2 candidates)
           3. RRF fusion of both lists
-          4. Optional CrossEncoder reranking (if RAG_ENABLE_RERANK)
+          4. Optional CrossEncoder reranking (env ``RAG_ENABLE_RERANK`` or
+             ``force_rerank=True``)
           5. Return top-k
 
         Otherwise: standard semantic similarity search.
@@ -846,8 +860,15 @@ class ProjectVectorStore:
         Args:
             include_shared: If True, also search other project collections
                 and merge results (current project gets a boost).
+            force_hybrid: Per-call override for ``RAG_ENABLE_HYBRID`` env
+                (``None`` = use env, ``True``/``False`` = force).
+            force_rerank: Per-call override for ``RAG_ENABLE_RERANK`` env.
         """
         collection = self._get_or_create_collection(project_id)
+
+        # Resolve effective flags (per-call overrides beat env)
+        use_hybrid = RAG_ENABLE_HYBRID if force_hybrid is None else force_hybrid
+        use_rerank = RAG_ENABLE_RERANK if force_rerank is None else force_rerank
 
         # Build Qdrant filter for priority
         qdrant_filter = None
@@ -861,8 +882,10 @@ class ProjectVectorStore:
                 ]
             )
 
-        if RAG_ENABLE_HYBRID and BM25_AVAILABLE:
-            local_result = await self._hybrid_query(project_id, collection, query, k, qdrant_filter)
+        if use_hybrid and BM25_AVAILABLE:
+            local_result = await self._hybrid_query(
+                project_id, collection, query, k, qdrant_filter, use_rerank=use_rerank
+            )
         else:
             # ── Standard semantic-only path ───────────────────────────────────
             results = collection.similarity_search_with_score(
@@ -1007,8 +1030,14 @@ class ProjectVectorStore:
         query: str,
         k: int,
         qdrant_filter: QdrantFilter | None,
+        use_rerank: bool | None = None,
     ) -> QueryResult:
-        """Hybrid search: semantic + BM25 -> RRF -> optional rerank."""
+        """Hybrid search: semantic + BM25 -> RRF -> optional rerank.
+
+        ``use_rerank`` defaults to the env flag ``RAG_ENABLE_RERANK`` when None.
+        """
+        if use_rerank is None:
+            use_rerank = RAG_ENABLE_RERANK
 
         # 1. Semantic candidates (expanded)
         semantic_k = k * RAG_CANDIDATE_MULTIPLIER
@@ -1031,8 +1060,8 @@ class ProjectVectorStore:
         # 3. RRF fusion
         fused = self._rrf_fusion([semantic_ranked, bm25_ranked])
 
-        # 4. Optional reranking
-        if RAG_ENABLE_RERANK and RERANK_AVAILABLE:
+        # 4. Optional reranking (respects per-call override, falls back to env)
+        if use_rerank and RERANK_AVAILABLE:
             rerank_pool = fused[: k * 2]
             final = self._rerank(query, rerank_pool, top_k=k)
         else:
@@ -1132,19 +1161,29 @@ async def get_project_context_with_sources(
     query: str,
     k: int = 5,
     include_shared: bool = False,
+    force_hybrid: bool | None = None,
+    force_rerank: bool | None = None,
 ) -> tuple[str, list[dict]]:
     """
     Get relevant project context with structured source information.
 
     Args:
         include_shared: If True, also include results from other projects.
+        force_hybrid / force_rerank: Per-call overrides for env flags (None=env).
 
     Returns:
         tuple of (formatted context string, list of source document dicts)
         Each source dict: {content, source, chunk_index, priority, score[, project_id]}
     """
     store = get_vector_store()
-    result = await store.query(project_id, query, k=k, include_shared=include_shared)
+    result = await store.query(
+        project_id,
+        query,
+        k=k,
+        include_shared=include_shared,
+        force_hybrid=force_hybrid,
+        force_rerank=force_rerank,
+    )
 
     if not result.documents:
         return "", []

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -49,6 +49,7 @@ dependencies = [
     { name = "sentence-transformers" },
     { name = "sqlalchemy" },
     { name = "structlog" },
+    { name = "tavily-python" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
@@ -109,6 +110,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi"], marker = "extra == 'monitoring'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "structlog", specifier = ">=24.4.0" },
+    { name = "tavily-python", specifier = ">=0.5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
@@ -3083,6 +3085,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tavily-python"
+version = "0.7.23"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "requests" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/d1/197419d6133643848514e5e84e8f41886e825b73bf91ae235a1595c964f5/tavily_python-0.7.23.tar.gz", hash = "sha256:3b92232e0e29ab68898b765f281bb4f2c650b02210b64affbc48e15292e96161", size = 25968, upload-time = "2026-03-09T19:17:32.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/27/f9c6e9249367be0772fb754849e03cbbc6ad8d80a479bf30ea8811828b2e/tavily_python-0.7.23-py3-none-any.whl", hash = "sha256:52ef85c44b926bce3f257570cd32bc1bd4db54666acf3105617f27411a59e188", size = 19079, upload-time = "2026-03-09T19:17:29.593Z" },
 ]
 
 [[package]]

--- a/src/dashboard/src/pages/PlaygroundPage.tsx
+++ b/src/dashboard/src/pages/PlaygroundPage.tsx
@@ -82,6 +82,7 @@ interface PlaygroundSession {
   rag_k: number
   rag_hybrid_override: boolean | null
   rag_rerank_override: boolean | null
+  rag_include_shared: boolean
   available_tools: string[]
   enabled_tools: string[]
   messages: PlaygroundMessage[]
@@ -200,6 +201,7 @@ async function updateSettings(
     rag_k: number
     rag_hybrid_override: boolean | null
     rag_rerank_override: boolean | null
+    rag_include_shared: boolean
   }>
 ): Promise<PlaygroundSession> {
   const res = await authFetch(`${API_BASE}/playground/sessions/${sessionId}/settings`, {
@@ -1036,8 +1038,28 @@ export function PlaygroundPage() {
                           </span>
                         </label>
 
+                        {/* Cross-project include_shared */}
+                        <label className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={currentSession.rag_include_shared}
+                            onChange={(e) =>
+                              handleUpdateSettings({
+                                rag_include_shared: e.target.checked,
+                              })
+                            }
+                            className="rounded border-gray-300 dark:border-gray-600"
+                            aria-label="Include other projects in RAG search"
+                          />
+                          <span className="text-xs text-gray-700 dark:text-gray-300">
+                            다른 프로젝트 지식 포함 (cross-project)
+                          </span>
+                        </label>
+
                         <p className="text-[10px] text-gray-400">
-                          기본값은 서버 환경변수를 따릅니다. 체크 해제 시 이 세션에서만 비활성화됩니다.
+                          하이브리드/재정렬은 서버 환경변수 기본값, 체크 해제 시 세션 단위 비활성화.
+                          cross-project는 기본 OFF — ON 시 다른 프로젝트 콜렉션도 검색에 포함되며,
+                          현재 프로젝트가 RRF에서 우선순위를 받습니다.
                         </p>
                       </div>
                     )}

--- a/src/dashboard/src/pages/PlaygroundPage.tsx
+++ b/src/dashboard/src/pages/PlaygroundPage.tsx
@@ -79,6 +79,9 @@ interface PlaygroundSession {
   max_tokens: number
   system_prompt: string | null
   rag_enabled: boolean
+  rag_k: number
+  rag_hybrid_override: boolean | null
+  rag_rerank_override: boolean | null
   available_tools: string[]
   enabled_tools: string[]
   messages: PlaygroundMessage[]
@@ -194,6 +197,9 @@ async function updateSettings(
     system_prompt: string
     enabled_tools: string[]
     rag_enabled: boolean
+    rag_k: number
+    rag_hybrid_override: boolean | null
+    rag_rerank_override: boolean | null
   }>
 ): Promise<PlaygroundSession> {
   const res = await authFetch(`${API_BASE}/playground/sessions/${sessionId}/settings`, {
@@ -959,6 +965,82 @@ export function PlaygroundPage() {
                         </div>
                       )
                     })()}
+
+                    {/* RAG advanced controls (visible only when RAG is on) */}
+                    {currentSession.rag_enabled && currentSession.project_id && (
+                      <div
+                        className="mt-3 ml-6 space-y-3 border-l-2 border-gray-200 dark:border-gray-700 pl-3"
+                        aria-label="RAG advanced settings"
+                      >
+                        {/* k slider */}
+                        <div>
+                          <div className="flex items-center justify-between mb-1">
+                            <label
+                              htmlFor="rag-k-slider"
+                              className="text-xs text-gray-700 dark:text-gray-300"
+                            >
+                              검색 청크 수 (k)
+                            </label>
+                            <span className="text-xs font-medium text-gray-900 dark:text-gray-100">
+                              {currentSession.rag_k} chunks
+                            </span>
+                          </div>
+                          <input
+                            id="rag-k-slider"
+                            type="range"
+                            min={3}
+                            max={15}
+                            step={1}
+                            value={currentSession.rag_k}
+                            onChange={(e) =>
+                              handleUpdateSettings({ rag_k: parseInt(e.target.value, 10) })
+                            }
+                            className="w-full accent-blue-500"
+                            aria-label="RAG chunk retrieval count"
+                          />
+                        </div>
+
+                        {/* Hybrid override */}
+                        <label className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={currentSession.rag_hybrid_override ?? true}
+                            onChange={(e) =>
+                              handleUpdateSettings({
+                                rag_hybrid_override: e.target.checked,
+                              })
+                            }
+                            className="rounded border-gray-300 dark:border-gray-600"
+                            aria-label="Toggle hybrid BM25 + semantic search"
+                          />
+                          <span className="text-xs text-gray-700 dark:text-gray-300">
+                            하이브리드 검색 (BM25 + 의미)
+                          </span>
+                        </label>
+
+                        {/* Rerank override */}
+                        <label className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={currentSession.rag_rerank_override ?? true}
+                            onChange={(e) =>
+                              handleUpdateSettings({
+                                rag_rerank_override: e.target.checked,
+                              })
+                            }
+                            className="rounded border-gray-300 dark:border-gray-600"
+                            aria-label="Toggle CrossEncoder reranking"
+                          />
+                          <span className="text-xs text-gray-700 dark:text-gray-300">
+                            CrossEncoder 재정렬
+                          </span>
+                        </label>
+
+                        <p className="text-[10px] text-gray-400">
+                          기본값은 서버 환경변수를 따릅니다. 체크 해제 시 이 세션에서만 비활성화됩니다.
+                        </p>
+                      </div>
+                    )}
                   </div>
 
                   {/* Tools */}

--- a/tests/backend/test_playground_service.py
+++ b/tests/backend/test_playground_service.py
@@ -1,0 +1,223 @@
+"""Unit tests for Playground service after the RAG/Tools overhaul.
+
+Covers:
+- _to_lc_messages() handles legacy tool-role entries without tool_call_id
+- _coerce_llm_content() flattens Gemini multi-part responses
+- PlaygroundSession parses legacy JSON dicts (missing rag_k / overrides)
+- PlaygroundExecuteRequest carries per-request RAG overrides
+- invoke_with_tools force-final round triggers when budget is exhausted
+- LLMService._build_messages injects RAG context as a separate SystemMessage
+- DEFAULT_SYSTEM_PROMPT contains the updated Gemini-specific guidance
+- web_search dispatches to Tavily when TAVILY_API_KEY is set, DDG otherwise
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from models.playground import (
+    PlaygroundExecuteRequest,
+    PlaygroundMessage,
+    PlaygroundSession,
+)
+from services.llm_service import LLMService, _build_messages
+from services.playground_service import (
+    DEFAULT_SYSTEM_PROMPT,
+    _coerce_llm_content,
+    _to_lc_messages,
+)
+
+
+# ─────────────────────────────────────────────────────────────
+# Helpers / conversions
+# ─────────────────────────────────────────────────────────────
+
+
+def test_to_lc_messages_absorbs_legacy_tool_role() -> None:
+    """Legacy tool entries (no tool_call_id) must not break conversion."""
+    msgs = [
+        PlaygroundMessage(role="user", content="hi"),
+        PlaygroundMessage(role="assistant", content="hello"),
+        PlaygroundMessage(role="tool", content="Called web_search"),
+        PlaygroundMessage(role="system", content="SHOULD BE DROPPED"),
+    ]
+    out = _to_lc_messages(msgs)
+    assert [type(m).__name__ for m in out] == [
+        "HumanMessage",
+        "AIMessage",
+        "SystemMessage",
+    ]
+    assert "[previous tool call]" in out[2].content
+
+
+def test_coerce_llm_content_flattens_multipart() -> None:
+    """Gemini tool_use blocks must not leak into persisted text."""
+    parts = [
+        {"type": "text", "text": "real answer"},
+        {"type": "tool_use", "name": "x", "input": {}},
+    ]
+    assert _coerce_llm_content(parts) == "real answer"
+
+
+def test_coerce_llm_content_passthrough_string() -> None:
+    assert _coerce_llm_content("plain") == "plain"
+
+
+# ─────────────────────────────────────────────────────────────
+# Model defaults / legacy compat
+# ─────────────────────────────────────────────────────────────
+
+
+def test_legacy_session_json_fills_rag_defaults() -> None:
+    """Sessions persisted before the schema change should still parse."""
+    legacy = {
+        "id": "abc",
+        "name": "legacy",
+        "messages": [],
+        "executions": [],
+        # explicitly no rag_k / rag_hybrid_override / rag_rerank_override
+    }
+    sess = PlaygroundSession(**legacy)
+    assert sess.rag_k == 5
+    assert sess.rag_hybrid_override is None
+    assert sess.rag_rerank_override is None
+
+
+def test_request_carries_per_call_rag_overrides() -> None:
+    req = PlaygroundExecuteRequest(
+        prompt="hi",
+        rag_k=12,
+        rag_hybrid_override=True,
+        rag_rerank_override=False,
+    )
+    assert req.rag_k == 12
+    assert req.rag_hybrid_override is True
+    assert req.rag_rerank_override is False
+
+
+def test_default_system_prompt_is_gemini_specific() -> None:
+    assert "단일 출처" in DEFAULT_SYSTEM_PROMPT
+    assert "제공된 컨텍스트에 없습니다" in DEFAULT_SYSTEM_PROMPT
+
+
+# ─────────────────────────────────────────────────────────────
+# LLMService message building + force-final
+# ─────────────────────────────────────────────────────────────
+
+
+def test_build_messages_separates_rag_into_system_message() -> None:
+    msgs = _build_messages(
+        system_prompt="Sys",
+        history=[HumanMessage(content="prev_u"), AIMessage(content="prev_a")],
+        prompt="current",
+        rag_context="RAG BLOCK",
+        extra_context={"k": "v"},
+    )
+    # System, RAG-System, prev_u, prev_a, current-Human
+    assert len(msgs) == 5
+    assert isinstance(msgs[0], SystemMessage) and msgs[0].content == "Sys"
+    assert isinstance(msgs[1], SystemMessage)
+    assert "RAG BLOCK" in msgs[1].content
+    assert "source of truth" in msgs[1].content.lower()
+    assert isinstance(msgs[2], HumanMessage) and msgs[2].content == "prev_u"
+    assert isinstance(msgs[3], AIMessage) and msgs[3].content == "prev_a"
+    assert isinstance(msgs[4], HumanMessage)
+    assert "current" in msgs[4].content
+    assert "- k: v" in msgs[4].content
+
+
+def test_build_messages_without_history_or_rag() -> None:
+    msgs = _build_messages(
+        system_prompt=None,
+        history=None,
+        prompt="just ask",
+    )
+    assert len(msgs) == 1
+    assert isinstance(msgs[0], HumanMessage)
+    assert msgs[0].content == "just ask"
+
+
+@pytest.mark.asyncio
+async def test_invoke_with_tools_force_final_on_budget_exhaustion() -> None:
+    """When tool iterations run out we must still return a real answer."""
+    # Mock LLM that *always* wants to call a tool, forcing budget exhaustion.
+    mock_llm = MagicMock()
+
+    always_tool_response = MagicMock()
+    always_tool_response.content = ""
+    always_tool_response.tool_calls = [
+        {"name": "web_search", "args": {"query": "x"}, "id": "t1"}
+    ]
+    always_tool_response.usage_metadata = {"input_tokens": 10, "output_tokens": 2}
+
+    # Raw llm.ainvoke (used for the force-final round) returns a clean answer.
+    forced_final = MagicMock()
+    forced_final.content = "final synthesized answer"
+    forced_final.usage_metadata = {"input_tokens": 20, "output_tokens": 5}
+
+    mock_llm.ainvoke = AsyncMock(return_value=forced_final)
+    mock_bound = MagicMock()
+    mock_bound.ainvoke = AsyncMock(return_value=always_tool_response)
+    mock_llm.bind_tools = MagicMock(return_value=mock_bound)
+
+    async def fake_exec(_name, _args, working_directory=None):
+        return {"success": True, "results": []}
+
+    with (
+        patch.object(LLMService, "_get_llm", return_value=mock_llm),
+        patch("services.playground_tools.execute_tool", side_effect=fake_exec),
+    ):
+        resp = await LLMService.invoke_with_tools(
+            prompt="q",
+            tools=["web_search"],
+            model_id="gemini-3.1-pro-preview",
+            max_tool_iterations=2,
+        )
+
+    assert resp.content == "final synthesized answer"
+    # Budget of 2 rounds -> 2 tool calls recorded before force-final kicks in
+    assert len(resp.tool_calls) == 2
+
+
+# ─────────────────────────────────────────────────────────────
+# Web search provider dispatch
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_web_search_uses_tavily_when_key_set(monkeypatch) -> None:
+    from services import playground_tools
+
+    async def fake_tavily(query, max_results, api_key):
+        return {
+            "success": True,
+            "query": query,
+            "provider": "tavily",
+            "results": [{"title": "t", "url": "u", "snippet": "s", "score": 0.9}],
+            "total": 1,
+            "answer": "synthesized",
+        }
+
+    monkeypatch.setenv("TAVILY_API_KEY", "fake-key")
+    monkeypatch.setattr(playground_tools.PlaygroundTools, "_web_search_tavily", fake_tavily)
+
+    res = await playground_tools.PlaygroundTools.web_search("test", 3)
+    assert res["provider"] == "tavily"
+    assert res["answer"] == "synthesized"
+
+
+@pytest.mark.asyncio
+async def test_web_search_falls_back_to_ddg_without_key(monkeypatch) -> None:
+    from services import playground_tools
+
+    async def fake_ddg(query, max_results=5):
+        return {"success": True, "provider": "duckduckgo", "results": []}
+
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.setattr(playground_tools.PlaygroundTools, "_web_search_ddg", fake_ddg)
+
+    res = await playground_tools.PlaygroundTools.web_search("test", 3)
+    assert res["provider"] == "duckduckgo"

--- a/tests/backend/test_rag_verification.py
+++ b/tests/backend/test_rag_verification.py
@@ -462,9 +462,9 @@ class TestTroubleshooting:
         # 기본 임베딩 제공자가 일관되는지
         assert rag_mod.EMBEDDING_PROVIDER in ("huggingface", "openai", "google")
 
-        # HuggingFace 기본값 확인
+        # HuggingFace 기본값 확인 (BAAI/bge-m3 — 다국어, 1024-dim)
         if rag_mod.EMBEDDING_PROVIDER == "huggingface":
-            assert rag_mod.DEFAULT_EMBEDDING_MODEL == "sentence-transformers/all-MiniLM-L6-v2"
+            assert rag_mod.DEFAULT_EMBEDDING_MODEL == "BAAI/bge-m3"
         elif rag_mod.EMBEDDING_PROVIDER == "openai":
             assert rag_mod.DEFAULT_EMBEDDING_MODEL == "text-embedding-3-small"
         elif rag_mod.EMBEDDING_PROVIDER == "google":


### PR DESCRIPTION
## Summary
- Main branch CI가 계속 실패하던 원인 수정 — 테스트의 assert만 outdated.
- \`services/rag_service.py:91\`은 이미 \`DEFAULT_EMBEDDING_MODEL = \"BAAI/bge-m3\"\`인데 테스트는 \`sentence-transformers/all-MiniLM-L6-v2\`를 기대하고 있었음.

## Root Cause
최근 RAG 개선 커밋들(\`080c1cd feat(rag): fair cross-project retrieval with rerank\` 외)에서 기본 HuggingFace 임베딩 모델을 \`BAAI/bge-m3\`로 업그레이드했으나, \`test_rag_verification.py:467\`의 assert를 함께 업데이트하지 않아 main CI가 지속 실패 상태였음.

## Changes
- \`tests/backend/test_rag_verification.py:467\`: expected 값을 \`BAAI/bge-m3\`로 수정 + 주석 갱신

## Test Plan
- [x] \`pytest tests/backend/test_rag_verification.py::TestTroubleshooting::test_embedding_model_consistency\` → PASSED
- [x] 전체 RAG verification 스위트에 영향 없음 (assert 값만 교체)

🤖 Generated with [Claude Code](https://claude.com/claude-code)