### PR TITLE
chore: ignore nested .claude runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,14 @@ src/dashboard/coverage/
 .claude/gemini-daemon/.daemon-disabled
 .claude/snapshots/
 .claude/scheduled_tasks.lock
+
+# Nested .claude/ runtime artifacts (e.g. src/backend/.claude/, src/dashboard/.claude/)
+**/.claude/coordination/
+**/.claude/gemini-bridge/daemon.log
+**/.claude/gemini-bridge/.review-lock
+**/.claude/gemini-bridge/reviews/
+**/.claude/gemini-daemon/daemon.log
+**/.claude/snapshots/
 .temp/
 
 # TypeScript incremental build cache


### PR DESCRIPTION
## Summary
- Root `.gitignore` patterns like `.claude/coordination/` are anchored to the repo root due to their mid-path slash, so runtime artifacts produced under `src/backend/.claude/` and `src/dashboard/.claude/` were not being ignored.
- Add `**/.claude/...` variants so the same rules apply at any depth, preventing accidental commits of gemini-bridge daemon logs and coordination state JSON.

## Changes
- `.gitignore`: add 6 `**/.claude/...` patterns (coordination, gemini-bridge daemon.log/.review-lock/reviews, gemini-daemon daemon.log, snapshots)

## Test Plan
- [x] `git check-ignore -v src/backend/.claude/coordination/gemini-state.json` → matches new rule at `.gitignore:78`
- [x] `git check-ignore -v src/backend/.claude/gemini-bridge/daemon.log` → matches `.gitignore:79`
- [x] Same checks for `src/dashboard/.claude/...` — both match
- [x] `git status` no longer lists `src/backend/.claude/` or `src/dashboard/.claude/` as untracked

## Why merge this first
This is the first of 4 split PRs. Merging this first prevents daemon logs and coordination JSON from leaking into the subsequent playground/projects/rag PRs if the daemon writes to them during review.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)