### PR TITLE
feat(playground): opt-in rules & memory injection into system prompt

### DIFF
--- a/src/backend/alembic/versions/d1a2b3c4e5f7_add_rules_memory_injection_to_playground.py
+++ b/src/backend/alembic/versions/d1a2b3c4e5f7_add_rules_memory_injection_to_playground.py
@@ -1,0 +1,51 @@
+"""add rules/memory injection columns to playground_sessions
+
+Revision ID: d1a2b3c4e5f7
+Revises: c9f1e52a3b7c
+Create Date: 2026-04-20
+
+Adds per-session opt-in columns for Claude Code rule and memory injection
+into the playground LLM system prompt:
+
+- ``rules_mode``       : off | global | project | both
+- ``memory_mode``      : off | index | full
+- ``selected_rule_ids``/``selected_memory_ids``: JSONB allow-list (empty = all)
+- ``context_budget_tokens``: soft cap on injected size
+
+Idempotent ADD COLUMN IF NOT EXISTS for safe re-runs.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "d1a2b3c4e5f7"
+down_revision: str | Sequence[str] | None = "c9f1e52a3b7c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE playground_sessions
+            ADD COLUMN IF NOT EXISTS rules_mode VARCHAR(16) NOT NULL DEFAULT 'off',
+            ADD COLUMN IF NOT EXISTS memory_mode VARCHAR(16) NOT NULL DEFAULT 'off',
+            ADD COLUMN IF NOT EXISTS selected_rule_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+            ADD COLUMN IF NOT EXISTS selected_memory_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+            ADD COLUMN IF NOT EXISTS context_budget_tokens INTEGER NOT NULL DEFAULT 8000
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE playground_sessions
+            DROP COLUMN IF EXISTS rules_mode,
+            DROP COLUMN IF EXISTS memory_mode,
+            DROP COLUMN IF EXISTS selected_rule_ids,
+            DROP COLUMN IF EXISTS selected_memory_ids,
+            DROP COLUMN IF EXISTS context_budget_tokens
+        """
+    )

--- a/src/backend/api/playground.py
+++ b/src/backend/api/playground.py
@@ -1,10 +1,11 @@
 """Playground API routes."""
 
 import logging
+from typing import Literal
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.deps import get_current_user_optional
 from api.rag import trigger_background_indexing
@@ -20,6 +21,7 @@ from models.playground import (
 )
 from models.project import PROJECTS_REGISTRY, get_project
 from services.llm_service import LLMService
+from services.playground_context import build_effective_system_prompt
 from services.playground_service import PlaygroundService
 
 logger = logging.getLogger(__name__)
@@ -61,6 +63,49 @@ async def get_session(session_id: str):
     return session
 
 
+class EffectiveSystemPromptResponse(BaseModel):
+    """Preview of the system prompt that will be sent to the LLM."""
+
+    session_id: str
+    system_prompt: str
+    base_length: int
+    effective_length: int
+    rules_mode: str
+    memory_mode: str
+
+
+@router.get(
+    "/sessions/{session_id}/effective-system-prompt",
+    response_model=EffectiveSystemPromptResponse,
+)
+async def get_effective_system_prompt(
+    session_id: str,
+    current_user: UserModel | None = Depends(get_current_user_optional),
+):
+    """Preview the final system prompt that will be sent to the LLM.
+
+    Includes the session base ``system_prompt`` plus any rules/memory bodies
+    selected by ``rules_mode`` / ``memory_mode``. Useful for debugging why
+    the model behaves (or doesn't behave) as expected.
+    """
+    session = PlaygroundService.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    # Authorization: if a user is attached to the session, require match.
+    if current_user and session.user_id and session.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+
+    effective = build_effective_system_prompt(session)
+    return EffectiveSystemPromptResponse(
+        session_id=session.id,
+        system_prompt=effective,
+        base_length=len(session.system_prompt or ""),
+        effective_length=len(effective),
+        rules_mode=session.rules_mode,
+        memory_mode=session.memory_mode,
+    )
+
+
 @router.delete("/sessions/{session_id}")
 async def delete_session(session_id: str):
     """Delete a playground session."""
@@ -86,6 +131,12 @@ class SessionSettingsUpdate(BaseModel):
     rag_hybrid_override: bool | None = None
     rag_rerank_override: bool | None = None
     rag_include_shared: bool | None = None
+    # Claude Code rules / memory injection
+    rules_mode: Literal["off", "global", "project", "both"] | None = None
+    memory_mode: Literal["off", "index", "full"] | None = None
+    selected_rule_ids: list[str] | None = None
+    selected_memory_ids: list[str] | None = None
+    context_budget_tokens: int | None = Field(default=None, ge=500, le=64000)
 
 
 @router.patch("/sessions/{session_id}/settings", response_model=PlaygroundSession)
@@ -111,6 +162,11 @@ async def update_session_settings(
         rag_hybrid_override=data.rag_hybrid_override,
         rag_rerank_override=data.rag_rerank_override,
         rag_include_shared=data.rag_include_shared,
+        rules_mode=data.rules_mode,
+        memory_mode=data.memory_mode,
+        selected_rule_ids=data.selected_rule_ids,
+        selected_memory_ids=data.selected_memory_ids,
+        context_budget_tokens=data.context_budget_tokens,
     )
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/src/backend/db/models/playground.py
+++ b/src/backend/db/models/playground.py
@@ -46,6 +46,14 @@ class PlaygroundSessionModel(Base):
     # Include results from OTHER project collections (cross-project RAG)
     rag_include_shared = Column(Boolean, default=False, nullable=False, server_default="false")
 
+    # Claude Code rules / memory injection mode (opt-in).
+    # Modes are stored as strings; application layer validates via Literal.
+    rules_mode = Column(String(16), nullable=False, default="off", server_default="off")
+    memory_mode = Column(String(16), nullable=False, default="off", server_default="off")
+    selected_rule_ids = Column(JSONB, default=list, nullable=False, server_default="[]")
+    selected_memory_ids = Column(JSONB, default=list, nullable=False, server_default="[]")
+    context_budget_tokens = Column(Integer, nullable=False, default=8000, server_default="8000")
+
     # Tools
     available_tools = Column(JSONB, default=list)
     enabled_tools = Column(JSONB, default=list)

--- a/src/backend/models/playground.py
+++ b/src/backend/models/playground.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -107,6 +107,18 @@ class PlaygroundSession(BaseModel):
     # (e.g. Obsidian).
     rag_include_shared: bool = False
 
+    # Claude Code rules / memory injection (opt-in).
+    # When a mode is not "off", matching rule/memory bodies are prepended to
+    # ``system_prompt`` at LLM invocation time. See
+    # ``services.playground_context.build_effective_system_prompt``.
+    rules_mode: Literal["off", "global", "project", "both"] = "off"
+    memory_mode: Literal["off", "index", "full"] = "off"
+    # Empty list = "include everything allowed by mode". Non-empty = allow-list.
+    selected_rule_ids: list[str] = Field(default_factory=list)
+    selected_memory_ids: list[str] = Field(default_factory=list)
+    # Soft cap on total tokens injected for rules + memory (LLM-independent).
+    context_budget_tokens: int = Field(default=8000, ge=500, le=64000)
+
     # Tools
     available_tools: list[str] = Field(default_factory=list)
     enabled_tools: list[str] = Field(default_factory=list)
@@ -137,6 +149,13 @@ class PlaygroundSessionCreate(BaseModel):
     model: str = Field(default_factory=_get_default_model)
     system_prompt: str | None = None
     rag_enabled: bool = False
+
+    # Optional at creation time — can also be edited later via settings PATCH.
+    rules_mode: Literal["off", "global", "project", "both"] = "off"
+    memory_mode: Literal["off", "index", "full"] = "off"
+    selected_rule_ids: list[str] = Field(default_factory=list)
+    selected_memory_ids: list[str] = Field(default_factory=list)
+    context_budget_tokens: int = Field(default=8000, ge=500, le=64000)
 
 
 class PlaygroundExecuteRequest(BaseModel):

--- a/src/backend/services/playground_context.py
+++ b/src/backend/services/playground_context.py
@@ -1,0 +1,241 @@
+"""Build effective system prompt for playground LLM calls.
+
+Composes the session's base ``system_prompt`` with Claude Code rules and
+memory entries, so the playground's answering LLM shares the same guidance
+Claude Code itself operates under.
+
+Design notes:
+- Rules and memory are **concatenated into the system prompt string** rather
+  than retrieved via RAG similarity. Rules are "always apply" guidance; RAG
+  similarity would cause them to flicker in/out per question.
+- LLM pipeline (``LLMService.invoke`` / ``invoke_with_tools``) is not
+  modified — it receives a single ``system_prompt`` string as before.
+- Inclusion is opt-in via ``PlaygroundSession.rules_mode`` and
+  ``PlaygroundSession.memory_mode``.
+- A soft token budget (``context_budget_tokens``) bounds total injected size.
+  Estimation uses ``len(text) // 4`` which is good enough for a truncation
+  trigger in mixed Korean/English bodies.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+from models.playground import PlaygroundSession
+from models.project_config import MemoryConfig, RuleConfig
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────
+# Narrow protocol so tests can stub without importing the heavy
+# ProjectConfigMonitor singleton.
+# ─────────────────────────────────────────────────────────────
+
+
+class _ConfigSource(Protocol):
+    def get_global_rules(self) -> list[RuleConfig]: ...
+
+    def get_project_rules(self, project_id: str) -> list[RuleConfig]: ...
+
+    def get_rule_content(
+        self, project_id: str, rule_id: str, is_global: bool = False
+    ) -> tuple[RuleConfig | None, str]: ...
+
+    def get_project_memories(self, project_id: str) -> list[MemoryConfig]: ...
+
+    def get_memory_content(
+        self, project_id: str, memory_id: str
+    ) -> tuple[MemoryConfig | None, str]: ...
+
+    def get_memory_index(self, project_id: str) -> str: ...
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate used only for soft-capping injected context."""
+    return max(1, len(text) // 4)
+
+
+def _truncate_to_budget(body: str, token_budget: int) -> str:
+    """Trim the tail of a body so its estimated tokens fit the budget.
+
+    We slice on a character boundary proportional to the budget, then append
+    a visible marker so the model knows content was omitted.
+    """
+    if _estimate_tokens(body) <= token_budget:
+        return body
+    char_budget = max(200, token_budget * 4 - 40)  # leave room for marker
+    return body[:char_budget].rstrip() + "\n\n…[truncated]"
+
+
+def _strip_frontmatter(body: str) -> str:
+    """Drop a leading YAML frontmatter block if present.
+
+    Rules/memory files often begin with ``---\\n...\\n---`` which is
+    metadata for tooling and wastes tokens in the prompt.
+    """
+    lines = body.splitlines()
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                return "\n".join(lines[i + 1 :]).lstrip("\n")
+    return body
+
+
+def _format_section(header: str, body: str) -> str:
+    return f"\n\n### {header}\n{body.strip()}\n"
+
+
+# ─────────────────────────────────────────────────────────────
+# Collection helpers
+# ─────────────────────────────────────────────────────────────
+
+
+def _collect_rules(session: PlaygroundSession, source: _ConfigSource) -> list[tuple[str, str]]:
+    """Return ``[(header, body), ...]`` for rules selected by session."""
+    if session.rules_mode == "off":
+        return []
+
+    include_global = session.rules_mode in ("global", "both")
+    include_project = session.rules_mode in ("project", "both") and bool(session.project_id)
+    allow_list = set(session.selected_rule_ids)
+
+    entries: list[tuple[str, str]] = []
+
+    if include_global:
+        for rule in source.get_global_rules():
+            if allow_list and rule.rule_id not in allow_list:
+                continue
+            _, content = source.get_rule_content("global", rule.rule_id, is_global=True)
+            if not content:
+                continue
+            header = f"Global Rule · {rule.name or rule.rule_id}"
+            entries.append((header, _strip_frontmatter(content)))
+
+    if include_project and session.project_id:
+        for rule in source.get_project_rules(session.project_id):
+            if allow_list and rule.rule_id not in allow_list:
+                continue
+            _, content = source.get_rule_content(session.project_id, rule.rule_id, is_global=False)
+            if not content:
+                continue
+            header = f"Project Rule · {rule.name or rule.rule_id}"
+            entries.append((header, _strip_frontmatter(content)))
+
+    return entries
+
+
+def _collect_memories(session: PlaygroundSession, source: _ConfigSource) -> list[tuple[str, str]]:
+    """Return ``[(header, body), ...]`` for memory entries selected by session."""
+    if session.memory_mode == "off" or not session.project_id:
+        return []
+
+    entries: list[tuple[str, str]] = []
+
+    index_body = source.get_memory_index(session.project_id)
+    if index_body.strip():
+        entries.append(("Memory Index (MEMORY.md)", index_body))
+
+    if session.memory_mode == "full":
+        allow_list = set(session.selected_memory_ids)
+        for memory in source.get_project_memories(session.project_id):
+            if allow_list and memory.memory_id not in allow_list:
+                continue
+            _, content = source.get_memory_content(session.project_id, memory.memory_id)
+            if not content:
+                continue
+            header = f"Memory · {memory.name or memory.memory_id}"
+            entries.append((header, _strip_frontmatter(content)))
+
+    return entries
+
+
+# ─────────────────────────────────────────────────────────────
+# Budget enforcement
+# ─────────────────────────────────────────────────────────────
+
+
+def _fit_to_budget(entries: list[tuple[str, str]], token_budget: int) -> list[tuple[str, str]]:
+    """Keep short entries intact; truncate the longest when over budget.
+
+    Strategy: sort by length ascending, admit while the running total fits.
+    Once an entry would overflow, admit a truncated version and stop.
+    """
+    if token_budget <= 0:
+        return []
+
+    ordered = sorted(entries, key=lambda e: len(e[1]))
+    fitted: list[tuple[str, str]] = []
+    remaining = token_budget
+
+    for header, body in ordered:
+        cost = _estimate_tokens(body) + _estimate_tokens(header) + 8  # headers+glue
+        if cost <= remaining:
+            fitted.append((header, body))
+            remaining -= cost
+            continue
+        if remaining > 100:
+            trimmed = _truncate_to_budget(body, remaining - _estimate_tokens(header) - 8)
+            fitted.append((header, trimmed))
+        break
+
+    # Restore original order so the prompt reads top-down (global → project →
+    # memory), not length-sorted.
+    original_order = {id(e): i for i, e in enumerate(entries)}
+    fitted.sort(key=lambda e: original_order.get(id(e), 1_000_000))
+    return fitted
+
+
+# ─────────────────────────────────────────────────────────────
+# Public API
+# ─────────────────────────────────────────────────────────────
+
+
+def build_effective_system_prompt(
+    session: PlaygroundSession,
+    source: _ConfigSource | None = None,
+) -> str:
+    """Compose the final system prompt sent to the LLM.
+
+    Returns ``session.system_prompt`` unchanged when no rule/memory modes are
+    active. Never raises on manager errors — falls back to the base prompt
+    with a logged warning, so a bad rule file cannot break playground.
+    """
+    base_prompt = session.system_prompt or ""
+
+    if session.rules_mode == "off" and session.memory_mode == "off":
+        return base_prompt
+
+    try:
+        if source is None:
+            # Local import to avoid a top-level cycle (monitor imports many
+            # services that may transitively import this module).
+            from services.project_config_monitor import get_project_config_monitor
+
+            source = get_project_config_monitor()
+
+        rule_entries = _collect_rules(session, source)
+        memory_entries = _collect_memories(session, source)
+    except Exception as e:  # pragma: no cover — defensive
+        logger.warning("Failed to collect rules/memory for session %s: %s", session.id, e)
+        return base_prompt
+
+    all_entries = rule_entries + memory_entries
+    fitted = _fit_to_budget(all_entries, session.context_budget_tokens)
+
+    if not fitted:
+        return base_prompt
+
+    sections = [_format_section(h, b) for h, b in fitted]
+    header_note = (
+        "\n\n---\n"
+        "## Claude Code Context\n"
+        "The following rules and memory entries reflect the user's global and "
+        "project-specific guidance. Follow them unless they conflict with the "
+        "session's base instructions above."
+    )
+    return f"{base_prompt}{header_note}{''.join(sections)}".strip() or base_prompt
+
+
+__all__ = ["build_effective_system_prompt"]

--- a/src/backend/services/playground_service.py
+++ b/src/backend/services/playground_service.py
@@ -24,6 +24,7 @@ from models.playground import (
     PlaygroundToolTest,
 )
 from services.llm_service import LLMResponse, LLMService
+from services.playground_context import build_effective_system_prompt
 from utils.time import utcnow
 
 logger = logging.getLogger(__name__)
@@ -285,6 +286,11 @@ class PlaygroundService:
             model=data.model,
             system_prompt=data.system_prompt or DEFAULT_SYSTEM_PROMPT,
             rag_enabled=data.rag_enabled,
+            rules_mode=data.rules_mode,
+            memory_mode=data.memory_mode,
+            selected_rule_ids=list(data.selected_rule_ids),
+            selected_memory_ids=list(data.selected_memory_ids),
+            context_budget_tokens=data.context_budget_tokens,
             available_tools=list(PLAYGROUND_TOOLS.keys()),
         )
         _sessions[session.id] = session
@@ -340,6 +346,11 @@ class PlaygroundService:
         rag_hybrid_override: bool | None = None,
         rag_rerank_override: bool | None = None,
         rag_include_shared: bool | None = None,
+        rules_mode: str | None = None,
+        memory_mode: str | None = None,
+        selected_rule_ids: list[str] | None = None,
+        selected_memory_ids: list[str] | None = None,
+        context_budget_tokens: int | None = None,
     ) -> PlaygroundSession | None:
         """Update session settings."""
         _load_sessions()  # Ensure sessions are loaded
@@ -375,6 +386,16 @@ class PlaygroundService:
             session.rag_rerank_override = rag_rerank_override
         if rag_include_shared is not None:
             session.rag_include_shared = rag_include_shared
+        if rules_mode is not None:
+            session.rules_mode = rules_mode  # type: ignore[assignment]
+        if memory_mode is not None:
+            session.memory_mode = memory_mode  # type: ignore[assignment]
+        if selected_rule_ids is not None:
+            session.selected_rule_ids = list(selected_rule_ids)
+        if selected_memory_ids is not None:
+            session.selected_memory_ids = list(selected_memory_ids)
+        if context_budget_tokens is not None:
+            session.context_budget_tokens = context_budget_tokens
 
         session.updated_at = utcnow()
         _save_sessions()  # Persist to file
@@ -463,13 +484,17 @@ class PlaygroundService:
             # Check if tools are enabled
             enabled_tools = execution.tools_enabled or []
 
+            # Compose the session system prompt with opt-in rules/memory once
+            # per invocation (identical for tool and non-tool paths).
+            effective_system_prompt = build_effective_system_prompt(session)
+
             if enabled_tools:
                 # Use tool-enabled LLM invocation
                 llm_response: LLMResponse = await LLMService.invoke_with_tools(
                     prompt=request.prompt,
                     tools=enabled_tools,
                     model_id=session.model,
-                    system_prompt=session.system_prompt,
+                    system_prompt=effective_system_prompt,
                     temperature=execution.temperature,
                     max_tokens=execution.max_tokens,
                     context=request.context or None,
@@ -496,7 +521,7 @@ class PlaygroundService:
                 llm_response = await LLMService.invoke(
                     prompt=request.prompt,
                     model_id=session.model,
-                    system_prompt=session.system_prompt,
+                    system_prompt=effective_system_prompt,
                     temperature=execution.temperature,
                     max_tokens=execution.max_tokens,
                     context=request.context or None,
@@ -627,6 +652,9 @@ class PlaygroundService:
         full_response = ""
         token_info: dict | None = None
 
+        # Compose once — shared by streaming and tool-enabled branches.
+        effective_system_prompt = build_effective_system_prompt(session)
+
         try:
             if enabled_tools:
                 # Tool-enabled: single-shot invoke_with_tools, yield final answer.
@@ -634,7 +662,7 @@ class PlaygroundService:
                     prompt=request.prompt,
                     tools=enabled_tools,
                     model_id=session.model,
-                    system_prompt=session.system_prompt,
+                    system_prompt=effective_system_prompt,
                     temperature=temperature,
                     max_tokens=max_tokens,
                     context=request.context or None,
@@ -655,7 +683,7 @@ class PlaygroundService:
                 async for chunk, info in LLMService.stream_with_tokens(
                     prompt=request.prompt,
                     model_id=session.model,
-                    system_prompt=session.system_prompt,
+                    system_prompt=effective_system_prompt,
                     temperature=temperature,
                     max_tokens=max_tokens,
                     context=request.context or None,
@@ -874,6 +902,11 @@ class PlaygroundService:
             rag_hybrid_override=getattr(model, "rag_hybrid_override", None),
             rag_rerank_override=getattr(model, "rag_rerank_override", None),
             rag_include_shared=bool(getattr(model, "rag_include_shared", False)),
+            rules_mode=getattr(model, "rules_mode", None) or "off",
+            memory_mode=getattr(model, "memory_mode", None) or "off",
+            selected_rule_ids=list(getattr(model, "selected_rule_ids", None) or []),
+            selected_memory_ids=list(getattr(model, "selected_memory_ids", None) or []),
+            context_budget_tokens=getattr(model, "context_budget_tokens", None) or 8000,
             available_tools=model.available_tools or [],
             enabled_tools=model.enabled_tools or [],
             messages=[PlaygroundMessage(**m) for m in (model.messages or [])],
@@ -904,6 +937,11 @@ class PlaygroundService:
             "rag_hybrid_override": session.rag_hybrid_override,
             "rag_rerank_override": session.rag_rerank_override,
             "rag_include_shared": session.rag_include_shared,
+            "rules_mode": session.rules_mode,
+            "memory_mode": session.memory_mode,
+            "selected_rule_ids": list(session.selected_rule_ids),
+            "selected_memory_ids": list(session.selected_memory_ids),
+            "context_budget_tokens": session.context_budget_tokens,
             "available_tools": session.available_tools,
             "enabled_tools": session.enabled_tools,
             "messages": [m.model_dump(mode="json") for m in session.messages],

--- a/src/dashboard/src/pages/PlaygroundPage.tsx
+++ b/src/dashboard/src/pages/PlaygroundPage.tsx
@@ -83,6 +83,11 @@ interface PlaygroundSession {
   rag_hybrid_override: boolean | null
   rag_rerank_override: boolean | null
   rag_include_shared: boolean
+  rules_mode: 'off' | 'global' | 'project' | 'both'
+  memory_mode: 'off' | 'index' | 'full'
+  selected_rule_ids: string[]
+  selected_memory_ids: string[]
+  context_budget_tokens: number
   available_tools: string[]
   enabled_tools: string[]
   messages: PlaygroundMessage[]
@@ -202,6 +207,11 @@ async function updateSettings(
     rag_hybrid_override: boolean | null
     rag_rerank_override: boolean | null
     rag_include_shared: boolean
+    rules_mode: 'off' | 'global' | 'project' | 'both'
+    memory_mode: 'off' | 'index' | 'full'
+    selected_rule_ids: string[]
+    selected_memory_ids: string[]
+    context_budget_tokens: number
   }>
 ): Promise<PlaygroundSession> {
   const res = await authFetch(`${API_BASE}/playground/sessions/${sessionId}/settings`, {
@@ -210,6 +220,53 @@ async function updateSettings(
     body: JSON.stringify(settings),
   })
   if (!res.ok) throw new Error('Failed to update settings')
+  return res.json()
+}
+
+interface RuleSummary {
+  rule_id: string
+  name: string
+  description: string
+  is_global: boolean
+}
+
+interface MemorySummary {
+  memory_id: string
+  name: string
+  description: string
+}
+
+async function fetchProjectConfigByPath(
+  projectPath: string
+): Promise<{ rules: RuleSummary[]; memories: MemorySummary[] } | null> {
+  const res = await authFetch(
+    `${API_BASE}/project-configs/by-path?path=${encodeURIComponent(projectPath)}`
+  )
+  if (!res.ok) return null
+  const data = (await res.json()) as {
+    rules?: RuleSummary[]
+    memories?: MemorySummary[]
+  }
+  return {
+    rules: data.rules ?? [],
+    memories: data.memories ?? [],
+  }
+}
+
+async function fetchGlobalRules(): Promise<RuleSummary[]> {
+  const res = await authFetch(`${API_BASE}/project-configs/global/rules`)
+  if (!res.ok) return []
+  const data = (await res.json()) as unknown
+  return Array.isArray(data) ? (data as RuleSummary[]) : []
+}
+
+async function fetchEffectiveSystemPrompt(
+  sessionId: string
+): Promise<{ system_prompt: string; base_length: number; effective_length: number }> {
+  const res = await authFetch(
+    `${API_BASE}/playground/sessions/${sessionId}/effective-system-prompt`
+  )
+  if (!res.ok) throw new Error('Failed to fetch effective system prompt')
   return res.json()
 }
 
@@ -288,6 +345,14 @@ export function PlaygroundPage() {
   const [mdReadStatuses, setMdReadStatuses] = useState<Record<string, 'reading' | 'done' | 'error'>>({})
   const [isDragOver, setIsDragOver] = useState(false)
 
+  // Context injection (Claude Code rules + memory)
+  const [globalRules, setGlobalRules] = useState<RuleSummary[]>([])
+  const [projectRules, setProjectRules] = useState<RuleSummary[]>([])
+  const [projectMemories, setProjectMemories] = useState<MemorySummary[]>([])
+  const [showEffectivePrompt, setShowEffectivePrompt] = useState(false)
+  const [effectivePromptText, setEffectivePromptText] = useState('')
+  const [effectivePromptLoading, setEffectivePromptLoading] = useState(false)
+
   useEffect(() => {
     loadData()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -296,6 +361,54 @@ export function PlaygroundPage() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [currentSession?.messages])
+
+  // Load Claude Code rules/memories whenever the session's project changes —
+  // these lists drive the "Context injection" multi-selects in the settings
+  // panel. Global rules are fetched once; project-scoped ones refetch per
+  // selected project.
+  useEffect(() => {
+    let cancelled = false
+    fetchGlobalRules()
+      .then((rules) => {
+        if (!cancelled) setGlobalRules(rules)
+      })
+      .catch(() => {
+        if (!cancelled) setGlobalRules([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const projectId = currentSession?.project_id ?? null
+    if (!projectId) {
+      setProjectRules([])
+      setProjectMemories([])
+      return
+    }
+    const project = projects.find((p) => p.id === projectId)
+    if (!project) {
+      setProjectRules([])
+      setProjectMemories([])
+      return
+    }
+    fetchProjectConfigByPath(project.path)
+      .then((summary) => {
+        if (cancelled || !summary) return
+        setProjectRules(summary.rules)
+        setProjectMemories(summary.memories)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setProjectRules([])
+        setProjectMemories([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [currentSession?.project_id, projects])
 
   // Poll indexing status for projects that are currently indexing
   useEffect(() => {
@@ -424,6 +537,41 @@ export function PlaygroundPage() {
     } catch (e) {
       handleError(e)
     }
+  }
+
+  // Fetch the fully-composed system prompt (base + rules + memory) and open
+  // the preview modal. Keeps UI honest about what the LLM actually receives.
+  const handleShowEffectivePrompt = async () => {
+    if (!currentSession) return
+    setEffectivePromptLoading(true)
+    setShowEffectivePrompt(true)
+    try {
+      const result = await fetchEffectiveSystemPrompt(currentSession.id)
+      setEffectivePromptText(result.system_prompt)
+    } catch (e) {
+      handleError(e)
+      setEffectivePromptText('')
+    } finally {
+      setEffectivePromptLoading(false)
+    }
+  }
+
+  const toggleRuleSelection = (ruleId: string) => {
+    if (!currentSession) return
+    const current = currentSession.selected_rule_ids ?? []
+    const next = current.includes(ruleId)
+      ? current.filter((id) => id !== ruleId)
+      : [...current, ruleId]
+    void handleUpdateSettings({ selected_rule_ids: next })
+  }
+
+  const toggleMemorySelection = (memoryId: string) => {
+    if (!currentSession) return
+    const current = currentSession.selected_memory_ids ?? []
+    const next = current.includes(memoryId)
+      ? current.filter((id) => id !== memoryId)
+      : [...current, memoryId]
+    void handleUpdateSettings({ selected_memory_ids: next })
   }
 
   const handleDeleteMessage = async (messageId: string) => {
@@ -863,6 +1011,172 @@ export function PlaygroundPage() {
                     />
                   </div>
 
+                  {/* Claude Code Context Injection */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        Claude Context
+                      </label>
+                      <button
+                        type="button"
+                        onClick={handleShowEffectivePrompt}
+                        aria-label="Preview effective system prompt"
+                        className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                      >
+                        Preview
+                      </button>
+                    </div>
+
+                    {/* Rules mode */}
+                    <div>
+                      <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                        Rules
+                      </label>
+                      <select
+                        aria-label="Rules injection mode"
+                        value={currentSession.rules_mode}
+                        onChange={(e) =>
+                          handleUpdateSettings({
+                            rules_mode: e.target.value as PlaygroundSession['rules_mode'],
+                          })
+                        }
+                        className="w-full px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                      >
+                        <option value="off">Off</option>
+                        <option value="global">Global (~/.claude/rules)</option>
+                        <option value="project" disabled={!currentSession.project_id}>
+                          Project (.claude/rules)
+                        </option>
+                        <option value="both" disabled={!currentSession.project_id}>
+                          Both
+                        </option>
+                      </select>
+                    </div>
+
+                    {currentSession.rules_mode !== 'off' && (
+                      <div className="max-h-40 overflow-y-auto rounded border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800">
+                        {[...(currentSession.rules_mode !== 'project' ? globalRules : []),
+                          ...((currentSession.rules_mode === 'project' ||
+                            currentSession.rules_mode === 'both') ? projectRules : []),
+                        ].map((rule) => {
+                          const selected = (currentSession.selected_rule_ids ?? []).includes(rule.rule_id)
+                          // Empty selection means "include all allowed by mode"
+                          const effectivelyOn = selected || (currentSession.selected_rule_ids ?? []).length === 0
+                          return (
+                            <label
+                              key={`${rule.is_global ? 'g' : 'p'}:${rule.rule_id}`}
+                              className="flex items-start gap-2 px-2 py-1.5 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={effectivelyOn}
+                                onChange={() => toggleRuleSelection(rule.rule_id)}
+                                className="mt-0.5 rounded border-gray-300 dark:border-gray-600"
+                                aria-label={`Toggle rule ${rule.name}`}
+                              />
+                              <span className="flex-1">
+                                <span className="font-medium text-gray-800 dark:text-gray-200">
+                                  {rule.is_global ? 'G · ' : 'P · '}{rule.name}
+                                </span>
+                                {rule.description && (
+                                  <span className="block text-gray-500 dark:text-gray-400 truncate">
+                                    {rule.description}
+                                  </span>
+                                )}
+                              </span>
+                            </label>
+                          )
+                        })}
+                        {globalRules.length === 0 && projectRules.length === 0 && (
+                          <div className="px-2 py-2 text-xs text-gray-500 dark:text-gray-400">
+                            No rules found.
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Memory mode */}
+                    <div>
+                      <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                        Memory
+                      </label>
+                      <select
+                        aria-label="Memory injection mode"
+                        value={currentSession.memory_mode}
+                        disabled={!currentSession.project_id}
+                        onChange={(e) =>
+                          handleUpdateSettings({
+                            memory_mode: e.target.value as PlaygroundSession['memory_mode'],
+                          })
+                        }
+                        className="w-full px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white disabled:opacity-50"
+                      >
+                        <option value="off">Off</option>
+                        <option value="index">Index only (MEMORY.md)</option>
+                        <option value="full">Full (index + files)</option>
+                      </select>
+                      {!currentSession.project_id && (
+                        <p className="text-[11px] text-gray-400 mt-1">
+                          프로젝트를 선택해야 메모리를 주입할 수 있습니다
+                        </p>
+                      )}
+                    </div>
+
+                    {currentSession.memory_mode === 'full' && projectMemories.length > 0 && (
+                      <div className="max-h-40 overflow-y-auto rounded border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800">
+                        {projectMemories.map((memory) => {
+                          const selected = (currentSession.selected_memory_ids ?? []).includes(memory.memory_id)
+                          const effectivelyOn = selected || (currentSession.selected_memory_ids ?? []).length === 0
+                          return (
+                            <label
+                              key={memory.memory_id}
+                              className="flex items-start gap-2 px-2 py-1.5 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={effectivelyOn}
+                                onChange={() => toggleMemorySelection(memory.memory_id)}
+                                className="mt-0.5 rounded border-gray-300 dark:border-gray-600"
+                                aria-label={`Toggle memory ${memory.name}`}
+                              />
+                              <span className="flex-1">
+                                <span className="font-medium text-gray-800 dark:text-gray-200">
+                                  {memory.name}
+                                </span>
+                                {memory.description && (
+                                  <span className="block text-gray-500 dark:text-gray-400 truncate">
+                                    {memory.description}
+                                  </span>
+                                )}
+                              </span>
+                            </label>
+                          )
+                        })}
+                      </div>
+                    )}
+
+                    {/* Token budget */}
+                    <div>
+                      <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                        Context budget (tokens)
+                      </label>
+                      <input
+                        type="number"
+                        min={500}
+                        max={64000}
+                        step={500}
+                        value={currentSession.context_budget_tokens}
+                        onChange={(e) => {
+                          const v = parseInt(e.target.value, 10)
+                          if (!Number.isNaN(v)) {
+                            handleUpdateSettings({ context_budget_tokens: v })
+                          }
+                        }}
+                        className="w-full px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                      />
+                    </div>
+                  </div>
+
                   {/* RAG Context */}
                   <div>
                     <label className="flex items-center gap-2 cursor-pointer">
@@ -1111,6 +1425,53 @@ export function PlaygroundPage() {
       )}
 
       {/* New Session Dialog */}
+      {showEffectivePrompt && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Effective system prompt preview"
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-3xl mx-4 max-h-[80vh] flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Effective System Prompt
+              </h3>
+              <button
+                onClick={() => setShowEffectivePrompt(false)}
+                className="p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                aria-label="Close preview"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="p-4 overflow-y-auto flex-1">
+              {effectivePromptLoading ? (
+                <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Loading…
+                </div>
+              ) : (
+                <pre className="text-xs whitespace-pre-wrap break-words font-mono text-gray-800 dark:text-gray-200">
+                  {effectivePromptText || '(empty)'}
+                </pre>
+              )}
+            </div>
+            <div className="p-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+              <span>
+                {effectivePromptText ? `${effectivePromptText.length} chars` : ''}
+              </span>
+              <button
+                onClick={() => setShowEffectivePrompt(false)}
+                className="px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {showNewSessionDialog && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md mx-4">

--- a/tests/backend/test_playground_context.py
+++ b/tests/backend/test_playground_context.py
@@ -1,0 +1,234 @@
+"""Unit tests for ``services.playground_context.build_effective_system_prompt``.
+
+These tests verify that Claude Code rules and memory bodies are composed
+into the playground LLM system prompt correctly across modes, without
+hitting the real filesystem. A stub ``_ConfigSource`` stands in for
+``ProjectConfigMonitor``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from models.playground import PlaygroundSession
+from models.project_config import MemoryConfig, RuleConfig
+from services.playground_context import build_effective_system_prompt
+
+
+# ─────────────────────────────────────────────────────────────
+# Stub config source
+# ─────────────────────────────────────────────────────────────
+
+
+def _rule(rule_id: str, is_global: bool, name: str, body: str) -> tuple[RuleConfig, str]:
+    cfg = RuleConfig(
+        rule_id=rule_id,
+        project_id="global" if is_global else "proj-1",
+        name=name,
+        description="",
+        file_path=f"/tmp/{rule_id}.md",
+        is_global=is_global,
+        modified_at=datetime.utcnow(),
+    )
+    return cfg, body
+
+
+def _memory(memory_id: str, name: str, body: str) -> tuple[MemoryConfig, str]:
+    cfg = MemoryConfig(
+        memory_id=memory_id,
+        project_id="proj-1",
+        name=name,
+        description="",
+        file_path=f"/tmp/{memory_id}.md",
+        memory_type="user",
+        modified_at=datetime.utcnow(),
+    )
+    return cfg, body
+
+
+@dataclass
+class _Stub:
+    global_rules: list[tuple[RuleConfig, str]] = field(default_factory=list)
+    project_rules: list[tuple[RuleConfig, str]] = field(default_factory=list)
+    memories: list[tuple[MemoryConfig, str]] = field(default_factory=list)
+    memory_index: str = ""
+
+    def get_global_rules(self) -> list[RuleConfig]:
+        return [c for c, _ in self.global_rules]
+
+    def get_project_rules(self, project_id: str) -> list[RuleConfig]:
+        return [c for c, _ in self.project_rules]
+
+    def get_rule_content(
+        self, project_id: str, rule_id: str, is_global: bool = False
+    ) -> tuple[RuleConfig | None, str]:
+        pool = self.global_rules if is_global else self.project_rules
+        for cfg, body in pool:
+            if cfg.rule_id == rule_id:
+                return cfg, body
+        return None, ""
+
+    def get_project_memories(self, project_id: str) -> list[MemoryConfig]:
+        return [c for c, _ in self.memories]
+
+    def get_memory_content(
+        self, project_id: str, memory_id: str
+    ) -> tuple[MemoryConfig | None, str]:
+        for cfg, body in self.memories:
+            if cfg.memory_id == memory_id:
+                return cfg, body
+        return None, ""
+
+    def get_memory_index(self, project_id: str) -> str:
+        return self.memory_index
+
+
+def _session(**overrides) -> PlaygroundSession:
+    return PlaygroundSession(
+        name="test",
+        system_prompt="BASE-PROMPT",
+        project_id=overrides.pop("project_id", "proj-1"),
+        **overrides,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# Off modes
+# ─────────────────────────────────────────────────────────────
+
+
+def test_returns_base_prompt_when_all_modes_off() -> None:
+    """With both modes off, no rules/memory are fetched."""
+    session = _session(rules_mode="off", memory_mode="off")
+    stub = _Stub(global_rules=[_rule("g1", True, "Coding", "never mutate")])
+    result = build_effective_system_prompt(session, source=stub)
+    assert result == "BASE-PROMPT"
+
+
+def test_returns_base_when_no_project_and_only_project_mode() -> None:
+    """rules_mode=project with no project_id yields only the base prompt."""
+    session = _session(rules_mode="project", project_id=None)
+    stub = _Stub(project_rules=[_rule("p1", False, "BackendRule", "use asyncpg")])
+    result = build_effective_system_prompt(session, source=stub)
+    assert result == "BASE-PROMPT"
+
+
+# ─────────────────────────────────────────────────────────────
+# Injection
+# ─────────────────────────────────────────────────────────────
+
+
+def test_global_rules_injected_when_mode_global() -> None:
+    session = _session(rules_mode="global", memory_mode="off")
+    stub = _Stub(
+        global_rules=[_rule("coding", True, "Coding Style", "never mutate objects")],
+        project_rules=[_rule("backend", False, "Backend", "use asyncpg")],
+    )
+    result = build_effective_system_prompt(session, source=stub)
+    assert "BASE-PROMPT" in result
+    assert "never mutate objects" in result
+    # Project rule must NOT appear under "global" mode
+    assert "use asyncpg" not in result
+
+
+def test_both_mode_injects_global_and_project_rules() -> None:
+    session = _session(rules_mode="both", memory_mode="off")
+    stub = _Stub(
+        global_rules=[_rule("coding", True, "Coding Style", "never mutate objects")],
+        project_rules=[_rule("backend", False, "Backend Rule", "use asyncpg only")],
+    )
+    result = build_effective_system_prompt(session, source=stub)
+    assert "never mutate objects" in result
+    assert "use asyncpg only" in result
+
+
+def test_memory_index_mode_includes_only_index() -> None:
+    session = _session(rules_mode="off", memory_mode="index")
+    stub = _Stub(
+        memory_index="# MEMORY.md\n- project_hooks_canonical_source",
+        memories=[_memory("project_hooks_canonical_source", "Hooks", "full body here")],
+    )
+    result = build_effective_system_prompt(session, source=stub)
+    assert "project_hooks_canonical_source" in result
+    assert "full body here" not in result  # only index, not individual files
+
+
+def test_memory_full_mode_includes_bodies() -> None:
+    session = _session(rules_mode="off", memory_mode="full")
+    stub = _Stub(
+        memory_index="# MEMORY.md",
+        memories=[_memory("m1", "Hooks", "full body here")],
+    )
+    result = build_effective_system_prompt(session, source=stub)
+    assert "full body here" in result
+
+
+# ─────────────────────────────────────────────────────────────
+# Allow-list (selected ids)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_selected_rule_ids_act_as_allow_list() -> None:
+    session = _session(
+        rules_mode="global",
+        memory_mode="off",
+        selected_rule_ids=["coding"],
+    )
+    stub = _Stub(
+        global_rules=[
+            _rule("coding", True, "Coding Style", "never mutate"),
+            _rule("security", True, "Security", "never log secrets"),
+        ]
+    )
+    result = build_effective_system_prompt(session, source=stub)
+    assert "never mutate" in result
+    assert "never log secrets" not in result
+
+
+# ─────────────────────────────────────────────────────────────
+# Budget enforcement
+# ─────────────────────────────────────────────────────────────
+
+
+def test_budget_truncates_longest_entry_first() -> None:
+    big = "X" * 50_000  # ~12_500 tokens
+    small = "Keep me intact"
+    session = _session(
+        rules_mode="global",
+        memory_mode="off",
+        context_budget_tokens=1000,  # forces truncation
+    )
+    stub = _Stub(
+        global_rules=[
+            _rule("big", True, "Big Rule", big),
+            _rule("small", True, "Small Rule", small),
+        ]
+    )
+    result = build_effective_system_prompt(session, source=stub)
+    assert "Keep me intact" in result
+    assert "…[truncated]" in result or len(result) < 20_000
+
+
+def test_zero_budget_returns_base_prompt() -> None:
+    session = _session(
+        rules_mode="global", memory_mode="off", context_budget_tokens=500
+    )
+    # With empty rules, nothing to inject — should fall through to base.
+    stub = _Stub()
+    result = build_effective_system_prompt(session, source=stub)
+    assert result == "BASE-PROMPT"
+
+
+# ─────────────────────────────────────────────────────────────
+# Frontmatter stripping
+# ─────────────────────────────────────────────────────────────
+
+
+def test_frontmatter_is_stripped_from_rule_body() -> None:
+    body_with_fm = "---\nname: Coding\n---\n\n# Coding Style\nNEVER-MUTATE-MARKER"
+    session = _session(rules_mode="global", memory_mode="off")
+    stub = _Stub(global_rules=[_rule("coding", True, "Coding", body_with_fm)])
+    result = build_effective_system_prompt(session, source=stub)
+    assert "NEVER-MUTATE-MARKER" in result
+    assert "name: Coding" not in result


### PR DESCRIPTION
## Summary
Adds per-session, opt-in controls so a Playground session can pull Claude Code rules and memory entries into the effective LLM system prompt. Injection is off by default; existing sessions are unaffected.

## DB migration — ⚠️ reviewer attention
Alembic revision `d1a2b3c4e5f7` adds 5 columns to `playground_sessions`:
- `rules_mode` (`off | global | project | both`) default `off`
- `memory_mode` (`off | index | full`) default `off`
- `selected_rule_ids` JSONB default `[]`
- `selected_memory_ids` JSONB default `[]`
- `context_budget_tokens` INTEGER default 8000

Uses `ADD COLUMN IF NOT EXISTS` — safe to re-run / idempotent.

## Changes
- `services/playground_context.py` (new): `build_effective_system_prompt(session, rules, memories)` assembles user system_prompt + rule bodies + memory bodies with a soft token budget
- `models/playground.py`: add fields to `PlaygroundSession` + `PlaygroundSessionCreate` with `Literal` enums and `Field(ge=500, le=64000)` for budget validation
- `db/models/playground.py`: matching SQLAlchemy columns
- `api/playground.py`: expose the new fields through session CRUD
- `services/playground_service.py`: plumb the context builder into invocation
- `pages/PlaygroundPage.tsx`: new context panel for mode + per-id allow-list UI
- `tests/backend/test_playground_context.py` (new): 10 tests covering mode matrix and budget truncation

## Test Plan
- [x] `pytest tests/backend/test_playground_context.py -x` → 10/10 passed
- [x] `tsc --noEmit` in `src/dashboard/` → no errors
- [x] `ast.parse` syntax check on all changed backend files → OK
- [ ] Apply migration against a staging DB and verify no data loss on `playground_sessions`
- [ ] Manual smoke test: create a session with `rules_mode=global`, invoke LLM, confirm rule bodies appear in the prompt transcript

## Merge prerequisites
None — this PR can land independently. Recommended to merge after #68 (gitignore fix) so the follow-up PRs stay clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)