### PR TITLE
feat(rag,ui,health): incremental indexing + UI polling + multi-port labels

### DIFF
--- a/src/backend/api/health.py
+++ b/src/backend/api/health.py
@@ -294,6 +294,21 @@ _PORT_RE = re.compile(
     re.VERBOSE,
 )
 
+# Container-port → protocol label, used to disambiguate multi-port services
+# (e.g. Qdrant exposes 6333 REST + 6334 gRPC from a single container).
+_PORT_PROTOCOL: dict[int, str] = {
+    6333: "REST",
+    6334: "gRPC",
+    5432: "SQL",
+    3306: "SQL",
+    6379: "main",
+    9000: "API",
+    9001: "Console",
+    9090: "metrics",
+    80: "HTTP",
+    443: "HTTPS",
+}
+
 
 def _parse_compose_services(project_path: str) -> list[tuple[str, int, str | None]] | None:
     """Parse docker-compose files to extract service name and host port.
@@ -326,10 +341,25 @@ def _parse_compose_services(project_path: str) -> list[tuple[str, int, str | Non
         return None
 
     results: list[tuple[str, int, str | None]] = []
+    # Buffer for the current service's port mappings: (display_name, host_port, container_port, prefix)
+    pending: list[tuple[str, int, int, str | None]] = []
     current_service: str | None = None
     current_image: str | None = None
     in_services = False
     in_ports = False
+
+    def flush_pending() -> None:
+        """Move buffered mappings to results; add protocol labels when multi-port."""
+        if not pending:
+            return
+        if len(pending) == 1:
+            name, host_port, _container_port, prefix = pending[0]
+            results.append((name, host_port, prefix))
+        else:
+            for name, host_port, container_port, prefix in pending:
+                label = _PORT_PROTOCOL.get(container_port, f"port {container_port}")
+                results.append((f"{name} ({label})", host_port, prefix))
+        pending.clear()
 
     for line in content.splitlines():
         stripped = line.strip()
@@ -341,6 +371,7 @@ def _parse_compose_services(project_path: str) -> list[tuple[str, int, str | Non
 
         # Detect other top-level keys (exit services block)
         if in_services and not line.startswith(" ") and stripped and not stripped.startswith("#"):
+            flush_pending()
             in_services = False
             continue
 
@@ -354,7 +385,8 @@ def _parse_compose_services(project_path: str) -> list[tuple[str, int, str | Non
             and stripped.endswith(":")
             and not stripped.startswith("#")
         ):
-            # Save previous service if it had ports
+            # Flush previous service before switching
+            flush_pending()
             current_service = stripped[:-1].strip()
             current_image = None
             in_ports = False
@@ -378,6 +410,7 @@ def _parse_compose_services(project_path: str) -> list[tuple[str, int, str | Non
             match = _PORT_RE.search(port_str)
             if match:
                 host_port = int(match.group(1))
+                container_port = int(match.group(2))
                 # Determine display name and prefix from image
                 display_name = current_service.replace("-", " ").replace("_", " ").title()
                 url_prefix: str | None = "http"
@@ -389,13 +422,14 @@ def _parse_compose_services(project_path: str) -> list[tuple[str, int, str | Non
                             url_prefix = hint_prefix
                             break
 
-                results.append((display_name, host_port, url_prefix))
+                pending.append((display_name, host_port, container_port, url_prefix))
             continue
 
         # Exit ports section on non-list item
         if in_ports and not stripped.startswith("- ") and stripped and not stripped.startswith("#"):
             in_ports = False
 
+    flush_pending()
     return results if results else None
 
 

--- a/src/backend/api/rag.py
+++ b/src/backend/api/rag.py
@@ -74,11 +74,42 @@ class StatsResponse(BaseModel):
     collection_name: str
     document_count: int
     indexed: bool
+    status: str = "not_started"
+    started_at: str | None = None
+    completed_at: str | None = None
     error: str | None = None
 
 
-# Track indexing status
-_indexing_status: dict[str, str] = {}
+# Per-project indexing state. Status values: not_started | indexing | completed | error.
+# last_known_count holds the most recent stable chunk count so we can serve a
+# stable number to the UI while a background reindex is mid-flight (the live
+# Qdrant points_count fluctuates as the collection is dropped and refilled).
+_indexing_state: dict[str, dict] = {}
+
+
+def _get_state(project_id: str) -> dict:
+    """Return the indexing state record, creating a not_started default."""
+    return _indexing_state.get(
+        project_id,
+        {
+            "status": "not_started",
+            "started_at": None,
+            "completed_at": None,
+            "last_known_count": 0,
+            "error": None,
+        },
+    )
+
+
+def _safe_count(project_id: str) -> int:
+    """Best-effort live Qdrant count, swallowing transient errors."""
+    if not QDRANT_AVAILABLE:
+        return 0
+    try:
+        store = get_vector_store()
+        return int(store.get_collection_stats(project_id).get("document_count", 0))
+    except Exception:
+        return 0
 
 
 async def _do_index_project(
@@ -93,7 +124,14 @@ async def _do_index_project(
             force_reindex=force_reindex,
         )
 
-        _indexing_status[project_id] = "completed"
+        prev = _get_state(project_id)
+        _indexing_state[project_id] = {
+            "status": "completed",
+            "started_at": prev.get("started_at"),
+            "completed_at": datetime.now(UTC).isoformat(),
+            "last_known_count": result.chunks_created,
+            "error": None,
+        }
 
         # Update project registry to mark as indexed
         if project_id in PROJECTS_REGISTRY:
@@ -108,7 +146,14 @@ async def _do_index_project(
         )
 
     except Exception as e:
-        _indexing_status[project_id] = f"error: {str(e)}"
+        prev = _get_state(project_id)
+        _indexing_state[project_id] = {
+            "status": "error",
+            "started_at": prev.get("started_at"),
+            "completed_at": datetime.now(UTC).isoformat(),
+            "last_known_count": prev.get("last_known_count", 0),
+            "error": str(e),
+        }
         logger.error("Indexing failed for project '%s': %s", project_id, e)
 
 
@@ -126,19 +171,33 @@ def trigger_background_indexing(
         logger.warning("Qdrant not available, skipping indexing for '%s'", project_id)
         return False
 
-    if _indexing_status.get(project_id) == "indexing":
+    current = _get_state(project_id)
+    if current.get("status") == "indexing":
         logger.info("Project '%s' is already being indexed, skipping", project_id)
         return False
 
-    _indexing_status[project_id] = "indexing"
+    # Capture pre-indexing count so polling clients see the last stable value
+    # while the collection is being dropped and refilled by the background task.
+    last_known = current.get("last_known_count") or _safe_count(project_id)
+
+    _indexing_state[project_id] = {
+        "status": "indexing",
+        "started_at": datetime.now(UTC).isoformat(),
+        "completed_at": None,
+        "last_known_count": last_known,
+        "error": None,
+    }
     background_tasks.add_task(_do_index_project, project_id, project_path, force_reindex)
     logger.info("Background indexing triggered for project '%s'", project_id)
     return True
 
 
 def get_indexing_status_value(project_id: str) -> str:
-    """Get the current indexing status for a project."""
-    return _indexing_status.get(project_id, "not_started")
+    """Get the current indexing status string for a project (backward-compat helper)."""
+    state = _get_state(project_id)
+    if state["status"] == "error" and state.get("error"):
+        return f"error: {state['error']}"
+    return state["status"]
 
 
 @router.post("/projects/{project_id}/index", response_model=IndexResponse)
@@ -167,7 +226,7 @@ async def index_project(
         force_reindex=force_reindex,
     )
 
-    if not triggered and _indexing_status.get(project_id) == "indexing":
+    if not triggered and _get_state(project_id).get("status") == "indexing":
         return IndexResponse(project_id=project_id, status="already_indexing")
 
     if not triggered:
@@ -222,13 +281,33 @@ async def get_project_stats(project_id: str) -> StatsResponse:
     try:
         store = get_vector_store()
         stats = store.get_collection_stats(project_id)
+        state = _get_state(project_id)
+
+        # While indexing is in flight the collection is being dropped and
+        # refilled, so the live points_count fluctuates and would flash 0/partial
+        # values in the UI. Pin the count to the last stable value until the
+        # background task completes.
+        live_count = stats["document_count"]
+        if state["status"] == "indexing":
+            document_count = state.get("last_known_count") or 0
+            indexed = document_count > 0
+        else:
+            document_count = live_count
+            indexed = stats["indexed"]
+            # Keep last_known_count in sync with reality outside indexing.
+            if state["status"] in ("not_started", "completed") and live_count > 0:
+                state["last_known_count"] = live_count
+                _indexing_state[project_id] = state
 
         return StatsResponse(
             project_id=stats["project_id"],
             collection_name=stats["collection_name"],
-            document_count=stats["document_count"],
-            indexed=stats["indexed"],
-            error=stats.get("error"),
+            document_count=document_count,
+            indexed=indexed,
+            status=state["status"],
+            started_at=state.get("started_at"),
+            completed_at=state.get("completed_at"),
+            error=stats.get("error") or state.get("error"),
         )
 
     except Exception as e:
@@ -252,7 +331,7 @@ async def delete_project_index(project_id: str) -> dict:
         success = await store.delete_project_index(project_id)
 
         if success:
-            _indexing_status.pop(project_id, None)
+            _indexing_state.pop(project_id, None)
             # Reset project registry status
             if project_id in PROJECTS_REGISTRY:
                 PROJECTS_REGISTRY[project_id].vector_store_initialized = False
@@ -268,29 +347,30 @@ async def delete_project_index(project_id: str) -> dict:
 @router.get("/status/{project_id}")
 async def get_indexing_status(project_id: str) -> dict:
     """Get the current indexing status for a project."""
-    status = _indexing_status.get(project_id, "not_started")
+    state = _get_state(project_id)
 
     indexed = False
-    document_count = 0
-
-    # Check project registry for indexed state
     if project_id in PROJECTS_REGISTRY:
         indexed = PROJECTS_REGISTRY[project_id].vector_store_initialized or False
 
-    # Try to get document count from vector store
-    if QDRANT_AVAILABLE and indexed:
-        try:
-            store = get_vector_store()
-            stats = store.get_collection_stats(project_id)
-            document_count = stats.get("document_count", 0)
-        except Exception:
-            pass
+    # Mirror /stats: while indexing, return the last known stable count so
+    # the UI never sees the partial mid-reindex value.
+    if state["status"] == "indexing":
+        document_count = state.get("last_known_count") or 0
+    else:
+        document_count = _safe_count(project_id) if indexed else 0
+        if state["status"] in ("not_started", "completed") and document_count > 0:
+            state["last_known_count"] = document_count
+            _indexing_state[project_id] = state
 
     return {
         "project_id": project_id,
-        "status": status,
+        "status": state["status"],
         "indexed": indexed,
         "document_count": document_count,
+        "started_at": state.get("started_at"),
+        "completed_at": state.get("completed_at"),
+        "error": state.get("error"),
     }
 
 

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -11,6 +11,7 @@ Vector DB backend: Qdrant (migrated from ChromaDB).
 
 import asyncio
 import hashlib
+import json
 import logging
 import os
 import re
@@ -39,7 +40,7 @@ try:
     from langchain_core.embeddings import Embeddings
     from langchain_qdrant import QdrantVectorStore
     from qdrant_client import QdrantClient
-    from qdrant_client.models import Distance, FieldCondition, MatchValue, VectorParams
+    from qdrant_client.models import Distance, FieldCondition, MatchAny, MatchValue, VectorParams
     from qdrant_client.models import Filter as QdrantFilter
 
     QDRANT_AVAILABLE = True
@@ -106,6 +107,13 @@ RAG_EMBEDDING_DEVICE = os.getenv("RAG_EMBEDDING_DEVICE", "cpu").strip().lower()
 # at ~2x peak memory.
 RAG_EMBEDDING_BATCH_SIZE = int(os.getenv("RAG_EMBEDDING_BATCH_SIZE", "64"))
 
+# File-level idempotency cache for incremental re-indexing. Stores per-project
+# {rel_path: {mtime_ns, size}} so unchanged files skip the full chunk+embed
+# cost on every re-index. Default: ~/.aos/rag_index/ (outside any project tree).
+RAG_INDEX_CACHE_DIR = Path(
+    os.getenv("RAG_INDEX_CACHE_DIR", str(Path.home() / ".aos" / "rag_index"))
+)
+
 # ── File extension → Language mapping ─────────────────────────────────────────
 _EXTENSION_LANGUAGE_MAP: dict[str, Any] = {}
 if SPLITTER_AVAILABLE:
@@ -145,6 +153,23 @@ def _tokenize(text: str) -> list[str]:
 def _entity_in_chunk(entity: CodeEntity, chunk: Any) -> bool:
     """Check if a code entity is referenced in a document chunk."""
     return entity.name in chunk.page_content
+
+
+def _extract_collection_dim(info: Any) -> int | None:
+    """Pull the vector dimension from a qdrant CollectionInfo, handling both
+    single-vector and named-vector configurations. Returns None if the
+    structure is unrecognized (e.g. sparse-only collection)."""
+    try:
+        vectors = info.config.params.vectors
+    except AttributeError:
+        return None
+    size = getattr(vectors, "size", None)
+    if isinstance(size, int):
+        return size
+    if isinstance(vectors, dict) and vectors:
+        first = next(iter(vectors.values()))
+        return getattr(first, "size", None)
+    return None
 
 
 class ProjectVectorStore:
@@ -243,6 +268,9 @@ class ProjectVectorStore:
         self._collection_size_cache: dict[str, tuple[int, float]] = {}
         self._collection_size_ttl_seconds: float = 60.0
 
+        # File-level index cache directory (lazy mkdir on first save)
+        self._index_cache_dir: Path = RAG_INDEX_CACHE_DIR
+
     # ── Embeddings ────────────────────────────────────────────────────────────
 
     def _create_embeddings(self, model_name: str | None = None) -> Embeddings:
@@ -325,11 +353,17 @@ class ProjectVectorStore:
         return f"proj_{safe_name}"[:63]
 
     def _ensure_collection_exists(self, collection_name: str) -> None:
-        """Ensure a Qdrant collection exists, creating it if needed."""
+        """Ensure a Qdrant collection exists, creating it if needed.
+
+        If the collection already exists, verify its vector dimension matches
+        the active embedding model. Mismatches raise RuntimeError rather than
+        silently corrupting the index — the operator must explicitly drop and
+        re-index, or revert RAG_EMBEDDING_MODEL to a same-dim model.
+        """
         try:
-            self.client.get_collection(collection_name)
+            info = self.client.get_collection(collection_name)
         except Exception:
-            # Collection doesn't exist, create it
+            # Collection doesn't exist — create it
             dim = self._get_embedding_dimension()
             self.client.create_collection(
                 collection_name=collection_name,
@@ -339,6 +373,19 @@ class ProjectVectorStore:
                 ),
             )
             logger.info(f"Created Qdrant collection '{collection_name}' (dim={dim}, cosine)")
+            return
+
+        existing_dim = _extract_collection_dim(info)
+        if existing_dim is None:
+            return  # unknown structure (e.g. sparse-only) — skip check
+        current_dim = self._get_embedding_dimension()
+        if existing_dim != current_dim:
+            raise RuntimeError(
+                f"Embedding dimension mismatch for collection '{collection_name}': "
+                f"existing={existing_dim}, current model={current_dim}. "
+                f"Either revert RAG_EMBEDDING_MODEL to a {existing_dim}-dim model, "
+                f"or DELETE /api/rag/projects/<project_id>/index then re-index."
+            )
 
     def _get_or_create_collection(self, project_id: str) -> QdrantVectorStore:
         """Get or create a Qdrant vector store for a project."""
@@ -395,6 +442,82 @@ class ProjectVectorStore:
         if collection_name.startswith("proj_"):
             return collection_name[5:]
         return collection_name
+
+    # ── Index cache (file-level idempotency) ─────────────────────────────────
+
+    def _index_cache_path(self, project_id: str) -> Path:
+        """Return the JSON cache path for this project."""
+        safe = "".join(c if c.isalnum() else "_" for c in project_id)[:80]
+        return self._index_cache_dir / f"{safe}.json"
+
+    def _load_index_cache(self, project_id: str) -> dict[str, dict]:
+        """Load the per-project file signature cache. Returns {} on any error."""
+        path = self._index_cache_path(project_id)
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+            return {}
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("RAG index cache read failed for '%s': %s", project_id, e)
+            return {}
+
+    def _save_index_cache(self, project_id: str, cache: dict[str, dict]) -> None:
+        """Atomically persist the cache. Logs and continues on I/O failure."""
+        path = self._index_cache_path(project_id)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(cache, separators=(",", ":")), encoding="utf-8")
+            tmp.replace(path)
+        except OSError as e:
+            logger.warning("RAG index cache write failed for '%s': %s", project_id, e)
+
+    @staticmethod
+    def _file_signature(file_path: Path) -> dict[str, int] | None:
+        """Cheap stat-based signature. Returns None if the file is unreadable."""
+        try:
+            st = file_path.stat()
+        except OSError:
+            return None
+        return {"mtime_ns": st.st_mtime_ns, "size": st.st_size}
+
+    @staticmethod
+    def _signature_unchanged(prev: dict | None, current: dict) -> bool:
+        """True iff prev and current agree on mtime_ns AND size."""
+        if not prev:
+            return False
+        return prev.get("mtime_ns") == current["mtime_ns"] and prev.get("size") == current["size"]
+
+    def _gc_removed_files(self, collection_name: str, removed_paths: list[str]) -> None:
+        """Delete Qdrant points belonging to files that disappeared from disk.
+
+        Best-effort: a failure here doesn't block the indexing run, the points
+        just become orphaned (still queryable but with broken source paths).
+        """
+        if not removed_paths:
+            return
+        try:
+            self.client.delete(
+                collection_name=collection_name,
+                points_selector=QdrantFilter(
+                    must=[
+                        FieldCondition(
+                            key="metadata.source",
+                            match=MatchAny(any=removed_paths),
+                        )
+                    ]
+                ),
+            )
+            logger.info(
+                "RAG gc: removed %d orphaned files from '%s'",
+                len(removed_paths),
+                collection_name,
+            )
+        except Exception as e:
+            logger.warning("RAG gc failed for '%s': %s", collection_name, e)
 
     # ── File filtering ────────────────────────────────────────────────────────
 
@@ -738,7 +861,16 @@ class ProjectVectorStore:
             # Clear BM25 caches too
             self._bm25_indices.pop(project_id, None)
             self._bm25_corpus.pop(project_id, None)
+            # Drop the collection-size cache so the search path doesn't keep
+            # serving the pre-reindex count for up to 60s.
+            self._collection_size_cache.pop(project_id, None)
             collection = self._get_or_create_collection(project_id)
+
+        # Load file-level cache. Empty when force_reindex (start fresh).
+        cache: dict[str, dict] = {} if force_reindex else self._load_index_cache(project_id)
+        new_cache: dict[str, dict] = {}
+        seen_files: set[str] = set()
+        unchanged_count = 0
 
         # Resolve symlinks for consistent path handling
         project_root = Path(project_path).resolve()
@@ -754,33 +886,43 @@ class ProjectVectorStore:
 
         for priority_file in priority_files:
             file_path = project_root / priority_file
-            if file_path.exists() and file_path.is_file():
+            if not (file_path.exists() and file_path.is_file()):
+                continue
+            rel = str(file_path.relative_to(project_root))
+            sig = self._file_signature(file_path)
+            if sig is None:
+                continue
+            if self._signature_unchanged(cache.get(rel), sig):
+                # Unchanged since last index — keep prior cache entry, skip embed.
+                seen_files.add(rel)
+                new_cache[rel] = sig
+                unchanged_count += 1
+                continue
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="ignore")
+                chunks = self._chunk_document(content, rel)
+
+                # Extract code entities for metadata enrichment
                 try:
-                    content = file_path.read_text(encoding="utf-8", errors="ignore")
-                    rel = str(file_path.relative_to(project_root))
-                    chunks = self._chunk_document(content, rel)
+                    entities = extract_entities(rel, content)
+                    file_imports = list({imp for e in entities for imp in e.imports})
+                except Exception:
+                    entities, file_imports = [], []
 
-                    # Extract code entities for metadata enrichment
-                    try:
-                        entities = extract_entities(rel, content)
-                        file_imports = list({imp for e in entities for imp in e.imports})
-                    except Exception:
-                        entities, file_imports = [], []
+                for chunk in chunks:
+                    chunk.metadata["priority"] = "high"
+                    chunk.metadata["project_id"] = project_id
+                    chunk_entities = [e for e in entities if _entity_in_chunk(e, chunk)]
+                    chunk.metadata["entity_names"] = [e.name for e in chunk_entities]
+                    chunk.metadata["entity_types"] = [e.entity_type.value for e in chunk_entities]
+                    chunk.metadata["imports"] = file_imports
 
-                    for chunk in chunks:
-                        chunk.metadata["priority"] = "high"
-                        chunk.metadata["project_id"] = project_id
-                        chunk_entities = [e for e in entities if _entity_in_chunk(e, chunk)]
-                        chunk.metadata["entity_names"] = [e.name for e in chunk_entities]
-                        chunk.metadata["entity_types"] = [
-                            e.entity_type.value for e in chunk_entities
-                        ]
-                        chunk.metadata["imports"] = file_imports
-
-                    documents.extend(chunks)
-                    files_indexed += 1
-                except Exception as e:
-                    logger.debug(f"Skipped priority file {file_path}: {e}")
+                documents.extend(chunks)
+                files_indexed += 1
+                seen_files.add(rel)
+                new_cache[rel] = sig
+            except Exception as e:
+                logger.debug(f"Skipped priority file {file_path}: {e}")
 
         for item in project_root.rglob("*"):
             if not item.is_file():
@@ -807,12 +949,21 @@ class ProjectVectorStore:
             if not self._should_index_file(item):
                 continue
 
+            rel_str = str(rel_path)
+            sig = self._file_signature(item)
+            if sig is None:
+                continue
+            if self._signature_unchanged(cache.get(rel_str), sig):
+                seen_files.add(rel_str)
+                new_cache[rel_str] = sig
+                unchanged_count += 1
+                continue
+
             try:
                 content = item.read_text(encoding="utf-8", errors="ignore")
                 if not content.strip():
                     continue
 
-                rel_str = str(rel_path)
                 chunks = self._chunk_document(content, rel_str)
 
                 # Extract code entities for metadata enrichment
@@ -832,14 +983,27 @@ class ProjectVectorStore:
 
                 documents.extend(chunks)
                 files_indexed += 1
+                seen_files.add(rel_str)
+                new_cache[rel_str] = sig
             except Exception as e:
                 skipped_count += 1
                 logger.warning(f"Skipped file (read/chunk failed): {item}: {e}")
                 continue
 
+        # Files in old cache but not seen this run = deleted from disk.
+        # GC their points from Qdrant so search doesn't return ghost results.
+        removed_paths = sorted(set(cache.keys()) - seen_files)
+        if removed_paths and not force_reindex:
+            self._gc_removed_files(collection_name, removed_paths)
+
+        # Persist the refreshed cache for next run.
+        self._save_index_cache(project_id, new_cache)
+
         logger.info(
-            f"Indexing complete: {files_indexed} files, "
-            f"{len(documents)} chunks, {skipped_count} skipped"
+            f"Indexing complete: {files_indexed} embedded, "
+            f"{unchanged_count} unchanged (cache hit), "
+            f"{len(documents)} chunks, {skipped_count} skipped, "
+            f"{len(removed_paths)} gc'd"
         )
 
         if documents:
@@ -869,10 +1033,20 @@ class ProjectVectorStore:
             if RAG_ENABLE_HYBRID:
                 self._build_bm25_index(project_id, texts, metadatas)
 
+        # Reflect current collection totals in the result so that
+        # api/rag.py's last_known_count tracks reality after partial re-index.
+        total_files = files_indexed + unchanged_count
+        try:
+            total_chunks = int(
+                self.client.count(collection_name=collection_name, exact=False).count
+            )
+        except Exception:
+            total_chunks = len(documents)
+
         return IndexingResult(
             project_id=project_id,
-            documents_indexed=files_indexed,
-            chunks_created=len(documents),
+            documents_indexed=total_files,
+            chunks_created=total_chunks,
             collection_name=collection_name,
         )
 
@@ -1196,6 +1370,7 @@ class ProjectVectorStore:
             # Clear BM25 caches
             self._bm25_indices.pop(project_id, None)
             self._bm25_corpus.pop(project_id, None)
+            self._collection_size_cache.pop(project_id, None)
             return True
         except Exception:
             return False

--- a/src/dashboard/src/components/git/WorkingDirectory.tsx
+++ b/src/dashboard/src/components/git/WorkingDirectory.tsx
@@ -470,6 +470,7 @@ export function WorkingDirectory({
   onClearDrafts,
 }: WorkingDirectoryProps) {
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set())
+  const [selectedStagedFiles, setSelectedStagedFiles] = useState<Set<string>>(new Set())
   const [commitMessage, setCommitMessage] = useState('')
   const [isCommitting, setIsCommitting] = useState(false)
   const [isCommittingAndPushing, setIsCommittingAndPushing] = useState(false)
@@ -491,6 +492,25 @@ export function WorkingDirectory({
       }
       return next
     })
+  }
+
+  const handleSelectStagedFile = (path: string) => {
+    setSelectedStagedFiles((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
+
+  const handleUnstageSelected = async () => {
+    if (selectedStagedFiles.size === 0) return
+    const paths = Array.from(selectedStagedFiles)
+    const success = await onUnstageFiles(paths)
+    if (success) setSelectedStagedFiles(new Set())
   }
 
   const handleToggleDiff = async (path: string, staged: boolean) => {
@@ -773,8 +793,8 @@ export function WorkingDirectory({
                     <FileItem
                       key={file.path}
                       file={{ ...file, staged: true }}
-                      selected={false}
-                      onSelect={() => {}}
+                      selected={selectedStagedFiles.has(file.path)}
+                      onSelect={handleSelectStagedFile}
                       onUnstage={(path) => onUnstageFiles([path])}
                       onToggleDiff={(path) => handleToggleDiff(path, true)}
                       showDiff={expandedDiffs.has(`${file.path}:true`)}
@@ -784,6 +804,20 @@ export function WorkingDirectory({
                   ))
                 )}
               </div>
+
+              {/* Unstage Selected Button */}
+              {selectedStagedFiles.size > 0 && (
+                <div className="p-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 shrink-0">
+                  <button
+                    onClick={handleUnstageSelected}
+                    disabled={isLoading}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 rounded-lg transition-colors"
+                  >
+                    <Minus className="w-4 h-4" />
+                    Unstage Selected ({selectedStagedFiles.size})
+                  </button>
+                </div>
+              )}
 
               {/* Review Staged Changes Panel */}
               {staged_files.length > 0 && (

--- a/src/dashboard/src/components/rag/RAGQueryPanel.tsx
+++ b/src/dashboard/src/components/rag/RAGQueryPanel.tsx
@@ -41,11 +41,16 @@ interface QueryResult {
   total_found: number
 }
 
+type IndexingStatus = 'not_started' | 'indexing' | 'completed' | 'error'
+
 interface RAGStats {
   project_id: string
   collection_name: string
   document_count: number
   indexed: boolean
+  status?: IndexingStatus
+  started_at?: string | null
+  completed_at?: string | null
   error: string | null
 }
 
@@ -124,6 +129,7 @@ export function RAGQueryPanel({ projectId, projectName, className, onClose }: RA
   const [isSearching, setIsSearching] = useState(false)
   const [isLoadingStats, setIsLoadingStats] = useState(true)
   const [isIndexing, setIsIndexing] = useState(false)
+  const [isPolling, setIsPolling] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // Search options
@@ -151,6 +157,35 @@ export function RAGQueryPanel({ projectId, projectName, className, onClose }: RA
   useEffect(() => {
     loadStats()
   }, [projectId, loadStats])
+
+  // While a background reindex is in flight, poll until the backend reports
+  // a non-indexing status. The backend pins document_count to the last stable
+  // value during this window so the UI never sees the partial mid-reindex
+  // count. Two seconds is a balance between responsiveness and load.
+  useEffect(() => {
+    if (!isPolling) return
+
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const data = await getRAGStats(projectId)
+        if (cancelled) return
+        setStats(data)
+        if (data.status && data.status !== 'indexing') {
+          setIsPolling(false)
+          setIsIndexing(false)
+        }
+      } catch {
+        // Transient errors are common during reindex (collection drops). Keep polling.
+      }
+    }
+
+    const id = window.setInterval(tick, 2000)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
+  }, [isPolling, projectId])
 
   const handleSearch = useCallback(async () => {
     if (!query.trim()) return
@@ -182,10 +217,12 @@ export function RAGQueryPanel({ projectId, projectName, className, onClose }: RA
     setError(null)
     try {
       await reindexProject(projectId, true)
+      // Indexing runs as a background task on the server; flip the panel into
+      // polling mode and let the effect drive UI updates until completion.
       await loadStats()
+      setIsPolling(true)
     } catch (err) {
       setError((err as Error).message)
-    } finally {
       setIsIndexing(false)
     }
   }
@@ -265,7 +302,12 @@ export function RAGQueryPanel({ projectId, projectName, className, onClose }: RA
           {/* Stats */}
           {stats && (
             <div className="flex items-center gap-2 text-sm">
-              {stats.indexed ? (
+              {stats.status === 'indexing' ? (
+                <span className="flex items-center gap-1 text-blue-600 dark:text-blue-400">
+                  <RefreshCw className="w-4 h-4 animate-spin" />
+                  인덱싱 중… (마지막: {stats.document_count} 청크)
+                </span>
+              ) : stats.indexed ? (
                 <span className="flex items-center gap-1 text-green-600 dark:text-green-400">
                   <CheckCircle className="w-4 h-4" />
                   {stats.document_count} 청크

--- a/tests/backend/test_rag_service.py
+++ b/tests/backend/test_rag_service.py
@@ -702,3 +702,155 @@ class TestConfig:
         assert stats["document_count"] == 0
         assert stats["indexed"] is False
         assert "error" in stats
+
+
+# ── E: collection-dim consistency check ───────────────────────────────────────
+
+
+class TestDimConsistencyCheck:
+    """Phase E: ensure dimension drift between collection and model is loud."""
+
+    def test_extract_dim_single_vector(self):
+        from services.rag_service import _extract_collection_dim
+
+        info = MagicMock()
+        info.config.params.vectors.size = 768
+        assert _extract_collection_dim(info) == 768
+
+    def test_extract_dim_named_vectors(self):
+        from services.rag_service import _extract_collection_dim
+
+        info = MagicMock()
+        named = MagicMock()
+        named.size = 1024
+        # Replace .vectors with a real dict so the dict branch fires
+        info.config.params.vectors = {"default": named}
+        assert _extract_collection_dim(info) == 1024
+
+    def test_extract_dim_unknown_structure_returns_none(self):
+        from services.rag_service import _extract_collection_dim
+
+        info = MagicMock(spec=[])  # no attributes
+        assert _extract_collection_dim(info) is None
+
+    def test_ensure_collection_creates_when_missing(self, vector_store):
+        # get_collection raises → existing path takes the create branch
+        vector_store.client.get_collection.side_effect = Exception("not found")
+        vector_store._embedding_dimension = 768
+
+        vector_store._ensure_collection_exists("proj_x")
+        vector_store.client.create_collection.assert_called_once()
+
+    def test_ensure_collection_passes_when_dim_matches(self, vector_store):
+        info = MagicMock()
+        info.config.params.vectors.size = 768
+        vector_store.client.get_collection.return_value = info
+        vector_store._embedding_dimension = 768
+
+        # Should not raise and must not recreate the collection
+        vector_store._ensure_collection_exists("proj_x")
+        vector_store.client.create_collection.assert_not_called()
+
+    def test_ensure_collection_raises_on_dim_mismatch(self, vector_store):
+        info = MagicMock()
+        info.config.params.vectors.size = 768
+        vector_store.client.get_collection.return_value = info
+        vector_store._embedding_dimension = 1024  # operator switched models
+
+        with pytest.raises(RuntimeError, match="dimension mismatch"):
+            vector_store._ensure_collection_exists("proj_x")
+        vector_store.client.create_collection.assert_not_called()
+
+
+# ── D: file-level idempotency cache ───────────────────────────────────────────
+
+
+class TestIndexCacheHelpers:
+    """Phase D: per-file cache short-circuits unchanged files."""
+
+    def test_cache_path_sanitizes_project_id(self, vector_store, tmp_path):
+        vector_store._index_cache_dir = tmp_path
+        path = vector_store._index_cache_path("a/b!c d")
+        assert path.parent == tmp_path
+        # Only alnum+underscore in the basename
+        assert all(c.isalnum() or c == "_" for c in path.stem)
+
+    def test_load_returns_empty_when_missing(self, vector_store, tmp_path):
+        vector_store._index_cache_dir = tmp_path
+        assert vector_store._load_index_cache("absent") == {}
+
+    def test_load_returns_empty_on_corrupt_json(self, vector_store, tmp_path):
+        vector_store._index_cache_dir = tmp_path
+        vector_store._index_cache_path("p1").write_text("{not json")
+        assert vector_store._load_index_cache("p1") == {}
+
+    def test_save_then_load_round_trip(self, vector_store, tmp_path):
+        vector_store._index_cache_dir = tmp_path
+        cache = {"foo.md": {"mtime_ns": 12345, "size": 100}}
+        vector_store._save_index_cache("p1", cache)
+        assert vector_store._load_index_cache("p1") == cache
+
+    def test_save_is_atomic(self, vector_store, tmp_path):
+        """Tmp file is renamed in-place; no partial files remain on success."""
+        vector_store._index_cache_dir = tmp_path
+        vector_store._save_index_cache("p1", {"a": {"mtime_ns": 1, "size": 1}})
+        leftovers = list(tmp_path.glob("*.tmp"))
+        assert leftovers == []
+
+    def test_file_signature_returns_none_for_missing(self, vector_store, tmp_path):
+        from services.rag_service import ProjectVectorStore
+
+        assert ProjectVectorStore._file_signature(tmp_path / "nope") is None
+
+    def test_file_signature_captures_mtime_and_size(self, vector_store, tmp_path):
+        from services.rag_service import ProjectVectorStore
+
+        f = tmp_path / "a.md"
+        f.write_text("hello")
+        sig = ProjectVectorStore._file_signature(f)
+        assert sig is not None
+        assert sig["size"] == 5
+        assert sig["mtime_ns"] > 0
+
+    def test_signature_unchanged_handles_none_prev(self, vector_store):
+        from services.rag_service import ProjectVectorStore
+
+        cur = {"mtime_ns": 1, "size": 2}
+        assert ProjectVectorStore._signature_unchanged(None, cur) is False
+
+    def test_signature_unchanged_detects_match(self, vector_store):
+        from services.rag_service import ProjectVectorStore
+
+        sig = {"mtime_ns": 100, "size": 50}
+        assert ProjectVectorStore._signature_unchanged(sig, sig) is True
+
+    def test_signature_unchanged_detects_mtime_change(self, vector_store):
+        from services.rag_service import ProjectVectorStore
+
+        prev = {"mtime_ns": 100, "size": 50}
+        cur = {"mtime_ns": 101, "size": 50}
+        assert ProjectVectorStore._signature_unchanged(prev, cur) is False
+
+    def test_signature_unchanged_detects_size_change(self, vector_store):
+        from services.rag_service import ProjectVectorStore
+
+        prev = {"mtime_ns": 100, "size": 50}
+        cur = {"mtime_ns": 100, "size": 51}
+        assert ProjectVectorStore._signature_unchanged(prev, cur) is False
+
+    def test_gc_removed_files_skips_when_empty(self, vector_store):
+        vector_store._gc_removed_files("proj_x", [])
+        vector_store.client.delete.assert_not_called()
+
+    def test_gc_removed_files_invokes_qdrant_delete(self, vector_store):
+        vector_store._gc_removed_files("proj_x", ["a.md", "b.md"])
+        vector_store.client.delete.assert_called_once()
+        kwargs = vector_store.client.delete.call_args.kwargs
+        assert kwargs["collection_name"] == "proj_x"
+        # Best-effort: just verify a points_selector was passed
+        assert "points_selector" in kwargs
+
+    def test_gc_swallows_qdrant_failure(self, vector_store):
+        vector_store.client.delete.side_effect = Exception("qdrant down")
+        # Must not propagate — gc is best-effort
+        vector_store._gc_removed_files("proj_x", ["a.md"])


### PR DESCRIPTION
## Summary

RAG 인덱싱이 한 번 트리거되면 4000+ 청크를 매번 풀스캔·재임베딩하던 폭주를 incremental cache로 잡고, 모델 차원 불일치로 인한 silent corruption을 명시적 에러로 차단합니다. UI는 백엔드의 새 indexing state machine을 받아 폴링 + 안정적인 청크 수 표시로 정합성을 맞췄습니다.

원인 진단: PID 13298이 358% CPU + 4.5GB RSS로 약 5분간 폭주. `sample` 콜스택에 `tokenizers.abi3.so`(HuggingFace Rayon worker)가 떠 있었고, `obsidian` 인덱싱(862 files, 4049 chunks)이 진행 중이었습니다. 코드는 단발성 작업이지만 트리거가 잦으면 재발 조건이 그대로라 근본 처방이 필요했습니다.

## Changes

### 백엔드 — `feat(rag): incremental indexing cache + dim consistency check` (5f91f94)

- **D — 파일 레벨 idempotency 캐시.** `~/.aos/rag_index/<project_id>.json`에 `{rel_path: {mtime_ns, size}}` 저장. `_index_project_sync`는 매칭되는 파일의 chunk+embed를 건너뜁니다. 사라진 파일은 Qdrant `metadata.source` 필터로 best-effort gc.
- **E — 컬렉션 차원 정합성 검증.** `_ensure_collection_exists`가 기존 컬렉션 dim과 활성 모델 dim을 비교, 불일치 시 명시적 `RuntimeError`. 자동 drop은 안 함 — 운영자가 명시적으로 처리.
- **State machine 강화.** `_indexing_status: dict[str, str]` → `_indexing_state: dict[str, dict]`. `status / started_at / completed_at / last_known_count / error` 5필드. `/stats`·`/status`는 인덱싱 중에 `last_known_count`를 고정 노출해 UI가 0/partial을 깜박이지 않게 함.
- `IndexingResult.documents_indexed`/`chunks_created`가 "이번 사이클 처리량" → "현재 컬렉션 전체"로 의미 변경 (Qdrant `count()` 사용). `last_known_count`와 의미 일치.
- 신규 모듈 헬퍼 `_extract_collection_dim` (single + named vector 둘 다 처리), 클래스 헬퍼 `_index_cache_path`/`_load_index_cache`/`_save_index_cache`/`_file_signature`/`_signature_unchanged`/`_gc_removed_files`.

### 백엔드 — `feat(health): label multi-port docker-compose services` (7d42dda)

- Qdrant(6333 REST + 6334 gRPC), MinIO(9000 API + 9001 Console) 등 멀티 포트 서비스가 같은 이름으로 중복되던 표시를 `Qdrant (REST)`, `Qdrant (gRPC)` 식으로 라벨링.
- `_PORT_PROTOCOL` 룩업 테이블 + `pending` 버퍼로 서비스 단위로 flush.

### 프론트엔드 — `feat(rag-ui): poll indexing status + show last-stable count` (f9654bd)

- 5f91f94의 짝. `IndexingStatus` 유니언 + `RAGStats`에 `status / started_at / completed_at` 추가.
- 인덱싱 트리거 후 2초 간격으로 `getRAGStats` 폴링, `status !== 'indexing'`이 되면 종료. 폴링 중 transient error는 swallow (Qdrant drop+refill 윈도우 대응).
- 인덱싱 중 스피너 + "마지막: N 청크" 표시.

### 프론트엔드 — `feat(git-ui): batch unstage selected files` (12f7cd5)

- `WorkingDirectory.tsx`의 staged 파일 패널이 `onSelect={() => {}}` dead handler였던 것을 살림.
- `selectedStagedFiles` Set + `handleSelectStagedFile`/`handleUnstageSelected` + 빨간 "Unstage Selected (N)" 액션 바.

## Test Plan

- [x] `pytest tests/backend/test_rag_service.py tests/backend/test_rag_verification.py` → **90 passed** (신규 19 + 기존 71)
- [x] `tsc --noEmit` (dashboard) → exit 0
- [x] pre-commit lefthook의 ruff format/check, eslint --fix 모두 통과
- [x] 실측 (머지 후 권장): 백엔드 재시작 → `obsidian` 재인덱싱 → 첫 회는 기존과 동일, 두 번째 회는 캐시 hit으로 수십 초 → 한 자릿수 초로 단축되는지 확인
- [x] 실측: `RAG_EMBEDDING_MODEL`을 다른 차원 모델로 바꿔보고 인덱싱 시도 → 명확한 RuntimeError 메시지 확인
- [x] 실측: dashboard에서 "재인덱싱" 클릭 → 스피너 + "마지막: N 청크" 표시 → 완료 후 자연스럽게 청크 수 갱신
- [x] 실측: staged 파일 다중 선택 → "Unstage Selected (N)" 클릭 → 일괄 unstage 동작 확인

## Notes

- `RAG_INDEX_CACHE_DIR` 환경변수로 캐시 위치 오버라이드 가능 (기본 `~/.aos/rag_index/`).
- 첫 머지 후엔 캐시가 비어있어 한 번은 풀 인덱싱 발생. 그 다음부터 incremental.
- 컬렉션 차원 검증은 기존 정상 운영 중인 시스템(`intfloat/multilingual-e5-base` 768-dim ↔ `proj_*` dim=768)에는 영향 0.
