### PR TITLE
fix(git): use commit SHA for git refs on detached HEAD

### DIFF
--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -84,12 +84,31 @@ class GitService:
 
     @property
     def current_branch(self) -> str:
-        """Get the current branch name."""
+        """Get the current branch name as a display label.
+
+        On detached HEAD, returns a human-readable marker like ``HEAD@abc1234``.
+        That marker is NOT a valid git revision — git will reject it with
+        ``fatal: bad revision``. Use :pyattr:`current_ref` whenever the value
+        will be passed to git (rev-list, iter_commits, push, pull, ...).
+        """
         try:
             return self.repo.active_branch.name
         except TypeError:
             # Detached HEAD state
             return f"HEAD@{self.repo.head.commit.hexsha[:7]}"
+
+    @property
+    def current_ref(self) -> str:
+        """Get a git-resolvable revision for the current HEAD.
+
+        Returns the active branch name when checked out normally, or the full
+        commit SHA when HEAD is detached. Always safe to pass to GitPython /
+        ``git`` as a revision argument.
+        """
+        try:
+            return self.repo.active_branch.name
+        except TypeError:
+            return self.repo.head.commit.hexsha
 
     # =========================================================================
     # Worktree Operations
@@ -507,7 +526,10 @@ class GitService:
         """
         commits: list[GitCommit] = []
         try:
-            ref = branch or self.current_branch
+            # current_ref (not current_branch) so detached HEAD resolves to the
+            # commit SHA rather than the "HEAD@abc1234" display label, which
+            # git rejects as ``fatal: bad revision``.
+            ref = branch or self.current_ref
             for commit in self.repo.iter_commits(ref, max_count=limit, skip=skip):
                 commits.append(self._commit_to_model(commit))
         except GitCommandError as e:
@@ -1387,7 +1409,7 @@ class GitService:
         Returns:
             Pull result
         """
-        branch = branch or self.current_branch
+        branch = branch or self.current_ref
         try:
             remote_obj = self.repo.remotes[remote]
 
@@ -1433,7 +1455,7 @@ class GitService:
         Returns:
             Push result
         """
-        branch = branch or self.current_branch
+        branch = branch or self.current_ref
         try:
             remote_obj = self.repo.remotes[remote]
 


### PR DESCRIPTION
## Summary

- Detached HEAD 상태에서 Process Manager / Git 페이지가 `fatal: bad revision 'HEAD@abc1234'` 로 죽던 버그를 수정합니다.
- 원인은 `GitService.current_branch`가 detached HEAD일 때 사람이 읽는 라벨(`HEAD@<short-sha>`)을 반환하는데, 같은 클래스 안에서 그 값을 git에 그대로 revision으로 넘기던 호출부들이 있었기 때문입니다.
- 라벨용 `current_branch`는 그대로 두고, 새 `current_ref` 프로퍼티(detached 시 full SHA 반환)를 추가해 git revision 사용처(`get_commits`, `pull`, `push`)에서만 사용하도록 분리했습니다.

## Changes

- `src/backend/services/git_service.py`
  - `current_branch` 프로퍼티에 라벨 용도 명시(docstring)
  - 신규 `current_ref` 프로퍼티 — detached HEAD 시 `repo.head.commit.hexsha` 반환
  - `get_commits`(line 510): `branch or self.current_branch` → `branch or self.current_ref`
  - `pull`(line 1390): 동일
  - `push`(line 1436): 동일

UI 표시·응답 모델 등 라벨이 의도된 곳(`list_branches`, `GitWorkingStatus.branch`, `GitWorktree.branch` 등)은 손대지 않았습니다.

## Test plan

- [x] `ruff check` / `ruff format` (lefthook 자동 적용)
- [x] 정상 브랜치 체크아웃 상태에서 `current_branch == current_ref == active_branch.name`, `get_commits()` 정상 동작 확인
- [x] **Detached HEAD 재현 케이스(임시 repo)**: 이전엔 `fatal: bad revision 'HEAD@<sha>'`, 수정 후 `current_branch == 'HEAD@<sha>'`(라벨), `current_ref == '<full sha>'`, `get_commits` 정상 동작 확인
- [ ] 머지 후 LiveMetro 같은 detached HEAD worktree에서 Process Manager / commits 화면 정상 로드 확인

## Notes

- 같은 패턴이 `pull` / `push`에도 있어 한 번에 정리했습니다. detached HEAD에서 push 자체는 의미가 모호하지만, 적어도 잘못된 ref 문자열로 git이 죽는 사고는 사라집니다.
- 화면에 `HEAD@abc1234` 라벨로 노출되던 부분은 그대로 유지되어 UI 표시는 변하지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)