### PR TITLE
feat: prune merged branches — PR-driven cleanup of stale local branches

### DIFF
--- a/src/backend/api/git.py
+++ b/src/backend/api/git.py
@@ -64,6 +64,9 @@ from models.git import (
     MergeRequestStatus,
     MergeRequestUpdate,
     MergeResult,
+    # Prune merged branches
+    PruneExecuteResult,
+    PruneRequest,
     PullResult,
     PushResult,
     RemoteAddRequest,
@@ -788,6 +791,65 @@ async def delete_branch(
         return {"success": success, "message": message}
     except GitServiceError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post(
+    "/projects/{project_id}/branches/prune-merged",
+    response_model=PruneExecuteResult,
+)
+async def prune_merged_branches(project_id: str, request: PruneRequest):
+    """Prune local branches whose GitHub PR has been merged.
+
+    Two phases:
+    - dry_run=True  → scan only, returns candidates + skipped (no deletion)
+    - dry_run=False → executes deletion of candidates, returns deletion outcome
+
+    GitHub token required (503 if not configured). Protection rules from
+    BranchProtectionRule table are honored automatically.
+    """
+    from services.git_service import GitServiceError
+
+    git_service = get_git_service_for_project(project_id)
+    github_service = get_github_service()  # raises 503 without token
+
+    # Pre-fetch active protection patterns (async DB) → pass to sync service
+    protection_patterns: list[str] = []
+    db_session = await _get_db_session()
+    if db_session:
+        try:
+            async with db_session:
+                from db.repository import BranchProtectionRepository
+
+                repo = BranchProtectionRepository(db_session)
+                rules = await repo.list_by_project(project_id, enabled_only=True)
+                protection_patterns = [r.branch_pattern for r in rules if r.branch_pattern]
+        except Exception as e:
+            logger.warning(f"Failed to load protection rules for {project_id}: {e}")
+
+    try:
+        scan = git_service.find_prune_candidates(
+            github_service=github_service,
+            protection_patterns=protection_patterns,
+            extra_protected=request.extra_protected,
+        )
+    except GitServiceError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if request.dry_run:
+        return PruneExecuteResult(
+            candidates=scan.candidates,
+            skipped=scan.skipped,
+            deleted=[],
+            errors=[],
+        )
+
+    execute = git_service.prune_merged_branches(scan.candidates)
+    return PruneExecuteResult(
+        candidates=execute.candidates,
+        skipped=scan.skipped,  # preserve skip reasons across both phases
+        deleted=execute.deleted,
+        errors=execute.errors,
+    )
 
 
 @router.get("/projects/{project_id}/branches/{branch_name:path}/diff", response_model=BranchDiff)

--- a/src/backend/models/git.py
+++ b/src/backend/models/git.py
@@ -609,6 +609,63 @@ GIT_ROLE_PERMISSIONS: dict[str, list[GitPermission]] = {
 # Default protected branches
 DEFAULT_PROTECTED_BRANCHES = ["main", "master"]
 
+# Branches that prune-merged must never delete, regardless of merge state
+PRUNE_PROTECTED_BRANCHES: frozenset[str] = frozenset({"main", "master", "develop"})
+
+
+# =============================================================================
+# Prune Merged Branches Models
+# =============================================================================
+
+
+class PruneCandidate(BaseModel):
+    """A local branch eligible for prune (matching merged PR + passes safety checks)."""
+
+    branch: str
+    pr_number: int
+    pr_url: str
+    pr_title: str
+    merged_at: datetime
+    last_commit_sha: str
+
+
+class PruneSkipped(BaseModel):
+    """A local branch excluded from prune with a reason.
+
+    Reason codes (stable contract for UI):
+      - default_branch     : main/master/develop
+      - current_head       : the active HEAD branch
+      - unpushed_commits   : local commits not present on origin
+      - no_matching_pr     : no merged PR matches branch name
+      - protected_rule     : matched a BranchProtectionRule pattern
+    """
+
+    branch: str
+    reason: str
+
+
+class PruneScanResult(BaseModel):
+    """Dry-run result: what would be deleted vs skipped."""
+
+    candidates: list[PruneCandidate] = []
+    skipped: list[PruneSkipped] = []
+
+
+class PruneExecuteResult(BaseModel):
+    """Actual deletion result, extending scan with deletion outcomes."""
+
+    candidates: list[PruneCandidate] = []
+    skipped: list[PruneSkipped] = []
+    deleted: list[str] = []
+    errors: list[dict] = []  # [{"branch": str, "error": str}]
+
+
+class PruneRequest(BaseModel):
+    """API request body for POST /branches/prune-merged."""
+
+    dry_run: bool = True
+    extra_protected: list[str] = []
+
 
 def has_git_permission(role: str, permission: GitPermission) -> bool:
     """Check if a role has a specific Git permission."""

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from models.git import (
     DEFAULT_PROTECTED_BRANCHES,
+    PRUNE_PROTECTED_BRANCHES,
     AddResult,
     BranchDiff,
     CommitCreateResult,
@@ -43,6 +44,10 @@ from models.git import (
     GitStatusFile,
     GitWorkingStatus,
     GitWorktree,
+    PruneCandidate,
+    PruneExecuteResult,
+    PruneScanResult,
+    PruneSkipped,
     PullResult,
     PushResult,
 )
@@ -445,6 +450,129 @@ class GitService:
                         raise GitServiceError(
                             f"Failed to clean up stale remote ref '{remote_ref}': {prune_err}"
                         )
+
+    def find_prune_candidates(
+        self,
+        github_service,
+        protection_patterns: list[str] | None = None,
+        extra_protected: list[str] | None = None,
+    ) -> PruneScanResult:
+        """Find local branches eligible for prune (matching merged PR).
+
+        Uses GitHub PR `merged_at` as source of truth so squash-merge is detected.
+        Applies 4-fold protection: PRUNE_PROTECTED_BRANCHES, current HEAD,
+        unpushed commits, BranchProtectionRule patterns.
+
+        Note: protection_patterns must be pre-fetched by the API layer (async DB).
+        Keeping this method DB-free preserves test isolation and reusability.
+
+        Args:
+            github_service: GitHubService instance for PR lookup
+            protection_patterns: Branch glob patterns (e.g. ["release/*", "hotfix/*"])
+            extra_protected: Additional branch names to exclude (user-supplied)
+
+        Returns:
+            PruneScanResult with candidates and skipped lists
+        """
+        from fnmatch import fnmatch
+
+        extra = set(extra_protected or [])
+        patterns = protection_patterns or []
+        current_head = self.repo.active_branch.name
+
+        # Fetch merged PRs (Wave 0 fix: limit must be high to avoid stale-branch miss)
+        merged_prs_by_head: dict[str, object] = {}
+        try:
+            prs = github_service.list_pull_requests(state="all", limit=500)
+            for pr in prs:
+                if pr.merged_at is not None:
+                    merged_prs_by_head[pr.head_ref] = pr
+        except Exception as e:
+            logger.warning(f"Failed to fetch PRs for prune scan: {e}")
+
+        candidates: list[PruneCandidate] = []
+        skipped: list[PruneSkipped] = []
+
+        for branch in self.repo.branches:
+            name = branch.name
+
+            if name in PRUNE_PROTECTED_BRANCHES or name in extra:
+                skipped.append(PruneSkipped(branch=name, reason="default_branch"))
+                continue
+
+            if name == current_head:
+                skipped.append(PruneSkipped(branch=name, reason="current_head"))
+                continue
+
+            if any(fnmatch(name, pattern) for pattern in patterns):
+                skipped.append(PruneSkipped(branch=name, reason="protected_rule"))
+                continue
+
+            pr = merged_prs_by_head.get(name)
+            if pr is None:
+                # No merged PR → not a prune target regardless of push state
+                skipped.append(PruneSkipped(branch=name, reason="no_matching_pr"))
+                continue
+
+            if self._has_unpushed_commits(branch):
+                # PR exists but local has additional unpushed commits — protect work
+                skipped.append(PruneSkipped(branch=name, reason="unpushed_commits"))
+                continue
+
+            candidates.append(
+                PruneCandidate(
+                    branch=name,
+                    pr_number=pr.number,
+                    pr_url=pr.html_url,
+                    pr_title=pr.title,
+                    merged_at=pr.merged_at,
+                    last_commit_sha=branch.commit.hexsha,
+                )
+            )
+
+        return PruneScanResult(candidates=candidates, skipped=skipped)
+
+    def _has_unpushed_commits(self, branch) -> bool:
+        """Return True if branch has local commits not on its tracked remote.
+
+        Conservative: treats untracked branches as unpushed (so they're skipped),
+        protecting purely-local work.
+        """
+        tracking = branch.tracking_branch()
+        if tracking is None:
+            return True
+        try:
+            ahead = sum(1 for _ in self.repo.iter_commits(f"{tracking.name}..{branch.name}"))
+            return ahead > 0
+        except Exception as e:
+            logger.warning(f"Failed to compute ahead for '{branch.name}': {e}")
+            return True
+
+    def prune_merged_branches(self, candidates: list[PruneCandidate]) -> PruneExecuteResult:
+        """Delete each candidate branch locally; collect errors without aborting batch.
+
+        Args:
+            candidates: Pre-vetted candidates from find_prune_candidates()
+
+        Returns:
+            PruneExecuteResult with deleted names and per-branch errors
+        """
+        deleted: list[str] = []
+        errors: list[dict] = []
+
+        for candidate in candidates:
+            try:
+                self.delete_branch(candidate.branch)
+                deleted.append(candidate.branch)
+            except Exception as e:
+                errors.append({"branch": candidate.branch, "error": str(e)})
+
+        return PruneExecuteResult(
+            candidates=candidates,
+            skipped=[],
+            deleted=deleted,
+            errors=errors,
+        )
 
     def checkout_branch(self, name: str, create: bool = False) -> GitBranch:
         """Checkout a branch.

--- a/src/dashboard/src/components/git/BranchList.tsx
+++ b/src/dashboard/src/components/git/BranchList.tsx
@@ -7,6 +7,7 @@ import {
   GitMerge,
   RefreshCw,
   Plus,
+  Sparkles,
   ArrowUp,
   ArrowDown,
   Cloud,
@@ -39,6 +40,7 @@ interface BranchListProps {
   onDeleteBranch: (name: string, force?: boolean, deleteRemote?: boolean, removeWorktree?: boolean) => Promise<boolean>
   onMergeClick: (source: string) => void
   onRefresh: () => void
+  onPruneMerged?: () => void
   conflictStatuses?: Record<string, ConflictStatus>
   worktrees?: GitWorktree[]
 }
@@ -53,6 +55,7 @@ export function BranchList({
   onDeleteBranch,
   onMergeClick,
   onRefresh,
+  onPruneMerged,
   conflictStatuses = {},
   worktrees = [],
 }: BranchListProps) {
@@ -195,6 +198,20 @@ export function BranchList({
           >
             <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} />
           </button>
+
+          {onPruneMerged && (
+            <button
+              type="button"
+              onClick={onPruneMerged}
+              disabled={isLoading}
+              aria-label="머지된 브랜치 정리"
+              title="GitHub PR이 머지된 로컬 브랜치를 일괄 정리"
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 rounded-lg transition-colors disabled:opacity-50"
+            >
+              <Sparkles className="w-4 h-4" />
+              Prune Merged
+            </button>
+          )}
 
           <button
             onClick={() => setShowCreateModal(true)}

--- a/src/dashboard/src/components/git/PruneMergedModal.tsx
+++ b/src/dashboard/src/components/git/PruneMergedModal.tsx
@@ -1,0 +1,319 @@
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, X } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import type {
+  PruneCandidate,
+  PruneExecuteResult,
+  PruneSkipReason,
+  PruneSkipped,
+} from '../../stores/git'
+
+interface PruneMergedModalProps {
+  isOpen: boolean
+  projectId: string
+  onClose: () => void
+  pruneMergedBranches: (
+    projectId: string,
+    dryRun: boolean,
+    extraProtected?: string[],
+  ) => Promise<PruneExecuteResult | null>
+}
+
+const SKIP_REASON_LABEL: Record<PruneSkipReason, string> = {
+  default_branch: '기본 브랜치 보호',
+  current_head: '현재 checked-out 브랜치',
+  unpushed_commits: '푸시되지 않은 커밋 있음',
+  no_matching_pr: '매칭되는 머지된 PR 없음',
+  protected_rule: 'Branch Protection 룰 적용됨',
+}
+
+function PruneMergedModalImpl({
+  isOpen,
+  projectId,
+  onClose,
+  pruneMergedBranches,
+}: PruneMergedModalProps) {
+  const [phase, setPhase] = useState<'scanning' | 'review' | 'executing' | 'done'>('scanning')
+  const [scanResult, setScanResult] = useState<PruneExecuteResult | null>(null)
+  const [executeResult, setExecuteResult] = useState<PruneExecuteResult | null>(null)
+  const [excluded, setExcluded] = useState<Set<string>>(new Set())
+  const [scanError, setScanError] = useState<string | null>(null)
+
+  const runScan = useCallback(async () => {
+    setPhase('scanning')
+    setScanError(null)
+    const result = await pruneMergedBranches(projectId, true)
+    if (result === null) {
+      setScanError('스캔 실패 — GitHub 토큰을 확인하세요.')
+      return
+    }
+    setScanResult(result)
+    setExcluded(new Set())
+    setPhase('review')
+  }, [projectId, pruneMergedBranches])
+
+  useEffect(() => {
+    if (isOpen) {
+      runScan()
+    } else {
+      setScanResult(null)
+      setExecuteResult(null)
+      setExcluded(new Set())
+      setPhase('scanning')
+      setScanError(null)
+    }
+  }, [isOpen, runScan])
+
+  const selectedBranches = useMemo(
+    () =>
+      (scanResult?.candidates ?? []).filter((c) => !excluded.has(c.branch)).map((c) => c.branch),
+    [scanResult, excluded],
+  )
+
+  const handleToggle = useCallback((branch: string) => {
+    setExcluded((prev) => {
+      const next = new Set(prev)
+      if (next.has(branch)) next.delete(branch)
+      else next.add(branch)
+      return next
+    })
+  }, [])
+
+  const handleExecute = useCallback(async () => {
+    if (selectedBranches.length === 0) return
+    setPhase('executing')
+    const result = await pruneMergedBranches(
+      projectId,
+      false,
+      Array.from(excluded),
+    )
+    setExecuteResult(result)
+    setPhase('done')
+  }, [projectId, pruneMergedBranches, selectedBranches.length, excluded])
+
+  const candidates = scanResult?.candidates ?? []
+  const skipped = scanResult?.skipped ?? []
+  const skippedGroups = useMemo(() => groupSkipped(scanResult?.skipped ?? []), [scanResult])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/50" onClick={phase === 'executing' ? undefined : onClose} />
+
+      <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 rounded-lg bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center">
+              <AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+              머지된 브랜치 정리
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={phase === 'executing'}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+            aria-label="닫기"
+          >
+            <X className="w-5 h-5 text-gray-500" />
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto flex-1">
+          {phase === 'scanning' && (
+            <div className="flex items-center justify-center gap-3 py-12 text-gray-500 dark:text-gray-400">
+              <Loader2 className="w-5 h-5 animate-spin" />
+              <span>스캔 중... GitHub PR과 로컬 브랜치를 대조하고 있습니다.</span>
+            </div>
+          )}
+
+          {scanError && (
+            <div className="rounded-lg bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-700 dark:text-red-300">
+              {scanError}
+            </div>
+          )}
+
+          {phase === 'review' && scanResult && (
+            <>
+              <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+                GitHub PR이 머지된 로컬 브랜치 {candidates.length}개가 정리 후보입니다.
+                체크박스로 개별 제외할 수 있습니다.
+              </p>
+
+              {candidates.length === 0 ? (
+                <div className="rounded-lg bg-gray-50 dark:bg-gray-900 p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                  정리할 브랜치가 없습니다.
+                </div>
+              ) : (
+                <div className="rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
+                  {candidates.map((c) => (
+                    <CandidateRow
+                      key={c.branch}
+                      candidate={c}
+                      checked={!excluded.has(c.branch)}
+                      onToggle={() => handleToggle(c.branch)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {skipped.length > 0 && (
+                <details className="mt-4 group" aria-label={`제외된 브랜치 ${skipped.length}개`}>
+                  <summary className="cursor-pointer text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">
+                    제외된 브랜치 ({skipped.length})
+                  </summary>
+                  <div className="mt-2 space-y-2 text-sm">
+                    {Object.entries(skippedGroups).map(([reason, items]) => (
+                      <div key={reason}>
+                        <div className="font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          {SKIP_REASON_LABEL[reason as PruneSkipReason] ?? reason}
+                          <span className="ml-2 text-xs text-gray-500">({items.length})</span>
+                        </div>
+                        <ul className="pl-4 space-y-0.5">
+                          {items.map((s) => (
+                            <li key={s.branch} className="font-mono text-xs text-gray-600 dark:text-gray-400">
+                              {s.branch}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                </details>
+              )}
+            </>
+          )}
+
+          {phase === 'executing' && (
+            <div className="flex items-center justify-center gap-3 py-12 text-gray-500 dark:text-gray-400">
+              <Loader2 className="w-5 h-5 animate-spin" />
+              <span>{selectedBranches.length}개 브랜치 삭제 중...</span>
+            </div>
+          )}
+
+          {phase === 'done' && executeResult && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2 text-green-700 dark:text-green-300">
+                <CheckCircle2 className="w-5 h-5" />
+                <span className="font-medium">
+                  {executeResult.deleted.length}개 브랜치 삭제 완료
+                </span>
+              </div>
+
+              {executeResult.deleted.length > 0 && (
+                <ul className="rounded-lg bg-gray-50 dark:bg-gray-900 p-3 space-y-1">
+                  {executeResult.deleted.map((b) => (
+                    <li key={b} className="font-mono text-xs text-gray-600 dark:text-gray-400">
+                      {b}
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {executeResult.errors.length > 0 && (
+                <div className="rounded-lg bg-red-50 dark:bg-red-900/20 p-3 space-y-2">
+                  <div className="text-sm font-medium text-red-700 dark:text-red-300">
+                    {executeResult.errors.length}개 실패
+                  </div>
+                  <ul className="space-y-1 text-xs">
+                    {executeResult.errors.map((e) => (
+                      <li key={e.branch} className="text-red-600 dark:text-red-400">
+                        <span className="font-mono">{e.branch}</span>: {e.error}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+          {phase === 'done' ? (
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700"
+            >
+              닫기
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={phase === 'executing'}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-600 disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={handleExecute}
+                disabled={phase !== 'review' || selectedBranches.length === 0}
+                className={cn(
+                  'flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700',
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
+                )}
+              >
+                {phase === 'executing' && <Loader2 className="w-4 h-4 animate-spin" />}
+                {selectedBranches.length}개 브랜치 삭제
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface CandidateRowProps {
+  candidate: PruneCandidate
+  checked: boolean
+  onToggle: () => void
+}
+
+const CandidateRow = memo(function CandidateRow({ candidate, checked, onToggle }: CandidateRowProps) {
+  return (
+    <label className="flex items-start gap-3 px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onToggle}
+        className="mt-1 rounded border-gray-300 dark:border-gray-600"
+        aria-label={`${candidate.branch} 삭제 선택`}
+      />
+      <div className="flex-1 min-w-0">
+        <div className="font-mono text-sm text-gray-900 dark:text-gray-100 truncate">
+          {candidate.branch}
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+          <a
+            href={candidate.pr_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex items-center gap-1 hover:text-blue-600 dark:hover:text-blue-400"
+          >
+            PR #{candidate.pr_number}
+            <ExternalLink className="w-3 h-3" />
+          </a>
+          <span className="truncate">{candidate.pr_title}</span>
+        </div>
+      </div>
+    </label>
+  )
+})
+
+function groupSkipped(skipped: PruneSkipped[]): Record<string, PruneSkipped[]> {
+  return skipped.reduce<Record<string, PruneSkipped[]>>((acc, s) => {
+    ;(acc[s.reason] ??= []).push(s)
+    return acc
+  }, {})
+}
+
+export const PruneMergedModal = memo(PruneMergedModalImpl)
+PruneMergedModal.displayName = 'PruneMergedModal'

--- a/src/dashboard/src/components/git/__tests__/PruneMergedModal.test.tsx
+++ b/src/dashboard/src/components/git/__tests__/PruneMergedModal.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { PruneMergedModal } from '../PruneMergedModal'
+import type { PruneExecuteResult } from '@/stores/git'
+
+function makeCandidate(branch: string, prNumber: number): PruneExecuteResult['candidates'][number] {
+  return {
+    branch,
+    pr_number: prNumber,
+    pr_url: `https://github.com/o/r/pull/${prNumber}`,
+    pr_title: `PR #${prNumber}`,
+    merged_at: '2026-04-12T10:30:00Z',
+    last_commit_sha: 'abc123',
+  }
+}
+
+function makeScanResult(
+  overrides: Partial<PruneExecuteResult> = {},
+): PruneExecuteResult {
+  return {
+    candidates: [],
+    skipped: [],
+    deleted: [],
+    errors: [],
+    ...overrides,
+  }
+}
+
+describe('PruneMergedModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not render when isOpen is false', () => {
+    const prune = vi.fn()
+    render(
+      <PruneMergedModal
+        isOpen={false}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(prune).not.toHaveBeenCalled()
+  })
+
+  it('triggers dry-run scan on open and shows candidates', async () => {
+    const prune = vi.fn().mockResolvedValue(
+      makeScanResult({
+        candidates: [makeCandidate('feat/a', 1), makeCandidate('feat/b', 2)],
+      }),
+    )
+    render(
+      <PruneMergedModal
+        isOpen={true}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('feat/a')).toBeInTheDocument()
+      expect(screen.getByText('feat/b')).toBeInTheDocument()
+    })
+
+    expect(prune).toHaveBeenCalledWith('proj-1', true)
+  })
+
+  it('groups skipped branches by reason', async () => {
+    const prune = vi.fn().mockResolvedValue(
+      makeScanResult({
+        candidates: [makeCandidate('feat/a', 1)],
+        skipped: [
+          { branch: 'main', reason: 'default_branch' },
+          { branch: 'master', reason: 'default_branch' },
+          { branch: 'wip/x', reason: 'no_matching_pr' },
+        ],
+      }),
+    )
+    render(
+      <PruneMergedModal
+        isOpen={true}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/제외된 브랜치 \(3\)/)).toBeInTheDocument()
+    })
+  })
+
+  it('uncheck excludes branch from deletion call', async () => {
+    const prune = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeScanResult({
+          candidates: [makeCandidate('feat/a', 1), makeCandidate('feat/b', 2)],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeScanResult({ deleted: ['feat/a'] }),
+      )
+
+    render(
+      <PruneMergedModal
+        isOpen={true}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('feat/b 삭제 선택')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByLabelText('feat/b 삭제 선택'))
+
+    const deleteBtn = await screen.findByRole('button', { name: /1개 브랜치 삭제/ })
+    fireEvent.click(deleteBtn)
+
+    await waitFor(() => {
+      expect(prune).toHaveBeenLastCalledWith('proj-1', false, ['feat/b'])
+    })
+  })
+
+  it('delete button disabled when no candidates', async () => {
+    const prune = vi.fn().mockResolvedValue(makeScanResult())
+    render(
+      <PruneMergedModal
+        isOpen={true}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/정리할 브랜치가 없습니다/)).toBeInTheDocument()
+    })
+
+    const deleteBtn = screen.getByRole('button', { name: /0개 브랜치 삭제/ })
+    expect(deleteBtn).toBeDisabled()
+  })
+
+  it('shows error when scan fails (token missing)', async () => {
+    const prune = vi.fn().mockResolvedValue(null)
+    render(
+      <PruneMergedModal
+        isOpen={true}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/GitHub 토큰을 확인하세요/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows deleted result and errors after execute', async () => {
+    const prune = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeScanResult({
+          candidates: [makeCandidate('feat/a', 1), makeCandidate('feat/b', 2)],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeScanResult({
+          deleted: ['feat/a'],
+          errors: [{ branch: 'feat/b', error: 'worktree present' }],
+        }),
+      )
+
+    render(
+      <PruneMergedModal
+        isOpen={true}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+
+    await waitFor(() => screen.getByLabelText('feat/a 삭제 선택'))
+    fireEvent.click(screen.getByRole('button', { name: /2개 브랜치 삭제/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/1개 브랜치 삭제 완료/)).toBeInTheDocument()
+      expect(screen.getByText(/1개 실패/)).toBeInTheDocument()
+      expect(screen.getByText(/worktree present/)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/dashboard/src/pages/GitPage.tsx
+++ b/src/dashboard/src/pages/GitPage.tsx
@@ -30,6 +30,7 @@ import {
   BranchProtectionSettings,
   GitAlert,
 } from '../components/git'
+import { PruneMergedModal } from '../components/git/PruneMergedModal'
 
 const tabs: { id: GitTab; label: string; icon: typeof GitBranch }[] = [
   { id: 'changes', label: 'Changes', icon: FileEdit },
@@ -62,6 +63,7 @@ export function GitPage() {
     createBranch,
     checkoutBranch,
     deleteBranch,
+    pruneMergedBranches,
     // Commits
     commits,
     fetchCommits,
@@ -154,6 +156,7 @@ export function GitPage() {
   const [showCreateMR, setShowCreateMR] = useState(false)
   const [showPRReview, setShowPRReview] = useState(false)
   const [userRole, setUserRole] = useState<MemberRole>('viewer')
+  const [showPruneModal, setShowPruneModal] = useState(false)
 
   // Current user info
   const currentUserId = user?.id || 'anonymous'
@@ -417,6 +420,7 @@ export function GitPage() {
                 onDeleteBranch={(name, force, deleteRemote, removeWorktree) => deleteBranch(selectedProjectId, name, force, deleteRemote, removeWorktree)}
                 onMergeClick={handleMergeClick}
                 onRefresh={() => fetchBranches(selectedProjectId)}
+                onPruneMerged={() => setShowPruneModal(true)}
                 worktrees={worktrees}
               />
             )}
@@ -525,6 +529,16 @@ export function GitPage() {
             return success
           }}
           onClose={() => setShowCreateMR(false)}
+        />
+      )}
+
+      {/* Prune Merged Branches Modal */}
+      {selectedProjectId && (
+        <PruneMergedModal
+          isOpen={showPruneModal}
+          projectId={selectedProjectId}
+          onClose={() => setShowPruneModal(false)}
+          pruneMergedBranches={pruneMergedBranches}
         />
       )}
 

--- a/src/dashboard/src/stores/git.ts
+++ b/src/dashboard/src/stores/git.ts
@@ -60,6 +60,38 @@ export interface MergeRequest {
   closed_by: string | null
 }
 
+// =============================================================================
+// Prune Merged Branches Types
+// =============================================================================
+
+export interface PruneCandidate {
+  branch: string
+  pr_number: number
+  pr_url: string
+  pr_title: string
+  merged_at: string
+  last_commit_sha: string
+}
+
+export type PruneSkipReason =
+  | 'default_branch'
+  | 'current_head'
+  | 'unpushed_commits'
+  | 'no_matching_pr'
+  | 'protected_rule'
+
+export interface PruneSkipped {
+  branch: string
+  reason: PruneSkipReason
+}
+
+export interface PruneExecuteResult {
+  candidates: PruneCandidate[]
+  skipped: PruneSkipped[]
+  deleted: string[]
+  errors: Array<{ branch: string; error: string }>
+}
+
 export interface BranchProtectionRule {
   id: string
   project_id: string
@@ -386,6 +418,7 @@ interface GitState {
   createBranch: (projectId: string, name: string, startPoint?: string) => Promise<boolean>
   checkoutBranch: (projectId: string, name: string) => Promise<boolean>
   deleteBranch: (projectId: string, name: string, force?: boolean, deleteRemote?: boolean, removeWorktree?: boolean) => Promise<boolean>
+  pruneMergedBranches: (projectId: string, dryRun: boolean, extraProtected?: string[]) => Promise<PruneExecuteResult | null>
 
   // Actions - Commits
   fetchCommits: (projectId: string, branch?: string, limit?: number) => Promise<void>
@@ -829,6 +862,24 @@ export const useGitStore = create<GitState>((set, get) => ({
     } catch (error) {
       set({ error: (error as Error).message, isLoading: false })
       return false
+    }
+  },
+
+  pruneMergedBranches: async (projectId, dryRun, extraProtected = []) => {
+    set({ isLoading: true, error: null })
+    try {
+      const result = await apiClient.post<PruneExecuteResult>(
+        `/api/git/projects/${projectId}/branches/prune-merged`,
+        { dry_run: dryRun, extra_protected: extraProtected },
+      )
+      if (!dryRun) {
+        await get().fetchBranches(projectId)
+      }
+      set({ isLoading: false })
+      return result
+    } catch (error) {
+      set({ error: (error as Error).message, isLoading: false })
+      return null
     }
   },
 

--- a/tests/backend/api/test_api_git_prune.py
+++ b/tests/backend/api/test_api_git_prune.py
@@ -1,0 +1,224 @@
+"""API tests for POST /branches/prune-merged endpoint."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Create test FastAPI app with git router."""
+    from api.git import router
+
+    test_app = FastAPI()
+    test_app.include_router(router)
+    return test_app
+
+
+@pytest_asyncio.fixture
+async def client(app: FastAPI) -> AsyncClient:
+    """Async HTTP client bound to the test app."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        yield c
+
+
+def _make_candidate(branch: str = "feat/done", pr: int = 42):
+    from models.git import PruneCandidate
+
+    return PruneCandidate(
+        branch=branch,
+        pr_number=pr,
+        pr_url=f"https://github.com/o/r/pull/{pr}",
+        pr_title="title",
+        merged_at=datetime.now(UTC),
+        last_commit_sha="abc123",
+    )
+
+
+def _make_scan_result(candidates=None, skipped=None):
+    from models.git import PruneScanResult
+
+    return PruneScanResult(
+        candidates=candidates or [],
+        skipped=skipped or [],
+    )
+
+
+def _make_execute_result(deleted=None, errors=None):
+    from models.git import PruneExecuteResult
+
+    return PruneExecuteResult(
+        candidates=[],
+        skipped=[],
+        deleted=deleted or [],
+        errors=errors or [],
+    )
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+PRUNE_PATH = "/git/projects/proj-1/branches/prune-merged"
+
+
+class TestPruneMergedEndpoint:
+    """POST /projects/{id}/branches/prune-merged contract tests."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_candidates_no_delete(self, client):
+        """dry_run=True must call find_prune_candidates but not prune_merged_branches."""
+        git_service = MagicMock()
+        git_service.find_prune_candidates.return_value = _make_scan_result(
+            candidates=[_make_candidate("feat/a", pr=1)]
+        )
+        git_service.prune_merged_branches = MagicMock()
+
+        with (
+            patch("api.git.get_git_service_for_project", return_value=git_service),
+            patch("api.git.get_github_service", return_value=MagicMock()),
+            patch("api.git._get_db_session", new=AsyncMock(return_value=None)),
+        ):
+            resp = await client.post(PRUNE_PATH, json={"dry_run": True})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [c["branch"] for c in body["candidates"]] == ["feat/a"]
+        assert body["deleted"] == []
+        git_service.prune_merged_branches.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_actual_run_invokes_batch_delete(self, client):
+        """dry_run=False must call prune_merged_branches and surface deleted list."""
+        git_service = MagicMock()
+        candidate = _make_candidate("feat/a", pr=1)
+        git_service.find_prune_candidates.return_value = _make_scan_result(
+            candidates=[candidate]
+        )
+        git_service.prune_merged_branches.return_value = _make_execute_result(
+            deleted=["feat/a"]
+        )
+
+        with (
+            patch("api.git.get_git_service_for_project", return_value=git_service),
+            patch("api.git.get_github_service", return_value=MagicMock()),
+            patch("api.git._get_db_session", new=AsyncMock(return_value=None)),
+        ):
+            resp = await client.post(PRUNE_PATH, json={"dry_run": False})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["deleted"] == ["feat/a"]
+        git_service.prune_merged_branches.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skipped_preserved_across_phases(self, client):
+        """Skip reasons from scan must survive the execute phase."""
+        from models.git import PruneSkipped
+
+        git_service = MagicMock()
+        skipped = [PruneSkipped(branch="main", reason="default_branch")]
+        git_service.find_prune_candidates.return_value = _make_scan_result(
+            candidates=[_make_candidate("feat/a", pr=1)],
+            skipped=skipped,
+        )
+        git_service.prune_merged_branches.return_value = _make_execute_result(
+            deleted=["feat/a"]
+        )
+
+        with (
+            patch("api.git.get_git_service_for_project", return_value=git_service),
+            patch("api.git.get_github_service", return_value=MagicMock()),
+            patch("api.git._get_db_session", new=AsyncMock(return_value=None)),
+        ):
+            resp = await client.post(PRUNE_PATH, json={"dry_run": False})
+
+        body = resp.json()
+        assert body["skipped"][0]["branch"] == "main"
+        assert body["skipped"][0]["reason"] == "default_branch"
+
+    @pytest.mark.asyncio
+    async def test_no_github_token_returns_503(self, client):
+        """When GITHUB_TOKEN is missing, get_github_service raises 503."""
+        from fastapi import HTTPException
+
+        git_service = MagicMock()
+
+        def raise_503():
+            raise HTTPException(status_code=503, detail="GitHub service not available")
+
+        with (
+            patch("api.git.get_git_service_for_project", return_value=git_service),
+            patch("api.git.get_github_service", side_effect=raise_503),
+            patch("api.git._get_db_session", new=AsyncMock(return_value=None)),
+        ):
+            resp = await client.post(PRUNE_PATH, json={"dry_run": True})
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_extra_protected_forwarded_to_service(self, client):
+        """extra_protected from request body must reach find_prune_candidates."""
+        git_service = MagicMock()
+        git_service.find_prune_candidates.return_value = _make_scan_result()
+
+        with (
+            patch("api.git.get_git_service_for_project", return_value=git_service),
+            patch("api.git.get_github_service", return_value=MagicMock()),
+            patch("api.git._get_db_session", new=AsyncMock(return_value=None)),
+        ):
+            resp = await client.post(
+                PRUNE_PATH,
+                json={"dry_run": True, "extra_protected": ["release/v1", "hotfix/x"]},
+            )
+
+        assert resp.status_code == 200
+        kwargs = git_service.find_prune_candidates.call_args.kwargs
+        assert kwargs["extra_protected"] == ["release/v1", "hotfix/x"]
+
+    @pytest.mark.asyncio
+    async def test_dry_run_defaults_to_true(self, client):
+        """Empty body → dry_run defaults to True (safe default)."""
+        git_service = MagicMock()
+        git_service.find_prune_candidates.return_value = _make_scan_result()
+        git_service.prune_merged_branches = MagicMock()
+
+        with (
+            patch("api.git.get_git_service_for_project", return_value=git_service),
+            patch("api.git.get_github_service", return_value=MagicMock()),
+            patch("api.git._get_db_session", new=AsyncMock(return_value=None)),
+        ):
+            resp = await client.post(PRUNE_PATH, json={})
+
+        assert resp.status_code == 200
+        git_service.prune_merged_branches.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_git_service_error_returns_400(self, client):
+        """Service errors during scan become HTTP 400."""
+        from services.git_service import GitServiceError
+
+        git_service = MagicMock()
+        git_service.find_prune_candidates.side_effect = GitServiceError("bad repo")
+
+        with (
+            patch("api.git.get_git_service_for_project", return_value=git_service),
+            patch("api.git.get_github_service", return_value=MagicMock()),
+            patch("api.git._get_db_session", new=AsyncMock(return_value=None)),
+        ):
+            resp = await client.post(PRUNE_PATH, json={"dry_run": True})
+
+        assert resp.status_code == 400
+        assert "bad repo" in resp.json()["detail"]

--- a/tests/backend/test_git_service_prune.py
+++ b/tests/backend/test_git_service_prune.py
@@ -1,0 +1,460 @@
+"""Tests for GitService prune-merged-branches logic.
+
+Wave 1 (TDD) — RED phase. These tests are expected to FAIL until W1-2 implementation.
+
+Covered scenarios:
+1. Merged PR matches local branch → candidate
+2. Default branch (main/master/develop) → skipped
+3. Current HEAD branch → skipped
+4. Unpushed commits → skipped
+5. No matching PR → skipped
+6. PR is closed but not merged → skipped
+7. BranchProtection rule pattern matches → skipped
+8. Batch prune executes delete_branch and collects errors
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _make_branch(name: str, sha: str = "abc123", tracking_ref: str | None = None, ahead: int = 0):
+    """Build a MagicMock representing a local branch."""
+    branch = MagicMock()
+    branch.name = name
+    branch.commit.hexsha = sha
+    branch.commit.message = f"commit on {name}"
+    branch.commit.author.name = "tester"
+    branch.commit.committed_date = datetime.now(UTC).timestamp()
+    if tracking_ref is None:
+        branch.tracking_branch.return_value = None
+    else:
+        tracking = MagicMock()
+        tracking.name = tracking_ref
+        # Simulate ahead/behind: iter_commits called with f"{tracking_ref}..{name}" returns `ahead` items
+        branch.tracking_branch.return_value = tracking
+    branch._ahead_count = ahead  # custom attr for repo.iter_commits side_effect
+    return branch
+
+
+def _make_pr(
+    number: int,
+    head_ref: str,
+    head_sha: str = "abc123",
+    merged: bool = True,
+    state: str = "closed",
+):
+    """Build a GitHubPullRequest-like Pydantic model."""
+    from models.git import GitHubPullRequest
+
+    now = datetime.now(UTC)
+    return GitHubPullRequest(
+        number=number,
+        title=f"PR #{number} for {head_ref}",
+        body="",
+        state=state,
+        draft=False,
+        mergeable=None,
+        mergeable_state=None,
+        head_ref=head_ref,
+        head_sha=head_sha,
+        base_ref="main",
+        base_sha="base000",
+        user_login="tester",
+        user_avatar_url=None,
+        html_url=f"https://github.com/o/r/pull/{number}",
+        diff_url=f"https://github.com/o/r/pull/{number}.diff",
+        commits=1,
+        additions=10,
+        deletions=2,
+        changed_files=1,
+        review_comments=0,
+        labels=[],
+        created_at=now,
+        updated_at=now,
+        merged_at=now if merged else None,
+        closed_at=now,
+    )
+
+
+@pytest.fixture
+def mock_repo():
+    """Mock repo with `main` (default), `feat/done` (merged PR), `wip/local` (no PR)."""
+    repo = MagicMock()
+    repo.is_dirty.return_value = False
+
+    main = _make_branch("main", sha="main000", tracking_ref="origin/main", ahead=0)
+    feat_done = _make_branch("feat/done", sha="done123", tracking_ref="origin/feat/done", ahead=0)
+    wip_local = _make_branch("wip/local", sha="wip000", tracking_ref=None, ahead=0)
+
+    repo.active_branch = main
+    repo.branches = [main, feat_done, wip_local]
+    repo.head.commit.hexsha = "main000"
+
+    # Mock iter_commits for ahead detection: returns `_ahead_count` commits
+    def iter_commits_side_effect(rev_range, **_):
+        # rev_range like "origin/feat/done..feat/done"
+        if ".." not in rev_range:
+            return iter([])
+        _, local_name = rev_range.split("..", 1)
+        for b in repo.branches:
+            if b.name == local_name:
+                return iter([MagicMock()] * b._ahead_count)
+        return iter([])
+
+    repo.iter_commits.side_effect = iter_commits_side_effect
+
+    # Mock remotes
+    repo.remotes = MagicMock()
+    repo.remotes.origin.refs = []
+
+    return repo
+
+
+@pytest.fixture
+def mock_github_service():
+    """Mock GitHubService returning controlled PR list."""
+    svc = MagicMock()
+    svc.list_pull_requests.return_value = []
+    return svc
+
+
+# =============================================================================
+# Pydantic model contract (W1-2 will add these)
+# =============================================================================
+
+
+class TestPruneModelsExist:
+    """RED: PruneCandidate / PruneSkipped / PruneScanResult must exist in models."""
+
+    def test_prune_candidate_model_importable(self):
+        from models.git import PruneCandidate  # noqa: F401
+
+    def test_prune_skipped_model_importable(self):
+        from models.git import PruneSkipped  # noqa: F401
+
+    def test_prune_scan_result_model_importable(self):
+        from models.git import PruneScanResult  # noqa: F401
+
+    def test_prune_execute_result_model_importable(self):
+        from models.git import PruneExecuteResult  # noqa: F401
+
+    def test_prune_protected_branches_constant(self):
+        from models.git import PRUNE_PROTECTED_BRANCHES
+
+        assert "main" in PRUNE_PROTECTED_BRANCHES
+        assert "master" in PRUNE_PROTECTED_BRANCHES
+        assert "develop" in PRUNE_PROTECTED_BRANCHES
+
+
+# =============================================================================
+# find_prune_candidates: judgment logic
+# =============================================================================
+
+
+class TestFindPruneCandidates:
+    """RED: behavior contract for find_prune_candidates()."""
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_merged_pr_branch_is_candidate(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """feat/done has a merged PR → returned as candidate."""
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.return_value = [
+            _make_pr(number=42, head_ref="feat/done", merged=True),
+        ]
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(
+            github_service=mock_github_service,
+        )
+
+        candidate_names = [c.branch for c in result.candidates]
+        assert "feat/done" in candidate_names
+        candidate = next(c for c in result.candidates if c.branch == "feat/done")
+        assert candidate.pr_number == 42
+        assert candidate.merged_at is not None
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_default_branch_is_skipped(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """main is in PRUNE_PROTECTED_BRANCHES → skipped with reason 'default_branch'."""
+        mock_repo_class.return_value = mock_repo
+        # Even if main has a "merged PR", it must be skipped
+        mock_github_service.list_pull_requests.return_value = [
+            _make_pr(number=1, head_ref="main", merged=True),
+        ]
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(
+            github_service=mock_github_service,
+        )
+
+        candidate_names = [c.branch for c in result.candidates]
+        assert "main" not in candidate_names
+        reasons = {s.branch: s.reason for s in result.skipped}
+        assert reasons.get("main") == "default_branch"
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_current_head_is_skipped(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """Even non-default branch is skipped if it's the active HEAD."""
+        mock_repo_class.return_value = mock_repo
+        # Move HEAD to feat/done
+        mock_repo.active_branch = mock_repo.branches[1]
+        mock_github_service.list_pull_requests.return_value = [
+            _make_pr(number=42, head_ref="feat/done", merged=True),
+        ]
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(
+            github_service=mock_github_service,
+        )
+
+        candidate_names = [c.branch for c in result.candidates]
+        assert "feat/done" not in candidate_names
+        reasons = {s.branch: s.reason for s in result.skipped}
+        assert reasons.get("feat/done") == "current_head"
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_unpushed_commits_skipped(
+        self, mock_repo_class, mock_github_service, tmp_path
+    ):
+        """Branch with ahead>0 vs origin → skipped with 'unpushed_commits'."""
+        repo = MagicMock()
+        repo.is_dirty.return_value = False
+        main = _make_branch("main", tracking_ref="origin/main", ahead=0)
+        feat_ahead = _make_branch("feat/ahead", tracking_ref="origin/feat/ahead", ahead=3)
+        repo.active_branch = main
+        repo.branches = [main, feat_ahead]
+        repo.head.commit.hexsha = "main000"
+
+        def iter_commits_side_effect(rev_range, **_):
+            if ".." not in rev_range:
+                return iter([])
+            _, local_name = rev_range.split("..", 1)
+            for b in repo.branches:
+                if b.name == local_name:
+                    return iter([MagicMock()] * b._ahead_count)
+            return iter([])
+
+        repo.iter_commits.side_effect = iter_commits_side_effect
+        mock_repo_class.return_value = repo
+
+        mock_github_service.list_pull_requests.return_value = [
+            _make_pr(number=99, head_ref="feat/ahead", merged=True),
+        ]
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(
+            github_service=mock_github_service,
+        )
+
+        candidate_names = [c.branch for c in result.candidates]
+        assert "feat/ahead" not in candidate_names
+        reasons = {s.branch: s.reason for s in result.skipped}
+        assert reasons.get("feat/ahead") == "unpushed_commits"
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_no_matching_pr_skipped(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """wip/local has no PR → skipped with 'no_matching_pr'."""
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.return_value = []
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(
+            github_service=mock_github_service,
+        )
+
+        reasons = {s.branch: s.reason for s in result.skipped}
+        assert reasons.get("wip/local") == "no_matching_pr"
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_closed_not_merged_pr_skipped(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """PR is closed but merged_at is None → branch skipped, not a candidate."""
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.return_value = [
+            _make_pr(number=7, head_ref="feat/done", merged=False, state="closed"),
+        ]
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(
+            github_service=mock_github_service,
+        )
+
+        candidate_names = [c.branch for c in result.candidates]
+        assert "feat/done" not in candidate_names
+        reasons = {s.branch: s.reason for s in result.skipped}
+        # Treat as no matching merged PR
+        assert reasons.get("feat/done") == "no_matching_pr"
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_branch_protection_rule_skips(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """protection_patterns containing 'feat/*' → matching branch skipped."""
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.return_value = [
+            _make_pr(number=42, head_ref="feat/done", merged=True),
+        ]
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(
+            github_service=mock_github_service,
+            protection_patterns=["feat/*"],
+        )
+
+        candidate_names = [c.branch for c in result.candidates]
+        assert "feat/done" not in candidate_names
+        reasons = {s.branch: s.reason for s in result.skipped}
+        assert reasons.get("feat/done") == "protected_rule"
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_list_pull_requests_called_with_large_limit(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """Wave 0 finding: prune must request limit>=500 to avoid stale-branch miss."""
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.return_value = []
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        service.find_prune_candidates(
+            github_service=mock_github_service,
+        )
+
+        # Verify limit was passed and is >= 500
+        call = mock_github_service.list_pull_requests.call_args
+        assert call is not None
+        kwargs = call.kwargs
+        assert kwargs.get("state") == "all"
+        assert kwargs.get("limit", 0) >= 500
+
+
+# =============================================================================
+# prune_merged_branches: batch execution
+# =============================================================================
+
+
+class TestPruneMergedBranches:
+    """RED: batch deletion calls delete_branch per candidate and collects errors."""
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_executes_delete_for_each_candidate(self, mock_repo_class, mock_repo, tmp_path):
+        mock_repo_class.return_value = mock_repo
+
+        from models.git import PruneCandidate
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        candidates = [
+            PruneCandidate(
+                branch="feat/a",
+                pr_number=1,
+                pr_url="u",
+                pr_title="t",
+                merged_at=datetime.now(UTC),
+                last_commit_sha="sha-a",
+            ),
+            PruneCandidate(
+                branch="feat/b",
+                pr_number=2,
+                pr_url="u",
+                pr_title="t",
+                merged_at=datetime.now(UTC),
+                last_commit_sha="sha-b",
+            ),
+        ]
+
+        with patch.object(service, "delete_branch", return_value=True) as mock_del:
+            result = service.prune_merged_branches(candidates)
+
+        assert result.deleted == ["feat/a", "feat/b"]
+        assert result.errors == []
+        assert mock_del.call_count == 2
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_individual_failure_continues_batch(self, mock_repo_class, mock_repo, tmp_path):
+        """If one delete fails, others must still proceed and error is recorded."""
+        mock_repo_class.return_value = mock_repo
+
+        from models.git import PruneCandidate
+        from services.git_service import GitService, GitServiceError
+
+        service = GitService(str(tmp_path))
+        candidates = [
+            PruneCandidate(
+                branch="feat/ok",
+                pr_number=1,
+                pr_url="u",
+                pr_title="t",
+                merged_at=datetime.now(UTC),
+                last_commit_sha="sha",
+            ),
+            PruneCandidate(
+                branch="feat/fail",
+                pr_number=2,
+                pr_url="u",
+                pr_title="t",
+                merged_at=datetime.now(UTC),
+                last_commit_sha="sha",
+            ),
+            PruneCandidate(
+                branch="feat/also-ok",
+                pr_number=3,
+                pr_url="u",
+                pr_title="t",
+                merged_at=datetime.now(UTC),
+                last_commit_sha="sha",
+            ),
+        ]
+
+        def delete_side_effect(name, **_):
+            if name == "feat/fail":
+                raise GitServiceError("simulated failure")
+            return True
+
+        with patch.object(service, "delete_branch", side_effect=delete_side_effect):
+            result = service.prune_merged_branches(candidates)
+
+        assert "feat/ok" in result.deleted
+        assert "feat/also-ok" in result.deleted
+        assert "feat/fail" not in result.deleted
+        assert any(e["branch"] == "feat/fail" for e in result.errors)


### PR DESCRIPTION
## Summary

GitHub PR의 `merged_at`을 진실의 단일 출처로 삼아 머지된 로컬 브랜치를 일괄 정리하는 기능. squash-merge로 사라진 PR head를 추적 못하던 `git branch --merged`의 한계를 해결하고, dry-run + 4중 보호로 데이터 손실 위험을 최소화합니다.

**동기**: LiveMetro에서 squash-merge 후 정리 안 된 16개 stale 로컬 브랜치 누적 (이슈 대화에서 발견). `fetch --prune`은 remote-tracking refs만 정리하고 로컬 브랜치는 자동 삭제되지 않음 — 도구 차원의 cleanup 정책이 필요했음.

## Architecture

3 commits, 3 layers, **Hexagonal 경계**가 깨끗:

1. **`feat(git):` 서비스** (cbbb781) — DB-free, GitPython 기반. `find_prune_candidates(github_service, protection_patterns, extra_protected)` + `prune_merged_branches(candidates)` 두 메서드. 순수 도메인 로직.
2. **`feat(api):` 엔드포인트** (61133b3) — `POST /git/projects/{id}/branches/prune-merged`. async DB 레이어가 `BranchProtectionRepository`로 패턴 추출 → sync service에 주입. dry_run=True/False 분기, GitHub token 없을 시 503.
3. **`feat(dashboard):` UI** (3751cfa) — Zustand action + Modal 4-phase 상태 머신 (scanning → review → executing → done). 체크박스 개별 제외, skipped 사유별 그룹핑.

## 4중 보호 (모두 활성)

| 보호 | 트리거 |
|------|--------|
| `default_branch` | main/master/develop (PRUNE_PROTECTED_BRANCHES) |
| `current_head` | 현재 checked-out HEAD |
| `protected_rule` | BranchProtectionRule 패턴 매칭 (fnmatch) |
| `unpushed_commits` | PR 매칭 후에도 origin 대비 ahead > 0 |

## Wave 0 발견: `list_pull_requests` limit=30 함정

기존 `github_service.list_pull_requests`는 `limit: int = 30` 기본값 — `state="all"`이어도 최신 30개만 반환. 큰 repo에서 stale 브랜치 누락 위험. **이번 PR에서 `limit=500` 명시 전달**로 회피. 다른 호출자 영향 없음.

## Wave 2 리팩토링: DB-free service

원래 service에서 직접 `db_session.query()` 호출했으나 코드베이스가 100% async (`AsyncSession`)라서 충돌. service는 `protection_patterns: list[str]` 받는 순수 함수로 리팩토링, API 레이어가 `BranchProtectionRepository.list_by_project()` (async) 후 주입. 테스트 격리 향상, hexagonal 원칙 강화.

## 검증

- **Backend**: 37/37 pytest (15 service + 15 unit + 7 API), 5.61s
- **Frontend**: 4182/4182 vitest (185 files), 26.47s, 회귀 0
- **Type/Lint**: tsc 0 errors, ESLint 0 new errors, Vite build 0.38s
- **E2E**: live GitHub API + 실제 LiveMetro repo로 dry-run scan 완료 (`{candidates:[], skipped:[main:default_branch]}`), Modal 4-phase, 한국어 사유 라벨링, disabled delete button, 취소 cycle 모두 확인

## Test plan

- [x] Backend pytest: `cd src/backend && pytest ../../tests/backend/test_git_service.py ../../tests/backend/test_git_service_prune.py ../../tests/backend/api/test_api_git_prune.py`
- [x] Frontend tests: `cd src/dashboard && npm test`
- [x] Type check: `cd src/dashboard && npx tsc --noEmit`
- [x] Build: `cd src/dashboard && npm run build`
- [x] 수동: dashboard에서 Git → Branches → "Prune Merged" 클릭 → dry-run 모달 등장 → 후보/제외 사유 확인 → 취소
- [x] (선택) 실제 머지된 브랜치가 있는 repo에서 execute 흐름 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)