### PR TITLE
fix(ci): restore green baseline on main

### DIFF
--- a/src/backend/services/audit_service.py
+++ b/src/backend/services/audit_service.py
@@ -683,9 +683,7 @@ class AuditService:
         trend_rows = (
             await db.execute(
                 _scoped(
-                    select(AuditLogModel.created_at).where(
-                        AuditLogModel.created_at >= window_start
-                    )
+                    select(AuditLogModel.created_at).where(AuditLogModel.created_at >= window_start)
                 )
             )
         ).all()

--- a/tests/backend/api/test_usage_jsonl.py
+++ b/tests/backend/api/test_usage_jsonl.py
@@ -53,7 +53,7 @@ def _assistant_entry(*, ts: datetime, model: str, **usage_kwargs: int) -> dict:
 
 def test_aggregates_tokens_per_day_per_model(isolated_jsonl_env: Path) -> None:
     """Sums input + output + cache tokens, grouped by date and model."""
-    now = datetime.now(UTC).replace(microsecond=0)
+    now = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
     today = now.date()
 
     _write_jsonl(


### PR DESCRIPTION
## Summary

- Backend CI on **every PR** (incl. dependabot #94-#97) was failing for two unrelated reasons on `main`. Neither was caused by the PRs themselves — they all only touch `/src/dashboard`.
- This PR restores the green baseline so dependabot PRs can rebase and pass.

## Root cause

### 1. `ruff format` violation in `services/audit_service.py`

The file shipped with a 3-line `select()` block that fits within `line-length = 100`, so `ruff format --check .` exits non-zero. Likely slipped past a previous merge (suspected `e4c4100 feat(audit): 감사 로그 통계 고도화`).

```diff
- select(AuditLogModel.created_at).where(
-     AuditLogModel.created_at >= window_start
- )
+ select(AuditLogModel.created_at).where(AuditLogModel.created_at >= window_start)
```

### 2. Flaky test `test_aggregates_tokens_per_day_per_model`

`tests/backend/api/test_usage_jsonl.py:54` used `datetime.now(UTC) - timedelta(hours=1..3)` and asserted that all three entries land in today's bucket. The failing CI run at **01:17 UTC** put the 2h/3h entries into *yesterday's* bucket, giving `165` instead of the expected `195` (30 tokens missing).

Fix: pin `now` to 12:00 UTC so ±3h stays on the same calendar day. Semantics unchanged (the test verifies the "today" bucket; the specific hour does not matter).

## Test plan

- [x] `ruff format --check .` passes locally (240 files clean)
- [x] `ruff check .` still passes (no new lint regressions)
- [x] `pytest tests/backend/api/test_usage_jsonl.py -v` → 9 / 9 PASSED
- [ ] CI green on this PR
- [ ] After merge, rebase #94 / #95 / #96 / #97 → CI green

## Follow-up (out of scope)

- Investigate how the unformatted file slipped through husky/lint-staged on `e4c4100`. Suspect merge commit bypassed the pre-commit hook.
- Consider adding `freezegun` or a session-wide clock fixture so future "today-bucket" tests are immune to midnight boundaries by construction, not by convention.
- Pin `ruff` version in `pyproject.toml` (currently `>=0.8.0`) so CI ↔ local don't drift across minor releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
