### PR TITLE
feat(llm): 모델 레지스트리 최신화 (Opus 4.8, GPT-5.5, Gemini 3.1 Pro 2M)

### DIFF
--- a/src/backend/models/claude_session.py
+++ b/src/backend/models/claude_session.py
@@ -55,7 +55,7 @@ class ClaudeSessionInfo(BaseModel):
     session_id: str = Field(..., description="Unique session ID (UUID)")
     slug: str = Field(..., description="Human-readable slug like 'federated-booping-frog'")
     status: SessionStatus = Field(default=SessionStatus.UNKNOWN, description="Session status")
-    model: str = Field(default="unknown", description="Model name like 'claude-opus-4-6'")
+    model: str = Field(default="unknown", description="Model name like 'claude-opus-4-8'")
     project_path: str = Field(
         ..., description="Encoded project path like '-Users-username-Work-MyProject'"
     )
@@ -204,10 +204,11 @@ class TasksResponse(BaseModel):
 
 # Cost per 1K tokens for different models
 MODEL_COSTS = {
-    "claude-opus-4-6": {"input": 0.015, "output": 0.075},
+    "claude-opus-4-8": {"input": 0.015, "output": 0.075},
     "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
     "claude-haiku-4-5-20251001": {"input": 0.001, "output": 0.005},
     # Legacy model IDs for backward compatibility
+    "claude-opus-4-6": {"input": 0.015, "output": 0.075},
     "claude-opus-4-5-20251101": {"input": 0.015, "output": 0.075},
     "claude-sonnet-4-20250514": {"input": 0.003, "output": 0.015},
     "claude-3-5-sonnet-20241022": {"input": 0.003, "output": 0.015},

--- a/src/backend/models/context_usage.py
+++ b/src/backend/models/context_usage.py
@@ -17,7 +17,7 @@ class LLMProvider(str, Enum):
 # Provider context window limits (tokens)
 PROVIDER_CONTEXT_LIMITS = {
     LLMProvider.ANTHROPIC: {
-        "claude-opus-4-6": 200_000,
+        "claude-opus-4-8": 200_000,
         "claude-sonnet-4-6": 200_000,
         "claude-haiku-4-5-20251001": 200_000,
         "default": 200_000,

--- a/src/backend/models/llm_models.py
+++ b/src/backend/models/llm_models.py
@@ -42,12 +42,12 @@ class LLMModelConfig(BaseModel):
 # All supported models with their configurations
 _MODELS: list[LLMModelConfig] = [
     # ─────────────────────────────────────────────────────────
-    # Anthropic Claude Models (updated 2026-04-12)
+    # Anthropic Claude Models (updated 2026-05-30)
     # Pricing: USD per 1K tokens. Docs: https://docs.anthropic.com/en/docs/about-claude/models
     # ─────────────────────────────────────────────────────────
     LLMModelConfig(
-        id="claude-opus-4-6",
-        display_name="Claude Opus 4.6",
+        id="claude-opus-4-8",
+        display_name="Claude Opus 4.8",
         provider=LLMProvider.ANTHROPIC,
         context_window=1000000,  # 1M tokens
         input_price=0.005,  # $5.00/1M tokens
@@ -79,7 +79,7 @@ _MODELS: list[LLMModelConfig] = [
         supports_vision=True,
     ),
     # ─────────────────────────────────────────────────────────
-    # Google Gemini Models (updated 2026-04-12)
+    # Google Gemini Models (updated 2026-05-30)
     # Pricing: USD per 1K tokens. Docs: https://ai.google.dev/gemini-api/docs/models
     # ─────────────────────────────────────────────────────────
     LLMModelConfig(
@@ -97,7 +97,7 @@ _MODELS: list[LLMModelConfig] = [
         id="gemini-3.1-pro-preview",
         display_name="Gemini 3.1 Pro",
         provider=LLMProvider.GOOGLE,
-        context_window=1048576,
+        context_window=2097152,  # 2M tokens (released 2026-02-19)
         input_price=0.002,  # $2.00/1M tokens (≤200K context)
         output_price=0.012,  # $12.00/1M tokens (≤200K context)
         is_default=False,
@@ -138,9 +138,20 @@ _MODELS: list[LLMModelConfig] = [
         supports_vision=True,
     ),
     # ─────────────────────────────────────────────────────────
-    # OpenAI Models (updated 2026-04-12)
+    # OpenAI Models (updated 2026-05-30)
     # Pricing: USD per 1K tokens. Docs: https://platform.openai.com/docs/pricing
     # ─────────────────────────────────────────────────────────
+    LLMModelConfig(
+        id="gpt-5.5",
+        display_name="GPT-5.5",
+        provider=LLMProvider.OPENAI,
+        context_window=1000000,  # 1M tokens (flagship, released 2026-04)
+        input_price=0.005,  # $5.00/1M tokens
+        output_price=0.03,  # $30.00/1M tokens
+        is_default=False,  # gpt-5.4 remains default (production-recommended, lower cost)
+        supports_tools=True,
+        supports_vision=True,
+    ),
     LLMModelConfig(
         id="gpt-5.4",
         display_name="GPT-5.4",

--- a/src/dashboard/src/components/CostMonitor.tsx
+++ b/src/dashboard/src/components/CostMonitor.tsx
@@ -63,7 +63,7 @@ function isIgnoredModel(value: string): boolean {
   return IGNORED_MODELS.some((m) => lower.includes(m))
 }
 
-/** Extract model family: claude-opus-4-6 → opus, gemini-2.0-flash → flash */
+/** Extract model family: claude-opus-4-8 → opus, gemini-2.0-flash → flash */
 function getModelFamily(model: string): string {
   const lower = model.toLowerCase()
   // Claude: claude-{family}-{version}

--- a/src/dashboard/src/stores/__tests__/settings.test.ts
+++ b/src/dashboard/src/stores/__tests__/settings.test.ts
@@ -72,7 +72,7 @@ describe('settings store', () => {
 
       const state = useSettingsStore.getState()
       expect(state.llmProvider).toBe('openai')
-      expect(state.model).toBe('gpt-5.4')
+      expect(state.model).toBe('gpt-5.5')
     })
 
     it('selects google/gemini models when switching to google', () => {
@@ -100,8 +100,8 @@ describe('settings store', () => {
     it('updates model', () => {
       const { setModel } = useSettingsStore.getState()
 
-      setModel('claude-opus-4-6')
-      expect(useSettingsStore.getState().model).toBe('claude-opus-4-6')
+      setModel('claude-opus-4-8')
+      expect(useSettingsStore.getState().model).toBe('claude-opus-4-8')
     })
   })
 
@@ -363,7 +363,7 @@ describe('settings store', () => {
     })
 
     it('returns multiple models when several share the same provider', () => {
-      const extra = makeModel({ id: 'claude-opus-4-6', provider: 'anthropic' })
+      const extra = makeModel({ id: 'claude-opus-4-8', provider: 'anthropic' })
       useSettingsStore.setState({
         availableModels: [anthropicModel, extra, googleModel, ollamaModel],
       })
@@ -434,8 +434,8 @@ describe('settings store', () => {
 
       useSettingsStore.getState().setLLMProvider('anthropic')
 
-      // Fallback for anthropic is 'claude-opus-4-6'
-      expect(useSettingsStore.getState().model).toBe('claude-opus-4-6')
+      // Fallback for anthropic is 'claude-opus-4-8'
+      expect(useSettingsStore.getState().model).toBe('claude-opus-4-8')
       expect(useSettingsStore.getState().llmProvider).toBe('anthropic')
     })
 
@@ -458,7 +458,7 @@ describe('settings store', () => {
 describe('getModelsForProvider (legacy exported function)', () => {
   it('returns anthropic models', () => {
     const models = getModelsForProvider('anthropic')
-    expect(models).toContain('claude-opus-4-6')
+    expect(models).toContain('claude-opus-4-8')
     expect(models).toContain('claude-sonnet-4-6')
   })
 

--- a/src/dashboard/src/stores/settings.ts
+++ b/src/dashboard/src/stores/settings.ts
@@ -102,9 +102,9 @@ interface SettingsState {
 
 // Fallback models when API is unavailable
 const fallbackModels: Record<LLMProvider, string[]> = {
-  anthropic: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+  anthropic: ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
   google: ['gemini-3-flash-preview', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
-  openai: ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'o3', 'o4-mini'],
+  openai: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'o3', 'o4-mini'],
   local: ['exaone3.5:7.8b', 'llama3:8b', 'mistral:7b', 'codellama:7b'],
 }
 


### PR DESCRIPTION
- LLM Router 레지스트리(llm_models.py): claude-opus-4-6→claude-opus-4-8, gpt-5.5 신규 추가(default는 비용 고려해 gpt-5.4 유지), Gemini 3.1 Pro context_window 1,048,576→2,097,152 (2M)
- 프론트 fallback 목록(settings.ts)·테스트·CostMonitor 예시 동기화
- Claude Code 세션 추적 맵: opus-4-8 추가, opus-4-6 레거시 비용 보존