### PR TITLE
feat(deploy): 단계적 self-host 배포 준비 (1단계)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,15 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # Security (change in production!)
 # =============================================================================
 
-# JWT Secret Key - CHANGE THIS!
-SESSION_SECRET_KEY=aos-secret-key-change-in-production
+# JWT Secret Key - REQUIRED.
+# Leave empty: ./setup.sh auto-generates a strong value.
+# Manual: python -c "import secrets; print(secrets.token_hex(32))"
+SESSION_SECRET_KEY=
+
+# First-admin bootstrap: comma-separated emails granted admin role.
+# OAuth users are promoted on first login; email/password users on their
+# next login after registering (see docs/self-host-quickstart.md).
+SUPER_ADMIN_EMAILS=
 
 # Field Encryption (hex-encoded 32-byte key, generate with: python -c "import os; print(os.urandom(32).hex())")
 # Leave empty to disable field encryption (plaintext storage)
@@ -48,7 +55,15 @@ SESSION_SECRET_KEY=aos-secret-key-change-in-production
 # Database (auto-configured by docker-compose)
 # =============================================================================
 
-# Local development (matches docker-compose postgres credentials)
+# Postgres credentials used by docker-compose to provision the DB container
+# and to build the in-container DATABASE_URL. POSTGRES_PASSWORD is REQUIRED;
+# leave empty and ./setup.sh auto-generates a strong value on a fresh install.
+POSTGRES_USER=aos
+POSTGRES_PASSWORD=
+POSTGRES_DB=aos
+
+# Direct DATABASE_URL for local (non-docker) development only.
+# docker-compose ignores this and builds the URL from POSTGRES_* above.
 DATABASE_URL=postgresql+asyncpg://aos:aos@localhost:5432/aos
 
 REDIS_URL=redis://localhost:6379/0
@@ -70,12 +85,15 @@ PORT=8000
 DEBUG=false
 LOG_LEVEL=INFO
 
-# Frontend URL (for OAuth callbacks)
+# Frontend URL (for OAuth callbacks).
+# Remote self-host: set to the externally reachable dashboard URL
+# (e.g. http://<server-ip>:5173 or https://aos.example.com), NOT localhost.
 FRONTEND_URL=http://localhost:5173
 
 # CORS - 아래 두 형식 모두 지원:
 #   쉼표 구분: http://localhost:3000,http://localhost:5173
 #   JSON 배열: '["http://localhost:3000","http://localhost:5173"]'  (shell source 시 single-quote 필수)
+# Remote self-host: include the same externally reachable URL as FRONTEND_URL.
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # =============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .env.local
 .env.*.local
 
+# Maintainer-local Compose overrides (host-specific bind mounts; never shipped)
+docker-compose.override.yml
+
 # Dependencies
 node_modules/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -25,16 +25,21 @@ LangGraph 기반 멀티 에이전트 오케스트레이션 서비스입니다.
 git clone https://github.com/k002bill2/Agent-System.git
 cd Agent-System
 
-# 2. 환경변수 설정
+# 2. 환경변수 설정 (LLM 키만 — 보안 시크릿은 setup.sh가 자동 생성)
 cp .env.example .env
-# .env 파일 편집하여 API 키 설정
+# .env 파일 편집하여 API 키 설정 (GOOGLE_API_KEY 또는 ANTHROPIC_API_KEY)
 
-# 3. 실행 (미리 빌드된 이미지 사용, 빌드 불필요)
-docker compose up -d
+# 3. 셋업: 시크릿 자동 생성 + 이미지 빌드 + 전체 기동
+./setup.sh
 
 # 4. 접속
 open http://localhost:5173
 ```
+
+> **Self-host로 팀에 배포하나요?** 원격 접속 설정, 첫 관리자 계정 부트스트랩,
+> 백업, 그리고 **보안 주의사항(내부망 전용)** 은
+> [docs/self-host-quickstart.md](docs/self-host-quickstart.md)를 참조하세요.
+> `docker compose up -d`를 직접 실행하면 시크릿 미설정으로 실패하므로 `./setup.sh`를 사용하세요.
 
 ### 필수 환경변수
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
     ports:
       - "${BACKEND_PORT:-8000}:8000"
     environment:
-      # Database
-      - DATABASE_URL=postgresql+asyncpg://aos:aos@postgres:5432/aos
+      # Database (URL built from POSTGRES_* in .env; password is required)
+      - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER:-aos}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD or run ./setup.sh}@postgres:5432/${POSTGRES_DB:-aos}
       - USE_DATABASE=true
       # Redis
       - REDIS_URL=redis://redis:6379/0
@@ -50,21 +50,24 @@ services:
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
-      # JWT
-      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY:-aos-secret-key-change-in-production}
-      - FRONTEND_URL=http://localhost:5173
+      # JWT (required — run ./setup.sh to auto-generate)
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY:?set SESSION_SECRET_KEY or run ./setup.sh}
+      # First-admin bootstrap (comma-separated emails)
+      - SUPER_ADMIN_EMAILS=${SUPER_ADMIN_EMAILS:-}
+      # Frontend URL & CORS — set to the externally reachable URL for remote self-host
+      - FRONTEND_URL=${FRONTEND_URL:-http://localhost:5173}
+      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:5173}
       # Claude Code paths (inside container)
       - CLAUDE_HOME=/home/aos/.claude
       - CLAUDE_PROJECTS_PATH=/home/aos/.claude/projects
     volumes:
-      # Claude Code directory (sessions, stats, settings)
-      - ${HOME}/.claude:/home/aos/.claude:ro
-      # Warp launch configurations (host ↔ container sync)
-      - ${HOME}/.warp/launch_configurations:/home/aos/.warp/launch_configurations
       # ChromaDB persistence
       - chromadb_data:/app/data/chromadb
       # Summary cache (writable)
       - summary_cache:/app/data/summaries
+      # NOTE: host ~/.claude and ~/.warp mounts (Claude Code usage monitoring +
+      # Warp sync) are maintainer-local and live in docker-compose.override.yml,
+      # which Compose auto-merges on that machine only. See docs/self-host-quickstart.md.
     depends_on:
       postgres:
         condition: service_healthy
@@ -87,9 +90,9 @@ services:
     image: postgres:16-alpine
     container_name: aos-postgres
     environment:
-      POSTGRES_USER: aos
-      POSTGRES_PASSWORD: aos
-      POSTGRES_DB: aos
+      POSTGRES_USER: ${POSTGRES_USER:-aos}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD or run ./setup.sh}
+      POSTGRES_DB: ${POSTGRES_DB:-aos}
     volumes:
       - ./infra/docker/data/postgres:/var/lib/postgresql/data
       # Note: SQLAlchemy auto-creates tables on startup
@@ -97,7 +100,7 @@ services:
     ports:
       - "${PG_PORT:-5432}:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aos -d aos"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-aos} -d ${POSTGRES_DB:-aos}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -46,15 +46,20 @@
 
 > **Qdrant healthcheck 관련**: Qdrant 공식 이미지에는 `curl`/`wget`이 포함되어 있지 않아 Docker healthcheck을 설정할 수 없습니다. `docker-compose.yml`에서는 `condition: service_started`로 Qdrant 시작만 확인합니다. Qdrant의 `/healthz` 엔드포인트는 호스트에서 `curl http://localhost:6333/healthz`로 외부 확인 가능합니다.
 
+> **사내/팀 self-host라면** 원격 접속·첫 관리자 부트스트랩·백업·**보안 주의사항**을 정리한
+> [self-host 퀵스타트](./self-host-quickstart.md)를 먼저 참고하세요.
+
 ### 배포 절차
 
 ```bash
-# 1. 환경 변수 설정
+# 1. 환경 변수 설정 (LLM 키만 — 시크릿은 setup.sh가 자동 생성)
 cp .env.example .env
-# .env 편집: GOOGLE_API_KEY, SESSION_SECRET_KEY 등 설정
+# .env 편집: GOOGLE_API_KEY (또는 ANTHROPIC_API_KEY) 설정
 
-# 2. 전체 서비스 시작 (프로젝트 루트에서 실행)
-docker compose up -d
+# 2. 셋업 — 시크릿 자동 생성 + 빌드 + 전체 기동
+./setup.sh
+#    (또는 .env에 강한 SESSION_SECRET_KEY·POSTGRES_PASSWORD를 직접 넣었다면:
+#     docker compose up -d --build )
 
 # 3. 상태 확인
 docker compose ps
@@ -62,6 +67,10 @@ docker compose ps
 # 4. 로그 확인
 docker compose logs -f backend
 ```
+
+> **보안**: `docker-compose.yml`은 `SESSION_SECRET_KEY`·`POSTGRES_PASSWORD`가 비어 있으면
+> 즉시 실패합니다(약한 기본 시크릿 배포 방지). `setup.sh`가 강한 값을 자동 생성하므로
+> 이 스크립트를 사용하세요.
 
 ### 개발 환경 (인프라만)
 

--- a/docs/self-host-quickstart.md
+++ b/docs/self-host-quickstart.md
@@ -1,0 +1,165 @@
+# AOS Self-Host 퀵스타트 (사내/신뢰된 팀용)
+
+이 문서는 **각 팀이 자신의 독립 인스턴스로** AOS를 운영하는 self-host 배포를 다룹니다.
+한 대의 머신(또는 사내 서버)에 Docker로 전체 스택(앱 + PostgreSQL + Redis + Qdrant)을
+띄우고, 같은 팀원들이 브라우저로 접속해 사용하는 형태입니다.
+
+> ⚠️ **보안 경고 — 반드시 읽으세요**
+>
+> 현재 버전(1단계)은 **일부 API 엔드포인트가 무인증·소유권 미검사** 상태입니다
+> (`GET/PUT/DELETE /projects/{id}`, `GET/DELETE /sessions/{id}`,
+> `GET/PATCH /playground/sessions/{id}` 등). 따라서:
+>
+> - ✅ **신뢰된 내부망 / VPN / 사내 LAN 안에서만** 사용하세요.
+> - ❌ **공개 인터넷에 포트포워딩하거나 노출하지 마세요.** 외부 공개가 필요하면
+>   2단계(공유 SaaS용 auth 강화)가 완료된 뒤에 진행해야 합니다.
+>
+> 여러 사용자가 **하나의 인스턴스를 공유**하는 SaaS 형태는 아직 지원되지 않습니다.
+> 팀별 독립 인스턴스(이 문서의 방식)는 DB가 물리적으로 분리되어 안전합니다.
+
+---
+
+## 사전 요구사항
+
+| 항목 | 최소 |
+|------|------|
+| Docker | 24.0+ |
+| Docker Compose | 2.20+ (플러그인 `docker compose`) |
+| RAM | 4GB |
+| 디스크 | 10GB |
+| LLM API 키 | Google Gemini **또는** Anthropic Claude (Ollama는 로컬, 키 불필요) |
+
+`python3` 또는 `openssl` 중 하나가 있으면 `setup.sh`가 시크릿을 자동 생성합니다
+(대부분의 macOS/Linux에 기본 포함).
+
+---
+
+## 1. 설치 (로컬 / 단일 머신)
+
+```bash
+# 1) 클론
+git clone https://github.com/k002bill2/Agent-System.git
+cd Agent-System
+
+# 2) 환경변수: LLM 키만 먼저 설정 (시크릿은 setup.sh가 자동 생성)
+cp .env.example .env
+#    .env 편집 → GOOGLE_API_KEY 또는 ANTHROPIC_API_KEY 입력
+
+# 3) 셋업: 시크릿 자동 생성 + 이미지 빌드 + 전체 기동 + 헬스 대기
+./setup.sh
+
+# 4) 접속
+open http://localhost:5173   # Linux: xdg-open
+```
+
+`setup.sh`가 자동으로 수행하는 것:
+
+- `.env`가 없으면 `.env.example`에서 생성
+- `SESSION_SECRET_KEY`·`POSTGRES_PASSWORD`가 비어있거나 약한 기본값이면
+  **강한 랜덤 값으로 자동 생성**(멱등 — 이미 강한 값이면 그대로 둠)
+- 포트 충돌 감지
+- `docker compose up -d --build`로 전체 스택 기동
+- 백엔드 `/health`가 healthy가 될 때까지 대기
+
+> **왜 `docker compose up -d`를 직접 쓰지 않나?**
+> `docker-compose.yml`은 시크릿이 비어있으면 즉시 실패합니다
+> (`POSTGRES_PASSWORD is missing a value`). 이는 약한 기본 시크릿으로 배포되는
+> 사고를 막기 위한 의도적 안전장치입니다. `setup.sh`가 시크릿을 먼저 생성하므로
+> 이 스크립트를 쓰세요. (이미 `.env`에 강한 시크릿을 직접 넣었다면
+> `docker compose up -d --build`를 써도 됩니다.)
+
+---
+
+## 2. 원격 접속 (다른 팀원이 사내 서버로 접속)
+
+대시보드를 서버 IP나 사내 도메인으로 접속하게 하려면, `.env`에서 외부에서
+**실제로 접근 가능한 URL**을 지정한 뒤 재기동해야 합니다.
+
+```bash
+# .env 편집
+FRONTEND_URL=http://10.0.1.20:5173        # 또는 https://aos.사내도메인
+CORS_ORIGINS=http://10.0.1.20:5173        # FRONTEND_URL과 동일하게
+
+# 재기동
+docker compose up -d
+```
+
+> 프론트엔드는 상대경로(`/api`)로 백엔드를 호출하고 nginx가 프록시하므로,
+> 대시보드 포트(기본 5173)만 열면 됩니다. 백엔드(8000)를 따로 노출할 필요 없습니다.
+> `FRONTEND_URL`/`CORS_ORIGINS`는 OAuth 콜백과 CORS 허용을 위해 필요합니다.
+
+HTTPS가 필요하면 리버스 프록시(nginx/Caddy/Traefik) 뒤에 두고 `FRONTEND_URL`을
+`https://...`로 설정하세요. 쿠키 `secure` 플래그는 프로덕션 빌드에서 자동 적용됩니다.
+
+---
+
+## 3. 첫 관리자(admin) 계정 만들기
+
+최초 관리자는 `.env`의 `SUPER_ADMIN_EMAILS`로 부트스트랩합니다 (쉼표 구분).
+
+```bash
+# .env
+SUPER_ADMIN_EMAILS=you@example.com,teammate@example.com
+docker compose up -d   # 변경 반영
+```
+
+| 가입 방식 | admin 승격 시점 |
+|-----------|-----------------|
+| **OAuth (Google/GitHub)** | 첫 로그인 시 **즉시** 승격 |
+| **이메일/비밀번호** | 가입(register)이 아니라 **그 다음 로그인** 시 승격 |
+
+> 이메일 경로는 "가입 → 로그인" 두 단계를 거쳐야 admin이 됩니다. 더 매끄러운
+> 첫 관리자 경험은 2단계에서 개선될 예정입니다. 그때까지는 OAuth를 권장합니다.
+
+---
+
+## 4. 데이터 영속성과 백업
+
+| 데이터 | 저장 위치 | `down` | `down -v` |
+|--------|-----------|--------|-----------|
+| PostgreSQL | 호스트 바인드 마운트 `infra/docker/data/postgres/` | 보존 | 보존(바인드라 볼륨 삭제 영향 적음) |
+| Redis / Qdrant / ChromaDB | named 볼륨 | 보존 | **삭제됨** |
+
+```bash
+docker compose ps                 # 상태
+docker compose logs -f backend    # 로그
+docker compose down               # 중지(데이터 보존)
+docker compose down -v            # ⚠️ named 볼륨까지 삭제 — 신중히
+```
+
+**업그레이드 전 백업 필수**:
+
+```bash
+CONTAINER_NAME=aos-postgres DB_USER=aos ./infra/scripts/backup-db.sh
+# 새 코드 받기
+git pull && ./setup.sh            # setup.sh는 강한 시크릿을 덮어쓰지 않음(멱등)
+```
+
+> 기존 DB가 이미 있는 상태에서 `setup.sh`를 다시 돌려도 `POSTGRES_PASSWORD`는
+> 재생성하지 않습니다(기존 DB와 불일치 방지). 비밀번호를 바꾸려면 DB를 초기화하거나
+> `ALTER ROLE`로 수동 변경해야 합니다.
+
+---
+
+## 5. 유지보수자(maintainer) 전용 — Claude Code 연동
+
+저장소를 유지보수하는 머신에서 호스트의 `~/.claude`(Claude Code 사용량 모니터링)와
+`~/.warp`(Warp 연동)를 컨테이너에 마운트하려면, 자동 로드되는
+`docker-compose.override.yml`이 그 역할을 합니다. 이 파일은 **git-ignore**되어
+다른 사용자 체크아웃에는 포함되지 않습니다(신규 사용자 머신엔 해당 경로가 없으므로).
+연동이 필요 없으면 이 파일을 삭제하면 됩니다.
+
+---
+
+## 트러블슈팅
+
+| 증상 | 원인 / 해결 |
+|------|-------------|
+| `POSTGRES_PASSWORD is missing a value` | `docker compose up`을 직접 실행함 → `./setup.sh` 사용 |
+| `SESSION_SECRET_KEY ... insecure default` (백엔드 종료) | 시크릿 미설정 → `./setup.sh`로 생성 |
+| 원격 접속 시 로그인 실패 / CORS 에러 | `.env`의 `FRONTEND_URL`/`CORS_ORIGINS`를 외부 접근 URL로 설정 후 `docker compose up -d` |
+| 포트 충돌 | `.env`에서 `PG_PORT`/`REDIS_PORT`/`BACKEND_PORT`/`DASHBOARD_PORT`/`QDRANT_PORT` 오버라이드 |
+| LLM "Invalid API key" | `LLM_PROVIDER`와 해당 키 일치 확인, 결제/할당량 확인 |
+
+더 자세한 배포 옵션(Railway/Render, CI/CD, 모니터링, 롤백)은
+[docs/deployment.md](./deployment.md)를 참조하세요.

--- a/setup.sh
+++ b/setup.sh
@@ -45,6 +45,64 @@ else
     echo -e "${GREEN}[OK]${NC} .env exists"
 fi
 
+# --- 2.5. Secret bootstrap (auto-generate strong secrets) ---
+gen_secret() {
+    if command -v python3 &>/dev/null; then
+        python3 -c "import secrets; print(secrets.token_hex(32))"
+    elif command -v openssl &>/dev/null; then
+        openssl rand -hex 32
+    else
+        echo -e "${RED}Error: need python3 or openssl to generate secrets.${NC}" >&2
+        exit 1
+    fi
+}
+
+# Read the value of KEY= from .env ("" if absent). Never fails (|| true).
+env_value() {
+    grep -E "^$1=" .env | head -n1 | cut -d= -f2- || true
+}
+
+# Replace KEY=... in .env in place, or append if absent (portable; no sed -i).
+set_env_value() {
+    local key=$1 val=$2
+    if grep -qE "^${key}=" .env; then
+        awk -v key="$key" -v val="$val" \
+            'BEGIN{FS=OFS="="} $1==key{print key"="val; next} {print}' \
+            .env > .env.tmp && mv .env.tmp .env
+    else
+        printf '%s=%s\n' "$key" "$val" >> .env
+    fi
+}
+
+# SESSION_SECRET_KEY — safe to (re)generate whenever empty or the old default.
+SESSION_VAL="$(env_value SESSION_SECRET_KEY)"
+if [ -z "$SESSION_VAL" ] || [ "$SESSION_VAL" = "aos-secret-key-change-in-production" ]; then
+    NEW_SECRET="$(gen_secret)"
+    set_env_value SESSION_SECRET_KEY "$NEW_SECRET"
+    echo -e "${GREEN}[OK]${NC} Generated SESSION_SECRET_KEY (****${NEW_SECRET: -4})"
+else
+    echo -e "${GREEN}[OK]${NC} SESSION_SECRET_KEY already set"
+fi
+
+# POSTGRES_PASSWORD — postgres only applies it on a FRESH data dir, so never
+# rotate against an existing DB (it would break auth). Keep the current value.
+PG_DATA_DIR="infra/docker/data/postgres"
+PG_PW_VAL="$(env_value POSTGRES_PASSWORD)"
+if [ -d "$PG_DATA_DIR" ] && [ -n "$(ls -A "$PG_DATA_DIR" 2>/dev/null)" ]; then
+    if [ -z "$PG_PW_VAL" ]; then
+        set_env_value POSTGRES_PASSWORD "aos"
+        echo -e "${YELLOW}[keep]${NC} Existing Postgres data dir — set POSTGRES_PASSWORD=aos to match it"
+    else
+        echo -e "${GREEN}[OK]${NC} POSTGRES_PASSWORD already set (existing DB)"
+    fi
+elif [ -z "$PG_PW_VAL" ]; then
+    NEW_PG_PW="$(gen_secret)"
+    set_env_value POSTGRES_PASSWORD "$NEW_PG_PW"
+    echo -e "${GREEN}[OK]${NC} Generated POSTGRES_PASSWORD (****${NEW_PG_PW: -4})"
+else
+    echo -e "${GREEN}[OK]${NC} POSTGRES_PASSWORD already set"
+fi
+
 # --- 3. Port conflict detection ---
 check_port() {
     local port=$1
@@ -122,7 +180,7 @@ echo ""
 echo -e "${CYAN}=== AOS is running ===${NC}"
 echo -e "  Dashboard:  ${GREEN}http://localhost:${DASH_PORT}${NC}"
 echo -e "  Backend:    ${GREEN}http://localhost:${BACKEND_PORT}${NC}"
-echo -e "  PostgreSQL: postgresql://aos:aos@localhost:${PG_P}/aos"
+echo -e "  PostgreSQL: postgresql://aos:****@localhost:${PG_P}/aos  (credentials in .env)"
 echo -e "  Redis:      redis://localhost:${REDIS_P}"
 echo -e "  Qdrant:     http://localhost:${QDRANT_P}"
 echo ""

--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -149,6 +149,23 @@ else:
         if LOGGING_ENABLED and logger:
             logger.info("application_starting", env=os.getenv("ENV", "development"))
 
+        # Fail fast on a missing/default JWT secret outside debug mode: signing
+        # JWTs with a publicly-known key allows token forgery. setup.sh generates
+        # a strong value; see docs/self-host-quickstart.md.
+        _session_secret = os.getenv("SESSION_SECRET_KEY", "")
+        if not _session_secret or _session_secret == "aos-secret-key-change-in-production":
+            _secret_msg = (
+                "SESSION_SECRET_KEY is empty or the insecure default — set a strong "
+                "value (run ./setup.sh) before deploying to production."
+            )
+            if app.debug:
+                if logger:
+                    logger.warning("insecure_session_secret_key", detail=_secret_msg)
+                else:
+                    print(f"⚠️  {_secret_msg}")
+            else:
+                raise RuntimeError(_secret_msg)
+
         if USE_DATABASE:
             try:
                 from db.database import async_session_factory, init_db

--- a/src/dashboard/src/stores/auth.ts
+++ b/src/dashboard/src/stores/auth.ts
@@ -7,7 +7,10 @@ import {
 } from '../lib/cookieStorage'
 import { analytics } from '../services/analytics'
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+// Empty fallback = relative paths (/api/...), proxied by nginx (prod) or Vite (dev).
+// A hardcoded host breaks remote self-host: the browser would hit ITS OWN localhost.
+// Matches the canonical pattern in config/api.ts. Set VITE_API_URL to override.
+const API_BASE_URL = import.meta.env.VITE_API_URL || ''
 
 // ─────────────────────────────────────────────────────────────
 // Constants


### PR DESCRIPTION
## 배경

`agent-system`을 다른 사용자에게 배포하기 위한 검토 결과, **격리 단위 = 사용자별 독립 인스턴스(self-host)**, **대상 = 사내/소수 신뢰된 팀**, **우선순위 = 단계적(빠른 self-host → 이후 SaaS)** 로 방향을 정했습니다.

탐색 결과 인프라·CI/CD·프론트엔드는 준비도 "상"(self-contained 루트 `docker-compose.yml`, nginx 단일 오리진, GitHub Actions 완비)이지만, 백엔드에 무인증·소유권 미검사 엔드포인트가 남아 있어 **공유 SaaS는 불가**합니다. 반면 팀별 독립 인스턴스는 DB가 물리 분리되어 **신뢰된 내부망 전용** 전제 하에 즉시 배포 가능합니다. 이 PR은 그 1단계입니다.

## 변경 사항

| 영역 | 파일 | 내용 |
|------|------|------|
| 시크릿 부트스트랩 | `setup.sh` | `SESSION_SECRET_KEY`·`POSTGRES_PASSWORD` 자동 생성 (멱등 — 강한 값 보존, 기존 Postgres 데이터 디렉토리 있으면 비밀번호 미변경) |
| 배포 안전성 | `docker-compose.yml` | 시크릿·DB 자격증명·`CORS_ORIGINS`·`FRONTEND_URL` 파라미터화, `${VAR:?}` fail-fast 가드, `SUPER_ADMIN_EMAILS` 연동 |
| Portability | `docker-compose.yml` → `docker-compose.override.yml` | dev/macOS 전용 마운트(`~/.claude`·`~/.warp`)를 base에서 제거하고 git-ignore된 override로 분리 (maintainer 머신에서만 자동 병합) |
| 백엔드 가드 | `src/backend/api/app.py` | startup 시 약한/빈 `SESSION_SECRET_KEY` 감지 → `app.debug=False`면 fail-fast, debug면 warning |
| 원격 접속 | `src/dashboard/src/stores/auth.ts` | 하드코딩 `localhost:8000` → 상대경로(`''`) — 원격 호스트 접속 시 인증이 깨지던 문제 수정 |
| env 계약 | `.env.example` | 약한 기본 시크릿 제거, `POSTGRES_*`·`SUPER_ADMIN_EMAILS`·원격 URL 노브 추가 |
| 문서 | `docs/self-host-quickstart.md`(신규), `README.md`, `docs/deployment.md` | 복붙 가능한 퀵스타트 + 보안 배너, 배포 흐름을 `./setup.sh` 기준으로 갱신 |

## 검증

```
✅ 백엔드:   pytest 59 passed (api/health + auth_service) — C4 가드가 debug=True 테스트 무손상
✅ C4 가드:  debug=False + 약한 키 → RuntimeError (런타임 확인), py_compile OK
✅ 프론트:   tsc --noEmit exit 0 · vitest auth 10 passed · vite build ✓ built
✅ compose:  시크릿 미설정 → :? 가드 발동 · 설정 시 config rc=0 · dev 마운트 제거 확인
✅ override: git-ignore 확인 · 자동 병합으로 maintainer 마운트 복원
✅ setup.sh: bash -n OK · 시크릿 생성 로직 격리 테스트 5/5
```

> `docker compose build`(전체 이미지 빌드)는 Dockerfile 미변경 + `compose config`·`vite build`로 이미 검증돼 생략했습니다.

## ⚠️ 보안 (운영 시 필수)

1단계는 무인증·소유권 미검사 엔드포인트(`GET/PUT/DELETE /projects/{id}`, `GET/DELETE /sessions/{id}`, `GET/PATCH /playground/sessions/{id}`)가 남아 있습니다.
- ✅ **신뢰된 내부망 / VPN 전용**으로 운용
- ❌ **공개 인터넷 노출 금지** — 외부 공개는 2단계(auth 강화) 후

## 다음 단계 (2단계 — 미구현)

무인증 엔드포인트에 `get_current_user` + 소유권 필터, CORS 강화, 첫 admin UX 개선(`SUPER_ADMIN_EMAILS` + login-twice quirk 제거), 가입 통제 → 공유 SaaS 전환.

## 테스트 계획

신규 사용자 시뮬레이션(`~/.claude` 없는 클린 환경):
1. `cp .env.example .env` → LLM 키 입력 → `./setup.sh` → `.env`에 강한 시크릿 자동 생성, `curl localhost:8000/health` = 200
2. `SESSION_SECRET_KEY` 미설정 시 compose `:?` 실패, 약한 값 + `DEBUG=false`면 백엔드 fail-fast
3. `FRONTEND_URL`/`CORS_ORIGINS`를 LAN IP로 설정 → 다른 머신에서 로그인 → CORS 에러 없음
4. `SUPER_ADMIN_EMAILS`로 첫 admin 부트스트랩

🤖 Generated with [Claude Code](https://claude.com/claude-code)
