### PR TITLE
fix: 세션 상세 대화 내용 잘림 가시화 및 전체 조회 경로 보장

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -96,3 +96,8 @@
 - `offset`: 시작 오프셋 (기본: 0)
 - `project`: 프로젝트 이름 필터 (선택)
 - `source_user`: 소스 사용자 필터 (선택)
+
+**대화 내용 절단 정책** (`{id}`, `{id}/stream`, `{id}/activity`):
+- `{id}` / `{id}/stream`의 `recent_messages`는 **요약 윈도**입니다 — 파일 tail 일부만 파싱하고 최근 N개 메시지만, 각 본문은 길이 캡(기본 2000자)으로 제한됩니다.
+- 절단은 더 이상 무표시가 아닙니다. 각 `SessionMessage`/`ActivityEvent`는 `content_truncated`(bool)와 `full_length`(원본 길이)를 포함하고, `ClaudeSessionDetail`은 `messages_truncated`(bool)로 부분 윈도 여부를 알립니다. 전체 대화는 `{id}/transcript`(절단 없음, 페이지네이션만)로 조회합니다.
+- `{id}/activity`의 `result` 이벤트 `tool_result`는 `json.dumps`로 직렬화 후 캡되어 잘린 결과도 유효한 JSON 접두사를 유지합니다.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -125,8 +125,8 @@ import { cn } from '@/lib/utils';
 |----------|------|
 | `SessionList` | 세션 목록 (정렬, 자동 새로고침) |
 | `SessionCard` | 세션 카드 (상태, 토큰, 비용) |
-| `SessionDetails` | 상세 정보 + Recent Activity |
-| `TranscriptViewer` | Raw 트랜스크립트 (JSON Tree) |
+| `SessionDetails` | 상세 정보 + Recent Activity (요약 윈도 시 "전체 Transcript 보기" 배너, 메시지별 잘림 표시) |
+| `TranscriptViewer` | Raw 트랜스크립트 (JSON Tree, 긴 문자열은 "더 보기" 토글로 전체 표시) |
 | `ProcessCleanupPanel` | 프로세스 정리 패널 |
 
 ### Project Config Components

--- a/src/backend/models/claude_session.py
+++ b/src/backend/models/claude_session.py
@@ -43,6 +43,12 @@ class SessionMessage(BaseModel):
     timestamp: datetime
     model: str | None = None
     content: str | None = None
+    content_truncated: bool = Field(
+        default=False, description="True if content was cut to a length cap"
+    )
+    full_length: int | None = Field(
+        default=None, description="Original content length when truncated"
+    )
     tool_name: str | None = None
     tool_id: str | None = None
     tool_input: dict | None = None  # Tool input parameters
@@ -99,6 +105,10 @@ class ClaudeSessionDetail(ClaudeSessionInfo):
     recent_messages: list[SessionMessage] = Field(
         default_factory=list, description="Recent messages (last 20)"
     )
+    messages_truncated: bool = Field(
+        default=False,
+        description="True if recent_messages is a partial window (message_count > shown)",
+    )
     current_task: str | None = Field(default=None, description="Current task description if active")
 
 
@@ -151,6 +161,12 @@ class ActivityEvent(BaseModel):
     type: ActivityEventType = Field(..., description="Event type")
     timestamp: datetime = Field(..., description="Event timestamp")
     content: str | None = Field(default=None, description="Text content")
+    content_truncated: bool = Field(
+        default=False, description="True if content was cut to a length cap"
+    )
+    full_length: int | None = Field(
+        default=None, description="Original content length when truncated"
+    )
     tool_name: str | None = Field(default=None, description="Tool name (for tool_use/tool_result)")
     tool_input: dict | None = Field(default=None, description="Tool input parameters")
     tool_result: str | None = Field(default=None, description="Tool result (for tool_result)")

--- a/src/backend/services/claude_session_monitor.py
+++ b/src/backend/services/claude_session_monitor.py
@@ -18,6 +18,30 @@ from pathlib import Path
 # Claude Code session files are named with UUID v4
 _UUID_PATTERN = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 
+# Recent-messages window for the session-details Overview tab.
+# Content is capped per message and the list is windowed; both are FLAGGED
+# (content_truncated / messages_truncated) so the UI can offer "view full".
+RECENT_MESSAGE_CONTENT_LIMIT = 2000  # per-message char cap (was a silent 500)
+RECENT_MESSAGE_WINDOW_LINES = 200  # raw lines parsed from file tail (was 50)
+RECENT_MESSAGE_COUNT = 20  # messages kept in recent_messages
+# Activity feed (separate timeline view) per-event content cap.
+ACTIVITY_CONTENT_LIMIT = 1000
+
+
+def _truncate_content(text: str | None, limit: int) -> tuple[str | None, bool, int | None]:
+    """Cap text to ``limit`` and report whether it was cut.
+
+    Returns (capped_text, was_truncated, original_length_or_None).
+    Never mutates input; always returns a fresh tuple.
+    """
+    if not text:
+        return (None if text is None else text), False, None
+    full_length = len(text)
+    if full_length > limit:
+        return text[:limit], True, full_length
+    return text, False, None
+
+
 import httpx
 
 from models.claude_session import (
@@ -614,8 +638,10 @@ class ClaudeSessionMonitor:
         with open(session_file, encoding="utf-8") as f:
             lines = f.readlines()
 
-        # Parse last 50 lines for recent messages
-        for line in lines[-50:]:
+        # Parse the file tail for recent messages. Window is line-based for cost,
+        # but generous enough that tool_use/empty entries don't crowd out real
+        # messages (the old 50-line window could yield <20 visible messages).
+        for line in lines[-RECENT_MESSAGE_WINDOW_LINES:]:
             line = line.strip()
             if not line:
                 continue
@@ -656,12 +682,17 @@ class ClaudeSessionMonitor:
                         elif not isinstance(result_content, str):
                             result_content = str(result_content) if result_content else ""
 
+                        capped, truncated, full_length = _truncate_content(
+                            result_content or None, RECENT_MESSAGE_CONTENT_LIMIT
+                        )
                         recent_messages.append(
                             SessionMessage(
                                 type=MessageType.TOOL_RESULT,
                                 timestamp=timestamp,
                                 tool_id=tool_use_id,
-                                content=result_content[:500] if result_content else None,
+                                content=capped,
+                                content_truncated=truncated,
+                                full_length=full_length,
                             )
                         )
                         continue
@@ -676,15 +707,20 @@ class ClaudeSessionMonitor:
                 if not content or (isinstance(content, str) and not content.strip()):
                     continue
 
+                capped, truncated, full_length = _truncate_content(
+                    content or None, RECENT_MESSAGE_CONTENT_LIMIT
+                )
                 recent_messages.append(
                     SessionMessage(
                         type=MessageType.USER,
                         timestamp=timestamp,
-                        content=content[:500] if content else None,
+                        content=capped,
+                        content_truncated=truncated,
+                        full_length=full_length,
                     )
                 )
 
-                # Track current task from user messages
+                # Track current task from user messages (short label)
                 if content:
                     current_task = content[:200]
 
@@ -704,7 +740,7 @@ class ClaudeSessionMonitor:
                     for item in content_list:
                         if isinstance(item, dict):
                             if item.get("type") == "text":
-                                content = item.get("text", "")[:500]
+                                content = item.get("text", "")
                             elif item.get("type") == "tool_use":
                                 tool_name = item.get("name")
                                 tool_id = item.get("id")
@@ -733,12 +769,17 @@ class ClaudeSessionMonitor:
                     )
                 elif content and content.strip():
                     # Skip assistant messages with empty content (e.g., thinking-only blocks)
+                    capped, truncated, full_length = _truncate_content(
+                        content, RECENT_MESSAGE_CONTENT_LIMIT
+                    )
                     recent_messages.append(
                         SessionMessage(
                             type=msg_type,
                             timestamp=timestamp,
                             model=model,
-                            content=content,
+                            content=capped,
+                            content_truncated=truncated,
+                            full_length=full_length,
                             usage=usage,
                         )
                     )
@@ -748,20 +789,28 @@ class ClaudeSessionMonitor:
                 message_data = entry.get("message", {})
                 content = message_data.get("content", "")
                 if content:
+                    capped, truncated, full_length = _truncate_content(
+                        content, RECENT_MESSAGE_CONTENT_LIMIT
+                    )
                     recent_messages.append(
                         SessionMessage(
                             type=MessageType.PROGRESS,
                             timestamp=timestamp,
-                            content=content[:200],
+                            content=capped,
+                            content_truncated=truncated,
+                            full_length=full_length,
                         )
                     )
 
-        # Keep only last 20 messages for the response
-        recent_messages = recent_messages[-20:]
+        # Keep only the most recent messages for the response. Flag when the
+        # full conversation is larger so the UI can link to the Raw Transcript.
+        recent_messages = recent_messages[-RECENT_MESSAGE_COUNT:]
+        messages_truncated = basic_info.message_count > len(recent_messages)
 
         return ClaudeSessionDetail(
             **basic_info.model_dump(),
             recent_messages=recent_messages,
+            messages_truncated=messages_truncated,
             current_task=current_task,
         )
 
@@ -1191,14 +1240,17 @@ class ClaudeSessionMonitor:
                                 elif not isinstance(result_content, str):
                                     result_content = str(result_content) if result_content else ""
 
+                                capped, truncated, full_length = _truncate_content(
+                                    result_content or None, ACTIVITY_CONTENT_LIMIT
+                                )
                                 events.append(
                                     ActivityEvent(
                                         id=event_id,
                                         type=ActivityEventType.TOOL_RESULT,
                                         timestamp=timestamp,
-                                        tool_result=result_content[:500]
-                                        if result_content
-                                        else None,
+                                        tool_result=capped,
+                                        content_truncated=truncated,
+                                        full_length=full_length,
                                         session_id=session_id,
                                     )
                                 )
@@ -1216,12 +1268,17 @@ class ClaudeSessionMonitor:
 
                     total_count += 1
                     if total_count > offset and len(events) < limit:
+                        capped, truncated, full_length = _truncate_content(
+                            content or None, ACTIVITY_CONTENT_LIMIT
+                        )
                         events.append(
                             ActivityEvent(
                                 id=event_id,
                                 type=ActivityEventType.USER,
                                 timestamp=timestamp,
-                                content=content[:1000] if content else None,
+                                content=capped,
+                                content_truncated=truncated,
+                                full_length=full_length,
                                 session_id=session_id,
                             )
                         )
@@ -1241,12 +1298,17 @@ class ClaudeSessionMonitor:
                                     if text_content and text_content.strip():
                                         total_count += 1
                                         if total_count > offset and len(events) < limit:
+                                            capped, truncated, full_length = _truncate_content(
+                                                text_content, ACTIVITY_CONTENT_LIMIT
+                                            )
                                             events.append(
                                                 ActivityEvent(
                                                     id=f"{event_id}_text",
                                                     type=ActivityEventType.ASSISTANT,
                                                     timestamp=timestamp,
-                                                    content=text_content[:1000],
+                                                    content=capped,
+                                                    content_truncated=truncated,
+                                                    full_length=full_length,
                                                     session_id=session_id,
                                                 )
                                             )
@@ -1269,14 +1331,25 @@ class ClaudeSessionMonitor:
                     total_count += 1
                     if total_count > offset and len(events) < limit:
                         result_data = entry.get("result", {})
-                        tool_result = str(result_data)[:500] if result_data else None
+                        # Serialize to JSON before capping so the structure is
+                        # not broken mid-dict (str(dict)[:500] could cut a value).
+                        result_str = (
+                            json.dumps(result_data, ensure_ascii=False, default=str)
+                            if result_data
+                            else None
+                        )
+                        capped, truncated, full_length = _truncate_content(
+                            result_str, ACTIVITY_CONTENT_LIMIT
+                        )
 
                         events.append(
                             ActivityEvent(
                                 id=event_id,
                                 type=ActivityEventType.TOOL_RESULT,
                                 timestamp=timestamp,
-                                tool_result=tool_result,
+                                tool_result=capped,
+                                content_truncated=truncated,
+                                full_length=full_length,
                                 session_id=session_id,
                             )
                         )
@@ -1468,12 +1541,17 @@ class ClaudeSessionMonitor:
                         elif not isinstance(result_content, str):
                             result_content = str(result_content) if result_content else ""
 
+                        capped, truncated, full_length = _truncate_content(
+                            result_content or None, ACTIVITY_CONTENT_LIMIT
+                        )
                         events.append(
                             ActivityEvent(
                                 id=event_id,
                                 type=ActivityEventType.TOOL_RESULT,
                                 timestamp=timestamp,
-                                tool_result=result_content[:500] if result_content else None,
+                                tool_result=capped,
+                                content_truncated=truncated,
+                                full_length=full_length,
                                 session_id=session_id,
                             )
                         )
@@ -1489,12 +1567,17 @@ class ClaudeSessionMonitor:
                 if not content or (isinstance(content, str) and not content.strip()):
                     continue
 
+                capped, truncated, full_length = _truncate_content(
+                    content or None, ACTIVITY_CONTENT_LIMIT
+                )
                 events.append(
                     ActivityEvent(
                         id=event_id,
                         type=ActivityEventType.USER,
                         timestamp=timestamp,
-                        content=content[:1000] if content else None,
+                        content=capped,
+                        content_truncated=truncated,
+                        full_length=full_length,
                         session_id=session_id,
                     )
                 )
@@ -1512,12 +1595,17 @@ class ClaudeSessionMonitor:
                                 text_content = item.get("text", "")
                                 # Skip empty text blocks (e.g., thinking-only responses)
                                 if text_content and text_content.strip():
+                                    capped, truncated, full_length = _truncate_content(
+                                        text_content, ACTIVITY_CONTENT_LIMIT
+                                    )
                                     events.append(
                                         ActivityEvent(
                                             id=f"{event_id}_text",
                                             type=ActivityEventType.ASSISTANT,
                                             timestamp=timestamp,
-                                            content=text_content[:1000],
+                                            content=capped,
+                                            content_truncated=truncated,
+                                            full_length=full_length,
                                             session_id=session_id,
                                         )
                                     )
@@ -1536,14 +1624,25 @@ class ClaudeSessionMonitor:
 
             elif msg_type == "result":
                 result_data = entry.get("result", {})
-                tool_result = str(result_data)[:500] if result_data else None
+                # JSON-serialize before capping to avoid breaking the structure
+                # mid-dict (str(dict)[:N] could cut a value in half).
+                result_str = (
+                    json.dumps(result_data, ensure_ascii=False, default=str)
+                    if result_data
+                    else None
+                )
+                capped, truncated, full_length = _truncate_content(
+                    result_str, ACTIVITY_CONTENT_LIMIT
+                )
 
                 events.append(
                     ActivityEvent(
                         id=event_id,
                         type=ActivityEventType.TOOL_RESULT,
                         timestamp=timestamp,
-                        tool_result=tool_result,
+                        tool_result=capped,
+                        content_truncated=truncated,
+                        full_length=full_length,
                         session_id=session_id,
                     )
                 )

--- a/src/dashboard/src/components/claude-sessions/SessionDetails.tsx
+++ b/src/dashboard/src/components/claude-sessions/SessionDetails.tsx
@@ -84,7 +84,13 @@ function formatToolInput(input: Record<string, unknown>): string {
   return ''
 }
 
-function MessageItem({ message }: { message: SessionMessage }) {
+function MessageItem({
+  message,
+  onViewTranscript,
+}: {
+  message: SessionMessage
+  onViewTranscript?: () => void
+}) {
   const time = new Date(message.timestamp).toLocaleTimeString()
   const toolInputSummary = message.tool_input ? formatToolInput(message.tool_input) : null
 
@@ -110,7 +116,10 @@ function MessageItem({ message }: { message: SessionMessage }) {
         </div>
         {/* Tool input summary */}
         {toolInputSummary && (
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate">
+          <p
+            className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate"
+            title={toolInputSummary}
+          >
             {toolInputSummary}
           </p>
         )}
@@ -119,12 +128,29 @@ function MessageItem({ message }: { message: SessionMessage }) {
             {message.content}
           </p>
         )}
+        {/* Content was capped by the backend — point users to the full transcript */}
+        {message.content_truncated && (
+          <button
+            type="button"
+            onClick={onViewTranscript}
+            aria-label="전체 메시지를 Raw Transcript에서 보기"
+            className="mt-1 text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 underline"
+          >
+            … 잘림{message.full_length ? ` (전체 ${message.full_length.toLocaleString()}자)` : ''} · 전체 보기
+          </button>
+        )}
       </div>
     </div>
   )
 }
 
-function OverviewContent({ session }: { session: ClaudeSessionDetail }) {
+function OverviewContent({
+  session,
+  onViewTranscript,
+}: {
+  session: ClaudeSessionDetail
+  onViewTranscript: () => void
+}) {
   return (
     <>
       {/* Header */}
@@ -148,7 +174,10 @@ function OverviewContent({ session }: { session: ClaudeSessionDetail }) {
             <p className="text-sm text-blue-700 dark:text-blue-300 font-medium">
               Current Task
             </p>
-            <p className="text-sm text-blue-600 dark:text-blue-400 mt-1 line-clamp-2">
+            <p
+              className="text-sm text-blue-600 dark:text-blue-400 mt-1 line-clamp-2"
+              title={session.current_task}
+            >
               {session.current_task}
             </p>
           </div>
@@ -232,6 +261,23 @@ function OverviewContent({ session }: { session: ClaudeSessionDetail }) {
           <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Recent Activity
           </h3>
+          {/* Overview is a recent-window summary — link to the full transcript */}
+          {session.messages_truncated && (
+            <div className="mb-2 flex items-center justify-between gap-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+              <span>
+                전체 {session.message_count.toLocaleString()}개 중 최근{' '}
+                {session.recent_messages.length}개만 표시 중
+              </span>
+              <button
+                type="button"
+                onClick={onViewTranscript}
+                aria-label="전체 대화를 Raw Transcript에서 보기"
+                className="font-medium underline hover:text-amber-800 dark:hover:text-amber-300 whitespace-nowrap"
+              >
+                전체 Transcript 보기
+              </button>
+            </div>
+          )}
           {session.recent_messages.length === 0 ? (
             <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
               No recent messages
@@ -239,7 +285,11 @@ function OverviewContent({ session }: { session: ClaudeSessionDetail }) {
           ) : (
             <div className="space-y-1">
               {session.recent_messages.map((message, index) => (
-                <MessageItem key={`msg-${message.type ?? 'unknown'}-${index}`} message={message} />
+                <MessageItem
+                  key={`msg-${message.type ?? 'unknown'}-${index}`}
+                  message={message}
+                  onViewTranscript={onViewTranscript}
+                />
               ))}
             </div>
           )}
@@ -304,7 +354,7 @@ export function SessionDetails() {
 
       {/* Tab Content */}
       {activeTab === 'overview' ? (
-        <OverviewContent session={session} />
+        <OverviewContent session={session} onViewTranscript={() => setActiveTab('transcript')} />
       ) : (
         <TranscriptViewer />
       )}

--- a/src/dashboard/src/components/claude-sessions/TranscriptViewer.tsx
+++ b/src/dashboard/src/components/claude-sessions/TranscriptViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { memo, useEffect, useState, useMemo } from 'react'
 import { useClaudeSessionsStore } from '../../stores/claudeSessions'
 import { cn } from '../../lib/utils'
 import {
@@ -86,13 +86,45 @@ function getEntryIcon(type: string) {
   }
 }
 
+// Default preview length for long string leaves. Full content stays reachable
+// via the "더 보기" toggle so the Raw Transcript never silently loses content.
+const STRING_PREVIEW_LIMIT = 500
+
+/**
+ * Renders a string leaf with an expand/collapse toggle when it exceeds the
+ * preview limit. Extracted into its own component because each string needs
+ * independent expand state (Hooks cannot live in JsonTree's string branch).
+ */
+const JsonString = memo(({ value }: { value: string }) => {
+  const [expanded, setExpanded] = useState(false)
+  const isLong = value.length > STRING_PREVIEW_LIMIT
+  const displayStr = !isLong || expanded ? value : value.slice(0, STRING_PREVIEW_LIMIT)
+
+  return (
+    <span className="text-green-600 dark:text-green-400 break-all whitespace-pre-wrap">
+      "{displayStr}"
+      {isLong && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? '문자열 접기' : `전체 문자열 보기 (${value.length.toLocaleString()}자)`}
+          className="ml-1 text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 underline"
+        >
+          {expanded ? '접기' : `… 더 보기 (${value.length.toLocaleString()}자)`}
+        </button>
+      )}
+    </span>
+  )
+})
+JsonString.displayName = 'JsonString'
+
 interface JsonTreeProps {
   data: unknown
   depth?: number
   maxDepth?: number
 }
 
-function JsonTree({ data, depth = 0, maxDepth = 6 }: JsonTreeProps) {
+function JsonTree({ data, depth = 0, maxDepth = 12 }: JsonTreeProps) {
   const [expanded, setExpanded] = useState(depth < 2)
 
   if (depth >= maxDepth) {
@@ -112,13 +144,7 @@ function JsonTree({ data, depth = 0, maxDepth = 6 }: JsonTreeProps) {
   }
 
   if (typeof data === 'string') {
-    // Truncate long strings
-    const displayStr = data.length > 500 ? data.slice(0, 500) + '...' : data
-    return (
-      <span className="text-green-600 dark:text-green-400 break-all whitespace-pre-wrap">
-        "{displayStr}"
-      </span>
-    )
+    return <JsonString value={data} />
   }
 
   if (Array.isArray(data)) {

--- a/src/dashboard/src/components/claude-sessions/__tests__/SessionDetails.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/SessionDetails.test.tsx
@@ -222,4 +222,51 @@ describe('SessionDetails', () => {
     expect(screen.getByText('Recent Activity')).toBeInTheDocument()
     expect(screen.queryByTestId('transcript-viewer')).not.toBeInTheDocument()
   })
+
+  describe('truncation affordances', () => {
+    it('shows a "view full transcript" banner when messages_truncated', () => {
+      storeState.selectedSession = { ...mockSession, messages_truncated: true }
+      render(<SessionDetails />)
+      expect(
+        screen.getByRole('button', { name: '전체 대화를 Raw Transcript에서 보기' })
+      ).toBeInTheDocument()
+    })
+
+    it('does not show the banner when not truncated', () => {
+      storeState.selectedSession = { ...mockSession, messages_truncated: false }
+      render(<SessionDetails />)
+      expect(
+        screen.queryByRole('button', { name: '전체 대화를 Raw Transcript에서 보기' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('switches to the transcript tab when the banner link is clicked', () => {
+      storeState.selectedSession = { ...mockSession, messages_truncated: true }
+      render(<SessionDetails />)
+      fireEvent.click(
+        screen.getByRole('button', { name: '전체 대화를 Raw Transcript에서 보기' })
+      )
+      expect(screen.getByTestId('transcript-viewer')).toBeInTheDocument()
+    })
+
+    it('shows a per-message "view full" link when a message content is truncated', () => {
+      storeState.selectedSession = {
+        ...mockSession,
+        messages_truncated: false,
+        recent_messages: [
+          {
+            type: 'assistant',
+            timestamp: '2026-01-15T10:56:00Z',
+            content: 'partial text',
+            content_truncated: true,
+            full_length: 4200,
+          },
+        ] as SessionMessage[],
+      }
+      render(<SessionDetails />)
+      expect(
+        screen.getByRole('button', { name: '전체 메시지를 Raw Transcript에서 보기' })
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/src/dashboard/src/components/claude-sessions/__tests__/TranscriptViewer.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/TranscriptViewer.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import type { TranscriptEntry } from '../../../types/claudeSession'
+
+// Mock lucide-react icons used by TranscriptViewer
+vi.mock('lucide-react', () => {
+  const Icon = (props: Record<string, unknown>) => <span {...props} />
+  return {
+    ChevronDown: Icon,
+    ChevronRight: Icon,
+    ChevronLeft: Icon,
+    User: Icon,
+    Bot: Icon,
+    Wrench: Icon,
+    CheckCircle: Icon,
+    Search: Icon,
+    Filter: Icon,
+    Loader2: Icon,
+    Brain: Icon,
+  }
+})
+
+// A string longer than the 500-char preview limit, with an end marker that
+// only appears once the string is fully expanded.
+const END_MARKER = 'END_OF_LONG_STRING_MARKER'
+const LONG_STRING = 'x'.repeat(540) + END_MARKER
+
+const longEntry: TranscriptEntry = {
+  sessionId: 'sess-1',
+  slug: 'demo',
+  version: '1.0.0',
+  gitBranch: 'main',
+  cwd: '/demo',
+  type: 'assistant',
+  message: { content: LONG_STRING },
+  timestamp: '2026-06-06T10:00:00Z',
+}
+
+let storeState: Record<string, unknown>
+
+vi.mock('../../../stores/claudeSessions', () => ({
+  useClaudeSessionsStore: vi.fn(() => storeState),
+}))
+
+import { TranscriptViewer } from '../TranscriptViewer'
+
+describe('TranscriptViewer — JsonString expand toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeState = {
+      selectedSessionId: 'sess-1',
+      transcriptEntries: [longEntry],
+      transcriptTotalCount: 1,
+      transcriptHasMore: false,
+      isLoadingTranscript: false,
+      fetchTranscript: vi.fn(),
+      clearTranscript: vi.fn(),
+    }
+  })
+
+  it('previews a long string and hides the tail until expanded', () => {
+    render(<TranscriptViewer />)
+    // Expand the transcript entry to reveal the JSON tree
+    fireEvent.click(screen.getByText('assistant'))
+
+    // The 500-char preview must NOT contain the end marker yet
+    expect(screen.queryByText(new RegExp(END_MARKER))).not.toBeInTheDocument()
+    // A "더 보기" affordance must be present (reports the full length)
+    expect(
+      screen.getByRole('button', { name: /전체 문자열 보기/ })
+    ).toBeInTheDocument()
+  })
+
+  it('reveals the full string when "더 보기" is clicked', () => {
+    render(<TranscriptViewer />)
+    fireEvent.click(screen.getByText('assistant'))
+
+    fireEvent.click(screen.getByRole('button', { name: /전체 문자열 보기/ }))
+
+    // Full content (including the tail marker) is now rendered
+    expect(screen.getByText(new RegExp(END_MARKER))).toBeInTheDocument()
+    // Toggle now collapses
+    expect(screen.getByRole('button', { name: '문자열 접기' })).toBeInTheDocument()
+  })
+
+  it('does not truncate short strings (no toggle)', () => {
+    storeState.transcriptEntries = [
+      { ...longEntry, message: { content: 'short content' } },
+    ]
+    render(<TranscriptViewer />)
+    fireEvent.click(screen.getByText('assistant'))
+
+    expect(screen.queryByRole('button', { name: /전체 문자열 보기/ })).not.toBeInTheDocument()
+  })
+})

--- a/src/dashboard/src/types/claudeSession.ts
+++ b/src/dashboard/src/types/claudeSession.ts
@@ -18,6 +18,8 @@ export interface SessionMessage {
   timestamp: string
   model?: string
   content?: string
+  content_truncated?: boolean  // content was cut to a length cap
+  full_length?: number  // original content length when truncated
   tool_name?: string
   tool_id?: string
   tool_input?: Record<string, unknown>
@@ -54,6 +56,7 @@ export interface ClaudeSessionInfo {
 
 export interface ClaudeSessionDetail extends ClaudeSessionInfo {
   recent_messages: SessionMessage[]
+  messages_truncated?: boolean  // recent_messages is a partial window of the full conversation
   current_task?: string
 }
 

--- a/tests/backend/test_claude_session_monitor.py
+++ b/tests/backend/test_claude_session_monitor.py
@@ -1,0 +1,118 @@
+"""Tests for ClaudeSessionMonitor truncation metadata.
+
+Focus: the session-details path must expose WHETHER content was truncated
+(content_truncated / full_length) and WHETHER the recent_messages list is a
+partial window (messages_truncated), so the UI can offer a "view full" affordance
+instead of silently hiding conversation content.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from services.claude_session_monitor import (
+    RECENT_MESSAGE_CONTENT_LIMIT,
+    ClaudeSessionMonitor,
+)
+
+
+def _write_session(projects_dir: Path, lines: list[dict]) -> str:
+    """Write a JSONL session file and return its session_id (UUID)."""
+    session_id = str(uuid.uuid4())
+    project_dir = projects_dir / "-Users-tester-Work-Demo"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    session_file = project_dir / f"{session_id}.jsonl"
+    with open(session_file, "w", encoding="utf-8") as f:
+        for entry in lines:
+            f.write(json.dumps(entry) + "\n")
+    return session_id
+
+
+def _user_line(text: str, ts: str = "2026-06-06T10:00:00Z") -> dict:
+    return {"type": "user", "timestamp": ts, "message": {"content": text}}
+
+
+def _assistant_line(text: str, ts: str = "2026-06-06T10:00:01Z") -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": text}],
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    }
+
+
+@pytest.fixture
+def monitor(tmp_path: Path) -> ClaudeSessionMonitor:
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()
+    mon = ClaudeSessionMonitor(
+        claude_projects_dirs=[str(projects_dir)], include_external=False
+    )
+    # Expose the temp projects dir for helpers
+    mon._test_projects_dir = projects_dir  # type: ignore[attr-defined]
+    return mon
+
+
+def test_long_message_sets_content_truncated_and_full_length(monitor):
+    """A message longer than the cap must be flagged, not silently cut."""
+    projects_dir: Path = monitor._test_projects_dir
+    long_text = "A" * (RECENT_MESSAGE_CONTENT_LIMIT + 500)
+    session_id = _write_session(projects_dir, [_user_line(long_text)])
+
+    detail = monitor.get_session_details(session_id)
+
+    assert detail is not None
+    msg = detail.recent_messages[-1]
+    assert msg.content is not None
+    assert len(msg.content) == RECENT_MESSAGE_CONTENT_LIMIT
+    assert msg.content_truncated is True
+    assert msg.full_length == RECENT_MESSAGE_CONTENT_LIMIT + 500
+
+
+def test_short_message_is_not_flagged(monitor):
+    """A short message must NOT be flagged as truncated."""
+    projects_dir: Path = monitor._test_projects_dir
+    session_id = _write_session(projects_dir, [_user_line("hello world")])
+
+    detail = monitor.get_session_details(session_id)
+
+    assert detail is not None
+    msg = detail.recent_messages[-1]
+    assert msg.content == "hello world"
+    assert msg.content_truncated is False
+    assert msg.full_length is None
+
+
+def test_many_messages_sets_messages_truncated(monitor):
+    """When there are more messages than the recent window, flag it."""
+    projects_dir: Path = monitor._test_projects_dir
+    lines = []
+    for i in range(25):
+        ts = datetime(2026, 6, 6, 10, 0, i, tzinfo=UTC).isoformat()
+        lines.append(_user_line(f"message number {i}", ts=ts))
+    session_id = _write_session(projects_dir, lines)
+
+    detail = monitor.get_session_details(session_id)
+
+    assert detail is not None
+    assert detail.message_count == 25
+    assert len(detail.recent_messages) <= 20
+    assert detail.messages_truncated is True
+
+
+def test_few_messages_not_messages_truncated(monitor):
+    """When all messages fit in the window, do not flag truncation."""
+    projects_dir: Path = monitor._test_projects_dir
+    lines = [_user_line("a"), _assistant_line("b")]
+    session_id = _write_session(projects_dir, lines)
+
+    detail = monitor.get_session_details(session_id)
+
+    assert detail is not None
+    assert detail.messages_truncated is False


### PR DESCRIPTION
## 배경

Claude `세션 상세(session details)` 뷰에서 대화 내용이 **무표시로 잘리는** 문제를 멀티 에이전트 진단(백엔드·프론트·데이터흐름 병렬 스윕)으로 근본 원인을 확정하고 수정했다.

- **Overview 탭**: 의도된 "최근 활동" 요약 윈도지만, 잘렸다는 표시도 전체 대화로 가는 링크도 없어 "내용이 사라졌다"는 인식을 유발 (`get_session_details`: tail 50줄 → 최근 20개 → 각 500자)
- **Raw Transcript 탭**: 백엔드는 원본 JSONL을 온전히 전송함에도 프론트 `JsonTree`가 모든 문자열을 500자로 잘라 "Raw" 약속을 위반

## 변경 사항

### 백엔드
- `models/claude_session.py`: `SessionMessage`/`ActivityEvent`에 `content_truncated`·`full_length`, `ClaudeSessionDetail`에 `messages_truncated` 추가
- `services/claude_session_monitor.py`:
  - `get_session_details`: 라인 윈도 50→200, 본문 캡 500→2000 + 절단 시 플래그, `messages_truncated` 계산
  - `get_session_activity` / SSE 증분: 절단 플래그 부착, `str(result_data)[:500]` → `json.dumps(...)[:N]` (dict 구조 중간 깨짐 버그 수정)

### 프론트엔드
- `TranscriptViewer.tsx`: `JsonString` 컴포넌트 추출 — 500자 하드컷 → **"더 보기" 펼침 토글**(전체 내용 접근), `maxDepth` 6→12
- `SessionDetails.tsx`: `messages_truncated` 시 **"전체 Transcript 보기" 배너**(탭 전환), 메시지별 잘림 링크, `current_task`·tool-input `title` 툴팁
- `types/claudeSession.ts`: 대응 타입 추가

### 문서
- `docs/api/agents.md`: 대화 내용 절단 정책 섹션 추가
- `docs/dashboard.md`: 컴포넌트 설명에 배너·토글 동작 반영

## 설계 원칙

"한계를 없애기"가 아니라 **"한계를 가시화하기"** — Overview는 요약으로 유지하되 잘림을 표시하고 전체로 이동할 길을 열었고, Raw 탭은 미리보기 500자로 렌더 성능을 지키되 토글로 전체를 보장한다.

## 테스트 계획

- [x] 백엔드 신규 `tests/backend/test_claude_session_monitor.py` (4): 절단 플래그·`messages_truncated`
- [x] 프론트 신규 `TranscriptViewer.test.tsx` (3): "더 보기" 펼침 토글
- [x] 프론트 `SessionDetails.test.tsx` (+4): 배너 표시/숨김/탭전환/메시지별 링크
- [x] 백엔드: `ruff check` clean, `pytest` 4 passed
- [x] 프론트: `tsc --noEmit` 0, `eslint` 0, `vitest` 298 passed, `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)