### PR TITLE
fix: RAG 리랭커 빈 후보 시 모델 다운로드 제거 (CI HF 429 플레이크 해소)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,14 @@ jobs:
           USE_DATABASE: "true"
           SESSION_SECRET_KEY: test-secret-key
           LLM_PROVIDER: google
+          # Force HuggingFace offline so tests never download models (prevents
+          # 429 flakes). All model code paths are mocked; a future unmocked
+          # test will fail loudly offline instead of hitting the network — mark
+          # such tests @pytest.mark.network (excluded below) and mock the model.
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: |
-          pytest ../../tests/backend -v --tb=short --cov=. --cov-report=xml
+          pytest ../../tests/backend -v --tb=short --cov=. --cov-report=xml -m "not network"
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -98,6 +98,9 @@ ignore = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["../../tests/backend"]
+markers = [
+    "network: requires external network or real model download (excluded in CI; run locally with -m network)",
+]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -761,8 +761,13 @@ class ProjectVectorStore:
         top_k: int,
     ) -> list[dict[str, Any]]:
         """Rerank candidates using CrossEncoder. Returns top_k results."""
+        # Short-circuit on empty input BEFORE loading the model: there is
+        # nothing to score, and instantiating CrossEncoder would trigger an
+        # unnecessary HuggingFace download (the source of CI 429 flakes).
+        if not candidates:
+            return candidates[:top_k]
         encoder = self._get_cross_encoder()
-        if encoder is None or not candidates:
+        if encoder is None:
             return candidates[:top_k]
 
         pairs = [(query, c["content"]) for c in candidates]

--- a/tests/backend/test_rag_service.py
+++ b/tests/backend/test_rag_service.py
@@ -352,8 +352,16 @@ class TestReranking:
         assert len(result) == 1
         assert result[0]["source"] == "a.py"
 
-    def test_rerank_empty_candidates(self, vector_store):
-        """Rerank handles empty candidate list."""
+    def test_rerank_empty_candidates(self, vector_store, monkeypatch):
+        """Rerank handles empty candidate list without touching the model.
+
+        Pins RERANK_AVAILABLE=False so the test never depends on whether
+        sentence_transformers happens to be installed (defense-in-depth on top
+        of the _rerank empty-candidate short-circuit).
+        """
+        import services.rag_service as rag_mod
+
+        monkeypatch.setattr(rag_mod, "RERANK_AVAILABLE", False)
         result = vector_store._rerank("query", [], top_k=5)
         assert result == []
 


### PR DESCRIPTION
## 배경

CI `Backend Tests`가 간헐적으로 `test_rag_service.py::TestReranking::test_rerank_empty_candidates`에서 실패했다. 원인은 코드가 아니라 **HuggingFace `429 Too Many Requests`** (`cross-encoder/ms-marco-MiniLM-L-6-v2` 다운로드). 멀티 에이전트 분석(근본원인 검증 + 테스트 스위트 전수 스윕 + CI 분석)으로 단일 순서 버그임을 확정했다.

## 근본 원인

`rag_service.py`의 `_rerank`가 값싼 `not candidates` 체크보다 **먼저** `_get_cross_encoder()`를 호출 → 빈 후보에도 `CrossEncoder(...)` 인스턴스화 → HF 다운로드. 테스트가 `RERANK_AVAILABLE`을 mock하지 않아 CI 기본값(True)을 상속 → 실제 다운로드 → 429.

## 변경 (a/b/c)

- **(a) 코드 최소 수정** — `_rerank`에서 빈-후보 short-circuit을 인코더 로드보다 앞으로 이동. 비어있지 않은 후보 경로는 **동작 불변**, 빈 후보는 모델 미접근으로 `[]` 반환.
- **(b) 테스트 보강** — `test_rerank_empty_candidates`에 `RERANK_AVAILABLE=False` 고정 → 라이브러리 설치 여부 의존 제거(defense-in-depth).
- **(c) CI 하드닝** — `ci.yml`에 `HF_HUB_OFFLINE=1`/`TRANSFORMERS_OFFLINE=1` + `pytest -m "not network"`, `pyproject.toml`에 `network` 마커 등록. 미래 unmocked 모델 테스트가 *조용한 다운로드* 대신 *즉시 실패* → 플레이크 재유입 차단.

## 코드 수정만으로 충분한가?

**충분.** 테스트 스위트 전수 스윕 결과 (a) 적용 후 남는 HF 다운로드 트리거 **0개** (다른 rerank 테스트는 mock/`RERANK_AVAILABLE=False`, integration 테스트는 rerank 비활성, 임베딩은 fixture에서 mock). (b)/(c)는 미래 회귀 방어.

## 테스트 계획 (RED → GREEN, offline 격리)

- [x] **RED**: `HF_HUB_OFFLINE=1` + 가짜 모델명으로 수정 전 빈-후보 테스트 → CI와 동일한 `OSError: couldn't connect to huggingface.co`로 FAIL (다운로드 경로 입증)
- [x] **GREEN**: (a) 적용 후 동일 조건 PASS
- [x] RAG 테스트 **90개** offline+`-m "not network"` 통과 (잔여 트리거 0개 입증)
- [x] `rag_service.py` ruff check / format clean
- [x] `network` 마커 등록으로 unknown-marker 경고 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)