### PR TITLE
refactor: HF 오프라인 가드를 conftest/addopts로 상향 (모든 pytest 실행 보호)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,14 +154,10 @@ jobs:
           USE_DATABASE: "true"
           SESSION_SECRET_KEY: test-secret-key
           LLM_PROVIDER: google
-          # Force HuggingFace offline so tests never download models (prevents
-          # 429 flakes). All model code paths are mocked; a future unmocked
-          # test will fail loudly offline instead of hitting the network — mark
-          # such tests @pytest.mark.network (excluded below) and mock the model.
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
+        # HF offline mode + network-marker exclusion are enforced for every
+        # pytest run by tests/backend/conftest.py and pyproject addopts.
         run: |
-          pytest ../../tests/backend -v --tb=short --cov=. --cov-report=xml -m "not network"
+          pytest ../../tests/backend -v --tb=short --cov=. --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v7

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -98,8 +98,9 @@ ignore = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["../../tests/backend"]
+addopts = "-m 'not network'"
 markers = [
-    "network: requires external network or real model download (excluded in CI; run locally with -m network)",
+    "network: requires external network or real model download (excluded by default via addopts; run with -m network)",
 ]
 
 [tool.mypy]

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -765,7 +765,7 @@ class ProjectVectorStore:
         # nothing to score, and instantiating CrossEncoder would trigger an
         # unnecessary HuggingFace download (the source of CI 429 flakes).
         if not candidates:
-            return candidates[:top_k]
+            return []
         encoder = self._get_cross_encoder()
         if encoder is None:
             return candidates[:top_k]

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -17,6 +17,13 @@ os.environ["USE_DATABASE"] = "false"
 os.environ["LLM_PROVIDER"] = "ollama"
 os.environ["OLLAMA_MODEL"] = "qwen2.5:7b"
 
+# Force HuggingFace offline so tests never download models (HF 429 flake
+# guard for every pytest invocation, local and CI). An unmocked model load
+# fails loudly instead of hitting the network — mark such tests
+# @pytest.mark.network and run them with: HF_HUB_OFFLINE=0 pytest -m network
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
 
 @pytest.fixture(scope="session")
 def anyio_backend():

--- a/tests/backend/test_rag_service.py
+++ b/tests/backend/test_rag_service.py
@@ -353,15 +353,12 @@ class TestReranking:
         assert result[0]["source"] == "a.py"
 
     def test_rerank_empty_candidates(self, vector_store, monkeypatch):
-        """Rerank handles empty candidate list without touching the model.
-
-        Pins RERANK_AVAILABLE=False so the test never depends on whether
-        sentence_transformers happens to be installed (defense-in-depth on top
-        of the _rerank empty-candidate short-circuit).
-        """
-        import services.rag_service as rag_mod
-
-        monkeypatch.setattr(rag_mod, "RERANK_AVAILABLE", False)
+        """Rerank returns [] for empty candidates without touching the model."""
+        monkeypatch.setattr(
+            vector_store,
+            "_get_cross_encoder",
+            lambda: pytest.fail("_rerank tried to load the model for empty candidates"),
+        )
         result = vector_store._rerank("query", [], top_k=5)
         assert result == []
 


### PR DESCRIPTION
## Summary
- `/simplify` 4관점 병렬 리뷰(Reuse·Simplification·Efficiency·Altitude) 후속 정리 — PR #104의 HF 429 플레이크 수정을 더 깊은 고도로 일반화
- 오프라인 가드가 CI 한 스텝이 아닌 **모든 pytest 실행**(로컬 포함)에 적용되도록 이동
- 빈 후보 회귀를 실제로 잡는 테스트로 강화 (기존 핀 방식은 회귀를 가렸음)

## Changes
- **`tests/backend/conftest.py`**: `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE`을 `os.environ.setdefault`로 추가 — import 시점에 적용되어 로컬·CI·미래 워크플로우 전부 보호. `HF_HUB_OFFLINE=0 pytest -m network`로 의도적 오버라이드 가능
- **`src/backend/pyproject.toml`**: `addopts = "-m 'not network'"` — network 마커 제외가 기본값이 됨 (CLI `-m network`가 우선함을 확인)
- **`.github/workflows/ci.yml`**: 이제 중복이 된 env 2줄·4줄 주석·`-m "not network"` 플래그 제거, 정식 소스를 가리키는 한 줄 주석으로 교체
- **`src/backend/services/rag_service.py`**: 빈 후보 시 `candidates[:top_k]` → `return []` (빈 리스트 슬라이스 간접 표현 제거)
- **`tests/backend/test_rag_service.py`**: `test_rerank_empty_candidates`의 `RERANK_AVAILABLE=False` 핀을 `_get_cross_encoder` 호출 시 `pytest.fail` 하는 스파이로 교체 — 기존 핀은 short-circuit이 삭제돼도 조용히 통과했음

## Test Plan
- [x] Red-Green 검증: short-circuit 일시 제거 → 테스트 FAIL → 복원 → PASS (새 테스트가 회귀를 실제로 감지)
- [x] 전체 백엔드 스위트: 1097 passed, 2 skipped — 실패 1건(`test_embedding_model_consistency`)은 로컬 `.env`의 `RAG_EMBEDDING_MODEL` 오버라이드로 인한 기존 문제로 HEAD에서도 동일 실패 (CI엔 `.env` 없음)
- [x] `pytest -m network` 오버라이드가 addopts를 정상적으로 이김 (1100개 deselect)
- [x] ci.yml YAML 파싱 검증, ruff 잔여 에러 4건은 HEAD와 동일한 기존 건
- [ ] CI green 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)