### PR TITLE
fix(harness): 머지 안착 ground-truth 검증 추가 (ghost-merge 방지)

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -47,9 +47,27 @@ git push --set-upstream origin [브랜치명]
 gh pr create --title "[메시지]" --body "[변경사항 요약]"
 ```
 
-### 7단계: 머지 (옵션 있을 때만)
+### 7단계: 머지 + 안착 검증 (옵션 있을 때만)
+
+1. 머지 실행 (브랜치 자동 삭제 분리 — 검증 통과 후 삭제):
 ```bash
-gh pr merge --[merge|squash|rebase] --delete-branch
+gh pr merge --[merge|squash|rebase]
+```
+
+2. **머지 안착 검증** — squash 머지는 merge-base를 갱신하지 않아 `git cherry`/`git branch --merged`가 false negative이므로 금지. GitHub가 권위 소스:
+```bash
+gh pr view --json state,mergedAt   # state == "MERGED" && mergedAt != null 확인
+```
+   - 오프라인/GitHub 미사용 폴백 — 브랜치가 건드린 파일이 베이스에 모두 반영됐는지 트리 직접 비교:
+     ```bash
+     git fetch origin
+     git diff --name-only -z origin/[베이스]...HEAD \
+       | xargs -0 git diff HEAD origin/[베이스] --   # 빈 출력이어야 안착 완료
+     ```
+
+3. 검증 통과 시에만 브랜치 삭제. 실패(`state != MERGED` 또는 diff 비어있지 않음)면 **STOP** — 삭제 금지, 사용자에게 보고:
+```bash
+git push origin --delete [브랜치] && git branch -D [브랜치]
 ```
 
 ### 8단계: 완료 출력

--- a/.claude/skills/merge-worktree/SKILL.md
+++ b/.claude/skills/merge-worktree/SKILL.md
@@ -137,9 +137,16 @@ EOF
 
 ### Phase 6: Verification
 
-1. **Confirm the commit**: Run `git -C <original-repo-path> log --oneline -3` and show the result to the user.
+1. **Ground-truth landing check (가장 중요)**: A squash merge does NOT update the merge-base, so `git cherry` / `git branch --merged` / 3-dot `git diff <target>...<branch>` all give **false negatives** — never use them. Instead, directly compare the trees of the files the worktree touched:
+   ```bash
+   git -C <original-repo-path> diff --name-only -z <target>...<worktree-branch> \
+     | xargs -0 git -C <original-repo-path> diff <worktree-branch> <target> --
+   ```
+   The output **must be empty** — that proves every worktree change landed in `<target>`. If it is non-empty, the squash merge dropped some changes: **stop immediately**, report to the user, and do NOT delete the worktree branch. (Use `-z | xargs -0`, not `-- $(...)`: under zsh an unquoted command substitution is not word-split, so the pathspec would match nothing and silently pass.)
 
-2. **Report summary**: Tell the user:
+2. **Confirm the commit**: Run `git -C <original-repo-path> log --oneline -3` and show the result to the user.
+
+3. **Report summary**: Tell the user:
    - The final commit hash
    - The commit summary line
    - Which branch it was merged into
@@ -157,6 +164,7 @@ EOF
 | Auto-resolving merge conflicts | Never auto-resolve — stop and report conflicts to the user |
 | Using `--no-verify` to skip pre-commit hooks | Never skip hooks; fix the underlying issue instead |
 | Forgetting to fetch the latest target branch | Always fetch in Phase 3 to avoid merge issues with stale local branches |
+| Trusting `git cherry` / `--merged` to confirm a squash merge landed | Squash doesn't update the merge-base → false negative; Phase 6 must verify via direct tree diff of the touched files |
 | Including implementation details in the commit summary line | Summary = what and why in imperative mood; details go in the Changes bullets |
 
 ## Important Notes


### PR DESCRIPTION
## Summary
- 인사이트 리포트 갭 분석(16 에이전트, 11 제안)에서 식별한 **유일한 진짜 갭** — 머지 안착 ground-truth 검증 부재 — 를 해결
- 하네스의 squash 머지 2지점에 squash-safe 검증을 추가해 ghost-merge(머지가 조용히 실패한 채 브랜치만 삭제되어 작업 유실)를 방지

## Changes
- `.claude/commands/commit-push-pr.md` 7단계: `gh pr merge` → **`gh pr view --json state,mergedAt` 검증** → 검증 통과 시에만 브랜치 삭제로 분리. 오프라인 폴백(touched 파일 트리 비교) 포함
- `.claude/skills/merge-worktree/SKILL.md` Phase 6: worktree가 건드린 파일이 target에 전부 안착했는지 트리 직접 비교 추가 + Common Mistakes 행 추가

## 왜 git cherry/--merged가 아니라 트리 비교인가
squash 머지는 merge-base를 갱신하지 않으므로 `git cherry`·`git branch --merged`·3-dot `git diff A...B`가 전부 **false negative**(완전 머지인데도 "안 머지됨"). 실측으로 `git cherry`가 `+` 출력 확인. 따라서:
- PR: GitHub가 권위 소스 → `gh pr view --json state,mergedAt`
- worktree: touched 파일 2-dot 트리 비교

## Test Plan
- [x] red-green 임시 repo 테스트: 완전 머지 → EMPTY(PASS), 파일 누락 → NON-EMPTY(누락 감지)
- [x] zsh word-split 함정 확인: `-- $FILES`는 false pass → `-z | xargs -0`로 교체 후 누락 감지 검증
- [x] 하네스 전체 grep: 다른 squash/머지검증 누락 지점 없음 확인
- [x] 리뷰어: 머지 후 실제 `gh pr view` 검증 1회 수동 확인 권장

## 후속 (이 PR 범위 밖)
`.claude/skills/commit-push-pr/SKILL.md`(commands 버전과 별개 파일)가 자체적으로 `git merge-base --is-ancestor`를 ghost-merge 검증에 사용 — **이것도 squash에서 false negative**. command/skill 중복 + 동일 결함이라 별도 정리 필요.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)