### PR TITLE
fix(git): Prune Merged 기능 복구 — repo 해석·PR 조회·삭제 다중 버그 수정

### DIFF
--- a/src/backend/api/git.py
+++ b/src/backend/api/git.py
@@ -841,6 +841,7 @@ async def prune_merged_branches(project_id: str, request: PruneRequest):
             skipped=scan.skipped,
             deleted=[],
             errors=[],
+            scan_error=scan.scan_error,
         )
 
     execute = git_service.prune_merged_branches(scan.candidates)
@@ -849,6 +850,7 @@ async def prune_merged_branches(project_id: str, request: PruneRequest):
         skipped=scan.skipped,  # preserve skip reasons across both phases
         deleted=execute.deleted,
         errors=execute.errors,
+        scan_error=scan.scan_error,
     )
 
 

--- a/src/backend/models/git.py
+++ b/src/backend/models/git.py
@@ -649,6 +649,9 @@ class PruneScanResult(BaseModel):
 
     candidates: list[PruneCandidate] = []
     skipped: list[PruneSkipped] = []
+    # Populated when the GitHub PR lookup itself failed (e.g. repo unresolved,
+    # bad token, network). Distinguishes a real failure from "nothing to prune".
+    scan_error: str | None = None
 
 
 class PruneExecuteResult(BaseModel):
@@ -658,6 +661,7 @@ class PruneExecuteResult(BaseModel):
     skipped: list[PruneSkipped] = []
     deleted: list[str] = []
     errors: list[dict] = []  # [{"branch": str, "error": str}]
+    scan_error: str | None = None  # mirrors PruneScanResult.scan_error
 
 
 class PruneRequest(BaseModel):

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -478,16 +478,25 @@ class GitService:
 
         extra = set(extra_protected or [])
         patterns = protection_patterns or []
-        current_head = self.repo.active_branch.name
+        # current_ref (not active_branch.name) so a detached HEAD resolves to a SHA
+        # instead of raising an unguarded TypeError that escapes as a 500.
+        current_head = self.current_ref
 
-        # Fetch merged PRs (Wave 0 fix: limit must be high to avoid stale-branch miss)
+        # Fetch merged PRs (Wave 0 fix: limit must be high to avoid stale-branch miss).
+        # Target the project's own origin repo, not a single global default.
         merged_prs_by_head: dict[str, object] = {}
+        scan_error: str | None = None
         try:
-            prs = github_service.list_pull_requests(state="all", limit=500)
+            prs = github_service.list_pull_requests(
+                repo=self._resolve_github_repo(), state="all", limit=500
+            )
             for pr in prs:
                 if pr.merged_at is not None:
                     merged_prs_by_head[pr.head_ref] = pr
         except Exception as e:
+            # Surface the failure (returned as scan_error) instead of silently
+            # producing "0 candidates", which is indistinguishable from success.
+            scan_error = str(e)
             logger.warning(f"Failed to fetch PRs for prune scan: {e}")
 
         candidates: list[PruneCandidate] = []
@@ -514,7 +523,7 @@ class GitService:
                 skipped.append(PruneSkipped(branch=name, reason="no_matching_pr"))
                 continue
 
-            if self._has_unpushed_commits(branch):
+            if self._has_unpushed_commits(branch, pr_head_sha=getattr(pr, "head_sha", None)):
                 # PR exists but local has additional unpushed commits — protect work
                 skipped.append(PruneSkipped(branch=name, reason="unpushed_commits"))
                 continue
@@ -530,23 +539,76 @@ class GitService:
                 )
             )
 
-        return PruneScanResult(candidates=candidates, skipped=skipped)
+        return PruneScanResult(candidates=candidates, skipped=skipped, scan_error=scan_error)
 
-    def _has_unpushed_commits(self, branch) -> bool:
-        """Return True if branch has local commits not on its tracked remote.
+    def _resolve_github_repo(self) -> str | None:
+        """Resolve this project's GitHub repo as ``owner/repo`` from its origin URL.
 
-        Conservative: treats untracked branches as unpushed (so they're skipped),
-        protecting purely-local work.
+        Handles both HTTPS (``https://github.com/owner/repo.git``) and SSH
+        (``git@github.com:owner/repo.git``) remotes. Returns None when there is no
+        parseable GitHub origin, in which case the GitHub service falls back to any
+        configured default and the failure surfaces via scan_error.
+        """
+        import re
+
+        try:
+            url = self.repo.remotes.origin.url
+        except Exception:
+            return None
+        if not isinstance(url, str) or not url:
+            return None
+        match = re.search(r"github\.com[:/]+([^/]+/[^/]+?)(?:\.git)?/?$", url.strip())
+        return match.group(1) if match else None
+
+    def _has_unpushed_commits(self, branch, pr_head_sha: str | None = None) -> bool:
+        """Return True if branch has local commits not preserved on the remote.
+
+        Resolution order:
+          1. configured upstream, else an ``origin/<name>`` remote-tracking ref →
+             compare the ahead-count against it.
+          2. no remote ref, but the branch tip is captured by the merged PR head
+             commit (the common "squash-merged, remote auto-deleted" case) → the
+             work lives in the merged PR, so it is not unpushed.
+          3. otherwise treat as purely-local work and protect it.
+
+        Fails safe: returns True (protect) on any uncertainty, because prune
+        deletes with ``force=True`` and this is the last guard against losing
+        local commits.
         """
         tracking = branch.tracking_branch()
-        if tracking is None:
-            return True
+        tracking_name = (
+            tracking.name if tracking is not None else self._find_remote_tracking_ref(branch.name)
+        )
+
+        if tracking_name is not None:
+            try:
+                ahead = sum(1 for _ in self.repo.iter_commits(f"{tracking_name}..{branch.name}"))
+                return ahead > 0
+            except Exception as e:
+                logger.warning(f"Failed to compute ahead for '{branch.name}': {e}")
+                return True
+
+        # No remote-tracking ref. Safe to delete only if the branch tip is an
+        # ancestor of (or equal to) the merged PR head — i.e. fully captured by it.
+        if pr_head_sha:
+            try:
+                if self.repo.is_ancestor(branch.commit.hexsha, pr_head_sha):
+                    return False
+            except Exception as e:
+                logger.warning(f"Failed ancestor check for '{branch.name}': {e}")
+
+        return True
+
+    def _find_remote_tracking_ref(self, branch_name: str) -> str | None:
+        """Find an existing ``<remote>/<branch_name>`` remote-tracking ref, if any."""
         try:
-            ahead = sum(1 for _ in self.repo.iter_commits(f"{tracking.name}..{branch.name}"))
-            return ahead > 0
+            for remote in self.repo.remotes:
+                ref_name = f"{remote.name}/{branch_name}"
+                if any(r.name == ref_name for r in remote.refs):
+                    return ref_name
         except Exception as e:
-            logger.warning(f"Failed to compute ahead for '{branch.name}': {e}")
-            return True
+            logger.warning(f"Failed to resolve remote ref for '{branch_name}': {e}")
+        return None
 
     def prune_merged_branches(self, candidates: list[PruneCandidate]) -> PruneExecuteResult:
         """Delete each candidate branch locally; collect errors without aborting batch.
@@ -562,7 +624,10 @@ class GitService:
 
         for candidate in candidates:
             try:
-                self.delete_branch(candidate.branch)
+                # force=True: candidates are confirmed-merged via the GitHub PR API,
+                # but squash/rebase merges aren't git-ancestors of the base, so a
+                # plain ``git branch -d`` would refuse them with "not fully merged".
+                self.delete_branch(candidate.branch, force=True)
                 deleted.append(candidate.branch)
             except Exception as e:
                 errors.append({"branch": candidate.branch, "error": str(e)})

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -487,8 +487,12 @@ class GitService:
         merged_prs_by_head: dict[str, object] = {}
         scan_error: str | None = None
         try:
+            # lite=True: the scan only needs head_ref/merged_at/number/title/url/
+            # head_sha (all in the list payload). Full conversion reads .mergeable
+            # etc., one API round-trip per PR — a 200+ PR scan took ~4 min and the
+            # client timed out.
             prs = github_service.list_pull_requests(
-                repo=self._resolve_github_repo(), state="all", limit=500
+                repo=self._resolve_github_repo(), state="all", limit=500, lite=True
             )
             for pr in prs:
                 if pr.merged_at is not None:

--- a/src/backend/services/github_service.py
+++ b/src/backend/services/github_service.py
@@ -98,6 +98,7 @@ class GitHubService:
         sort: str = "created",
         direction: str = "desc",
         limit: int = 30,
+        lite: bool = False,
     ) -> list[GitHubPullRequest]:
         """List pull requests.
 
@@ -109,6 +110,9 @@ class GitHubService:
             sort: Sort by (created, updated, popularity, long-running)
             direction: Sort direction (asc, desc)
             limit: Maximum number of PRs to return
+            lite: Use the list-payload-only conversion (no .mergeable/.commits/...
+                access). Each of those attributes triggers a per-PR API round-trip,
+                so a full bulk scan (e.g. prune) is orders of magnitude faster lite.
 
         Returns:
             List of pull requests
@@ -127,11 +131,12 @@ class GitHubService:
                 direction=direction,
             )
 
+            to_model = self._pr_to_model_lite if lite else self._pr_to_model
             result: list[GitHubPullRequest] = []
             for i, pr in enumerate(prs):
                 if i >= limit:
                     break
-                result.append(self._pr_to_model(pr))
+                result.append(to_model(pr))
 
             return result
 
@@ -553,6 +558,37 @@ class GitHubService:
             deletions=pr.deletions,
             changed_files=pr.changed_files,
             review_comments=pr.review_comments,
+            labels=[label.name for label in pr.labels],
+            created_at=pr.created_at,
+            updated_at=pr.updated_at,
+            merged_at=pr.merged_at,
+            closed_at=pr.closed_at,
+        )
+
+    def _pr_to_model_lite(self, pr: "PullRequest") -> GitHubPullRequest:
+        """Convert using only PR *list-payload* fields (fast bulk path).
+
+        Deliberately does NOT read ``mergeable``, ``mergeable_state``,
+        ``commits``, ``additions``, ``deletions``, ``changed_files`` or
+        ``review_comments``: none are present in the ``GET /pulls`` list response,
+        so PyGithub fetches the full PR (one API round-trip each) on first access.
+        For a 200+ PR scan that turned a ~2s call into ~4 minutes. Those fields
+        are left at their model defaults (None/0) — the prune scan never uses them.
+        """
+        return GitHubPullRequest(
+            number=pr.number,
+            title=pr.title,
+            body="",
+            state=pr.state,
+            draft=pr.draft,
+            head_ref=pr.head.ref,
+            head_sha=pr.head.sha,
+            base_ref=pr.base.ref,
+            base_sha=pr.base.sha,
+            user_login=pr.user.login if pr.user else "unknown",
+            user_avatar_url=pr.user.avatar_url if pr.user else None,
+            html_url=pr.html_url,
+            diff_url=pr.diff_url,
             labels=[label.name for label in pr.labels],
             created_at=pr.created_at,
             updated_at=pr.updated_at,

--- a/src/backend/services/github_service.py
+++ b/src/backend/services/github_service.py
@@ -8,6 +8,7 @@ from config import get_settings
 
 try:
     from github import Auth, Github, GithubException
+    from github.GithubObject import NotSet
     from github.PullRequest import PullRequest
     from github.Repository import Repository
 
@@ -17,6 +18,7 @@ except ImportError:
     Github = None
     GithubException = Exception
     Auth = None
+    NotSet = None
     PullRequest = None
     Repository = None
 
@@ -114,10 +116,13 @@ class GitHubService:
         repository = self._get_repo(repo)
 
         try:
+            # PyGithub distinguishes NotSet (omitted) from "" (filter on an empty
+            # branch ref, which matches nothing). Coercing None→"" silently returned
+            # zero PRs, breaking both the prune scan and the Pull Requests tab.
             prs = repository.get_pulls(
                 state=state,
-                base=base or "",
-                head=head or "",
+                base=base if base else NotSet,
+                head=head if head else NotSet,
                 sort=sort,
                 direction=direction,
             )

--- a/src/dashboard/src/components/git/PruneMergedModal.tsx
+++ b/src/dashboard/src/components/git/PruneMergedModal.tsx
@@ -44,8 +44,14 @@ function PruneMergedModalImpl({
     setScanError(null)
     const result = await pruneMergedBranches(projectId, true)
     if (result === null) {
-      setScanError('스캔 실패 — GitHub 토큰을 확인하세요.')
+      setScanError('스캔에 실패했습니다. 네트워크 연결과 GitHub 토큰(GITHUB_TOKEN) 설정을 확인하세요.')
+      setPhase('review') // stop the spinner; show the error banner
       return
+    }
+    if (result.scan_error) {
+      // The PR lookup failed server-side (e.g. repo unresolved). Surface the real
+      // reason instead of a misleading "정리할 브랜치가 없습니다".
+      setScanError(`GitHub PR 조회에 실패했습니다: ${result.scan_error}`)
     }
     setScanResult(result)
     setExcluded(new Set())

--- a/src/dashboard/src/components/git/__tests__/PruneMergedModal.test.tsx
+++ b/src/dashboard/src/components/git/__tests__/PruneMergedModal.test.tsx
@@ -147,7 +147,7 @@ describe('PruneMergedModal', () => {
     expect(deleteBtn).toBeDisabled()
   })
 
-  it('shows error when scan fails (token missing)', async () => {
+  it('shows error when scan returns null (network / token missing)', async () => {
     const prune = vi.fn().mockResolvedValue(null)
     render(
       <PruneMergedModal
@@ -159,7 +159,25 @@ describe('PruneMergedModal', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText(/GitHub 토큰을 확인하세요/)).toBeInTheDocument()
+      expect(screen.getByText(/스캔에 실패했습니다/)).toBeInTheDocument()
+    })
+  })
+
+  it('surfaces backend scan_error instead of a misleading "nothing to prune"', async () => {
+    const prune = vi.fn().mockResolvedValue(
+      makeScanResult({ scan_error: 'Repository name not specified' }),
+    )
+    render(
+      <PruneMergedModal
+        isOpen={true}
+        projectId="proj-1"
+        onClose={vi.fn()}
+        pruneMergedBranches={prune}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Repository name not specified/)).toBeInTheDocument()
     })
   })
 

--- a/src/dashboard/src/stores/git.ts
+++ b/src/dashboard/src/stores/git.ts
@@ -90,6 +90,9 @@ export interface PruneExecuteResult {
   skipped: PruneSkipped[]
   deleted: string[]
   errors: Array<{ branch: string; error: string }>
+  // Set when the GitHub PR lookup itself failed (repo unresolved, bad token,
+  // network) — distinguishes a real failure from a genuine "nothing to prune".
+  scan_error?: string | null
 }
 
 export interface BranchProtectionRule {

--- a/tests/backend/test_git_service_prune.py
+++ b/tests/backend/test_git_service_prune.py
@@ -14,7 +14,7 @@ Covered scenarios:
 """
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -458,3 +458,248 @@ class TestPruneMergedBranches:
         assert "feat/also-ok" in result.deleted
         assert "feat/fail" not in result.deleted
         assert any(e["branch"] == "feat/fail" for e in result.errors)
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_prune_uses_force_delete(self, mock_repo_class, mock_repo, tmp_path):
+        """Squash/rebase-merged branches are not git-ancestors of main, so vetted
+        candidates must be deleted with force=True (git branch -D), else every
+        delete fails with 'not fully merged'."""
+        mock_repo_class.return_value = mock_repo
+
+        from models.git import PruneCandidate
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        candidates = [
+            PruneCandidate(
+                branch="feat/squashed",
+                pr_number=7,
+                pr_url="u",
+                pr_title="t",
+                merged_at=datetime.now(UTC),
+                last_commit_sha="sha",
+            )
+        ]
+
+        with patch.object(service, "delete_branch", return_value=True) as mock_del:
+            service.prune_merged_branches(candidates)
+
+        assert mock_del.call_args.kwargs.get("force") is True
+
+
+# =============================================================================
+# F1: per-project GitHub repo resolution
+# =============================================================================
+
+
+class TestResolveGithubRepo:
+    """find_prune_candidates must target the project's own origin repo."""
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_resolves_owner_repo_from_origin_url(self, mock_repo_class, tmp_path):
+        from services.git_service import GitService
+
+        cases = [
+            ("https://github.com/k002bill2/LiveMetro.git", "k002bill2/LiveMetro"),
+            ("git@github.com:k002bill2/LiveMetro.git", "k002bill2/LiveMetro"),
+            ("https://github.com/owner/repo", "owner/repo"),
+        ]
+        for url, expected in cases:
+            repo = MagicMock()
+            repo.remotes.origin.url = url
+            mock_repo_class.return_value = repo
+            service = GitService(str(tmp_path))
+            assert service._resolve_github_repo() == expected, url
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_resolve_returns_none_when_origin_missing(self, mock_repo_class, tmp_path):
+        from services.git_service import GitService
+
+        repo = MagicMock()
+        # MagicMock url is not a str → cannot parse → None (also covers the
+        # existing unit-test fixtures whose origin.url is a bare MagicMock).
+        type(repo.remotes).origin = PropertyMock(side_effect=AttributeError)
+        mock_repo_class.return_value = repo
+        service = GitService(str(tmp_path))
+        assert service._resolve_github_repo() is None
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_find_prune_candidates_passes_resolved_repo(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """The resolved owner/repo must be forwarded to list_pull_requests."""
+        mock_repo.remotes.origin.url = "https://github.com/o/r.git"
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.return_value = []
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        service.find_prune_candidates(github_service=mock_github_service)
+
+        kwargs = mock_github_service.list_pull_requests.call_args.kwargs
+        assert kwargs.get("repo") == "o/r"
+
+
+# =============================================================================
+# F3: PR-fetch failure must be surfaced, not silently swallowed
+# =============================================================================
+
+
+class TestScanErrorSurfacing:
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_pr_fetch_failure_sets_scan_error(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """If list_pull_requests raises, scan_error is populated (not masked as 0)."""
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.side_effect = RuntimeError(
+            "Repository name not specified"
+        )
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        result = service.find_prune_candidates(github_service=mock_github_service)
+
+        assert result.scan_error is not None
+        assert "Repository name not specified" in result.scan_error
+        assert result.candidates == []
+
+
+# =============================================================================
+# F4: untracked-but-pushed branch must not be treated as unpushed
+# =============================================================================
+
+
+class TestHasUnpushedCommitsFallback:
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_untracked_branch_with_remote_ref_not_unpushed(
+        self, mock_repo_class, tmp_path
+    ):
+        """No upstream config but origin/<name> exists at same tip → not unpushed."""
+        repo = MagicMock()
+        branch = _make_branch("feat/pushed", tracking_ref=None, ahead=0)
+
+        origin = MagicMock()
+        origin.name = "origin"
+        ref = MagicMock()
+        ref.name = "origin/feat/pushed"
+        origin.refs = [ref]
+        repo.remotes = [origin]
+
+        # 0 commits ahead of the remote-tracking ref
+        repo.iter_commits.side_effect = lambda rev_range, **_: iter([])
+        mock_repo_class.return_value = repo
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        assert service._has_unpushed_commits(branch) is False
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_untracked_branch_without_remote_ref_is_unpushed(
+        self, mock_repo_class, tmp_path
+    ):
+        """Genuinely-local branch (no upstream, no origin/<name>) stays protected."""
+        repo = MagicMock()
+        branch = _make_branch("wip/local-only", tracking_ref=None, ahead=0)
+        origin = MagicMock()
+        origin.name = "origin"
+        origin.refs = []  # no matching remote ref
+        repo.remotes = [origin]
+        mock_repo_class.return_value = repo
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        assert service._has_unpushed_commits(branch) is True
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_squash_merged_no_remote_is_eligible(self, mock_repo_class, tmp_path):
+        """Canonical case: squash-merged, remote auto-deleted (no origin ref), but
+        the branch tip == merged PR head → work captured by PR → eligible."""
+        repo = MagicMock()
+        branch = _make_branch("feat/squashed", sha="deadc0de", tracking_ref=None)
+        origin = MagicMock()
+        origin.name = "origin"
+        origin.refs = []  # remote branch deleted after merge
+        repo.remotes = [origin]
+        repo.is_ancestor.return_value = True  # tip is ancestor/equal of PR head
+        mock_repo_class.return_value = repo
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        assert service._has_unpushed_commits(branch, pr_head_sha="deadc0de") is False
+        # arg order guard: is_ancestor(branch_tip, pr_head)
+        repo.is_ancestor.assert_called_once_with("deadc0de", "deadc0de")
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_descendant_of_pr_head_is_protected(self, mock_repo_class, tmp_path):
+        """Local commits added after the PR head (tip not ancestor) → protect."""
+        repo = MagicMock()
+        branch = _make_branch("feat/newer", sha="newcommit", tracking_ref=None)
+        origin = MagicMock()
+        origin.name = "origin"
+        origin.refs = []
+        repo.remotes = [origin]
+        repo.is_ancestor.return_value = False  # tip diverged beyond PR head
+        mock_repo_class.return_value = repo
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        assert service._has_unpushed_commits(branch, pr_head_sha="oldhead") is True
+
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_unresolvable_pr_head_is_protected(self, mock_repo_class, tmp_path):
+        """If the PR head commit isn't in the local object DB, fail safe → protect."""
+        repo = MagicMock()
+        branch = _make_branch("feat/missing-head", sha="abc", tracking_ref=None)
+        origin = MagicMock()
+        origin.name = "origin"
+        origin.refs = []
+        repo.remotes = [origin]
+        repo.is_ancestor.side_effect = Exception("bad object")
+        mock_repo_class.return_value = repo
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        assert service._has_unpushed_commits(branch, pr_head_sha="missingsha") is True
+
+
+# =============================================================================
+# F6: detached HEAD must not raise an unguarded TypeError
+# =============================================================================
+
+
+class TestDetachedHeadSafety:
+    @patch("services.git_service.Repo")
+    @patch("services.git_service.GIT_AVAILABLE", True)
+    def test_detached_head_does_not_raise(
+        self, mock_repo_class, mock_repo, mock_github_service, tmp_path
+    ):
+        """active_branch raises TypeError on detached HEAD; scan must still run."""
+        type(mock_repo).active_branch = PropertyMock(side_effect=TypeError)
+        mock_repo.head.commit.hexsha = "deadbeef000"
+        mock_repo_class.return_value = mock_repo
+        mock_github_service.list_pull_requests.return_value = []
+
+        from services.git_service import GitService
+
+        service = GitService(str(tmp_path))
+        # Must not raise; no branch is the (non-existent) current HEAD.
+        result = service.find_prune_candidates(github_service=mock_github_service)
+        assert all(s.reason != "current_head" for s in result.skipped)

--- a/tests/backend/test_github_service_list_prs.py
+++ b/tests/backend/test_github_service_list_prs.py
@@ -1,0 +1,54 @@
+"""Tests for GitHubService.list_pull_requests base/head filter handling.
+
+Regression for Bug F2: passing base=""/head="" (instead of PyGithub NotSet) to
+repository.get_pulls makes GitHub filter on an empty branch ref and return 0 PRs.
+This silently broke both the prune-merged scan and the Pull Requests tab.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def _service_without_init():
+    """Construct GitHubService bypassing __init__ (which needs a token + network)."""
+    from services.github_service import GitHubService
+
+    svc = GitHubService.__new__(GitHubService)
+    svc.default_repo = None
+    svc.github = MagicMock()
+    return svc
+
+
+class TestListPullRequestsFilters:
+    """list_pull_requests must not coerce None base/head into empty strings."""
+
+    def test_none_base_head_forwarded_as_notset(self):
+        """None base/head → PyGithub NotSet (omitted), never '' (which yields 0 PRs)."""
+        from github.GithubObject import NotSet
+
+        svc = _service_without_init()
+        mock_repo = MagicMock()
+        mock_repo.get_pulls.return_value = []
+
+        with patch.object(svc, "_get_repo", return_value=mock_repo):
+            svc.list_pull_requests(repo="o/r", state="all", limit=500)
+
+        kwargs = mock_repo.get_pulls.call_args.kwargs
+        assert kwargs["base"] is NotSet, "base must be NotSet, not empty string"
+        assert kwargs["head"] is NotSet, "head must be NotSet, not empty string"
+        assert kwargs["state"] == "all"
+
+    def test_explicit_base_head_preserved(self):
+        """Explicit base/head filters must still be forwarded verbatim."""
+        from github.GithubObject import NotSet
+
+        svc = _service_without_init()
+        mock_repo = MagicMock()
+        mock_repo.get_pulls.return_value = []
+
+        with patch.object(svc, "_get_repo", return_value=mock_repo):
+            svc.list_pull_requests(repo="o/r", state="open", base="main", head="feat/x")
+
+        kwargs = mock_repo.get_pulls.call_args.kwargs
+        assert kwargs["base"] == "main"
+        assert kwargs["head"] == "feat/x"
+        assert kwargs["base"] is not NotSet

--- a/tests/backend/test_github_service_list_prs.py
+++ b/tests/backend/test_github_service_list_prs.py
@@ -3,9 +3,14 @@
 Regression for Bug F2: passing base=""/head="" (instead of PyGithub NotSet) to
 repository.get_pulls makes GitHub filter on an empty branch ref and return 0 PRs.
 This silently broke both the prune-merged scan and the Pull Requests tab.
+
+Also covers the ``lite`` fast path used by the prune scan: it must read only the
+PR list-payload fields and never touch ``.mergeable``/``.commits``/etc., each of
+which triggers a per-PR API round-trip (the scan took ~4 minutes otherwise).
 """
 
-from unittest.mock import MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, PropertyMock, patch
 
 
 def _service_without_init():
@@ -52,3 +57,52 @@ class TestListPullRequestsFilters:
         assert kwargs["base"] == "main"
         assert kwargs["head"] == "feat/x"
         assert kwargs["base"] is not NotSet
+
+
+def _list_payload_pr():
+    """A PR mock whose list-payload fields are set but whose lazily-fetched
+    attributes raise if accessed (simulating PyGithub's per-PR completion GET)."""
+    pr = MagicMock()
+    pr.number = 7
+    pr.title = "feat: x"
+    pr.state = "closed"
+    pr.draft = False
+    pr.head.ref = "feat/x"
+    pr.head.sha = "headsha"
+    pr.base.ref = "main"
+    pr.base.sha = "basesha"
+    pr.user.login = "u"
+    pr.user.avatar_url = None
+    pr.html_url = "https://github.com/o/r/pull/7"
+    pr.diff_url = "https://github.com/o/r/pull/7.diff"
+    pr.labels = []
+    now = datetime.now(UTC)
+    pr.created_at = now
+    pr.updated_at = now
+    pr.merged_at = now
+    pr.closed_at = now
+    # These are NOT in the PR list payload — accessing them triggers a per-PR
+    # API round-trip. The lite path must never touch them.
+    for attr in ("mergeable", "mergeable_state", "commits", "additions",
+                 "deletions", "changed_files", "review_comments"):
+        setattr(type(pr), attr, PropertyMock(side_effect=AssertionError(f"{attr} fetched!")))
+    return pr
+
+
+class TestLiteListPath:
+    """The prune scan's lite path must avoid expensive lazy attributes."""
+
+    def test_lite_does_not_touch_expensive_attributes(self):
+        svc = _service_without_init()
+        mock_repo = MagicMock()
+        mock_repo.get_pulls.return_value = [_list_payload_pr()]
+
+        with patch.object(svc, "_get_repo", return_value=mock_repo):
+            result = svc.list_pull_requests(repo="o/r", state="all", limit=500, lite=True)
+
+        assert len(result) == 1
+        assert result[0].head_ref == "feat/x"
+        assert result[0].head_sha == "headsha"
+        assert result[0].merged_at is not None
+        # Lite intentionally leaves the expensive fields unfetched.
+        assert result[0].mergeable is None


### PR DESCRIPTION
## 요약

대시보드 Git 메뉴의 **Prune Merged(머지된 브랜치 정리)**가 모든 프로젝트에서 항상 "정리 후보 0개"를 반환하던 문제를 수정합니다. 사용자 제보(LiveMetro)에서 시작해, gh CLI를 ground-truth로 쓴 통합 검증으로 **층층이 쌓인 7개 버그**를 발견·수정했습니다.

15개 단위 테스트는 모두 통과하고 있었으나 `list_pull_requests`를 목으로 주입해 실제 배선(repo 해석·PR 필터·삭제)을 전혀 검증하지 않았습니다 — "목이 통합 버그를 가린" 사례.

## 수정 내용

| 버그 | 위치 | 수정 |
|------|------|------|
| 프로젝트 origin repo 미해석(전역 `GITHUB_DEFAULT_REPO` 의존) | `git_service.find_prune_candidates` | `_resolve_github_repo()`로 origin URL에서 `owner/repo` 파싱해 `list_pull_requests(repo=...)` 전달 |
| `get_pulls(base="", head="")` 빈 문자열 → GitHub 0건 | `github_service.list_pull_requests` | `NotSet`으로 전달 (Pull Requests 탭에도 영향) |
| PR 조회 예외를 조용히 삼킴 | `git_service` / `models/git` / `api/git` / 프론트 | `scan_error` 필드로 표면화 |
| upstream tracking 없으면 무조건 unpushed | `git_service._has_unpushed_commits` | `origin/<name>` ref 폴백 + 머지 PR `head_sha` 포함 판정(squash 머지+원격삭제 케이스 복구), fail-safe 보호 |
| `git branch -d`가 squash/rebase 머지 브랜치 거부 | `git_service.prune_merged_branches` | 검증된 후보는 `force=True` |
| detached HEAD에서 `active_branch.name` → uncaught 500 | `git_service.find_prune_candidates` | `current_ref` 사용 |
| 모든 실패를 "토큰 확인"으로 오표시 | `PruneMergedModal.tsx` / `stores/git.ts` | 실제 `scan_error`/에러 표시 |

### 동작 변경
삭제가 `force=True`(하드 삭제)로 변경됩니다. 후보는 (1) GitHub PR API로 머지 확인 + (2) 로컬 tip이 머지 PR head의 조상/동일(작업이 PR에 포함)일 때만 선정되며, 불확실하면 항상 보호(skip)하는 fail-safe입니다. squash/rebase 머지는 git 조상이 아니라 `force` 없이는 삭제 불가합니다.

## 테스트 계획

- 백엔드 prune 테스트 **35/35** (신규 TDD RED→GREEN 포함), 백엔드 전체 **1110 pass**
- ruff 통과, dashboard `tsc --noEmit` exit 0, dashboard **4199 pass**, 빌드 OK
- **라이브 end-to-end**(LiveMetro 실저장소, dry-run): squash 머지+원격삭제된 `chore/remove-report-verification`가 PR #221 후보로 정확히 식별됨
- 실제 삭제(execute)는 파괴적이라 라이브 대신 단위 테스트로 검증(기존 worktree/current-branch 가드 유지)

> ⚠️ 실행 중인 백엔드(uvicorn)는 재시작/리로드해야 변경이 반영됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
