### PR TITLE
chore(harness): /checkpoint→/wip-save 개명 + 죽은 agentLearnings 훅 제거

### DIFF
--- a/.claude/commands/wip-save.md
+++ b/.claude/commands/wip-save.md
@@ -4,9 +4,9 @@ description: 작업 상태 저장/복원 (WIP 커밋)
 argument-hint: [save|restore] [설명]
 ---
 
-# Checkpoint
+# WIP Save/Restore
 
-작업 중간 상태를 저장하고 복원합니다.
+작업 중간 상태를 저장하고 복원합니다. (구 `/checkpoint` — 네이티브 `/checkpoint` rewind alias와 이름 충돌하여 `/wip-save`로 개명. git 커밋 컨벤션 `checkpoint:`는 기존 WIP 커밋 복원 호환을 위해 유지.)
 
 ## Save (저장)
 

--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -89,19 +89,6 @@
         ]
       }
     ],
-    "SubagentStop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node .claude/hooks/agentLearnings.js 2>/dev/null || true",
-            "timeout": 5,
-            "statusMessage": "Saving learnings..."
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "matcher": "startup|resume",


### PR DESCRIPTION
## 요약

하네스 모더나이제이션 감사(native-vs-custom 렌즈, harness-legacy-scan 30에이전트)의 **프로젝트 로컬 적용분**. 예전 커스텀 에이전트 아키텍처를 현재 Claude Code 네이티브 기능과 비교해 중복·충돌을 정리.

### 변경 내용
- **`/checkpoint` → `/wip-save` 개명** (`PO-09`): 네이티브 `/checkpoint`(rewind alias)와 이름 충돌하여 shadow됨. WIP save/restore 기능은 유지하되 개명으로 충돌 해소. git 커밋 컨벤션 `checkpoint:`는 기존 WIP 커밋 복원 호환을 위해 유지. `restore.md`는 인프라 백업복원(`infra/scripts/restore-all.sh`)용이라 무관 → 보존.
- **죽은 `agentLearnings` 훅 제거** (`PO-11`): `hooks.json`의 `SubagentStop→agentLearnings.js` 등록 제거. CC 미발효 확인(settings.json 미등록 + 이번 세션 30+ 서브에이전트 종료에도 `learnings.md` 미생성). 백엔드는 `hooks.json`을 카운트/표시용으로만 소비(`project_discovery.py`)라 동작 영향 없음.

### 범위 밖 (이 PR 비포함)
- **전역 보안 수정** `SP-07`(ethicalValidator union 병합, red-green 14/14 PASS)은 `~/.claude/hooks/universal/`라 레포 밖.
- 크로스 프로젝트 항목(SP-05 cursor 키, SP-01/03 권한, Tier3 rules, cli-orchestrator 폐기)은 포터블 핸드오프 문서로 분리.

## 테스트 계획
- [x] `/wip-save` 커맨드 인식 확인 (harness가 skill로 로드)
- [x] `hooks.json` JSON 유효성 + `agentLearnings` 참조 0 확인
- [x] `tests/`에 hook_count/has_hooks/SubagentStop 단정 없음 확인(회귀 없음)
- [x] 개명 후 dangling 참조 없음(`/checkpoint` 참조 grep 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)