### PR TITLE
feat(llm-router): provider별 응답 지연 시간 표시

### DIFF
--- a/src/backend/models/llm_router.py
+++ b/src/backend/models/llm_router.py
@@ -49,6 +49,9 @@ class LLMProviderConfig(BaseModel):
     status: LLMProviderStatus = LLMProviderStatus.UNKNOWN
     last_health_check: datetime | None = None
     consecutive_failures: int = 0
+    # Latency (populated on read from the in-memory tracker; never persisted)
+    last_latency_ms: int | None = None
+    avg_latency_ms: float | None = None
     # Metadata
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime = Field(default_factory=utcnow)

--- a/src/backend/services/llm_router_service.py
+++ b/src/backend/services/llm_router_service.py
@@ -60,17 +60,41 @@ class LLMRouterService:
         return provider
 
     @staticmethod
+    def _latency_for(provider_id: str) -> tuple[int | None, float | None]:
+        """Aggregate (most-recent, mean) latency in ms for a provider.
+
+        Reads the in-memory ``_latency_tracker`` window. Returns ``(None, None)``
+        when no samples have been recorded for the provider.
+        """
+        samples = _latency_tracker.get(provider_id)
+        if not samples:
+            return None, None
+        return int(samples[-1]), sum(samples) / len(samples)
+
+    @staticmethod
+    def _with_latency(provider: LLMProviderConfig) -> LLMProviderConfig:
+        """Return a copy of *provider* with latency fields populated.
+
+        Never mutates the stored object: latency is a derived read-time value, so
+        ``model_copy`` keeps the in-memory registry clean.
+        """
+        last, avg = LLMRouterService._latency_for(provider.id)
+        return provider.model_copy(update={"last_latency_ms": last, "avg_latency_ms": avg})
+
+    @staticmethod
     def get_provider(provider_id: str) -> LLMProviderConfig | None:
-        """Get a provider by ID."""
-        return _providers.get(provider_id)
+        """Get a provider by ID (with read-time latency populated)."""
+        provider = _providers.get(provider_id)
+        return LLMRouterService._with_latency(provider) if provider else None
 
     @staticmethod
     def list_providers() -> list[LLMProviderConfig]:
         """List all providers sorted by priority (highest first)."""
-        return sorted(
+        ordered = sorted(
             _providers.values(),
             key=lambda p: (-p.priority, p.created_at),
         )
+        return [LLMRouterService._with_latency(p) for p in ordered]
 
     @staticmethod
     def update_provider(

--- a/src/dashboard/src/components/llm-router/LLMRouterSettings.tsx
+++ b/src/dashboard/src/components/llm-router/LLMRouterSettings.tsx
@@ -47,6 +47,8 @@ interface LLMProvider {
   status: ProviderStatus
   consecutive_failures: number
   last_health_check: string | null
+  last_latency_ms: number | null
+  avg_latency_ms: number | null
 }
 
 interface RouterConfig {
@@ -473,6 +475,15 @@ export function LLMRouterSettings() {
                           provider.consecutive_failures > 0 ? 'text-red-500' : 'text-gray-900 dark:text-white'
                         )}>
                           {provider.consecutive_failures}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2 col-span-2">
+                        <Clock className="w-4 h-4 text-gray-400" />
+                        <span className="text-gray-500 dark:text-gray-400">Latency (Last/Avg):</span>
+                        <span className="text-gray-900 dark:text-white">
+                          {provider.last_latency_ms != null ? `${provider.last_latency_ms}ms` : '—'}
+                          {' / '}
+                          {provider.avg_latency_ms != null ? `${Math.round(provider.avg_latency_ms)}ms` : '—'}
                         </span>
                       </div>
                     </div>

--- a/tests/backend/test_llm_router_latency.py
+++ b/tests/backend/test_llm_router_latency.py
@@ -1,0 +1,69 @@
+"""Tests for per-provider response latency exposure on the LLM router.
+
+The router already accumulates per-provider samples in ``_latency_tracker``.
+This surfaces them on ``LLMProviderConfig`` as ``last_latency_ms`` (most recent)
+and ``avg_latency_ms`` (mean of the retained window) without mutating the stored
+provider objects — injection happens on copies returned by the getters.
+"""
+
+import pytest
+
+import services.llm_router_service as svc
+from models.llm_router import LLMProvider, LLMProviderConfig
+from services.llm_router_service import LLMRouterService
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    svc._providers.clear()
+    svc._latency_tracker.clear()
+    yield
+    svc._providers.clear()
+    svc._latency_tracker.clear()
+
+
+def _add_provider() -> str:
+    provider = LLMProviderConfig(provider=LLMProvider.OPENAI, model="gpt-4")
+    svc._providers[provider.id] = provider
+    return provider.id
+
+
+def test_latency_for_no_data_returns_none_none():
+    pid = _add_provider()
+    assert LLMRouterService._latency_for(pid) == (None, None)
+
+
+def test_latency_for_returns_last_sample_and_mean():
+    pid = _add_provider()
+    svc._latency_tracker[pid] = [100.0, 200.0, 300.0]
+    assert LLMRouterService._latency_for(pid) == (300, 200.0)
+
+
+def test_list_providers_injects_latency_and_keeps_stored_clean():
+    pid = _add_provider()
+    svc._latency_tracker[pid] = [50.0, 150.0]
+
+    listed = LLMRouterService.list_providers()
+
+    assert listed[0].last_latency_ms == 150
+    assert listed[0].avg_latency_ms == 100.0
+    # the stored object must stay clean — injection happens on a copy
+    assert svc._providers[pid].last_latency_ms is None
+    assert svc._providers[pid].avg_latency_ms is None
+
+
+def test_get_provider_injects_latency():
+    pid = _add_provider()
+    svc._latency_tracker[pid] = [42.0]
+
+    got = LLMRouterService.get_provider(pid)
+
+    assert got.last_latency_ms == 42
+    assert got.avg_latency_ms == 42.0
+
+
+def test_provider_without_samples_exposes_none():
+    pid = _add_provider()
+    got = LLMRouterService.get_provider(pid)
+    assert got.last_latency_ms is None
+    assert got.avg_latency_ms is None


### PR DESCRIPTION
## 요약
대시보드 LLM 라우터 설정에서 각 provider의 **최근/평균 응답 지연(latency)** 을 표시합니다.

## 변경
- `LLMProviderConfig`에 `last_latency_ms` / `avg_latency_ms` 필드 추가 (read-time 파생, 미영속)
- 서비스 getter(`get_provider`/`list_providers`)가 `model_copy`로 latency 주입 — 저장 객체는 불변 유지
- `LLMRouterSettings` 확장 패널에 "Latency (Last/Avg)" 행 추가 (데이터 없으면 `—`)
- 새 헬퍼 `_latency_for`(집계) / `_with_latency`(주입), 기존 `_latency_tracker` 윈도우 활용

## 범위 밖 (의도적)
- `record_request_result` 자동 배선(`LLMService.invoke` 경로)은 별도 후속. 그 전까지는 `/record` 기록 시에만 값 표시.
- `avg_latency_ms`(provider별)는 stats 전역 `average_latency_ms`와 별개 — 이름 혼동 주의.

## 테스트 계획 (수동 게이트 통과)
- backend pytest (`test_llm_router_latency.py`, 5): `_latency_for` 집계 + getter 주입 + **저장 객체 불변** 가드
- frontend `tsc --noEmit`: 0 errors (비-export 인터페이스라 fixture fan-out 없음)
- frontend vitest (LLMRouterSettings): 10 passed
- `npm run build`: exit 0 / `ruff check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)