### PR TITLE
fix(llm-router): provider 키 마스킹이 저장된 키를 영구 손상시키는 버그 수정

### DIFF
--- a/src/backend/api/llm_router.py
+++ b/src/backend/api/llm_router.py
@@ -20,6 +20,20 @@ from services.llm_router_service import LLMRouterService
 router = APIRouter(prefix="/llm-router", tags=["llm-router"])
 
 
+def _masked(provider: LLMProviderConfig) -> LLMProviderConfig:
+    """Return a copy of *provider* with its ``api_key`` masked for safe exposure.
+
+    Masking must never mutate the stored provider: the in-memory registry shares
+    object references, so in-place masking would corrupt the real key on the first
+    API call. ``model_copy`` keeps the stored object intact.
+    """
+    if not provider.api_key:
+        return provider
+    key = provider.api_key
+    masked = "***" + key[-4:] if len(key) > 4 else "***"
+    return provider.model_copy(update={"api_key": masked})
+
+
 # ─────────────────────────────────────────────────────────────
 # Provider Management
 # ─────────────────────────────────────────────────────────────
@@ -29,11 +43,8 @@ router = APIRouter(prefix="/llm-router", tags=["llm-router"])
 async def list_providers():
     """List all LLM providers."""
     providers = LLMRouterService.list_providers()
-    # Mask API keys in response
-    for p in providers:
-        if p.api_key:
-            p.api_key = "***" + p.api_key[-4:] if len(p.api_key) > 4 else "***"
-    return providers
+    # Mask API keys in response (on copies — never mutate the stored providers)
+    return [_masked(p) for p in providers]
 
 
 @router.post("/providers", response_model=LLMProviderConfig)
@@ -46,10 +57,8 @@ async def create_provider(data: LLMProviderConfigCreate):
         resource_id=provider.id,
         metadata={"operation": "created", "provider": provider.provider, "name": provider.name},
     )
-    # Mask API key in response
-    if provider.api_key:
-        provider.api_key = "***" + provider.api_key[-4:] if len(provider.api_key) > 4 else "***"
-    return provider
+    # Mask API key in response (on a copy — never mutate the stored provider)
+    return _masked(provider)
 
 
 @router.get("/providers/{provider_id}", response_model=LLMProviderConfig)
@@ -58,10 +67,8 @@ async def get_provider(provider_id: str):
     provider = LLMRouterService.get_provider(provider_id)
     if not provider:
         raise HTTPException(status_code=404, detail="Provider not found")
-    # Mask API key in response
-    if provider.api_key:
-        provider.api_key = "***" + provider.api_key[-4:] if len(provider.api_key) > 4 else "***"
-    return provider
+    # Mask API key in response (on a copy — never mutate the stored provider)
+    return _masked(provider)
 
 
 @router.patch("/providers/{provider_id}", response_model=LLMProviderConfig)
@@ -76,10 +83,8 @@ async def update_provider(provider_id: str, data: LLMProviderConfigUpdate):
         resource_id=provider_id,
         metadata={"operation": "updated", "provider": provider.provider},
     )
-    # Mask API key in response
-    if provider.api_key:
-        provider.api_key = "***" + provider.api_key[-4:] if len(provider.api_key) > 4 else "***"
-    return provider
+    # Mask API key in response (on a copy — never mutate the stored provider)
+    return _masked(provider)
 
 
 @router.delete("/providers/{provider_id}")
@@ -224,11 +229,8 @@ async def update_router_config(data: UpdateRouterConfig):
 async def get_router_state():
     """Get the current router state."""
     state = LLMRouterService.get_router_state()
-    # Mask API keys in providers
-    for p in state.providers:
-        if p.api_key:
-            p.api_key = "***" + p.api_key[-4:] if len(p.api_key) > 4 else "***"
-    return state
+    # Mask API keys in providers (on copies — never mutate the stored providers)
+    return state.model_copy(update={"providers": [_masked(p) for p in state.providers]})
 
 
 @router.get("/stats", response_model=LLMRoutingStats)

--- a/tests/backend/test_llm_router_masking.py
+++ b/tests/backend/test_llm_router_masking.py
@@ -1,0 +1,47 @@
+"""Tests for LLM router API key masking — must not corrupt the stored key.
+
+Regression guard: the API layer masked ``api_key`` in-place on the live in-memory
+provider object returned by ``LLMRouterService.list_providers()``/``get_provider()``.
+Because the registry shares references, the first ``GET /providers`` call
+permanently overwrote the real key with ``***xxxx``, breaking provider auth.
+
+The fix exposes a ``_masked()`` helper that returns a masked *copy*, leaving the
+stored object untouched. The discriminating assertion is therefore on the
+original object, not the returned one — a test that only checks the response is
+masked passes even with the bug.
+"""
+
+from api.llm_router import _masked
+from models.llm_router import LLMProvider, LLMProviderConfig
+
+
+def _provider(api_key: str | None) -> LLMProviderConfig:
+    return LLMProviderConfig(provider=LLMProvider.OPENAI, model="gpt-4", api_key=api_key)
+
+
+def test_masked_returns_copy_without_mutating_original():
+    provider = _provider("sk-realkey1234")
+
+    masked = _masked(provider)
+
+    # the exposed copy is masked
+    assert masked.api_key == "***1234"
+    # the stored object keeps its real key — this assertion fails under the bug
+    assert provider.api_key == "sk-realkey1234"
+
+
+def test_masked_short_key_fully_hidden():
+    provider = _provider("abcd")  # len == 4, not > 4 → fully hidden
+
+    masked = _masked(provider)
+
+    assert masked.api_key == "***"
+    assert provider.api_key == "abcd"
+
+
+def test_masked_none_key_is_noop():
+    provider = _provider(None)
+
+    masked = _masked(provider)
+
+    assert masked.api_key is None


### PR DESCRIPTION
## 문제 (HIGH)
`list_providers()` / `get_provider()`가 인메모리 `_providers`의 **live 참조**를 반환하는데, API 층이 응답용 키 마스킹을 그 참조에 **in-place**로 수행한다(저장 객체의 key 필드를 마스킹 문자열로 덮어씀). 인메모리 저장이라 `GET /providers` 한 번 호출만으로 저장된 실제 키가 **영구히 마스킹 값으로 덮어써져**, 이후 해당 provider로의 LLM 인증이 깨진다. 생성 엔드포인트는 생성 즉시 손상.

## 수정
- 마스킹을 `_masked()` 헬퍼로 추출 — `model_copy(update=...)`로 **사본**을 마스킹해 저장 객체는 불변
- 5개 마스킹 사이트(list / create / get / patch / state) 전부 `_masked()`로 교체
- 마스킹은 프레젠테이션 관심사 → API 층에서 사본 처리 (서비스 계층 의미 불변)

## 테스트 (Red-Green 검증)
- `test_llm_router_masking.py` (3): 응답 사본은 마스킹되되 **저장 객체의 키는 온전**함을 단언
- Red-Green 증명: in-place 버그 재현 시 "원본 온전" 단언 실패 → 수정 복원 시 통과
- ruff: clean

## 비고
- `api/llm_router.py:47`의 `provider.name` 참조(존재하지 않는 필드)는 별개 이슈로 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)