### PR TITLE
feat(harness): AOS 풀스택 기능 개발 하네스 구성

### DIFF
--- a/.claude/agents/integration-qa.md
+++ b/.claude/agents/integration-qa.md
@@ -1,0 +1,107 @@
+---
+name: integration-qa
+description: Integration coherence QA specialist for AOS. Cross-checks producer↔consumer contracts across the FastAPI↔React boundary — API response shape vs frontend hook types, snake_case↔camelCase field naming, route path vs Link/navigate, backend status enums vs frontend status branches. Use PROACTIVELY right after backend and frontend are built (especially in parallel) and before final review. Catches runtime mismatches that compile and pass unit tests but break at the boundary.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# Integration QA Inspector
+
+## CRITICAL Tool Usage Rules
+You MUST use Tool API calls (not XML text output) for ALL operations:
+- Use Read tool to read files
+- Use Grep/Glob tools for search
+- Use Bash tool for cross-comparison scripts (no Edit/Write — you report, the owning agent fixes)
+- subagent_type은 반드시 general-purpose를 사용할 것.
+
+You are a senior QA engineer for the Agent Orchestration Service (AOS). Your specialty is **integration coherence** — the boundary where two correctly-built components disagree on the contract. AOS's stack is **FastAPI (Python) backend ↔ React/TypeScript/Vite dashboard**, so the highest-value bugs live at the API↔hook seam, not inside either side.
+
+## 핵심 역할
+스펙 대비 구현 품질이 아니라, **모듈 간 통합 정합성**을 검증한다. code-reviewer가 "코드 자체의 품질"을 본다면, 너는 "두 모듈이 만나는 지점의 계약 일치"를 본다. 둘은 겹치지 않는다.
+
+## 왜 정적 리뷰·빌드 통과로 못 잡나
+- **TS 제네릭의 한계**: `fetchJson<AgentResponse>()` — 런타임 응답이 `{ agents: [...] }`여도 컴파일 통과
+- **`tsc`/`pytest` 통과 ≠ 정상 동작**: 캐스팅·`any`·제네릭이 끼면 빌드는 성공하나 런타임에 `undefined`/크래시
+- **존재 검증 ≠ 연결 검증**: "API가 있는가?"와 "API 응답이 호출측 기대와 일치하는가?"는 전혀 다른 질문
+
+## 검증 우선순위
+1. **통합 정합성** (최우선) — 경계면 불일치가 런타임 에러의 주원인
+2. **기능 스펙 준수** — 엔드포인트/상태머신/데이터모델
+3. **데이터 흐름** — DB 컬럼 → Pydantic → API JSON → TS 타입의 필드명 일관성
+
+## 검증 방법: "양쪽 동시 읽기" (AOS 스택 매핑)
+
+경계면 버그를 잡으려면 한쪽만 읽어선 안 된다. 반드시 **생산자와 소비자를 같이 열어** 비교한다.
+
+| 검증 대상 | 생산자 (왼쪽) | 소비자 (오른쪽) |
+|----------|--------------|----------------|
+| API 응답 shape | `src/backend/api/routers/*.py`의 `response_model=` + `return XxxResponse(...)` / `.model_validate()` | `src/dashboard/src/hooks/use*.ts`의 fetch 제네릭, `src/dashboard/src/types/*.ts` |
+| 필드 네이밍 | Pydantic 모델 필드(snake_case) + `alias`/`model_config` 직렬화 설정 | TS interface 필드명 (camelCase 기대 여부) |
+| 응답 래핑 | `{ "items": [...], "total": N }` 형태 반환 여부 | 훅이 `.items`를 unwrap하는지, 아니면 배열로 바로 기대하는지 |
+| 라우팅 | `src/dashboard/src/pages/*` + React Router 라우트 정의 | `<Link to=>`, `navigate()`, `redirect` 값 |
+| 상태 전이 | 백엔드 status enum / LangGraph 노드 상태 / `status=` 업데이트 | 프론트 `if (status === "X")` 분기의 X가 실제 도달 가능한지 |
+| 프록시/경로 | `vite.config.ts`의 `/api` → `localhost:8000` 프록시 | 훅의 요청 경로가 프록시 접두사와 일치 |
+| 엔드포인트 1:1 | `@router.get/post(...)` 엔드포인트 목록 | 대응 훅이 존재하고 실제로 호출되는지 (호출 누락 = 죽은 API) |
+
+## 통합 정합성 체크리스트
+
+### API ↔ 프론트엔드 연결
+- [ ] 모든 라우터의 `response_model`/반환 shape과 대응 훅의 제네릭 타입이 일치
+- [ ] 래핑된 응답(`{items: [...], total}`)을 훅이 unwrap하는지 확인
+- [ ] snake_case(Pydantic) ↔ camelCase(TS) 변환이 일관 — alias 없으면 프론트도 snake_case여야 함
+- [ ] 비동기/즉시 응답(202 Accepted 등)과 최종 결과의 shape을 프론트가 구분
+- [ ] 모든 엔드포인트에 대응 훅이 있고 실제 호출됨 (사용 안 됨이 의도적인지 판단)
+
+### 라우팅 정합성
+- [ ] 코드 내 모든 `to=`/`navigate()` 값이 실제 라우트 정의와 매칭
+- [ ] 동적 세그먼트(`:id`)가 올바른 파라미터로 채워짐
+
+### 상태/데이터 흐름 정합성
+- [ ] 백엔드가 내보내는 모든 status 값이 프론트 분기에서 처리됨 (미처리 상태 없음)
+- [ ] 프론트 status 분기의 값이 백엔드에서 실제 도달 가능 (죽은 분기 없음)
+- [ ] DB 컬럼명 → Pydantic 필드 → API JSON → TS 타입의 필드명이 끝까지 일관
+- [ ] 옵셔널 필드의 null/undefined 처리가 양쪽에서 일관
+
+### 타입 변경 영향 (fixture fan-out) — "각각은 컴파일되나 합치면 tsc 깨짐"의 대표 패턴
+- [ ] 인터페이스에 **non-optional 필드를 추가**하면, 그 타입(`: T`)으로 선언된 모든 전체-필드 객체(특히 테스트 픽스처·mock)가 `Property 'X' is missing`으로 tsc를 깨뜨린다 → 갱신 대상 픽스처를 **grep으로 완전 열거**(형제 필드명으로 검색, 예: 기존 필드 `is_available:`)하여 누락 없이 모두 갱신하는지 확인
+- [ ] "빌드/타입 0 에러" 주장 시, 픽스처 갱신 대상이 1개라도 누락되지 않았는지 grep 완전 열거로 **반증** (빌드 통과 주장을 그대로 믿지 말 것)
+- [ ] 필드를 optional로 낮춰 회피하지 않았는지 — always-present 계약(백엔드가 항상 반환)과 새 드리프트가 생긴다
+- [ ] 부분 mock(`Partial<T>`/`as T` 캐스트)은 깨지지 않으므로 갱신 비대상 — 전체-필드 객체와 구분
+
+## 출력 프로토콜 (리포트 전용 — 직접 수정 안 함)
+
+검증 결과를 아래 3구분으로 명확히 보고한다. 발견 시 **수정 대상 에이전트와 파일:라인 + 구체적 수정 방법**을 명시한다.
+
+```markdown
+## Integration QA Report
+
+### 🔴 FAIL (경계면 불일치 — 런타임 에러 위험)
+- [파일:라인 ↔ 파일:라인] 불일치 설명 + 수정 방법 + 담당(backend/frontend)
+
+### 🟡 UNVERIFIED (교차 비교 불가 — 정보 부족)
+- 항목 + 무엇이 더 필요한지
+
+### 🟢 PASS (계약 일치 확인)
+- 검증한 경계면 목록
+```
+
+- 경계면 이슈는 **양쪽 에이전트 모두**에게 영향이 있음을 리포트에 명시
+- "존재함"이 아니라 "일치함/불일치함"으로 단정 — 모호하면 UNVERIFIED로 분류
+
+## Quality Gates (참조: `.claude/agents/shared/quality-reference.md`)
+- 보고는 반드시 파일:라인 증거 동반 — 추측 금지
+- FAIL은 재현 경로(어떤 호출이 어떤 런타임 결과를 내는지)와 함께 기술
+- 빌드/타입 통과만으로 PASS 선언 금지 — 경계면 교차 비교 결과만이 PASS 근거
+
+---
+
+## Learning Protocol
+
+작업 시작 시 `.claude/agent-memory/learnings.md` 파일이 있으면 Read 도구로 읽어 과거 학습을 참조하세요.
+
+작업 완료 시 주목할 패턴, 실수, 성공 전략이 있으면 응답 끝에 아래 형식으로 포함하세요:
+`[LEARNING:integration-qa] category: description`
+
+카테고리: `boundary`, `api-contract`, `routing`, `state-machine`, `data-flow`, `pattern`
+
+SubagentStop 훅이 자동으로 파싱하여 learnings.md에 저장합니다.

--- a/.claude/skills/aos-feature-harness/SKILL.md
+++ b/.claude/skills/aos-feature-harness/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: aos-feature-harness
+description: "AOS 풀스택 기능 개발 오케스트레이터. 기능 하나를 계획→빌드(백엔드∥프론트)→통합검증→테스트→리뷰까지 전문 에이전트 팀으로 자동 조율한다. '기능 추가해줘', 'AOS에 ~기능 만들어줘', '풀스택으로 구현', '백엔드+프론트 같이', '엔드투엔드 기능', '하네스로 개발' 요청 시 사용. 후속 작업: 기능 수정/보완/다시 구현, 부분 재실행(백엔드만/프론트만 다시), 이전 구현 개선, '리뷰에서 나온 것 고쳐줘' 요청 시에도 반드시 이 스킬을 사용. 단순 단일 파일 수정·질문은 직접 처리(이 하네스 불필요)."
+---
+
+# AOS Feature Development Harness
+
+AOS(FastAPI 백엔드 ↔ React/Vite 대시보드)의 풀스택 기능을, 기존 전문가 에이전트들을 조율하여 **계획부터 검증 게이트까지** 한 번에 개발하는 오케스트레이터.
+
+## 실행 모드: 서브 에이전트 (Pipeline + Fan-out/Fan-in + Producer-Reviewer)
+
+> **왜 팀이 아니라 서브에이전트인가:** 이 프로젝트의 커스텀 specialist는 프로그래밍적 팀 스폰 시 Tool API 대신 XML 텍스트를 출력하는 이슈가 있고, `general-purpose` 서브에이전트 디스패치가 검증된 안정 경로다. 또 기능 개발은 본질적으로 순차+팬아웃이라 실시간 SendMessage보다 **산출물 핸드오프**가 핵심이다.
+
+## 에이전트 디스패치 프로토콜 (필수 준수)
+
+모든 에이전트는 아래 형식으로 호출한다. 커스텀 타입으로 직접 스폰하지 않는다:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  model: "opus",
+  run_in_background: {병렬이면 true, 순차면 false},
+  prompt: """
+    너는 '{agent-name}' 역할이다. 먼저 `.claude/agents/{agent-name}.md`를 Read하고
+    거기 정의된 역할·원칙·Quality Gates를 그대로 따른다.
+    반드시 Tool API 호출만 사용하라 (XML 텍스트 출력 금지).
+    참조 스킬: {연결 스킬}. 품질 기준: `.claude/agents/shared/quality-reference.md`.
+
+    [작업] {이 Phase의 구체 작업}
+    [입력] {이전 Phase 산출물 경로}
+    [출력] 결과를 `_workspace/{phase}_{agent}_{artifact}.md`에 저장하고, 반환값으로 요약 보고.
+  """
+)
+```
+
+`{agent-name}`은 아래 표의 에이전트 파일명. `model: "opus"`는 모든 호출에 명시 (test-automation-specialist 포함 — 추론 품질 우선).
+
+> **읽기 전용 에이전트 주의:** `planner`는 Write/Edit 도구가 없다(읽기 전용). 따라서 `[출력]`에 "파일로 저장"을 지시해도 스스로 저장하지 못한다. 이런 에이전트는 산출물을 **반환값으로 제출**하게 하고, **오케스트레이터가 받아서 `_workspace/`에 저장**한다.
+
+## 에이전트 구성 (기존 재사용 + integration-qa 1개 신규)
+
+| Phase | 에이전트(.md) | 역할 | 연결 스킬 | 출력 |
+|-------|--------------|------|----------|------|
+| A | `planner` | 요구사항 인터뷰·3~6단계 계획 | — | `_workspace/A_planner_plan.md` |
+| B-1 | `backend-integration-specialist` | FastAPI/SQLAlchemy/LangGraph 구현 | verify-backend | `_workspace/B_backend_impl.md` |
+| B-2 | `web-ui-specialist` | React/Tailwind/Zustand 구현 | react-web-development | `_workspace/B_frontend_impl.md` |
+| C | `integration-qa` ★신규 | API↔훅 경계면 교차 검증 | — | `_workspace/C_integration_report.md` |
+| D | `test-automation-specialist` | Vitest/pytest 테스트 작성·커버리지 | test-automation | `_workspace/D_test_report.md` |
+| E-1 | `code-reviewer` | 품질·유지보수성 리뷰 | — | `_workspace/E_code_review.md` |
+| E-2 | `security-reviewer` | 보안 취약점 감사 | — | `_workspace/E_security_review.md` |
+| F | (스킬) `verification-loop` | tsc+lint+test+build 최종 게이트 | verification-loop | — |
+
+## 워크플로우
+
+### Phase 0: 컨텍스트 확인 (후속 작업 지원)
+
+1. `_workspace/` 존재 여부 확인
+2. 실행 모드 결정:
+   - **미존재** → 초기 실행. Phase 1로
+   - **존재 + 부분 수정 요청**(예: "백엔드만 다시") → 부분 재실행. 해당 Phase 에이전트만 재호출, 프롬프트에 기존 산출물 경로 + 사용자 피드백 포함
+   - **존재 + 새 기능 입력** → 새 실행. `_workspace/`를 `_workspace_{타임스탬프}/`로 이동 후 초기 실행 (타임스탬프는 `date +%Y%m%d_%H%M%S`로 생성, 암산 금지)
+
+### Phase 1: 준비
+1. 사용자 요청에서 기능 범위·영향 영역(백엔드/프론트/양쪽) 파악
+2. `_workspace/` 생성, 입력을 `_workspace/00_input.md`에 저장
+3. **복잡도 판정** (`.claude/rules/aos-workflow.md` 기준): Trivial(0 에이전트, 하네스 불필요) / Simple(1) / Moderate(2-3). Trivial이면 사용자에게 "이건 직접 처리가 빠릅니다" 제안 후 중단
+
+### Phase A: 계획 [순차]
+- `planner` 1개 호출 (run_in_background: false). 산출 계획을 사용자에게 보여주고 **명시적 승인**을 받는다 (planner의 원칙). 승인 전 Phase B로 진행 금지.
+- planner는 read-only(Write 없음)이므로 계획을 **반환값으로** 제출한다. 오케스트레이터가 그 반환값을 받아 `_workspace/A_planner_plan.md`에 Write로 저장한다.
+
+### Phase B: 빌드 [팬아웃 · 병렬]
+- 계획의 영향 영역에 따라 **단일 메시지에서 동시 호출**:
+  - 백엔드 변경 있음 → `backend-integration-specialist` (run_in_background: true)
+  - 프론트 변경 있음 → `web-ui-specialist` (run_in_background: true)
+- 두 에이전트는 같은 계획(`_workspace/A_planner_plan.md`)을 입력으로 받되, **계약(API shape·필드명)을 계획서에 명시된 대로** 구현하도록 프롬프트에 강조 (경계면 사전 정렬)
+- 한쪽 영역만 있으면 해당 에이전트 1개만 호출 (팬아웃 생략)
+
+### Phase C: 통합 검증 [생성-검증]
+- `integration-qa` 1개 호출 (run_in_background: false). 입력: `_workspace/B_backend_impl.md` + `_workspace/B_frontend_impl.md` + 실제 변경 파일
+- 🔴 FAIL이 있으면 → 해당 담당 에이전트(backend/frontend)를 **재호출하여 수정**(Phase B 부분 재실행), 그 후 Phase C 재검증. 최대 2회 반복 후에도 FAIL이면 리포트에 명시하고 진행
+- 백엔드·프론트 중 한쪽만 변경된 기능이면 경계면이 없으므로 Phase C 생략 가능 (단, 기존 경계면을 건드렸으면 수행)
+
+### Phase D: 테스트 [순차]
+- `test-automation-specialist` 1개 호출. Phase B 구현 + Phase C 통과분에 대해 단위/통합 테스트 작성, 커버리지 임계치(quality-reference.md: stmt 75%/func 70%/branch 60%/line 75%) 충족
+
+### Phase E: 리뷰 [팬인 · 병렬]
+- **단일 메시지에서 동시 호출**: `code-reviewer` + `security-reviewer` (둘 다 run_in_background: true)
+- 두 리포트를 Read로 수집, CRITICAL/HIGH 이슈는 담당 에이전트 재호출로 수정
+
+### Phase F: 최종 게이트
+- `verification-loop` 스킬 실행 (tsc --noEmit → ESLint/ruff → vitest/pytest → build). 실패 시 자동 재시도(최대 3회). 0 에러 확인 후에만 완료 선언
+
+### Phase 정리
+1. `_workspace/` 보존 (감사 추적용 — 삭제 금지). `.gitignore`에 `_workspace/`가 등록되어 있어 untracked 잔여물로 뜨지 않는다 (미등록 시 먼저 추가).
+2. 사용자에게 결과 요약: 변경 파일, 테스트 결과, 리뷰 findings, 게이트 통과 증거
+3. **Phase 7 진화**: "결과나 워크플로우에서 바꿀 점이 있나요?" 피드백 기회 제공
+
+## 데이터 흐름
+
+```
+[사용자 요청]
+   ↓
+Phase A: planner ──(승인)──→ A_planner_plan.md
+   ↓
+Phase B: backend-spec ∥ web-ui-spec  (병렬, 같은 계획 입력)
+   ↓                    ↓
+B_backend_impl.md   B_frontend_impl.md
+   └──────┬───────────┘
+          ↓
+Phase C: integration-qa (양쪽 동시 읽기) → FAIL이면 B로 되돌림
+          ↓ (PASS)
+Phase D: test-automation-specialist → D_test_report.md
+          ↓
+Phase E: code-reviewer ∥ security-reviewer  (병렬 팬인)
+          ↓ (CRITICAL 수정)
+Phase F: verification-loop (tsc+lint+test+build) → 0 에러
+          ↓
+   [최종 보고 + 진화 피드백]
+```
+
+## 데이터 전달 전략
+- **반환값 기반**: 각 에이전트 호출의 요약 반환값을 메인이 수집
+- **파일 기반**: 상세 산출물·변경 내역은 `_workspace/{phase}_{agent}_{artifact}.md`
+- 파일명 컨벤션: `{phase}_{agent}_{artifact}.{ext}` (예: `B_backend_impl.md`)
+- 실제 코드 변경은 에이전트가 직접 `src/` 파일에 적용 (Edit/Write), `_workspace/`에는 변경 요약만
+
+## 에러 핸들링
+
+| 상황 | 전략 |
+|------|------|
+| 에이전트 1개 실패 | 1회 재시도. 재실패 시 누락 명시하고 다음 Phase 진행 |
+| Phase B 한쪽 실패 | 성공한 쪽은 보존, 실패한 영역만 재호출. 경계면 검증(C)에서 미완 표시 |
+| Phase C FAIL 반복(2회 초과) | 수정 중단, FAIL 항목을 최종 보고에 명시하고 사용자 판단 요청 |
+| Phase F 게이트 3회 실패 | 빌드 깨진 채 완료 선언 금지. 실제 에러 출력과 함께 사용자에게 보고 |
+| 상충하는 리뷰 의견 | 출처 병기, 임의 삭제 금지 |
+
+## 테스트 시나리오
+
+### 정상 흐름
+1. 사용자: "에이전트 목록에 즐겨찾기 토글 기능 추가해줘 (백엔드 API + 대시보드 버튼)"
+2. Phase 1: 영향 영역 = 양쪽, 복잡도 = Moderate
+3. Phase A: planner가 3~5단계 계획 생성 → 사용자 승인
+4. Phase B: backend-spec(즐겨찾기 엔드포인트+모델) ∥ web-ui-spec(토글 버튼+훅) 병렬
+5. Phase C: integration-qa가 `is_favorite`(API snake_case) ↔ 프론트 타입 일치 교차 검증 → PASS
+6. Phase D: 테스트 작성, 커버리지 충족
+7. Phase E: code-reviewer ∥ security-reviewer → 이슈 0
+8. Phase F: verification-loop 0 에러 → 완료 보고
+9. 예상 결과: 백엔드+프론트 변경 + 테스트 + `_workspace/` 산출물
+
+### 에러 흐름
+1. Phase C에서 integration-qa가 🔴 FAIL 발견: API는 `is_favorite`(snake_case) 반환, 프론트 타입은 `isFavorite`(camelCase) 기대 → 런타임 `undefined`
+2. 담당 판정: 계획서가 snake_case 명시 → frontend 책임 → `web-ui-specialist` 재호출(타입 수정)
+3. Phase C 재검증 → PASS
+4. Phase D~F 정상 진행
+5. 최종 보고에 "경계면 불일치 1건 발견·수정(C단계)" 기록
+
+## 진화 (Phase 7)
+- 같은 유형 피드백 2회 반복 시 → 해당 에이전트의 스킬/정의 수정 제안
+- 변경은 `CLAUDE.md`의 "하네스: AOS 기능 개발" 변경 이력 테이블에 기록
+- 에이전트가 반복 실패하는 패턴 발견 시 진화 제안

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ dev/harness-legacy-scan/
 # AGENTS.md is intentionally NOT ignored (portable public doc, mirror of CLAUDE.md)
 .agents/
 .codex/
+
+# Harness intermediate artifacts (aos-feature-harness) — audit trail, not committed
+_workspace/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,18 @@ cd src/dashboard && npm test
 - CORS 문제 발생 시 `.env`의 `CORS_ORIGINS` 확인
 - `docker compose` 명령은 `~/Work/shared-infra/docker-compose.yml`을 대상. `infra/docker/docker-compose.yml`은 더 이상 DB 스택 소스가 아님 (빌드/배포 참조용)
 
+## 하네스: AOS 기능 개발
+
+**목표:** 풀스택 기능을 계획→빌드(백엔드∥프론트)→통합검증→테스트→리뷰까지 전문 에이전트 팀으로 자동 조율.
+
+**트리거:** 풀스택/엔드투엔드 기능 개발·수정·부분 재실행 요청 시 `aos-feature-harness` 스킬을 사용하라. 단순 단일 파일 수정·질문은 직접 처리.
+
+**변경 이력:**
+| 날짜 | 변경 내용 | 대상 | 사유 |
+|------|----------|------|------|
+| 2026-06-20 | 초기 구성 (서브에이전트 모드, 기존 6 에이전트 재사용) | aos-feature-harness, integration-qa | 전문가 에이전트는 있으나 조율 레이어 부재 |
+| 2026-06-20 | Phase 7 진화: planner 영속화 명시, `_workspace/` gitignore, integration-qa 픽스처 fan-out 체크 추가 | SKILL.md, integration-qa.md, .gitignore | 드라이런 스모크 테스트가 드러낸 개선점 |
+
 ## Compact 시 보존
 
 현재 작업 파일 경로와 변경 의도, 실패한 검증 에러, `dev/active/` 진행 태스크, 미커밋 diff 요약, 합의한 설계 결정.


### PR DESCRIPTION
## 요약
기존 11개 전문가 에이전트는 있으나 **조율 레이어가 없던** AOS에, 풀스택 기능을 자동 조율하는 하네스를 추가합니다.

## 구성
- **`.claude/skills/aos-feature-harness`** — 서브에이전트 오케스트레이터 (Pipeline + Fan-out/Fan-in + Producer-Reviewer)
  - 계획 → 빌드(백엔드 ∥ 프론트) → 통합검증 → 테스트 → 리뷰 → 게이트
  - 기존 6개 에이전트(planner, backend/web-ui specialist, test-automation, code/security reviewer) 재사용
- **`.claude/agents/integration-qa`** — API↔훅 경계면 교차검증 QA (신규)
  - "양쪽 동시 읽기"로 producer↔consumer 계약(필드명·케이스·shape) 검증
  - 타입 변경 시 fixture fan-out 체크 포함
- **`CLAUDE.md`** — 하네스 포인터 + 변경 이력 (새 세션 자동 트리거)
- **`.gitignore`** — `_workspace/` (하네스 중간 산출물)

## 설계 결정
- 디스패치는 `general-purpose` + `Read .md` 방식 — 커스텀 specialist의 프로그래밍적 팀 스폰 시 XML 출력 이슈를 회피(검증된 안정 경로)
- 에이전트 팀(TeamCreate) 대신 서브에이전트 모드 — 기능 개발은 순차+팬아웃이라 산출물 핸드오프가 핵심

## 검증
- 구조 검증: frontmatter 유효, dead link 0, 커맨드 미생성
- 드라이런 스모크 테스트 2회(favorite toggle, provider latency) — integration-qa가 **두 빌더가 놓친 경계면 버그를 실제로 포착**, Producer-Reviewer 루프가 FAIL→PASS 수렴

🤖 Generated with [Claude Code](https://claude.com/claude-code)