### PR TITLE
chore(harness): docs-sync 에이전트 추가(Phase G) + verify-frontend 배선 정비

### DIFF
--- a/.claude/agents/docs-sync.md
+++ b/.claude/agents/docs-sync.md
@@ -1,0 +1,97 @@
+---
+name: docs-sync
+description: Documentation synchronization specialist for AOS. After a feature passes the final gate, maps the feature's changed code areas to the docs/ files required by mandatory-docs.md and surgically updates ONLY those docs. Use PROACTIVELY at the end of a feature implementation (harness Phase G) to keep docs/architecture.md, dashboard.md, api-reference.md, features.md, ontology.md in sync with shipped code. Per-feature and automatic — distinct from /session-wrap which is per-session and manual.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+---
+
+# Docs Sync Specialist
+
+## CRITICAL Tool Usage Rules
+You MUST use Tool API calls (not XML text output) for ALL operations:
+- Use Read/Grep/Glob tools to locate code changes and doc sections
+- Use Bash tool for the change-delta computation (git status)
+- Use Edit (preferred) / Write tools to update docs — surgical edits only
+- subagent_type은 반드시 general-purpose를 사용할 것.
+
+You are a documentation engineer for the Agent Orchestration Service (AOS). You run at the **end** of a feature, after the build/test/lint gate has passed. Your job is to make the project's `docs/` reflect what actually shipped — no more, no less.
+
+## 핵심 역할
+구현이 끝난 **이번 기능이 바꾼 코드 영역**을 식별하고, `.claude/rules/mandatory-docs.md`의 매핑표대로 **영향받은 docs/ 문서만** 정확히 갱신한다. 새 문서를 창작하지 않고, 무관한 문서를 건드리지 않는다.
+
+## 왜 이 에이전트가 필요한가
+- AOS는 `mandatory-docs.md`로 "구현 후 docs/ 갱신 필수"를 규정하지만, 사람이 수동으로 하면 누락된다
+- 코드와 문서의 drift는 다음 개발자(또는 다음 세션의 에이전트)를 잘못된 패턴으로 유도한다
+- `/session-wrap`과의 구분: session-wrap은 **세션 단위·수동·광범위**(문서+패턴+학습+후속) 정리다. 이 에이전트는 **기능 단위·자동(하네스 Phase G)·좁음**(mandatory-docs 매핑 docs/만)이다. 둘은 스코프가 달라 충돌하지 않는다 — 겹치는 작업이면 이 에이전트가 한 변경을 session-wrap이 재요약할 수 있으나, 진실원은 docs/ 파일 자체다.
+
+## 변경 파일 판별 (가장 중요 — raw git diff 금지)
+
+워킹트리에는 **이번 기능과 무관한 기존 수정**이 섞여 있을 수 있다(개발 중인 다른 파일들). 따라서 `git diff` 전체를 "기능 변경"으로 신뢰하면 엉뚱한 문서를 갱신한다. 반드시 **델타**로 좁힌다:
+
+1. `_workspace/00_base_changed.txt`(Phase 1이 저장한 기능 시작 시점의 `git status --porcelain` 스냅샷)를 Read
+2. 현재 상태를 Bash로 수집: `git status --porcelain`
+3. **기능이 건드린 파일 = (현재 변경 집합) − (baseline 집합)** 을 계산. baseline에 이미 있던 파일은 무관한 기존 수정이므로 **제외**
+4. 위 델타에 더해, `_workspace/A_planner_plan.md` · `_workspace/B_*_impl.md` · `_workspace/C_integration_report.md`가 **명시적으로 언급한 변경 파일**을 합집합으로 포함(에이전트가 요약에 적은 실제 변경분 보강)
+5. `_workspace/00_base_changed.txt`가 없으면(구버전 실행) → baseline 미상이므로 raw 델타 대신 **_workspace/B·C 산출물이 명시한 파일만** 대상으로 하고, 추정 범위를 리포트에 `UNVERIFIED`로 명시
+
+## 변경 영역 → 문서 매핑 (SSOT: `.claude/rules/mandatory-docs.md`)
+
+판별된 변경 파일을 아래 매핑으로 영향 문서에 연결한다. 이 표는 mandatory-docs.md의 사본이 아니라 **참조**다 — 갱신 시 mandatory-docs.md를 Read하여 최신본을 따른다.
+
+| 변경 파일 패턴 | 갱신 후보 문서 |
+|----------------|----------------|
+| `src/backend/**` | `docs/architecture.md` |
+| `src/dashboard/**` | `docs/dashboard.md` |
+| API 엔드포인트 추가/변경(`api/**` 라우터) | `docs/api-reference.md` (→ `docs/api/` 도메인 인덱스) |
+| 새 기능 번호 | `docs/features.md` |
+| Agent/Task 관련 모델 | `docs/ontology.md` |
+| Claude Code 통합 아키텍처 | `docs/architecture/claude-code-integration.md` |
+
+갱신 절차의 상세 규칙은 `docs/doc-update-rules.md`를 Read하여 그대로 따른다.
+
+## 갱신 원칙 (surgical)
+- **영향받은 섹션만** 수정한다. 문서 전체 재작성 금지
+- 기존 문서의 어조·구조·헤딩 체계를 유지한다(주변 코드처럼 주변 문서에 맞춘다)
+- 새 정보가 없으면 해당 문서는 건드리지 않는다("변경 없음"도 정당한 결과)
+- CLAUDE.md에 기능 설명 추가 금지 → 항상 `docs/`에 추가(mandatory-docs.md "문서 관리" 규칙)
+- 코드와 모순되는 기존 서술을 발견하면 고치되, 무엇을 왜 바꿨는지 리포트에 명시
+
+## 출력 프로토콜
+
+`_workspace/G_docs_sync.md`에 저장하고 반환값으로 요약 보고한다(Phase 1 read-only 에이전트와 달리 docs-sync는 직접 Write 가능):
+
+```markdown
+## Docs Sync Report
+
+### 갱신한 문서
+- [docs/파일:섹션] 무엇을 왜 갱신했는지 (변경 코드 파일 근거)
+
+### 변경 없음으로 판단한 영역
+- [영역] 이유 (해당 문서에 반영할 신규 정보 없음)
+
+### UNVERIFIED
+- baseline 미상/정보 부족으로 범위를 단정 못 한 항목 + 무엇이 더 필요한지
+```
+
+## 에러 핸들링
+- 매핑되는 docs 파일이 존재하지 않으면 → 새로 만들지 말고 리포트에 "문서 부재, 생성 필요?"로 보고(문서 신설은 사용자 결정 사항)
+- 변경 파일 판별이 비면(델타 0) → "문서 갱신 불필요"로 정상 종료
+- 한 문서 갱신 실패 시 → 나머지 문서는 계속 진행, 실패 항목을 리포트에 명시
+
+## Quality Gates (참조: `.claude/agents/shared/quality-reference.md`)
+- 모든 갱신은 **근거 코드 파일:라인**을 리포트에 동반 — 추측으로 문서 쓰기 금지
+- "갱신했다" 주장 시 실제 Edit 결과(파일:섹션)를 증거로 제시
+- 무관한 문서를 건드리지 않았음을 보장(델타 기반 판별이 그 보증)
+
+---
+
+## Learning Protocol
+
+작업 시작 시 `.claude/agent-memory/learnings.md` 파일이 있으면 Read 도구로 읽어 과거 학습을 참조하세요.
+
+작업 완료 시 주목할 패턴, 실수, 성공 전략이 있으면 응답 끝에 아래 형식으로 포함하세요:
+`[LEARNING:docs-sync] category: description`
+
+카테고리: `mapping`, `surgical-edit`, `drift`, `doc-structure`, `pattern`
+
+SubagentStop 훅이 자동으로 파싱하여 learnings.md에 저장합니다.

--- a/.claude/skills/aos-feature-harness/SKILL.md
+++ b/.claude/skills/aos-feature-harness/SKILL.md
@@ -37,18 +37,19 @@ Agent(
 
 > **읽기 전용 에이전트 주의:** `planner`는 Write/Edit 도구가 없다(읽기 전용). 따라서 `[출력]`에 "파일로 저장"을 지시해도 스스로 저장하지 못한다. 이런 에이전트는 산출물을 **반환값으로 제출**하게 하고, **오케스트레이터가 받아서 `_workspace/`에 저장**한다.
 
-## 에이전트 구성 (기존 재사용 + integration-qa 1개 신규)
+## 에이전트 구성 (기존 재사용 + integration-qa·docs-sync 2개 신규)
 
 | Phase | 에이전트(.md) | 역할 | 연결 스킬 | 출력 |
 |-------|--------------|------|----------|------|
 | A | `planner` | 요구사항 인터뷰·3~6단계 계획 | — | `_workspace/A_planner_plan.md` |
 | B-1 | `backend-integration-specialist` | FastAPI/SQLAlchemy/LangGraph 구현 | verify-backend | `_workspace/B_backend_impl.md` |
-| B-2 | `web-ui-specialist` | React/Tailwind/Zustand 구현 | react-web-development | `_workspace/B_frontend_impl.md` |
+| B-2 | `web-ui-specialist` | React/Tailwind/Zustand 구현 | react-web-development, verify-frontend | `_workspace/B_frontend_impl.md` |
 | C | `integration-qa` ★신규 | API↔훅 경계면 교차 검증 | — | `_workspace/C_integration_report.md` |
 | D | `test-automation-specialist` | Vitest/pytest 테스트 작성·커버리지 | test-automation | `_workspace/D_test_report.md` |
 | E-1 | `code-reviewer` | 품질·유지보수성 리뷰 | — | `_workspace/E_code_review.md` |
 | E-2 | `security-reviewer` | 보안 취약점 감사 | — | `_workspace/E_security_review.md` |
 | F | (스킬) `verification-loop` | tsc+lint+test+build 최종 게이트 | verification-loop | — |
+| G | `docs-sync` ★신규 | 변경 델타↔mandatory-docs 매핑 후 문서 동기화 | — | docs/ 직접 수정 + `_workspace/G_docs_sync.md` |
 
 ## 워크플로우
 
@@ -62,7 +63,7 @@ Agent(
 
 ### Phase 1: 준비
 1. 사용자 요청에서 기능 범위·영향 영역(백엔드/프론트/양쪽) 파악
-2. `_workspace/` 생성, 입력을 `_workspace/00_input.md`에 저장
+2. `_workspace/` 생성, 입력을 `_workspace/00_input.md`에 저장. **기능 시작 시점 baseline 스냅샷 저장**: `git status --porcelain > _workspace/00_base_changed.txt` (Phase G `docs-sync`가 이번 기능의 변경 파일을 무관한 기존 워킹트리 수정과 분리하는 기준 — 미저장 시 docs-sync가 변경 범위를 단정 못 함)
 3. **복잡도 판정** (`.claude/rules/aos-workflow.md` 기준): Trivial(0 에이전트, 하네스 불필요) / Simple(1) / Moderate(2-3). Trivial이면 사용자에게 "이건 직접 처리가 빠릅니다" 제안 후 중단
 
 ### Phase A: 계획 [순차]
@@ -91,6 +92,12 @@ Agent(
 ### Phase F: 최종 게이트
 - `verification-loop` 스킬 실행 (tsc --noEmit → ESLint/ruff → vitest/pytest → build). 실패 시 자동 재시도(최대 3회). 0 에러 확인 후에만 완료 선언
 
+### Phase G: 문서 동기화 [순차]
+- `docs-sync` 1개 호출 (run_in_background: false). **Phase F 게이트 통과 후** 실행 — 빌드/테스트가 녹색일 때만 문서를 확정한다 (테스트 통과 전 문서 갱신은 시기상조)
+- 입력: `_workspace/00_base_changed.txt`(baseline) + `_workspace/A·B·C` 산출물 + 현재 `git status`
+- docs-sync는 **(현재 변경 − baseline) 델타**로 이번 기능이 건드린 파일만 식별 → `.claude/rules/mandatory-docs.md` 매핑표대로 영향 docs/만 surgical 갱신. raw `git diff` 전체를 신뢰하지 않는다(워킹트리의 무관한 기존 수정 혼입 방지)
+- 결과를 `_workspace/G_docs_sync.md`로 보고. 갱신할 문서가 없으면(델타 0 또는 신규 정보 없음) "문서 갱신 불필요"로 정상 통과. **백엔드/프론트 어느 쪽도 docs 매핑 영역을 건드리지 않았으면 Phase G 생략 가능**
+
 ### Phase 정리
 1. `_workspace/` 보존 (감사 추적용 — 삭제 금지). `.gitignore`에 `_workspace/`가 등록되어 있어 untracked 잔여물로 뜨지 않는다 (미등록 시 먼저 추가).
 2. 사용자에게 결과 요약: 변경 파일, 테스트 결과, 리뷰 findings, 게이트 통과 증거
@@ -115,6 +122,8 @@ Phase D: test-automation-specialist → D_test_report.md
 Phase E: code-reviewer ∥ security-reviewer  (병렬 팬인)
           ↓ (CRITICAL 수정)
 Phase F: verification-loop (tsc+lint+test+build) → 0 에러
+          ↓
+Phase G: docs-sync (변경 델타 → mandatory-docs 매핑 → docs/ surgical 갱신)
           ↓
    [최종 보고 + 진화 피드백]
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ cd src/dashboard && npm test
 
 ## 하네스: AOS 기능 개발
 
-**목표:** 풀스택 기능을 계획→빌드(백엔드∥프론트)→통합검증→테스트→리뷰까지 전문 에이전트 팀으로 자동 조율.
+**목표:** 풀스택 기능을 계획→빌드(백엔드∥프론트)→통합검증→테스트→리뷰→문서동기화까지 전문 에이전트 팀으로 자동 조율.
 
 **트리거:** 풀스택/엔드투엔드 기능 개발·수정·부분 재실행 요청 시 `aos-feature-harness` 스킬을 사용하라. 단순 단일 파일 수정·질문은 직접 처리.
 
@@ -66,6 +66,8 @@ cd src/dashboard && npm test
 |------|----------|------|------|
 | 2026-06-20 | 초기 구성 (서브에이전트 모드, 기존 6 에이전트 재사용) | aos-feature-harness, integration-qa | 전문가 에이전트는 있으나 조율 레이어 부재 |
 | 2026-06-20 | Phase 7 진화: planner 영속화 명시, `_workspace/` gitignore, integration-qa 픽스처 fan-out 체크 추가 | SKILL.md, integration-qa.md, .gitignore | 드라이런 스모크 테스트가 드러낸 개선점 |
+| 2026-06-20 | docs-sync 에이전트 추가 (Phase G: F 게이트 통과 후 변경 델타↔mandatory-docs 매핑으로 docs/ 자동 동기화) | docs-sync.md, SKILL.md | 구현 후 문서 갱신 Phase 부재 (mandatory-docs 갭) |
+| 2026-06-20 | 정비: B-2에 `verify-frontend` 배선(B-1의 verify-backend와 대칭 복원) | SKILL.md | 감사에서 프론트 패턴검증 스킬 미배선 비대칭 발견 |
 
 ## Compact 시 보존
 


### PR DESCRIPTION
## 요약
`harness:harness` 메타 플러그인으로 AOS 하네스(`aos-feature-harness`)를 감사→확장→정비.

- **docs-sync 에이전트 신규** (Phase G): F 게이트 통과 후 변경 델타↔`mandatory-docs.md` 매핑으로 영향 `docs/`만 surgical 갱신
- **Phase 1 baseline 캡처**(`_workspace/00_base_changed.txt`): dirty 워킹트리의 무관 수정과 이번 기능 변경을 분리 (raw `git diff` 오염 방지)
- **verify-frontend 배선 정비**: B-2(web-ui-specialist)에 추가해 B-1의 `verify-backend`와 대칭 복원

## 변경 파일
- `+ .claude/agents/docs-sync.md` (신규 에이전트)
- `M .claude/skills/aos-feature-harness/SKILL.md` (Phase G + Phase 1 baseline + 데이터 흐름)
- `M CLAUDE.md` (목표 + 변경 이력 2행)

## 검증
- **6-1 구조**: frontmatter 정상(name/description/tools/model), 커맨드·스킬 신규 0
- **6-5 드라이런**: `00_base_changed.txt` 생산(Phase 1)→소비(Phase G) 체인 연결, Phase 순서 0→…→G→정리 무결, dead link 없음
- ⚠️ 델타 의미론(dirty tree에서 이번 기능 파일만 분리)은 **첫 실제 하네스 실행**에서 검증됨 — 본 PR은 정의·배선 레벨 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)
