### PR TITLE
feat(claude-sessions): Overview 표시완화 + Transcript 딥링크 핸드오프

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -125,8 +125,8 @@ import { cn } from '@/lib/utils';
 |----------|------|
 | `SessionList` | 세션 목록 (정렬, 자동 새로고침) |
 | `SessionCard` | 세션 카드 (상태, 토큰, 비용) |
-| `SessionDetails` | 상세 정보 + Recent Activity (요약 윈도 시 "전체 Transcript 보기" 배너, 메시지별 잘림 표시) |
-| `TranscriptViewer` | Raw 트랜스크립트 (JSON Tree, 긴 문자열은 "더 보기" 토글로 전체 표시) |
+| `SessionDetails` | 상세 정보 + Recent Activity (요약 윈도 시 "전체 Transcript 보기" 배너, 메시지별 잘림 표시). 툴 인풋·메타데이터는 `title` 툴팁으로 전체값 hover 노출. "전체 보기" 클릭 시 해당 메시지 timestamp를 `TranscriptViewer`로 전달(딥링크) |
+| `TranscriptViewer` | Raw 트랜스크립트 (JSON Tree, 긴 문자열은 "더 보기" 토글로 전체 표시). `targetTimestamp` prop 수신 시 마지막(최신) 페이지로 점프, 그 페이지에 일치 entry가 있으면 instant 비교로 자동 펼침·스크롤·하이라이트 |
 | `ProcessCleanupPanel` | 프로세스 정리 패널 |
 
 ### Project Config Components

--- a/src/dashboard/src/components/claude-sessions/SessionDetails.tsx
+++ b/src/dashboard/src/components/claude-sessions/SessionDetails.tsx
@@ -66,22 +66,50 @@ function MessageIcon({ type }: { type: MessageType }) {
   }
 }
 
-function formatToolInput(input: Record<string, unknown>): string {
-  // Extract key values for display
-  if (input.file_path) return String(input.file_path).split('/').slice(-2).join('/')
-  if (input.pattern) return `"${input.pattern}"`
-  if (input.command) return String(input.command).slice(0, 50) + (String(input.command).length > 50 ? '...' : '')
-  if (input.query) return String(input.query).slice(0, 40) + (String(input.query).length > 40 ? '...' : '')
-  if (input.content) return `${String(input.content).slice(0, 30)}...`
-  if (input.url) return String(input.url).slice(0, 40)
+// Inline summary stays a single clipped line; the full value is exposed via the
+// title tooltip (hover reveal) so nothing is silently lost in the Overview.
+const TOOL_INPUT_SUMMARY_LIMIT = 120
+
+function capSummary(text: string): string {
+  return text.length > TOOL_INPUT_SUMMARY_LIMIT
+    ? `${text.slice(0, TOOL_INPUT_SUMMARY_LIMIT)}...`
+    : text
+}
+
+function formatToolInput(input: Record<string, unknown>): { summary: string; full: string } {
+  // Extract key values for display. `full` is the untruncated value for the tooltip.
+  if (input.file_path) {
+    const full = String(input.file_path)
+    return { summary: full.split('/').slice(-2).join('/'), full }
+  }
+  if (input.pattern) {
+    const full = `"${input.pattern}"`
+    return { summary: capSummary(full), full }
+  }
+  if (input.command) {
+    const full = String(input.command)
+    return { summary: capSummary(full), full }
+  }
+  if (input.query) {
+    const full = String(input.query)
+    return { summary: capSummary(full), full }
+  }
+  if (input.content) {
+    const full = String(input.content)
+    return { summary: capSummary(full), full }
+  }
+  if (input.url) {
+    const full = String(input.url)
+    return { summary: capSummary(full), full }
+  }
   // Fallback: show first key-value
   const keys = Object.keys(input)
   if (keys.length > 0) {
     const firstKey = keys[0]
-    const value = String(input[firstKey]).slice(0, 30)
-    return `${firstKey}: ${value}${String(input[firstKey]).length > 30 ? '...' : ''}`
+    const fullVal = String(input[firstKey])
+    return { summary: `${firstKey}: ${capSummary(fullVal)}`, full: `${firstKey}: ${fullVal}` }
   }
-  return ''
+  return { summary: '', full: '' }
 }
 
 function MessageItem({
@@ -89,10 +117,10 @@ function MessageItem({
   onViewTranscript,
 }: {
   message: SessionMessage
-  onViewTranscript?: () => void
+  onViewTranscript?: (targetTimestamp?: string) => void
 }) {
   const time = new Date(message.timestamp).toLocaleTimeString()
-  const toolInputSummary = message.tool_input ? formatToolInput(message.tool_input) : null
+  const toolInput = message.tool_input ? formatToolInput(message.tool_input) : null
 
   return (
     <div className="flex gap-3 py-2 px-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50">
@@ -114,13 +142,13 @@ function MessageItem({
             </span>
           )}
         </div>
-        {/* Tool input summary */}
-        {toolInputSummary && (
+        {/* Tool input summary — one clipped line, full value on hover (title) */}
+        {toolInput && toolInput.summary && (
           <p
             className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate"
-            title={toolInputSummary}
+            title={toolInput.full}
           >
-            {toolInputSummary}
+            {toolInput.summary}
           </p>
         )}
         {message.content && (
@@ -132,7 +160,7 @@ function MessageItem({
         {message.content_truncated && (
           <button
             type="button"
-            onClick={onViewTranscript}
+            onClick={() => onViewTranscript?.(message.timestamp)}
             aria-label="전체 메시지를 Raw Transcript에서 보기"
             className="mt-1 text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 underline"
           >
@@ -149,7 +177,7 @@ function OverviewContent({
   onViewTranscript,
 }: {
   session: ClaudeSessionDetail
-  onViewTranscript: () => void
+  onViewTranscript: (targetTimestamp?: string) => void
 }) {
   return (
     <>
@@ -197,14 +225,18 @@ function OverviewContent({
           {session.git_branch && (
             <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
               <GitBranch className="w-4 h-4" />
-              <span className="truncate">{session.git_branch}</span>
+              <span className="truncate" title={session.git_branch}>
+                {session.git_branch}
+              </span>
             </div>
           )}
 
           {/* Model */}
           <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
             <Bot className="w-4 h-4" />
-            <span className="truncate text-xs">{session.model}</span>
+            <span className="truncate text-xs" title={session.model}>
+              {session.model}
+            </span>
           </div>
 
           {/* Version */}
@@ -270,7 +302,7 @@ function OverviewContent({
               </span>
               <button
                 type="button"
-                onClick={onViewTranscript}
+                onClick={() => onViewTranscript()}
                 aria-label="전체 대화를 Raw Transcript에서 보기"
                 className="font-medium underline hover:text-amber-800 dark:hover:text-amber-300 whitespace-nowrap"
               >
@@ -302,6 +334,9 @@ function OverviewContent({
 export function SessionDetails() {
   const { selectedSession, isLoadingDetails } = useClaudeSessionsStore()
   const [activeTab, setActiveTab] = useState<TabType>('overview')
+  // Carries the timestamp of an Overview message the user wants to jump to in
+  // the Raw Transcript (deep-link handoff). Undefined = open transcript plainly.
+  const [transcriptTarget, setTranscriptTarget] = useState<string | undefined>(undefined)
 
   if (isLoadingDetails) {
     return (
@@ -354,9 +389,15 @@ export function SessionDetails() {
 
       {/* Tab Content */}
       {activeTab === 'overview' ? (
-        <OverviewContent session={session} onViewTranscript={() => setActiveTab('transcript')} />
+        <OverviewContent
+          session={session}
+          onViewTranscript={(ts) => {
+            setTranscriptTarget(ts)
+            setActiveTab('transcript')
+          }}
+        />
       ) : (
-        <TranscriptViewer />
+        <TranscriptViewer targetTimestamp={transcriptTarget} />
       )}
     </div>
   )

--- a/src/dashboard/src/components/claude-sessions/SessionDetails.tsx
+++ b/src/dashboard/src/components/claude-sessions/SessionDetails.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useClaudeSessionsStore } from '../../stores/claudeSessions'
 import { cn } from '../../lib/utils'
 import {
@@ -337,6 +337,13 @@ export function SessionDetails() {
   // Carries the timestamp of an Overview message the user wants to jump to in
   // the Raw Transcript (deep-link handoff). Undefined = open transcript plainly.
   const [transcriptTarget, setTranscriptTarget] = useState<string | undefined>(undefined)
+
+  // Selecting a different session must drop any pending deep-link target, else
+  // the viewer would jump to the new session's last page for a foreign message.
+  const sessionId = selectedSession?.session_id
+  useEffect(() => {
+    setTranscriptTarget(undefined)
+  }, [sessionId])
 
   if (isLoadingDetails) {
     return (

--- a/src/dashboard/src/components/claude-sessions/TranscriptViewer.tsx
+++ b/src/dashboard/src/components/claude-sessions/TranscriptViewer.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState, useMemo } from 'react'
+import { memo, useEffect, useRef, useState, useMemo } from 'react'
 import { useClaudeSessionsStore } from '../../stores/claudeSessions'
 import { cn } from '../../lib/utils'
 import {
@@ -211,14 +211,32 @@ function JsonTree({ data, depth = 0, maxDepth = 12 }: JsonTreeProps) {
 interface TranscriptEntryItemProps {
   entry: TranscriptEntry
   index: number
+  highlight?: boolean
 }
 
-function TranscriptEntryItem({ entry, index }: TranscriptEntryItemProps) {
-  const [expanded, setExpanded] = useState(false)
+function TranscriptEntryItem({ entry, index, highlight = false }: TranscriptEntryItemProps) {
+  const [expanded, setExpanded] = useState(highlight)
   const { type, detail } = getEntryTypeLabel(entry)
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Deep-link arrival: auto-expand the matched entry and scroll it into view.
+  useEffect(() => {
+    if (highlight) {
+      setExpanded(true)
+      ref.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [highlight])
 
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden bg-white dark:bg-gray-800">
+    <div
+      ref={ref}
+      className={cn(
+        'border rounded-lg overflow-hidden bg-white dark:bg-gray-800',
+        highlight
+          ? 'border-primary-500 ring-2 ring-primary-500'
+          : 'border-gray-200 dark:border-gray-700'
+      )}
+    >
       <button
         onClick={() => setExpanded(!expanded)}
         className={cn(
@@ -258,7 +276,28 @@ function TranscriptEntryItem({ entry, index }: TranscriptEntryItemProps) {
 
 const ITEMS_PER_PAGE = 50
 
-export function TranscriptViewer() {
+/**
+ * Compare two ISO timestamps by instant. The Overview path serializes timestamps
+ * via a Pydantic datetime (microsecond precision, e.g. `...123000Z`) while the
+ * transcript endpoint returns the raw JSONL string (`...123Z`). They denote the
+ * same moment but differ as strings, so an `===` join would never match.
+ */
+function sameInstant(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false
+  const ta = new Date(a).getTime()
+  return Number.isFinite(ta) && ta === new Date(b).getTime()
+}
+
+interface TranscriptViewerProps {
+  /**
+   * Timestamp of an Overview message to deep-link to. When set, the viewer jumps
+   * to the last page (where the most recent Overview messages live) and the
+   * matching entry is auto-expanded, scrolled into view, and highlighted.
+   */
+  targetTimestamp?: string
+}
+
+export function TranscriptViewer({ targetTimestamp }: TranscriptViewerProps = {}) {
   const {
     selectedSessionId,
     transcriptEntries,
@@ -272,15 +311,38 @@ export function TranscriptViewer() {
   const [filter, setFilter] = useState<FilterType>('all')
   const [searchQuery, setSearchQuery] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
+  // Tracks the target we've already jumped for, so manual paging isn't overridden.
+  const [jumpedFor, setJumpedFor] = useState<string | null>(null)
 
   // Fetch transcript when session changes
   useEffect(() => {
     if (selectedSessionId) {
       clearTranscript()
       setCurrentPage(1)
+      setJumpedFor(null)
       fetchTranscript(selectedSessionId, 0, ITEMS_PER_PAGE)
     }
   }, [selectedSessionId, fetchTranscript, clearTranscript])
+
+  // Deep-link handoff: once the total is known, jump to the last page for a
+  // fresh target. Runs once per target; manual pagination afterwards is kept.
+  useEffect(() => {
+    if (!targetTimestamp || jumpedFor === targetTimestamp) return
+    if (!selectedSessionId || transcriptTotalCount <= 0) return
+    const lastPage = Math.max(1, Math.ceil(transcriptTotalCount / ITEMS_PER_PAGE))
+    setJumpedFor(targetTimestamp)
+    if (lastPage !== currentPage) {
+      setCurrentPage(lastPage)
+      fetchTranscript(selectedSessionId, (lastPage - 1) * ITEMS_PER_PAGE, ITEMS_PER_PAGE)
+    }
+  }, [
+    targetTimestamp,
+    jumpedFor,
+    selectedSessionId,
+    transcriptTotalCount,
+    currentPage,
+    fetchTranscript,
+  ])
 
   // Filter and search entries
   const filteredEntries = useMemo(() => {
@@ -392,6 +454,7 @@ export function TranscriptViewer() {
               key={`${entry.timestamp}-${index}`}
               entry={entry}
               index={(currentPage - 1) * ITEMS_PER_PAGE + index}
+              highlight={sameInstant(entry.timestamp, targetTimestamp)}
             />
           ))
         )}

--- a/src/dashboard/src/components/claude-sessions/__tests__/SessionDetails.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/SessionDetails.test.tsx
@@ -22,9 +22,13 @@ vi.mock('lucide-react', () => ({
   Info: (props: Record<string, unknown>) => <span data-testid="icon-info" {...props} />,
 }))
 
-// Mock TranscriptViewer
+// Mock TranscriptViewer — capture props so we can assert the deep-link handoff
+const hoisted = vi.hoisted(() => ({ transcriptViewerProps: {} as Record<string, unknown> }))
 vi.mock('../TranscriptViewer', () => ({
-  TranscriptViewer: () => <div data-testid="transcript-viewer">Transcript Viewer</div>,
+  TranscriptViewer: (props: Record<string, unknown>) => {
+    hoisted.transcriptViewerProps = props
+    return <div data-testid="transcript-viewer">Transcript Viewer</div>
+  },
 }))
 
 const mockSession: ClaudeSessionDetail = {
@@ -90,6 +94,7 @@ describe('SessionDetails', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     storeState = { selectedSession: null, isLoadingDetails: false }
+    hoisted.transcriptViewerProps = {}
   })
 
   it('shows loading spinner when isLoadingDetails', () => {
@@ -266,6 +271,64 @@ describe('SessionDetails', () => {
       render(<SessionDetails />)
       expect(
         screen.getByRole('button', { name: '전체 메시지를 Raw Transcript에서 보기' })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('display relaxation & deep-link handoff', () => {
+    it('exposes the full tool input via a title tooltip (hover reveal, not truncated)', () => {
+      const longCmd = 'git log --oneline --graph ' + 'a'.repeat(200)
+      storeState.selectedSession = {
+        ...mockSession,
+        recent_messages: [
+          {
+            type: 'tool_use',
+            timestamp: '2026-01-15T10:57:00Z',
+            tool_name: 'Bash',
+            tool_input: { command: longCmd },
+          },
+        ] as SessionMessage[],
+      }
+      const { container } = render(<SessionDetails />)
+      // The inline summary stays one-line, but its title carries the FULL command
+      const tooltipEl = container.querySelector(`[title="${longCmd}"]`)
+      expect(tooltipEl).toBeInTheDocument()
+    })
+
+    it('passes the clicked message timestamp to TranscriptViewer on per-message "view full"', () => {
+      storeState.selectedSession = {
+        ...mockSession,
+        messages_truncated: false,
+        recent_messages: [
+          {
+            type: 'assistant',
+            timestamp: '2026-01-15T10:56:00Z',
+            content: 'partial text',
+            content_truncated: true,
+            full_length: 4200,
+          },
+        ] as SessionMessage[],
+      }
+      render(<SessionDetails />)
+      fireEvent.click(
+        screen.getByRole('button', { name: '전체 메시지를 Raw Transcript에서 보기' })
+      )
+      expect(screen.getByTestId('transcript-viewer')).toBeInTheDocument()
+      expect(hoisted.transcriptViewerProps.targetTimestamp).toBe('2026-01-15T10:56:00Z')
+    })
+
+    it('exposes git branch and model via title tooltips', () => {
+      storeState.selectedSession = {
+        ...mockSession,
+        git_branch: 'feature/a-very-long-branch-name-that-would-be-clipped',
+        model: 'claude-opus-4-8-with-a-long-identifier',
+      }
+      const { container } = render(<SessionDetails />)
+      expect(
+        container.querySelector('[title="feature/a-very-long-branch-name-that-would-be-clipped"]')
+      ).toBeInTheDocument()
+      expect(
+        container.querySelector('[title="claude-opus-4-8-with-a-long-identifier"]')
       ).toBeInTheDocument()
     })
   })

--- a/src/dashboard/src/components/claude-sessions/__tests__/SessionDetails.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/SessionDetails.test.tsx
@@ -317,6 +317,37 @@ describe('SessionDetails', () => {
       expect(hoisted.transcriptViewerProps.targetTimestamp).toBe('2026-01-15T10:56:00Z')
     })
 
+    it('clears a stale deep-link target when the selected session changes', () => {
+      storeState.selectedSession = {
+        ...mockSession,
+        session_id: 'sess-A',
+        messages_truncated: false,
+        recent_messages: [
+          {
+            type: 'assistant',
+            timestamp: '2026-01-15T10:56:00Z',
+            content: 'partial text',
+            content_truncated: true,
+            full_length: 4200,
+          },
+        ] as SessionMessage[],
+      }
+      const { rerender } = render(<SessionDetails />)
+
+      // Deep-link from a message in session A → target set, transcript tab active
+      fireEvent.click(
+        screen.getByRole('button', { name: '전체 메시지를 Raw Transcript에서 보기' })
+      )
+      expect(hoisted.transcriptViewerProps.targetTimestamp).toBe('2026-01-15T10:56:00Z')
+
+      // Switch to a different session while still on the transcript tab
+      storeState.selectedSession = { ...mockSession, session_id: 'sess-B' }
+      rerender(<SessionDetails />)
+
+      // The stale target must be cleared so session B does not jump unexpectedly
+      expect(hoisted.transcriptViewerProps.targetTimestamp).toBeUndefined()
+    })
+
     it('exposes git branch and model via title tooltips', () => {
       storeState.selectedSession = {
         ...mockSession,

--- a/src/dashboard/src/components/claude-sessions/__tests__/TranscriptViewer.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/TranscriptViewer.test.tsx
@@ -93,3 +93,53 @@ describe('TranscriptViewer — JsonString expand toggle', () => {
     expect(screen.queryByRole('button', { name: /전체 문자열 보기/ })).not.toBeInTheDocument()
   })
 })
+
+describe('TranscriptViewer — deep-link target handoff', () => {
+  // The transcript endpoint returns the raw JSONL timestamp (ms, 3 digits);
+  // the Overview path serializes via Pydantic datetime (6 digits). Same instant,
+  // different string — the join must compare by instant, not by ===.
+  const TRANSCRIPT_TS = '2026-06-06T10:00:00.123Z'
+  const OVERVIEW_TS = '2026-06-06T10:00:00.123000Z'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // jsdom does not implement scrollIntoView — stub it so the auto-scroll effect runs
+    Element.prototype.scrollIntoView = vi.fn()
+    storeState = {
+      selectedSessionId: 'sess-1',
+      transcriptEntries: [{ ...longEntry, timestamp: TRANSCRIPT_TS }],
+      transcriptTotalCount: 120, // 3 pages of 50
+      transcriptHasMore: true,
+      isLoadingTranscript: false,
+      fetchTranscript: vi.fn(),
+      clearTranscript: vi.fn(),
+    }
+  })
+
+  it('jumps to the last page when a targetTimestamp is provided', () => {
+    render(<TranscriptViewer targetTimestamp={OVERVIEW_TS} />)
+    // last page = ceil(120/50) = 3 -> offset (3-1)*50 = 100
+    expect(storeState.fetchTranscript).toHaveBeenCalledWith('sess-1', 100, 50)
+  })
+
+  it('auto-expands the matching entry by instant, even when ISO formats differ', () => {
+    // OVERVIEW_TS !== TRANSCRIPT_TS as strings, but they are the same instant.
+    render(<TranscriptViewer targetTimestamp={OVERVIEW_TS} />)
+    // The matched entry is expanded on arrival, so its inner "더 보기" toggle shows
+    expect(screen.getByRole('button', { name: /전체 문자열 보기/ })).toBeInTheDocument()
+  })
+
+  it('does not auto-expand when no target is provided', () => {
+    render(<TranscriptViewer />)
+    expect(
+      screen.queryByRole('button', { name: /전체 문자열 보기/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not jump pages when no target is provided', () => {
+    render(<TranscriptViewer />)
+    // only the initial page-1 fetch should have happened
+    expect(storeState.fetchTranscript).toHaveBeenCalledTimes(1)
+    expect(storeState.fetchTranscript).toHaveBeenCalledWith('sess-1', 0, 50)
+  })
+})


### PR DESCRIPTION
## Summary
- Claude Sessions **Overview의 잘림을 "표시 전용" 영역에서 완화**(툴 인풋·메타데이터를 `title` 툴팁으로 전체값 hover 노출)
- **"전체 보기" 핸드오프 개선**: 클릭 시 Raw Transcript의 최신 페이지로 점프하고, 일치 entry를 자동 펼침·스크롤·하이라이트
- 백엔드 캡(`RECENT_MESSAGE_COUNT=20` / `CONTENT_LIMIT=2000` / `WINDOW_LINES=200`)은 **의도적으로 유지** — Overview는 "훑기 요약", 완전본은 Raw Transcript라는 2-탭 분업 보존

## Background
"Overview를 잘림 없이 전부 보여달라"는 요청을 검토한 결과, 캡 제거는 Raw Transcript 역할을 복제하고 성능 회귀(line-window가 막던 대용량 세션 전체 파싱)를 유발하며 훑기 가치를 없앤다고 판단. 대신 **표시완화 + 더 똑똑한 핸드오프** 방향으로 구현(백엔드 무변경).

## Changes
**`SessionDetails.tsx`**
- `formatToolInput` → `{ summary, full }` 반환, 인라인 캡 30~50→120, `title`에 전체값(hover 노출)
- `git_branch`·`model` 메타데이터에 `title` 툴팁 추가
- `onViewTranscript(targetTimestamp?)` 시그니처화 → 메시지 "전체 보기" 클릭 시 해당 timestamp 전달
- 세션 전환 시 stale 딥링크 target 초기화(`session_id` 키 `useEffect`)

**`TranscriptViewer.tsx`**
- `targetTimestamp` prop 수신 → 최신 페이지로 점프(`jumpedFor` 가드로 target당 1회), 일치 entry 자동 펼침·`scrollIntoView`·ring 하이라이트
- `sameInstant()`: Pydantic(`...123000Z`)↔원본 JSONL(`...123Z`) timestamp 직렬화 격차를 `Date.getTime()` 비교로 흡수

**`docs/dashboard.md`**: SessionDetails/TranscriptViewer 동작 설명 동기화

## Known Limitation
Overview 20개 메시지는 최대 200줄에 걸쳐 있고 transcript 페이지는 50줄이라, 최신 ~50줄어치만 마지막 페이지에 확실히 안착. 더 오래된 윈도우 메시지는 1~3페이지 뒤에 있어 자동 하이라이트가 안 될 수 있음(단, "최신 페이지 점프"는 기존 1페이지 착지 대비 무조건 개선).

## Test Plan
- [x] `tsc --noEmit` exit 0
- [x] `eslint` exit 0
- [x] `vitest` 전체 4209 passed (신규: 툴팁·핸드오프 prop·메타 툴팁·last-page 점프·차등포맷 instant 매칭·stale target 초기화)
- [x] `npm run build` exit 0
- [x] timestamp 직렬화 격차를 실제 Pydantic 직렬화로 바이트 검증 후 `sameInstant` 수정(Red-Green)
- [x] stale 딥링크 target 버그 Red-Green 회귀 테스트

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)