### PR TITLE
refactor(settings): 미사용 LLM Configuration 카드 제거

### DIFF
--- a/src/dashboard/src/pages/SettingsPage.test.tsx
+++ b/src/dashboard/src/pages/SettingsPage.test.tsx
@@ -4,9 +4,6 @@ import { SettingsPage } from './SettingsPage'
 
 // Use vi.hoisted to declare mock fns that vi.mock factories can reference
 const {
-  mockSetLLMProvider,
-  mockSetModel,
-  mockSetApiKey,
   mockSetBackendUrl,
   mockSetTheme,
   mockSetNotificationSetting,
@@ -23,9 +20,6 @@ const {
   let _settingsOverrides: Record<string, unknown> = {}
   let _orchestrationOverrides: Record<string, unknown> = {}
   return {
-    mockSetLLMProvider: vi.fn(),
-    mockSetModel: vi.fn(),
-    mockSetApiKey: vi.fn(),
     mockSetBackendUrl: vi.fn(),
     mockSetTheme: vi.fn(),
     mockSetNotificationSetting: vi.fn(),
@@ -63,27 +57,18 @@ vi.mock('../components/usage', () => ({
 // Store mocks
 vi.mock('../stores/settings', () => ({
   useSettingsStore: () => ({
-    llmProvider: 'google',
-    model: 'gemini-pro',
-    apiKey: '',
     backendUrl: 'http://localhost:8000',
     theme: 'system',
     notifications: defaultNotifications,
     preferredTerminal: 'warp',
-    setLLMProvider: mockSetLLMProvider,
-    setModel: mockSetModel,
-    setApiKey: mockSetApiKey,
     setBackendUrl: mockSetBackendUrl,
     setTheme: mockSetTheme,
     setNotificationSetting: mockSetNotificationSetting,
     setPreferredTerminal: mockSetPreferredTerminal,
     fetchModels: vi.fn(),
-    getModelsForProvider: () => [],
     ...getSettingsOverrides(),
   }),
-  getModelsForProvider: () => ['model-a', 'model-b'],
   Theme: {},
-  LLMProvider: {},
   TerminalType: {},
   TERMINAL_DISPLAY_NAMES: {
     warp: 'Warp',
@@ -162,11 +147,6 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Connection')).toBeInTheDocument()
   })
 
-  it('renders LLM Configuration section', async () => {
-    await renderSettingsPage()
-    expect(screen.getByText('LLM Configuration')).toBeInTheDocument()
-  })
-
   it('renders Appearance section', async () => {
     await renderSettingsPage()
     expect(screen.getByText('Appearance')).toBeInTheDocument()
@@ -226,69 +206,6 @@ describe('SettingsPage', () => {
         fireEvent.change(input, { target: { value: 'http://example.com:9000' } })
       })
       expect(mockSetBackendUrl).toHaveBeenCalledWith('http://example.com:9000')
-    })
-  })
-
-  // ---- NEW: LLM Configuration ----
-
-  describe('LLM Configuration section', () => {
-    it('renders all four provider buttons', async () => {
-      await renderSettingsPage()
-      expect(screen.getByText('Anthropic')).toBeInTheDocument()
-      expect(screen.getByText('Gemini')).toBeInTheDocument()
-      expect(screen.getByText('OpenAI')).toBeInTheDocument()
-      expect(screen.getByText('Local')).toBeInTheDocument()
-    })
-
-    it('calls setLLMProvider when clicking a provider button', async () => {
-      await renderSettingsPage()
-      await act(async () => {
-        fireEvent.click(screen.getByText('Anthropic'))
-      })
-      expect(mockSetLLMProvider).toHaveBeenCalledWith('anthropic')
-    })
-
-    it('calls setLLMProvider for local provider', async () => {
-      await renderSettingsPage()
-      await act(async () => {
-        fireEvent.click(screen.getByText('Local'))
-      })
-      expect(mockSetLLMProvider).toHaveBeenCalledWith('local')
-    })
-
-    it('renders model dropdown with options from getModelsForProvider', async () => {
-      await renderSettingsPage()
-      const selects = screen.getAllByRole('combobox')
-      // First combobox is model select, second is terminal select
-      const modelSelect = selects[0]
-      const options = modelSelect.querySelectorAll('option')
-      expect(options).toHaveLength(2)
-      expect(options[0]).toHaveTextContent('model-a')
-      expect(options[1]).toHaveTextContent('model-b')
-    })
-
-    it('calls setModel when model selection changes', async () => {
-      await renderSettingsPage()
-      const selects = screen.getAllByRole('combobox')
-      const modelSelect = selects[0]
-      await act(async () => {
-        fireEvent.change(modelSelect, { target: { value: 'model-b' } })
-      })
-      expect(mockSetModel).toHaveBeenCalledWith('model-b')
-    })
-
-    it('calls setApiKey when API key input changes', async () => {
-      await renderSettingsPage()
-      const input = screen.getByPlaceholderText('sk-...')
-      await act(async () => {
-        fireEvent.change(input, { target: { value: 'sk-test-key-123' } })
-      })
-      expect(mockSetApiKey).toHaveBeenCalledWith('sk-test-key-123')
-    })
-
-    it('displays API key storage notice', async () => {
-      await renderSettingsPage()
-      expect(screen.getByText('API key is stored in memory only and not persisted')).toBeInTheDocument()
     })
   })
 

--- a/src/dashboard/src/pages/SettingsPage.tsx
+++ b/src/dashboard/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { useSettingsStore, getModelsForProvider as getFallbackModels, Theme, LLMProvider, TerminalType, TERMINAL_DISPLAY_NAMES } from '../stores/settings'
+import { useSettingsStore, Theme, TerminalType, TERMINAL_DISPLAY_NAMES } from '../stores/settings'
 import { useOrchestrationStore } from '../stores/orchestration'
 import { notificationService } from '../services/notificationService'
 import { cn } from '../lib/utils'
@@ -8,7 +8,6 @@ import {
   Server,
   Palette,
   Key,
-  Cpu,
   CheckCircle,
   XCircle,
   RefreshCw,
@@ -24,22 +23,15 @@ import { LLMAccountsSettings } from '../components/usage'
 
 export function SettingsPage() {
   const {
-    llmProvider,
-    model,
-    apiKey,
     backendUrl,
     theme,
     notifications,
-    setLLMProvider,
-    setModel,
-    setApiKey,
     setBackendUrl,
     setTheme,
     setNotificationSetting,
     preferredTerminal,
     setPreferredTerminal,
     fetchModels,
-    getModelsForProvider,
   } = useSettingsStore()
 
   const { connected, connect, disconnect } = useOrchestrationStore()
@@ -193,16 +185,10 @@ export function SettingsPage() {
     notificationService.playSound('approval')
   }
 
-  // Fetch models from API on mount
+  // Fetch models from API on mount (populates availableModels for MemberDetailPanel)
   useEffect(() => {
     fetchModels()
   }, [fetchModels])
-
-  // Use API models if available, fallback to hardcoded list
-  const apiModels = getModelsForProvider(llmProvider)
-  const models = apiModels.length > 0
-    ? apiModels.map(m => m.id)
-    : getFallbackModels(llmProvider)
 
   const handleReconnect = () => {
     disconnect()
@@ -299,83 +285,6 @@ export function SettingsPage() {
         <LLMAccountsSettings />
 
         {/* ── Row 2: Medium cards ── */}
-        {/* LLM Settings */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-            <Cpu className="w-5 h-5" />
-            LLM Configuration
-          </h3>
-          <div className="space-y-4">
-            {/* Provider */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Provider
-              </label>
-              <div className="flex gap-2">
-                {(['codex_cli', 'anthropic', 'google', 'openai', 'local'] as LLMProvider[]).map((provider) => {
-                  const label: Record<LLMProvider, string> = {
-                    codex_cli: 'Codex CLI',
-                    anthropic: 'Anthropic',
-                    google: 'Gemini',
-                    openai: 'OpenAI',
-                    local: 'Local',
-                  }
-                  return (
-                    <button
-                      key={provider}
-                      onClick={() => setLLMProvider(provider)}
-                      className={cn(
-                        'px-4 py-2 rounded-lg text-sm font-medium transition-colors',
-                        llmProvider === provider
-                          ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400'
-                          : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
-                      )}
-                    >
-                      {label[provider]}
-                    </button>
-                  )
-                })}
-              </div>
-            </div>
-
-            {/* Model */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Model
-              </label>
-              <select
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-              >
-                {models.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* API Key */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 flex items-center gap-2">
-                <Key className="w-4 h-4" />
-                API Key
-              </label>
-              <input
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-                placeholder="sk-..."
-              />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                API key is stored in memory only and not persisted
-              </p>
-            </div>
-          </div>
-        </div>
-
         {/* Claude Code */}
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
           <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4 flex items-center gap-2">

--- a/src/dashboard/src/stores/__tests__/settings.test.ts
+++ b/src/dashboard/src/stores/__tests__/settings.test.ts
@@ -18,9 +18,6 @@ describe('settings store', () => {
   beforeEach(() => {
     // Reset store to default state
     useSettingsStore.setState({
-      llmProvider: 'anthropic',
-      model: 'claude-sonnet-4-6',
-      apiKey: '',
       backendUrl: 'http://localhost:8000',
       theme: 'light',
       notifications: {
@@ -39,11 +36,6 @@ describe('settings store', () => {
   })
 
   describe('initial state', () => {
-    it('has default llmProvider as anthropic', () => {
-      const state = useSettingsStore.getState()
-      expect(state.llmProvider).toBe('anthropic')
-    })
-
     it('has default theme as light', () => {
       const state = useSettingsStore.getState()
       expect(state.theme).toBe('light')
@@ -61,66 +53,6 @@ describe('settings store', () => {
       expect(notifications.notifyApprovalRequired).toBe(true)
       expect(notifications.notifyTaskCompleted).toBe(false)
       expect(notifications.soundVolume).toBe(50)
-    })
-  })
-
-  describe('setLLMProvider', () => {
-    it('selects codex cli model when switching to codex_cli', () => {
-      const { setLLMProvider } = useSettingsStore.getState()
-
-      setLLMProvider('codex_cli')
-
-      const state = useSettingsStore.getState()
-      expect(state.llmProvider).toBe('codex_cli')
-      expect(state.model).toBe('codex-cli')
-    })
-
-    it('updates provider and selects first model', () => {
-      const { setLLMProvider } = useSettingsStore.getState()
-
-      setLLMProvider('openai')
-
-      const state = useSettingsStore.getState()
-      expect(state.llmProvider).toBe('openai')
-      expect(state.model).toBe('gpt-4o-mini')
-    })
-
-    it('selects google/gemini models when switching to google', () => {
-      const { setLLMProvider } = useSettingsStore.getState()
-
-      setLLMProvider('google')
-
-      const state = useSettingsStore.getState()
-      expect(state.llmProvider).toBe('google')
-      expect(state.model).toBe('gemini-3-flash-preview')
-    })
-
-    it('selects local models when switching to local', () => {
-      const { setLLMProvider } = useSettingsStore.getState()
-
-      setLLMProvider('local')
-
-      const state = useSettingsStore.getState()
-      expect(state.llmProvider).toBe('local')
-      expect(state.model).toBe('exaone3.5:7.8b')
-    })
-  })
-
-  describe('setModel', () => {
-    it('updates model', () => {
-      const { setModel } = useSettingsStore.getState()
-
-      setModel('claude-opus-4-8')
-      expect(useSettingsStore.getState().model).toBe('claude-opus-4-8')
-    })
-  })
-
-  describe('setApiKey', () => {
-    it('updates apiKey', () => {
-      const { setApiKey } = useSettingsStore.getState()
-
-      setApiKey('sk-test-key')
-      expect(useSettingsStore.getState().apiKey).toBe('sk-test-key')
     })
   })
 
@@ -408,61 +340,6 @@ describe('settings store', () => {
     })
   })
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // setLLMProvider with availableModels populated
-  // ──────────────────────────────────────────────────────────────────────────
-  describe('setLLMProvider with availableModels populated', () => {
-    it('selects the is_default model when one exists for the provider', () => {
-      const nonDefault = makeModel({ id: 'claude-haiku', provider: 'anthropic' })
-      const defaultModel = makeModel({
-        id: 'claude-sonnet-4-6',
-        provider: 'anthropic',
-        is_default: true,
-      })
-      useSettingsStore.setState({ availableModels: [nonDefault, defaultModel] })
-
-      useSettingsStore.getState().setLLMProvider('anthropic')
-
-      expect(useSettingsStore.getState().model).toBe('claude-sonnet-4-6')
-    })
-
-    it('selects the first model when no is_default model exists for the provider', () => {
-      const first = makeModel({ id: 'claude-first', provider: 'anthropic' })
-      const second = makeModel({ id: 'claude-second', provider: 'anthropic' })
-      useSettingsStore.setState({ availableModels: [first, second] })
-
-      useSettingsStore.getState().setLLMProvider('anthropic')
-
-      expect(useSettingsStore.getState().model).toBe('claude-first')
-    })
-
-    it('falls back to static fallback model when availableModels has no match', () => {
-      // availableModels only has google models, so anthropic falls back to static list
-      useSettingsStore.setState({
-        availableModels: [makeModel({ id: 'gemini-3-flash-preview', provider: 'google' })],
-      })
-
-      useSettingsStore.getState().setLLMProvider('anthropic')
-
-      // Fallback for anthropic is 'claude-opus-4-8'
-      expect(useSettingsStore.getState().model).toBe('claude-opus-4-8')
-      expect(useSettingsStore.getState().llmProvider).toBe('anthropic')
-    })
-
-    it("maps 'local' provider to 'ollama' when selecting from availableModels", () => {
-      const ollamaDefault = makeModel({
-        id: 'exaone3.5:7.8b',
-        provider: 'ollama',
-        is_default: true,
-      })
-      useSettingsStore.setState({ availableModels: [ollamaDefault] })
-
-      useSettingsStore.getState().setLLMProvider('local')
-
-      expect(useSettingsStore.getState().llmProvider).toBe('local')
-      expect(useSettingsStore.getState().model).toBe('exaone3.5:7.8b')
-    })
-  })
 })
 
 describe('getModelsForProvider (legacy exported function)', () => {

--- a/src/dashboard/src/stores/settings.ts
+++ b/src/dashboard/src/stores/settings.ts
@@ -63,11 +63,6 @@ const applyThemeToDocument = (theme: Theme) => {
 }
 
 interface SettingsState {
-  // LLM Settings
-  llmProvider: LLMProvider
-  model: string
-  apiKey: string
-
   // Connection
   backendUrl: string
 
@@ -86,9 +81,6 @@ interface SettingsState {
   modelsError: string | null
 
   // Actions
-  setLLMProvider: (provider: LLMProvider) => void
-  setModel: (model: string) => void
-  setApiKey: (key: string) => void
   setBackendUrl: (url: string) => void
   setTheme: (theme: Theme) => void
   setNotificationSetting: <K extends keyof NotificationSettings>(
@@ -145,9 +137,6 @@ export const useSettingsStore = create<SettingsState>()(
   persist(
     (set, get) => ({
       // Default values
-      llmProvider: 'codex_cli',
-      model: 'codex-cli',
-      apiKey: '',
       backendUrl: 'http://localhost:8000',
       theme: 'light',
       notifications: defaultNotifications,
@@ -159,18 +148,6 @@ export const useSettingsStore = create<SettingsState>()(
       modelsError: null,
 
       // Actions
-      setLLMProvider: (provider) => {
-        const state = get()
-        const providerModels = state.getModelsForProvider(provider)
-        const defaultModel = providerModels.find(m => m.is_default) || providerModels[0]
-        set({
-          llmProvider: provider,
-          model: defaultModel?.id || fallbackModels[provider]?.[0] || '',
-        })
-      },
-
-      setModel: (model) => set({ model }),
-      setApiKey: (apiKey) => set({ apiKey }),
       setBackendUrl: (backendUrl) => set({ backendUrl }),
 
       setTheme: (theme) => {
@@ -223,13 +200,10 @@ export const useSettingsStore = create<SettingsState>()(
     {
       name: 'agent-orchestration-service-settings',
       partialize: (state) => ({
-        llmProvider: state.llmProvider,
-        model: state.model,
         backendUrl: state.backendUrl,
         theme: state.theme,
         notifications: state.notifications,
         preferredTerminal: state.preferredTerminal,
-        // Note: apiKey is intentionally NOT persisted for security
         // Note: availableModels are fetched fresh, not persisted
       }),
     }


### PR DESCRIPTION
## 배경

Settings 페이지의 **LLM Configuration 카드**(Provider / Model / API Key)는 세 요소 모두 실제 동작에 연결되지 않은 죽은 UI였습니다.

- **API Key**: 별도 **"LLM API Keys"** 카드(`LLMAccountsSettings`)가 백엔드 영속 저장·검증까지 담당. 반면 이 카드의 `apiKey`는 zustand `partialize`에서 의도적으로 제외돼 새로고침 시 사라지고, store 바깥 어디에서도 소비되지 않음.
- **Provider / Model**: `llmProvider`/`model`도 `SettingsPage` 외 소비처 없음. 실제 LLM 운용은 **LLM API Keys** + **Model Version Updates**(`ModelUpdatePanel`) + **LLM Auto-Switch**(`LLMRouterSettings`)가 분담.

## 변경 내용

- `SettingsPage.tsx` — LLM Configuration 카드 JSX 제거 + 죽은 import(`Cpu`/`getFallbackModels`/`LLMProvider`)·store 구조분해·`apiModels`/`models` 계산 로직 정리
- `stores/settings.ts` — `apiKey`/`llmProvider`/`model` 필드·setter·기본값·`partialize` 항목 제거
- 관련 단위 테스트(`SettingsPage.test.tsx`, `settings.test.ts`) 정리

**보존(제거 시 회귀):**
- `fetchModels`/`availableModels` — `MemberDetailPanel`이 `availableModels`를 소비하며, 이를 채우는 유일한 트리거가 `SettingsPage`의 `fetchModels()` 호출
- `getModelsForProvider`(store 메서드 + legacy)·`fallbackModels`·`LLMProvider` 타입 — 라이브 데이터 기반 공용 유틸

diff: **+2 / -325** (순수 삭제)

## 테스트 계획

- [x] `tsc --noEmit` — exit 0
- [x] `eslint` (변경 4개 파일) — exit 0
- [x] 전체 테스트 스위트 — **187 files / 4190 tests 통과**
- [x] pre-commit 훅(tsc + eslint --fix) 통과
- [ ] (선택) dev 서버에서 Settings 페이지 grid 리플로우 육안 확인

## 호환성

localStorage에 남은 옛 `llmProvider`/`model` 키는 zustand가 다음 로드 시 조용히 무시 — 마이그레이션 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)