### PR TITLE
fix(dashboard): js-yaml 5 호환 위해 namespace import로 변경

### DIFF
--- a/src/dashboard/src/components/workflows/YamlEditor.tsx
+++ b/src/dashboard/src/components/workflows/YamlEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import yaml from 'js-yaml'
+import * as yaml from 'js-yaml'
 import { AlertCircle, Eye, Code, Copy, Check } from 'lucide-react'
 
 interface YamlEditorProps {


### PR DESCRIPTION
## 배경
Dependabot PR #127(js-yaml 4.2.0 → 5.x)이 Frontend Build 실패로 머지 불가 상태입니다.

```
[MISSING_EXPORT] "default" is not exported by "node_modules/js-yaml/dist/js-yaml.mjs".
  src/components/workflows/YamlEditor.tsx:2:8
  import yaml from 'js-yaml';
```

## 원인
js-yaml 5는 ESM-first로 전환하며 **default export를 제거**했습니다. v4까지 동작하던 `import yaml from 'js-yaml'`(default import)가 v5에서 깨집니다.

## 수정
`import yaml from 'js-yaml'` → `import * as yaml from 'js-yaml'` (namespace import).
namespace import는 v4·v5 모두에서 `yaml.load`가 동작하므로 양방향 호환됩니다. 사용처(`yaml.load(content)`)는 변경 없음.

## 영향 범위
- js-yaml 사용처는 `YamlEditor.tsx` 단 1곳 (전체 grep 확인)
- 1파일 1줄 변경

## 검증
- 로컬 `tsc -b`: yaml/YamlEditor 관련 에러 0 (현재 js-yaml 4 기준 빌드 통과 = 하위 호환 확인)
- 이 PR 머지 후 #127을 rebase하면 js-yaml 5 기준 빌드가 통과할 예정

## 후속
머지 후 #127에 `@dependabot rebase` → CI 통과 시 #127 머지