### PR TITLE
fix(dashboard): Vite 8/oxc용 nested tsconfig로 로컬 vitest 트랜스폼 복구

### DIFF
--- a/src/dashboard/src/tsconfig.json
+++ b/src/dashboard/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  // Vite 8(oxc) 전용 tsconfig.
+  // oxc 트랜스포머는 각 파일에 매칭되는 tsconfig(가장 가까운 것)를 요구하는데,
+  // 루트 tsconfig.json이 테스트/셋업 파일을 exclude하면 oxc가 vitest 트랜스폼 시
+  // "[TSCONFIG_ERROR] Tsconfig not found"로 실패한다(node 24+/최신 oxc 바이너리에서 발현).
+  // 이 파일은 src/ 하위 모든 파일(테스트 포함)을 커버해 oxc가 참조한다.
+  // tsc는 이 nested config를 자동 사용하지 않으므로 앱 타입체크(루트 tsconfig)는 영향 없음.
+  "extends": "../tsconfig.json",
+  "include": ["**/*"],
+  "exclude": []
+}


### PR DESCRIPTION
## 문제
로컬에서 `npm test` 실행 시 **189개 테스트 파일 전부 트랜스폼 실패**:
```
[TSCONFIG_ERROR] Failed to load tsconfig for 'src/test/setup.ts': Tsconfig not found
  Plugin: vite:oxc
```

## 근본 원인
- Vite 8은 esbuild → **oxc** 트랜스포머로 전환. oxc는 트랜스폼하는 각 파일에 대해 include/exclude로 매칭되는 tsconfig를 요구함(공식 문서 확인).
- 루트 `tsconfig.json`이 `src/**/*.test.*`, `src/test/**`를 **exclude** → 테스트/셋업 파일에 매칭되는 tsconfig가 없어 oxc가 에러.
- CI(node 20)는 미발현, 로컬(node 24+/최신 oxc 네이티브 바이너리)에서 발현.

## 왜 exclude를 제거하지 않는가
테스트를 루트 tsconfig에 포함하면 `tsc --noEmit`(CI Frontend Type Check)가 테스트 코드의 타입 에러(`global`/`afterEach` 미declare, 실제 TS2322 불일치)를 잡아 **CI가 깨짐**. 그래서 테스트는 앱 타입체크에서 제외되어야 함.

## 해법
`src/tsconfig.json`(모든 `src/` 하위 파일 include, extends 루트) 추가. oxc는 파일에서 위로 올라가 **가장 가까운** 이 config를 사용 → 에러 해소. tsc는 nested config를 자동 사용하지 않으므로 앱 타입체크는 루트 tsconfig(테스트 제외)를 그대로 사용 → 무영향.

## 검증 (로컬 node 24)
- `tsc --noEmit`: exit 0
- `tsc -b --force`: exit 0
- `npm test`: **189 파일 / 4214 테스트 전부 통과**