### PR TITLE
fix(external-usage): PR #136 코드리뷰 findings 반영 (정합성·보안·데이터 + 게이트)

### DIFF
--- a/src/backend/services/deployment_usage_credential_service.py
+++ b/src/backend/services/deployment_usage_credential_service.py
@@ -16,6 +16,7 @@ the HTTP status code; it never hardcodes or inspects scope strings.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from datetime import UTC, datetime, timedelta
@@ -24,6 +25,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from config import get_settings
 from db.models import DeploymentUsageCredentialModel
 from models.external_usage import (
     DeploymentUsageKeyResponse,
@@ -32,6 +34,8 @@ from models.external_usage import (
     ExternalProvider,
 )
 from utils.time import utcnow
+
+logger = logging.getLogger(__name__)
 
 # Provider → environment-variable fallback name.
 ENV_MAP: dict[ExternalProvider, str] = {
@@ -67,15 +71,22 @@ async def _get_row(
     return result.scalar_one_or_none()
 
 
-async def resolve_admin_key(db: AsyncSession, provider: ExternalProvider) -> str | None:
-    """Resolve the usage admin key: active DB row > env var > None."""
+async def _get_active_row(
+    db: AsyncSession, provider: ExternalProvider
+) -> DeploymentUsageCredentialModel | None:
+    """Return the ACTIVE credential row for a provider (used for collection)."""
     result = await db.execute(
         select(DeploymentUsageCredentialModel).where(
             DeploymentUsageCredentialModel.provider == provider.value,
             DeploymentUsageCredentialModel.is_active == True,  # noqa: E712
         )
     )
-    row = result.scalar_one_or_none()
+    return result.scalar_one_or_none()
+
+
+async def resolve_admin_key(db: AsyncSession, provider: ExternalProvider) -> str | None:
+    """Resolve the usage admin key: active DB row > env var > None."""
+    row = await _get_active_row(db, provider)
     if row is not None:
         return row.api_key  # decrypted automatically by EncryptedString
 
@@ -106,9 +117,12 @@ def _build_response(
     else:
         source = "none"
 
-    if row is not None:
+    # Mask the key that is actually the effective source — not merely whichever
+    # row exists. An inactive DB row with an env fallback reports source="env",
+    # so it must show the env key's mask, not the (unused) inactive DB key.
+    if source == "db" and row is not None:
         masked = _mask_key(row.api_key)
-    elif env_value:
+    elif source == "env" and env_value:
         masked = _mask_key(env_value)
     else:
         masked = None
@@ -140,16 +154,25 @@ async def upsert_deployment_key(
 ) -> DeploymentUsageKeyResponse:
     """Insert or update the single usage key for a provider.
 
-    ``data.api_key`` is optional (design A5): on an existing row, ``label`` and
-    ``is_active`` are always updated, but the encrypted key is overwritten **only
-    when a new key is provided** — omitting it preserves the current key (e.g. the
-    UI toggling ``is_active`` while holding only the masked key). Creating a new
-    row requires a key; ``None`` is rejected with ``ValueError``.
+    Partial-update semantics (design A5): only fields present in the request
+    body are written. ``api_key`` omitted preserves the current key; ``label``
+    / ``is_active`` omitted preserve their current values (so a label-only edit
+    never wipes ``is_active`` and an is_active-only toggle never wipes the
+    label). Creating a new row requires ``api_key``. Rejected when field
+    encryption is unavailable, so a high-privilege admin key is never written to
+    the DB in plaintext.
     """
+    fields = data.model_fields_set
     row = await _get_row(db, provider)
+
+    if row is None and data.api_key is None:
+        raise ValueError("api_key is required to create a new usage credential")
+    if (row is None or data.api_key is not None) and not get_settings().encryption_master_key:
+        raise ValueError(
+            "ENCRYPTION_MASTER_KEY must be configured before storing a usage admin key"
+        )
+
     if row is None:
-        if data.api_key is None:
-            raise ValueError("api_key is required to create a new usage credential")
         row = DeploymentUsageCredentialModel(
             provider=provider.value,
             api_key=data.api_key,
@@ -158,11 +181,12 @@ async def upsert_deployment_key(
         )
         db.add(row)
     else:
-        # Preserve the existing encrypted key unless a new one is supplied.
         if data.api_key is not None:
             row.api_key = data.api_key
-        row.label = data.label
-        row.is_active = data.is_active
+        if "label" in fields:
+            row.label = data.label
+        if "is_active" in fields:
+            row.is_active = data.is_active
         row.updated_at = utcnow()
 
     await db.commit()
@@ -195,6 +219,57 @@ def _classify_status(status_code: int) -> tuple[bool, bool]:
     return False, False
 
 
+def _status_result(status_code: int) -> tuple[int, str | None]:
+    return status_code, None if status_code == 200 else f"HTTP {status_code}"
+
+
+async def _probe_openai(
+    client: httpx.AsyncClient, api_key: str, start: datetime, now: datetime
+) -> tuple[int | None, str | None]:
+    resp = await client.get(
+        "https://api.openai.com/v1/organization/usage/completions",
+        headers={"Authorization": f"Bearer {api_key}"},
+        params={
+            "start_time": int(start.timestamp()),
+            "end_time": int(now.timestamp()),
+            "bucket_width": "1d",
+            "limit": 1,
+        },
+    )
+    return _status_result(resp.status_code)
+
+
+async def _probe_anthropic(
+    client: httpx.AsyncClient, api_key: str, start: datetime, now: datetime
+) -> tuple[int | None, str | None]:
+    resp = await client.get(
+        "https://api.anthropic.com/v1/organizations/usage_report/messages",
+        headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+        params={
+            "starting_at": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "ending_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "bucket_width": "1d",
+            "limit": 1,
+        },
+    )
+    return _status_result(resp.status_code)
+
+
+async def _probe_github(client: httpx.AsyncClient, api_key: str) -> tuple[int | None, str | None]:
+    org = os.getenv("EXTERNAL_GITHUB_ORG")
+    if not org:
+        return None, "EXTERNAL_GITHUB_ORG not configured"
+    resp = await client.get(
+        f"https://api.github.com/orgs/{org}/copilot/metrics",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    return _status_result(resp.status_code)
+
+
 async def _probe_usage_endpoint(
     provider: ExternalProvider, api_key: str
 ) -> tuple[int | None, str | None]:
@@ -204,52 +279,27 @@ async def _probe_usage_endpoint(
     """
     now = datetime.now(tz=UTC)
     start = now - timedelta(days=1)
-
     async with httpx.AsyncClient(timeout=10) as client:
         if provider == ExternalProvider.OPENAI:
-            resp = await client.get(
-                "https://api.openai.com/v1/organization/usage/completions",
-                headers={"Authorization": f"Bearer {api_key}"},
-                params={
-                    "start_time": int(start.timestamp()),
-                    "end_time": int(now.timestamp()),
-                    "bucket_width": "1d",
-                    "limit": 1,
-                },
-            )
-            return resp.status_code, None if resp.status_code == 200 else f"HTTP {resp.status_code}"
-
+            return await _probe_openai(client, api_key, start, now)
         if provider == ExternalProvider.ANTHROPIC:
-            resp = await client.get(
-                "https://api.anthropic.com/v1/organizations/usage_report/messages",
-                headers={
-                    "x-api-key": api_key,
-                    "anthropic-version": "2023-06-01",
-                },
-                params={
-                    "starting_at": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "ending_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "bucket_width": "1d",
-                    "limit": 1,
-                },
-            )
-            return resp.status_code, None if resp.status_code == 200 else f"HTTP {resp.status_code}"
-
+            return await _probe_anthropic(client, api_key, start, now)
         if provider == ExternalProvider.GITHUB_COPILOT:
-            org = os.getenv("EXTERNAL_GITHUB_ORG")
-            if not org:
-                return None, "EXTERNAL_GITHUB_ORG not configured"
-            resp = await client.get(
-                f"https://api.github.com/orgs/{org}/copilot/metrics",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
-            return resp.status_code, None if resp.status_code == 200 else f"HTTP {resp.status_code}"
-
+            return await _probe_github(client, api_key)
     return None, f"Unsupported provider for usage verification: {provider.value}"
+
+
+async def _record_verification(db: AsyncSession, provider: ExternalProvider) -> None:
+    """Stamp ``last_verified_at`` on the ACTIVE DB row only.
+
+    An env-sourced key has no active row, so nothing is stamped — this prevents
+    an inactive row from appearing "recently verified" when the env key was the
+    one actually probed.
+    """
+    row = await _get_active_row(db, provider)
+    if row is not None:
+        row.last_verified_at = utcnow()
+        await db.commit()
 
 
 async def verify_deployment_key(
@@ -269,35 +319,30 @@ async def verify_deployment_key(
     try:
         status_code, error_message = await _probe_usage_endpoint(provider, api_key)
     except Exception as exc:  # network/timeout/etc.
-        latency = (time.monotonic() - t0) * 1000
+        # Log detail server-side; never echo the exception (may embed the key).
+        logger.warning("Usage endpoint probe failed for %s: %s", provider.value, exc)
         return DeploymentUsageKeyVerifyResponse(
             provider=provider,
             is_valid=False,
             usage_capable=False,
-            error_message=str(exc),
-            latency_ms=round(latency, 1),
+            error_message="Usage endpoint request failed",
+            latency_ms=round((time.monotonic() - t0) * 1000, 1),
         )
 
-    latency = (time.monotonic() - t0) * 1000
-
+    latency = round((time.monotonic() - t0) * 1000, 1)
     if status_code is None:
-        # Misconfiguration (e.g. missing GitHub org) — cannot determine capability.
         return DeploymentUsageKeyVerifyResponse(
             provider=provider,
             is_valid=False,
             usage_capable=False,
             status_code=None,
             error_message=error_message,
-            latency_ms=round(latency, 1),
+            latency_ms=latency,
         )
 
     is_valid, usage_capable = _classify_status(status_code)
-
     if is_valid:
-        row = await _get_row(db, provider)
-        if row is not None:
-            row.last_verified_at = utcnow()
-            await db.commit()
+        await _record_verification(db, provider)
 
     return DeploymentUsageKeyVerifyResponse(
         provider=provider,
@@ -305,5 +350,5 @@ async def verify_deployment_key(
         usage_capable=usage_capable,
         status_code=status_code,
         error_message=error_message,
-        latency_ms=round(latency, 1),
+        latency_ms=latency,
     )

--- a/src/backend/services/external_usage_service.py
+++ b/src/backend/services/external_usage_service.py
@@ -473,10 +473,13 @@ class ExternalUsageService:
 
         gh_token = await resolve_admin_key(db, ExternalProvider.GITHUB_COPILOT)
         gh_org = os.getenv("EXTERNAL_GITHUB_ORG")
+        # Collection needs BOTH token and org (see _build_collectors), so the
+        # badge must reflect both — a token alone would show "configured" while
+        # collection silently skips.
         configs.append(
             ProviderConfig(
                 provider=ExternalProvider.GITHUB_COPILOT,
-                enabled=bool(gh_token),
+                enabled=bool(gh_token and gh_org),
                 api_key_masked=self._mask_key(gh_token) if gh_token else None,
                 org_id=gh_org,
             )

--- a/src/dashboard/src/components/usage/AdminKeyManager.tsx
+++ b/src/dashboard/src/components/usage/AdminKeyManager.tsx
@@ -71,10 +71,7 @@ const LABEL_MAX = 255
 // ─────────────────────────────────────────────────────────────
 
 /** Look up a provider's key row, defaulting to a "none" state when absent. */
-function resolveKey(
-  keys: DeploymentUsageKey[],
-  provider: ExternalProvider
-): DeploymentUsageKey {
+function resolveKey(keys: DeploymentUsageKey[], provider: ExternalProvider): DeploymentUsageKey {
   const found = keys.find((k) => k.provider === provider)
   if (found) return found
   return {
@@ -90,99 +87,120 @@ function resolveKey(
   }
 }
 
-interface ProviderBadgeProps {
-  provider: ExternalProvider
-}
+const ProviderBadge = memo(({ provider }: { provider: ExternalProvider }) => (
+  <span
+    className={cn(
+      'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
+      PROVIDER_BADGE[provider]
+    )}
+  >
+    {PROVIDER_LABELS[provider]}
+  </span>
+))
+ProviderBadge.displayName = 'ProviderBadge'
 
-function ProviderBadge({ provider }: ProviderBadgeProps) {
-  return (
-    <span
+const SourceBadge = memo(({ source }: { source: DeploymentUsageKeySource }) => (
+  <span
+    className={cn(
+      'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
+      SOURCE_BADGE[source]
+    )}
+    aria-label={`Key source: ${SOURCE_LABEL[source]}`}
+  >
+    {SOURCE_LABEL[source]}
+  </span>
+))
+SourceBadge.displayName = 'SourceBadge'
+
+/** Clickable active/inactive toggle for an existing DB key (design A5: toggle
+ * collection on/off without re-entering the key). */
+const ActiveToggle = memo(
+  ({
+    provider,
+    isActive,
+    disabled,
+    onToggle,
+  }: {
+    provider: ExternalProvider
+    isActive: boolean
+    disabled: boolean
+    onToggle: () => void
+  }) => (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      aria-label={`${PROVIDER_LABELS[provider]} 키 ${isActive ? '비활성화' : '활성화'}`}
+      aria-pressed={isActive}
       className={cn(
-        'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
-        PROVIDER_BADGE[provider]
+        'inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+        isActive
+          ? 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-300'
+          : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700/50 dark:text-gray-400'
       )}
     >
-      {PROVIDER_LABELS[provider]}
-    </span>
+      {isActive ? '활성' : '비활성'}
+    </button>
   )
-}
+)
+ActiveToggle.displayName = 'ActiveToggle'
 
-interface SourceBadgeProps {
-  source: DeploymentUsageKeySource
-}
-
-function SourceBadge({ source }: SourceBadgeProps) {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
-        SOURCE_BADGE[source]
-      )}
-      aria-label={`Key source: ${SOURCE_LABEL[source]}`}
-    >
-      {SOURCE_LABEL[source]}
-    </span>
-  )
-}
-
-interface VerifyResultViewProps {
-  result: DeploymentUsageKeyVerifyResult | null
-  isVerifying: boolean
-}
-
-function VerifyResultView({ result, isVerifying }: VerifyResultViewProps) {
-  if (isVerifying) {
-    return (
-      <span className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400">
-        <Loader2 className="w-3.5 h-3.5 animate-spin" />
-        검증 중...
-      </span>
-    )
-  }
-  if (result === null) return null
-
+/** Map a verify result to an icon + message + tone (keeps the view render tiny). */
+function describeVerify(
+  result: DeploymentUsageKeyVerifyResult
+): { icon: typeof ShieldCheck; text: string; tone: string; suffix: string | null } {
   if (result.is_valid && result.usage_capable) {
-    return (
-      <span
-        role="status"
-        className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400"
-      >
-        <ShieldCheck className="w-3.5 h-3.5" />
-        사용 가능
-        {result.latency_ms !== null && (
-          <span className="text-gray-400 dark:text-gray-500">
-            ({Math.round(result.latency_ms)}ms)
-          </span>
-        )}
-      </span>
-    )
+    return {
+      icon: ShieldCheck,
+      text: '사용 가능',
+      tone: 'text-emerald-600 dark:text-emerald-400',
+      suffix: result.latency_ms !== null ? `(${Math.round(result.latency_ms)}ms)` : null,
+    }
   }
-
   if (result.is_valid && !result.usage_capable) {
+    return {
+      icon: AlertCircle,
+      text: '키는 유효하나 usage 권한 없음',
+      tone: 'text-yellow-700 dark:text-yellow-400',
+      suffix: null,
+    }
+  }
+  return {
+    icon: XCircle,
+    text: result.error_message ?? '검증 실패',
+    tone: 'text-red-600 dark:text-red-400',
+    suffix: result.status_code !== null ? `(${result.status_code})` : null,
+  }
+}
+
+const VerifyResultView = memo(
+  ({
+    result,
+    isVerifying,
+  }: {
+    result: DeploymentUsageKeyVerifyResult | null
+    isVerifying: boolean
+  }) => {
+    if (isVerifying) {
+      return (
+        <span className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          검증 중...
+        </span>
+      )
+    }
+    if (result === null) return null
+    const { icon: Icon, text, tone, suffix } = describeVerify(result)
     return (
-      <span
-        role="status"
-        className="flex items-center gap-1 text-xs text-yellow-700 dark:text-yellow-400"
-      >
-        <AlertCircle className="w-3.5 h-3.5" />
-        키는 유효하나 usage 권한 없음
+      <span role="status" className={cn('flex items-center gap-1 text-xs', tone)}>
+        <Icon className="w-3.5 h-3.5" />
+        {text}
+        {suffix && <span className="text-gray-400 dark:text-gray-500">{suffix}</span>}
       </span>
     )
   }
-
-  return (
-    <span
-      role="status"
-      className="flex items-center gap-1 text-xs text-red-600 dark:text-red-400"
-    >
-      <XCircle className="w-3.5 h-3.5" />
-      {result.error_message ?? '검증 실패'}
-      {result.status_code !== null && (
-        <span className="text-gray-400 dark:text-gray-500">({result.status_code})</span>
-      )}
-    </span>
-  )
-}
+)
+VerifyResultView.displayName = 'VerifyResultView'
 
 // ─────────────────────────────────────────────────────────────
 // Add / edit form
@@ -194,168 +212,303 @@ interface ProviderKeyFormProps {
   onClose: () => void
 }
 
-function ProviderKeyForm({ provider, current, onClose }: ProviderKeyFormProps) {
+const KeyField = memo(
+  ({
+    provider,
+    current,
+    apiKey,
+    setApiKey,
+  }: {
+    provider: ExternalProvider
+    current: DeploymentUsageKey
+    apiKey: string
+    setApiKey: (v: string) => void
+  }) => {
+    const [showKey, setShowKey] = useState(false)
+    const fieldId = `admin-key-${provider}-key`
+    return (
+      <div>
+        <label htmlFor={fieldId} className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+          API Key
+          {current.has_db_key && (
+            <span className="text-gray-400 dark:text-gray-500"> (비워두면 현재 키 유지)</span>
+          )}
+        </label>
+        <div className="relative">
+          <input
+            id={fieldId}
+            type={showKey ? 'text' : 'password'}
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={current.api_key_masked ?? 'sk-...'}
+            autoComplete="off"
+            aria-label={`${PROVIDER_LABELS[provider]} API key`}
+            className="w-full px-2.5 py-1.5 pr-8 text-sm font-mono border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={() => setShowKey((v) => !v)}
+            aria-label={showKey ? 'API 키 숨기기' : 'API 키 표시'}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            {showKey ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+          </button>
+        </div>
+      </div>
+    )
+  }
+)
+KeyField.displayName = 'KeyField'
+
+const LabelField = memo(
+  ({
+    provider,
+    label,
+    setLabel,
+  }: {
+    provider: ExternalProvider
+    label: string
+    setLabel: (v: string) => void
+  }) => {
+    const fieldId = `admin-key-${provider}-label`
+    return (
+      <div>
+        <label htmlFor={fieldId} className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+          Label <span className="text-gray-400">(선택)</span>
+        </label>
+        <input
+          id={fieldId}
+          type="text"
+          value={label}
+          maxLength={LABEL_MAX}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="e.g. org-admin-key"
+          aria-label={`${PROVIDER_LABELS[provider]} key label`}
+          className="w-full px-2.5 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+    )
+  }
+)
+LabelField.displayName = 'LabelField'
+
+const FormActions = memo(({ isSaving, onClose }: { isSaving: boolean; onClose: () => void }) => (
+  <div className="flex items-center justify-end gap-2 mt-3">
+    <button
+      type="button"
+      onClick={onClose}
+      disabled={isSaving}
+      aria-label="취소"
+      className="flex items-center gap-1 px-2.5 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+    >
+      <X className="w-3 h-3" />
+      취소
+    </button>
+    <button
+      type="submit"
+      disabled={isSaving}
+      aria-label="키 저장"
+      className="flex items-center gap-1 px-2.5 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+    >
+      {isSaving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
+      저장
+    </button>
+  </div>
+))
+FormActions.displayName = 'FormActions'
+
+/** Validate the api_key box: '' is allowed only when a key already exists (A5). */
+function validateKeyInput(hasDbKey: boolean, trimmedKey: string): string | null {
+  if (!hasDbKey && trimmedKey === '') return '새 키에는 API 키가 필요합니다'
+  if (trimmedKey !== '' && (trimmedKey.length < API_KEY_MIN || trimmedKey.length > API_KEY_MAX)) {
+    return `API 키는 ${API_KEY_MIN}~${API_KEY_MAX}자여야 합니다`
+  }
+  return null
+}
+
+function useProviderKeyForm(provider: ExternalProvider, current: DeploymentUsageKey, onClose: () => void) {
   const upsertKey = useDeploymentUsageKeyStore((s) => s.upsertKey)
   const [apiKey, setApiKey] = useState('')
   const [label, setLabel] = useState(current.label ?? '')
   const [isActive, setIsActive] = useState(current.has_db_key ? current.is_active : true)
-  const [showKey, setShowKey] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
-
-  const fieldId = `admin-key-${provider}`
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const trimmedKey = apiKey.trim()
-    if (trimmedKey.length < API_KEY_MIN || trimmedKey.length > API_KEY_MAX) {
-      setLocalError(`API 키는 ${API_KEY_MIN}~${API_KEY_MAX}자여야 합니다`)
-      return
-    }
+    const invalid = validateKeyInput(current.has_db_key, trimmedKey)
+    if (invalid) return setLocalError(invalid)
     setLocalError(null)
     setIsSaving(true)
     const result = await upsertKey(provider, {
-      api_key: trimmedKey,
+      api_key: trimmedKey || undefined,
       label: label.trim() || null,
       is_active: isActive,
     })
     setIsSaving(false)
-    if (result) {
-      onClose()
-    } else {
-      setLocalError(useDeploymentUsageKeyStore.getState().error ?? '저장에 실패했습니다')
-    }
+    if (result) onClose()
+    else setLocalError(useDeploymentUsageKeyStore.getState().error ?? '저장에 실패했습니다')
   }
 
+  return { apiKey, setApiKey, label, setLabel, isActive, setIsActive, isSaving, localError, handleSubmit }
+}
+
+const ProviderKeyForm = memo(({ provider, current, onClose }: ProviderKeyFormProps) => {
+  const f = useProviderKeyForm(provider, current, onClose)
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={f.handleSubmit}
       className="mt-3 p-3 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-lg"
       aria-label={`${PROVIDER_LABELS[provider]} 키 설정 폼`}
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div>
-          <label
-            htmlFor={`${fieldId}-key`}
-            className="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-          >
-            API Key
-            {current.has_db_key && (
-              <span className="text-gray-400 dark:text-gray-500"> (저장 시 새 키로 교체)</span>
-            )}
-          </label>
-          <div className="relative">
-            <input
-              id={`${fieldId}-key`}
-              type={showKey ? 'text' : 'password'}
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder={current.api_key_masked ?? 'sk-...'}
-              autoComplete="off"
-              aria-label={`${PROVIDER_LABELS[provider]} API key`}
-              className="w-full px-2.5 py-1.5 pr-8 text-sm font-mono border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            <button
-              type="button"
-              onClick={() => setShowKey((v) => !v)}
-              aria-label={showKey ? 'API 키 숨기기' : 'API 키 표시'}
-              tabIndex={-1}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-            >
-              {showKey ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
-            </button>
-          </div>
-        </div>
-
-        <div>
-          <label
-            htmlFor={`${fieldId}-label`}
-            className="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-          >
-            Label <span className="text-gray-400">(선택)</span>
-          </label>
-          <input
-            id={`${fieldId}-label`}
-            type="text"
-            value={label}
-            maxLength={LABEL_MAX}
-            onChange={(e) => setLabel(e.target.value)}
-            placeholder="e.g. org-admin-key"
-            aria-label={`${PROVIDER_LABELS[provider]} key label`}
-            className="w-full px-2.5 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
+        <KeyField provider={provider} current={current} apiKey={f.apiKey} setApiKey={f.setApiKey} />
+        <LabelField provider={provider} label={f.label} setLabel={f.setLabel} />
       </div>
-
       <label className="flex items-center gap-2 mt-3 text-xs text-gray-600 dark:text-gray-300 cursor-pointer">
         <input
           type="checkbox"
-          checked={isActive}
-          onChange={(e) => setIsActive(e.target.checked)}
+          checked={f.isActive}
+          onChange={(e) => f.setIsActive(e.target.checked)}
           aria-label="수집에 이 키 사용 (비활성화 시 환경변수 폴백)"
           className="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
         />
         수집에 이 키 사용 (해제 시 환경변수로 폴백)
       </label>
-
-      {localError && (
+      {f.localError && (
         <div
           role="alert"
           className="flex items-center gap-1.5 mt-2 text-xs text-red-600 dark:text-red-400"
         >
           <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
-          {localError}
+          {f.localError}
         </div>
       )}
-
-      <div className="flex items-center justify-end gap-2 mt-3">
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={isSaving}
-          aria-label="취소"
-          className="flex items-center gap-1 px-2.5 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
-        >
-          <X className="w-3 h-3" />
-          취소
-        </button>
-        <button
-          type="submit"
-          disabled={isSaving}
-          aria-label="키 저장"
-          className="flex items-center gap-1 px-2.5 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {isSaving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
-          저장
-        </button>
-      </div>
+      <FormActions isSaving={f.isSaving} onClose={onClose} />
     </form>
   )
-}
+})
+ProviderKeyForm.displayName = 'ProviderKeyForm'
 
 // ─────────────────────────────────────────────────────────────
 // Provider row
 // ─────────────────────────────────────────────────────────────
 
-interface ProviderKeyRowProps {
-  providerKey: DeploymentUsageKey
+const RowInfo = memo(
+  ({ providerKey, onToggle, toggling }: {
+    providerKey: DeploymentUsageKey
+    onToggle: () => void
+    toggling: boolean
+  }) => {
+    const { provider, has_db_key, is_active, source, api_key_masked } = providerKey
+    return (
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <KeyRound className="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" />
+          <ProviderBadge provider={provider} />
+          <SourceBadge source={source} />
+          {has_db_key && (
+            <ActiveToggle
+              provider={provider}
+              isActive={is_active}
+              disabled={toggling}
+              onToggle={onToggle}
+            />
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-3 mt-1 pl-6">
+          <span className="text-xs font-mono text-gray-500 dark:text-gray-400">
+            {api_key_masked ?? '미설정'}
+          </span>
+          {source === 'env' && (
+            <span className="text-xs text-yellow-700 dark:text-yellow-400">
+              환경변수 사용 중 ({PROVIDER_ENV_VAR[provider]})
+            </span>
+          )}
+        </div>
+      </div>
+    )
+  }
+)
+RowInfo.displayName = 'RowInfo'
+
+const RowActions = memo(
+  ({ providerKey, result, isVerifying, isRemoving, onEdit, onVerify, onRemove }: {
+    providerKey: DeploymentUsageKey
+    result: DeploymentUsageKeyVerifyResult | null
+    isVerifying: boolean
+    isRemoving: boolean
+    onEdit: () => void
+    onVerify: () => void
+    onRemove: () => void
+  }) => {
+    const { provider, has_db_key, source } = providerKey
+    return (
+      <div className="flex flex-wrap items-center gap-2 pl-6 sm:pl-0">
+        <VerifyResultView result={result} isVerifying={isVerifying} />
+        <button
+          type="button"
+          onClick={onEdit}
+          aria-label={`${PROVIDER_LABELS[provider]} 키 ${has_db_key ? '수정' : '설정'}`}
+          className="flex items-center gap-1 px-2.5 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        >
+          {has_db_key ? <Pencil className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
+          {has_db_key ? '수정' : '설정'}
+        </button>
+        <button
+          type="button"
+          onClick={onVerify}
+          disabled={isVerifying || source === 'none'}
+          aria-label={`${PROVIDER_LABELS[provider]} 키 검증`}
+          className="px-2.5 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isVerifying ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : 'Verify'}
+        </button>
+        {has_db_key && (
+          <button
+            type="button"
+            onClick={onRemove}
+            disabled={isRemoving}
+            aria-label={`${PROVIDER_LABELS[provider]} 키 삭제`}
+            className="p-1.5 text-gray-400 hover:text-red-500 dark:hover:text-red-400 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isRemoving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+          </button>
+        )}
+      </div>
+    )
+  }
+)
+RowActions.displayName = 'RowActions'
+
+function failedVerify(provider: ExternalProvider): DeploymentUsageKeyVerifyResult {
+  return {
+    provider,
+    is_valid: false,
+    usage_capable: false,
+    status_code: null,
+    error_message: '검증 요청 실패',
+    latency_ms: null,
+  }
 }
 
-function ProviderKeyRow({ providerKey }: ProviderKeyRowProps) {
+function useProviderKeyRow(providerKey: DeploymentUsageKey) {
   const verifyKey = useDeploymentUsageKeyStore((s) => s.verifyKey)
   const removeKey = useDeploymentUsageKeyStore((s) => s.removeKey)
+  const upsertKey = useDeploymentUsageKeyStore((s) => s.upsertKey)
   const [isEditing, setIsEditing] = useState(false)
   const [verifyResult, setVerifyResult] = useState<DeploymentUsageKeyVerifyResult | null>(null)
   const [isVerifying, setIsVerifying] = useState(false)
   const [isRemoving, setIsRemoving] = useState(false)
-
-  const { provider, has_db_key, is_active, source, api_key_masked } = providerKey
+  const [isToggling, setIsToggling] = useState(false)
+  const { provider } = providerKey
 
   const handleVerify = async () => {
     setVerifyResult(null)
     setIsVerifying(true)
     const result = await verifyKey(provider)
-    setVerifyResult(result ?? { provider, is_valid: false, usage_capable: false, status_code: null, error_message: '검증 요청 실패', latency_ms: null })
+    setVerifyResult(result ?? failedVerify(provider))
     setIsVerifying(false)
   }
 
@@ -366,87 +519,52 @@ function ProviderKeyRow({ providerKey }: ProviderKeyRowProps) {
     setVerifyResult(null)
   }
 
+  const handleToggle = async () => {
+    setIsToggling(true)
+    await upsertKey(provider, { is_active: !providerKey.is_active })
+    setIsToggling(false)
+  }
+
+  return {
+    isEditing,
+    setIsEditing,
+    verifyResult,
+    isVerifying,
+    isRemoving,
+    isToggling,
+    handleVerify,
+    handleRemove,
+    handleToggle,
+  }
+}
+
+const ProviderKeyRow = memo(({ providerKey }: { providerKey: DeploymentUsageKey }) => {
+  const r = useProviderKeyRow(providerKey)
   return (
     <li className="px-4 py-3 border-b border-gray-100 dark:border-gray-700/50 last:border-0">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex-1 min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <KeyRound className="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" />
-            <ProviderBadge provider={provider} />
-            <SourceBadge source={source} />
-            {has_db_key && (
-              <span
-                className={cn(
-                  'inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium',
-                  is_active
-                    ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300'
-                    : 'bg-gray-100 text-gray-500 dark:bg-gray-700/50 dark:text-gray-400'
-                )}
-              >
-                {is_active ? '활성' : '비활성'}
-              </span>
-            )}
-          </div>
-          <div className="flex flex-wrap items-center gap-3 mt-1 pl-6">
-            <span className="text-xs font-mono text-gray-500 dark:text-gray-400">
-              {api_key_masked ?? '미설정'}
-            </span>
-            {source === 'env' && (
-              <span className="text-xs text-yellow-700 dark:text-yellow-400">
-                환경변수 사용 중 ({PROVIDER_ENV_VAR[provider]})
-              </span>
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2 pl-6 sm:pl-0">
-          <VerifyResultView result={verifyResult} isVerifying={isVerifying} />
-          <button
-            type="button"
-            onClick={() => setIsEditing((v) => !v)}
-            aria-label={`${PROVIDER_LABELS[provider]} 키 ${has_db_key ? '수정' : '설정'}`}
-            className="flex items-center gap-1 px-2.5 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-          >
-            {has_db_key ? <Pencil className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
-            {has_db_key ? '수정' : '설정'}
-          </button>
-          <button
-            type="button"
-            onClick={handleVerify}
-            disabled={isVerifying || source === 'none'}
-            aria-label={`${PROVIDER_LABELS[provider]} 키 검증`}
-            className="px-2.5 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            {isVerifying ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : 'Verify'}
-          </button>
-          {has_db_key && (
-            <button
-              type="button"
-              onClick={handleRemove}
-              disabled={isRemoving}
-              aria-label={`${PROVIDER_LABELS[provider]} 키 삭제`}
-              className="p-1.5 text-gray-400 hover:text-red-500 dark:hover:text-red-400 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {isRemoving ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <Trash2 className="w-4 h-4" />
-              )}
-            </button>
-          )}
-        </div>
+        <RowInfo providerKey={providerKey} onToggle={r.handleToggle} toggling={r.isToggling} />
+        <RowActions
+          providerKey={providerKey}
+          result={r.verifyResult}
+          isVerifying={r.isVerifying}
+          isRemoving={r.isRemoving}
+          onEdit={() => r.setIsEditing((v) => !v)}
+          onVerify={r.handleVerify}
+          onRemove={r.handleRemove}
+        />
       </div>
-
-      {isEditing && (
+      {r.isEditing && (
         <ProviderKeyForm
-          provider={provider}
+          provider={providerKey.provider}
           current={providerKey}
-          onClose={() => setIsEditing(false)}
+          onClose={() => r.setIsEditing(false)}
         />
       )}
     </li>
   )
-}
+})
+ProviderKeyRow.displayName = 'ProviderKeyRow'
 
 // ─────────────────────────────────────────────────────────────
 // Main component
@@ -456,6 +574,60 @@ export interface AdminKeyManagerProps {
   /** Additional CSS classes for the outer container. */
   className?: string
 }
+
+const KeyList = memo(
+  ({ keys, isLoading }: { keys: DeploymentUsageKey[]; isLoading: boolean }) => {
+    if (isLoading && keys.length === 0) {
+      return (
+        <div className="flex items-center justify-center gap-2 py-10 text-sm text-gray-400 dark:text-gray-500">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          키 정보를 불러오는 중...
+        </div>
+      )
+    }
+    return (
+      <ul className="mt-2">
+        {PROVIDERS.map((provider) => (
+          <ProviderKeyRow key={provider} providerKey={resolveKey(keys, provider)} />
+        ))}
+      </ul>
+    )
+  }
+)
+KeyList.displayName = 'KeyList'
+
+const ManagedKeysContent = memo(
+  ({
+    keys,
+    isLoading,
+    error,
+  }: {
+    keys: DeploymentUsageKey[]
+    isLoading: boolean
+    error: string | null
+  }) => (
+    <>
+      <p className="px-4 pt-3 text-xs text-gray-500 dark:text-gray-400">
+        provider별 usage 수집 키를 설정합니다. DB 키가 없으면 환경변수로 폴백합니다.
+      </p>
+      {error && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 mx-4 mt-3 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md text-xs text-red-700 dark:text-red-300"
+        >
+          <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+      <KeyList keys={keys} isLoading={isLoading} />
+      <div className="flex items-center gap-1.5 px-4 py-2.5 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700/50">
+        <CheckCircle className="w-3.5 h-3.5 flex-shrink-0" />
+        Verify는 실제 usage 엔드포인트 접근 권한(usage_capable)을 확인합니다.
+      </div>
+    </>
+  )
+)
+ManagedKeysContent.displayName = 'ManagedKeysContent'
 
 /**
  * Admin/manager-only manager for deployment-level usage admin keys.
@@ -476,9 +648,7 @@ export const AdminKeyManager = memo<AdminKeyManagerProps>(({ className }) => {
   const canManage = role === 'admin' || role === 'manager' || (user?.is_admin ?? false)
 
   useEffect(() => {
-    if (canManage) {
-      fetchKeys()
-    }
+    if (canManage) fetchKeys()
   }, [canManage, fetchKeys])
 
   return (
@@ -491,9 +661,7 @@ export const AdminKeyManager = memo<AdminKeyManagerProps>(({ className }) => {
     >
       <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <KeyRound className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-        <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
-          Usage Admin Keys
-        </h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Usage Admin Keys</h2>
       </div>
 
       {!canManage ? (
@@ -502,39 +670,7 @@ export const AdminKeyManager = memo<AdminKeyManagerProps>(({ className }) => {
           관리자 또는 매니저만 usage admin 키를 설정할 수 있습니다.
         </div>
       ) : (
-        <>
-          <p className="px-4 pt-3 text-xs text-gray-500 dark:text-gray-400">
-            provider별 usage 수집 키를 설정합니다. DB 키가 없으면 환경변수로 폴백합니다.
-          </p>
-
-          {error && (
-            <div
-              role="alert"
-              className="flex items-center gap-2 mx-4 mt-3 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md text-xs text-red-700 dark:text-red-300"
-            >
-              <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
-              {error}
-            </div>
-          )}
-
-          {isLoading && keys.length === 0 ? (
-            <div className="flex items-center justify-center gap-2 py-10 text-sm text-gray-400 dark:text-gray-500">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              키 정보를 불러오는 중...
-            </div>
-          ) : (
-            <ul className="mt-2">
-              {PROVIDERS.map((provider) => (
-                <ProviderKeyRow key={provider} providerKey={resolveKey(keys, provider)} />
-              ))}
-            </ul>
-          )}
-
-          <div className="flex items-center gap-1.5 px-4 py-2.5 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700/50">
-            <CheckCircle className="w-3.5 h-3.5 flex-shrink-0" />
-            Verify는 실제 usage 엔드포인트 접근 권한(usage_capable)을 확인합니다.
-          </div>
-        </>
+        <ManagedKeysContent keys={keys} isLoading={isLoading} error={error} />
       )}
     </section>
   )

--- a/src/dashboard/src/components/usage/__tests__/AdminKeyManager.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/AdminKeyManager.test.tsx
@@ -251,6 +251,36 @@ describe('AdminKeyManager', () => {
     })
   })
 
+  describe('A5 partial update (no key re-entry needed)', () => {
+    it('toggles is_active inline without re-entering the key', async () => {
+      mockKeyState = baseKeyState({ keys: [openaiDbKey] })
+      mockUpsertKey.mockResolvedValueOnce({ ...openaiDbKey, is_active: false })
+
+      render(<AdminKeyManager />)
+      fireEvent.click(screen.getByLabelText('OpenAI 키 비활성화'))
+
+      await waitFor(() =>
+        expect(mockUpsertKey).toHaveBeenCalledWith('openai', { is_active: false })
+      )
+    })
+
+    it('saves an existing-key edit with a blank api_key field (keeps current key)', async () => {
+      mockKeyState = baseKeyState({ keys: [openaiDbKey] })
+      mockUpsertKey.mockResolvedValueOnce(openaiDbKey)
+
+      render(<AdminKeyManager />)
+      fireEvent.click(screen.getByLabelText('OpenAI 키 수정'))
+      // Leave the API key box empty and just submit — must NOT be blocked.
+      fireEvent.click(screen.getByLabelText('키 저장'))
+
+      await waitFor(() => expect(mockUpsertKey).toHaveBeenCalled())
+      const [prov, payload] = mockUpsertKey.mock.calls[0]
+      expect(prov).toBe('openai')
+      expect(payload.api_key).toBeUndefined()
+      expect(payload).toMatchObject({ label: 'org-admin', is_active: true })
+    })
+  })
+
   describe('delete', () => {
     it('calls removeKey for the provider', async () => {
       mockKeyState = baseKeyState({ keys: [openaiDbKey] })

--- a/src/dashboard/src/stores/__tests__/deploymentUsageKeys.test.ts
+++ b/src/dashboard/src/stores/__tests__/deploymentUsageKeys.test.ts
@@ -139,6 +139,31 @@ describe('deploymentUsageKeys store', () => {
       expect(keys.find((k) => k.provider === 'anthropic')).toEqual(anthropicEnv)
     })
 
+    it('omits api_key and label from the PUT body when not provided (design A5)', async () => {
+      useDeploymentUsageKeyStore.setState({ keys: [openaiKey] })
+      mockPut.mockResolvedValueOnce({ ...openaiKey, is_active: false })
+
+      await useDeploymentUsageKeyStore.getState().upsertKey('openai', { is_active: false })
+
+      const [, body] = mockPut.mock.calls[0]
+      // api_key + label absent → backend preserves the current key and label.
+      expect(body).toEqual({ is_active: false })
+      expect('api_key' in (body as object)).toBe(false)
+    })
+
+    it('omits an empty-string api_key so the current key is preserved', async () => {
+      useDeploymentUsageKeyStore.setState({ keys: [openaiKey] })
+      mockPut.mockResolvedValueOnce(openaiKey)
+
+      await useDeploymentUsageKeyStore
+        .getState()
+        .upsertKey('openai', { api_key: '', label: 'renamed', is_active: true })
+
+      const [, body] = mockPut.mock.calls[0]
+      expect(body).toEqual({ label: 'renamed', is_active: true })
+      expect('api_key' in (body as object)).toBe(false)
+    })
+
     it('appends when no row exists for the provider', async () => {
       const created: DeploymentUsageKey = { ...openaiKey, provider: 'github_copilot' }
       mockPut.mockResolvedValueOnce(created)

--- a/src/dashboard/src/stores/deploymentUsageKeys.ts
+++ b/src/dashboard/src/stores/deploymentUsageKeys.ts
@@ -84,14 +84,16 @@ export const useDeploymentUsageKeyStore = create<DeploymentUsageKeyStore>((set) 
 
   upsertKey: async (provider, data) => {
     try {
-      // Build a clean payload: omit api_key when empty/undefined (keep current
-      // key on the backend); only include label/is_active when provided.
-      const payload: DeploymentUsageKeyUpsert = {}
-      if (data.api_key !== undefined && data.api_key.trim() !== '') {
-        payload.api_key = data.api_key.trim()
+      // Build a clean payload immutably: omit api_key when empty/undefined
+      // (keep current key on the backend); only include label/is_active when
+      // provided so the backend's partial-update preserves omitted fields.
+      const payload: DeploymentUsageKeyUpsert = {
+        ...(data.api_key !== undefined && data.api_key.trim() !== ''
+          ? { api_key: data.api_key.trim() }
+          : {}),
+        ...(data.label !== undefined ? { label: data.label } : {}),
+        ...(data.is_active !== undefined ? { is_active: data.is_active } : {}),
       }
-      if (data.label !== undefined) payload.label = data.label
-      if (data.is_active !== undefined) payload.is_active = data.is_active
 
       const updated = await apiClient.put<DeploymentUsageKey>(`${BASE_URL}/${provider}`, payload)
       set((s) => {

--- a/tests/backend/test_deployment_usage_credential_service.py
+++ b/tests/backend/test_deployment_usage_credential_service.py
@@ -43,7 +43,7 @@ async def _verify_with_status(status: int) -> tuple[object, AsyncMock]:
     mock_client = _mock_client(status)
     with (
         patch.object(ducs, "resolve_admin_key", AsyncMock(return_value="sk-chat-key")),
-        patch.object(ducs, "_get_row", AsyncMock(return_value=None)),
+        patch.object(ducs, "_get_active_row", AsyncMock(return_value=None)),
         patch(
             "services.deployment_usage_credential_service.httpx.AsyncClient",
             return_value=mock_client,
@@ -97,6 +97,38 @@ async def test_no_key_configured_short_circuits() -> None:
     assert result.error_message == "No usage key configured"
 
 
+async def test_verify_stamps_only_active_db_row_not_env() -> None:
+    """#6: a valid probe stamps the ACTIVE DB row; an env-sourced key (no active
+    row) stamps nothing, so an inactive row can't look 'recently verified'."""
+    # Active DB row present → stamped.
+    row = MagicMock()
+    db_with_row = AsyncMock()
+    with (
+        patch.object(ducs, "resolve_admin_key", AsyncMock(return_value="sk-admin")),
+        patch.object(ducs, "_get_active_row", AsyncMock(return_value=row)),
+        patch(
+            "services.deployment_usage_credential_service.httpx.AsyncClient",
+            return_value=_mock_client(200),
+        ),
+    ):
+        await ducs.verify_deployment_key(db_with_row, ExternalProvider.OPENAI)
+    assert row.last_verified_at is not None
+    db_with_row.commit.assert_awaited()
+
+    # Env-sourced (no active row) → nothing stamped, no commit.
+    db_env = AsyncMock()
+    with (
+        patch.object(ducs, "resolve_admin_key", AsyncMock(return_value="sk-env")),
+        patch.object(ducs, "_get_active_row", AsyncMock(return_value=None)),
+        patch(
+            "services.deployment_usage_credential_service.httpx.AsyncClient",
+            return_value=_mock_client(200),
+        ),
+    ):
+        await ducs.verify_deployment_key(db_env, ExternalProvider.OPENAI)
+    db_env.commit.assert_not_awaited()
+
+
 # ── upsert: partial update preserves the encrypted key (design A5) ──
 
 
@@ -133,5 +165,42 @@ async def test_upsert_new_provider_without_key_is_rejected() -> None:
     with patch.object(ducs, "_get_row", AsyncMock(return_value=None)):
         with pytest.raises(ValueError, match="api_key is required"):
             await ducs.upsert_deployment_key(db, ExternalProvider.ANTHROPIC, data)
+
+    db.commit.assert_not_awaited()
+
+
+async def test_upsert_is_active_only_preserves_label() -> None:
+    """#3: an is_active-only toggle must not wipe the existing label (partial update)."""
+    row = SimpleNamespace(
+        provider=ExternalProvider.OPENAI.value,
+        api_key="sk-original-secret-1234567890",
+        label="keep-me",
+        is_active=True,
+        last_verified_at=None,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=None,
+    )
+    db = AsyncMock()
+    data = DeploymentUsageKeyUpsert(is_active=False)  # only is_active in fields_set
+
+    with patch.object(ducs, "_get_row", AsyncMock(return_value=row)):
+        await ducs.upsert_deployment_key(db, ExternalProvider.OPENAI, data)
+
+    assert row.label == "keep-me"  # label preserved, not overwritten with None
+    assert row.is_active is False
+
+
+async def test_upsert_new_key_rejected_when_encryption_disabled() -> None:
+    """#4 fail-closed: storing a new admin key without ENCRYPTION_MASTER_KEY is rejected."""
+    db = AsyncMock()
+    data = DeploymentUsageKeyUpsert(api_key="sk-admin-secret-123456", is_active=True)
+    fake_settings = SimpleNamespace(encryption_master_key="")
+
+    with (
+        patch.object(ducs, "_get_row", AsyncMock(return_value=None)),
+        patch.object(ducs, "get_settings", return_value=fake_settings),
+    ):
+        with pytest.raises(ValueError, match="ENCRYPTION_MASTER_KEY"):
+            await ducs.upsert_deployment_key(db, ExternalProvider.OPENAI, data)
 
     db.commit.assert_not_awaited()


### PR DESCRIPTION
## 배경

PR #136(배포 단위 usage admin 키 DB 소싱)의 다중 에이전트 코드리뷰에서 확정된 결함을 수정합니다. #136은 이미 main에 머지됐고 CI를 통과했으나, CI/타입체커가 잡지 못하는 **런타임 정합성·데이터·보안 결함**이 남아 있었습니다. 이 PR이 그것들을 수정합니다.

## 수정한 findings

| # | 심각도 | 문제 | 수정 |
|---|--------|------|------|
| 1 | MED | **폼 A5 무력화** — 기존 키 편집 시에도 유효 api_key를 강제해 `is_active` 토글/label 수정 단독 불가 | 기존 키 편집 시 빈 api_key 허용(현재 키 유지) + 행에 인라인 `is_active` 토글 추가 |
| 2 | MED | **github 배지 거짓말** — `enabled`가 `gh_token`만 봐서 `EXTERNAL_GITHUB_ORG` 없어도 "configured" (수집은 token+org 필요) | `enabled = bool(gh_token and gh_org)` |
| 3 | MED | **label 소실** — PUT에서 label 생략 시 Pydantic default None이 기존 label을 덮어씀 | `model_fields_set` 기반 부분 업데이트(생략 필드 보존) |
| 4 | MED | **평문 저장** — `ENCRYPTION_MASTER_KEY` 미설정 시 org admin 키가 평문 저장(EncryptedString 폴백) | upsert 시 암호화 불가면 fail-closed 거부 |
| 5 | MED | **마스킹 불일치** — `source="env"`인데 비활성 DB row 있으면 DB 키 마스크 표시 | source와 일치하는 키를 마스킹 |
| 6 | MED | **오검증 타임스탬프** — env 키 검증 성공 시 비활성 DB row의 `last_verified_at` 갱신 | ACTIVE row에만 스탬프(`_get_active_row`) |
| 7 | MED | **Immutability 위반** (사용자 규칙) — store payload를 mutation으로 구성 | spread로 불변 생성 |
| bonus | LOW | verify 예외 시 `str(exc)`가 키 노출 가능 | 고정 메시지 반환 + 서버측 로깅 |

## 품질 게이트 (golden-principles)

- **함수 50줄 초과 해소**: `_probe_usage_endpoint`를 provider별 헬퍼로 분리, `verify_deployment_key`에서 `_record_verification` 추출, `resolve_admin_key`/verify가 `_get_active_row` 공유
- **프론트 분리 + memo**: `KeyField`/`LabelField`/`RowInfo`/`RowActions`/`KeyList`/`ManagedKeysContent` 컴포넌트 추출 + 로직 hook화(`useProviderKeyForm`/`useProviderKeyRow`) → 모든 함수 ≤50줄, 전 컴포넌트 `memo()`+`displayName`
- verify 에러 로깅(`logging.getLogger`)

## 테스트 / 검증 증거

- 회귀 테스트 추가: 백엔드 #3(label 보존)·#4(fail-closed)·#6(active-only 스탬프), 프론트 A5(store 생략×2, 컴포넌트 토글/빈키편집×2)
- **백엔드**: ruff 0 · mypy 0 · pytest deployment 9 passed (asyncio config 정상, `-o` 플래그 불필요)
- **프론트**: tsc 0 · eslint 0 · vitest 4218 passed · build ✓
- 함수 길이: 변경 파일 전 함수 ≤50줄 확인

## 리뷰 방식

편향 없는 4개 병렬 리뷰어(CLAUDE.md 준수 / 버그 / 보안 / 계약·엣지케이스)로 findings 수집 → 코드 대조로 confidence 채점(80 미만 필터) → 확정분만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
