### PR TITLE
feat(usage): Codex(ChatGPT) 사용량을 Claude 사용량 대시보드에 통합

### DIFF
--- a/src/backend/api/usage.py
+++ b/src/backend/api/usage.py
@@ -6,14 +6,18 @@ Fetches real usage data from Anthropic OAuth API using macOS Keychain credential
 import json
 import logging
 import os
+import select
+import sqlite3
+import subprocess
 import sys
+import time
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from services.claude_config_service import (
@@ -52,6 +56,25 @@ JSONL_TOKEN_CACHE_PATH = Path(
     )
 )
 JSONL_TOKEN_CACHE_TTL_SECONDS = 300  # 5 minutes
+
+# Codex desktop/CLI local thread state. This stores local token accounting, not
+# the ChatGPT account plan-limit percentages shown in the Codex app menu.
+CODEX_STATE_DB_PATH = Path(
+    os.getenv(
+        "CODEX_STATE_DB_PATH",
+        str(Path.home() / ".codex" / "state_5.sqlite"),
+    )
+)
+
+# Codex app-server exposes the ChatGPT account plan-limit snapshot used by the
+# Codex desktop menu. This is different from the local state DB token counters.
+CODEX_APP_SERVER_BIN = os.getenv("CODEX_APP_SERVER_BIN", "codex")
+CODEX_APP_SERVER_TIMEOUT_SECONDS = float(os.getenv("CODEX_APP_SERVER_TIMEOUT_SECONDS", "8"))
+CODEX_PLAN_CACHE_TTL_SECONDS = int(os.getenv("CODEX_PLAN_CACHE_TTL_SECONDS", "5"))
+_codex_plan_cache: dict[str, Any] = {
+    "response": None,
+    "timestamp": None,
+}
 
 # Anthropic OAuth Usage API
 ANTHROPIC_USAGE_API = "https://api.anthropic.com/api/oauth/usage"
@@ -219,6 +242,73 @@ class UsageResponse(BaseModel):
     weeklyTotalTokens: int = 0
     weeklySonnetTokens: int = 0
     weeklyOpusTokens: int = 0
+
+
+class CodexUsageBreakdown(BaseModel):
+    """Codex local usage grouped by a label."""
+
+    name: str
+    tokens: int = 0
+    threads: int = 0
+
+
+class CodexCliUsageResponse(BaseModel):
+    """Local Codex CLI usage reconstructed from Codex state DB."""
+
+    available: bool
+    source: str = "codex-state-db"
+    fiveHourTokens: int = 0
+    fiveHourThreads: int = 0
+    weeklyTokens: int = 0
+    weeklyThreads: int = 0
+    totalTokens: int = 0
+    totalThreads: int = 0
+    byModel: list[CodexUsageBreakdown] = Field(default_factory=list)
+    bySource: list[CodexUsageBreakdown] = Field(default_factory=list)
+    updatedAt: str | None = None
+    limitStatus: str = "not_exposed"
+    message: str | None = (
+        "Codex CLI exposes local token usage here; account remaining plan "
+        "percentages are not present in the local state DB."
+    )
+
+
+class CodexPlanWindow(BaseModel):
+    """A Codex ChatGPT subscription rate-limit window."""
+
+    usedPercent: float = 0
+    remainingPercent: float = 100
+    windowDurationMins: int | None = None
+    resetsAt: int | None = None
+    resetsAtIso: str | None = None
+    resetsInMinutes: float | None = None
+
+
+class CodexPlanLimitSnapshot(BaseModel):
+    """Codex ChatGPT subscription limit snapshot."""
+
+    limitId: str | None = None
+    limitName: str | None = None
+    primary: CodexPlanWindow | None = None
+    secondary: CodexPlanWindow | None = None
+    credits: dict[str, Any] | None = None
+    individualLimit: dict[str, Any] | None = None
+    planType: str | None = None
+    rateLimitReachedType: str | None = None
+
+
+class CodexPlanUsageResponse(BaseModel):
+    """ChatGPT subscription Codex plan usage from Codex app-server."""
+
+    available: bool
+    source: str = "codex-app-server"
+    codexLimit: CodexPlanLimitSnapshot | None = None
+    limitsById: dict[str, CodexPlanLimitSnapshot] = Field(default_factory=dict)
+    rateLimitResetCredits: dict[str, Any] | None = None
+    updatedAt: str | None = None
+    isCached: bool = False
+    cacheAgeSeconds: int | None = None
+    message: str | None = None
 
 
 def load_stats_cache() -> dict[str, Any] | None:
@@ -436,6 +526,320 @@ def calculate_weekly_tokens(daily_tokens: list[dict]) -> tuple[int, int, int]:
     return total, sonnet, opus
 
 
+def _codex_source_name(source: str | None) -> str:
+    """Convert Codex thread source values into dashboard-friendly labels."""
+    if not source:
+        return "unknown"
+    trimmed = source.strip()
+    if not trimmed:
+        return "unknown"
+    try:
+        parsed = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return trimmed
+    if isinstance(parsed, dict) and "subagent" in parsed:
+        return "subagent"
+    return trimmed
+
+
+def _codex_usage_totals(
+    conn: sqlite3.Connection, cutoff_ts: int | None = None
+) -> tuple[int, int, int | None]:
+    """Return (threads, tokens, latest_updated_at) for Codex/OpenAI threads."""
+    where = "WHERE lower(coalesce(model_provider, '')) = 'openai'"
+    params: tuple[int, ...] = ()
+    if cutoff_ts is not None:
+        where += " AND updated_at >= ?"
+        params = (cutoff_ts,)
+
+    row = conn.execute(
+        f"""
+        SELECT
+            COUNT(*) AS threads,
+            COALESCE(SUM(COALESCE(tokens_used, 0)), 0) AS tokens,
+            MAX(updated_at) AS updated_at
+        FROM threads
+        {where}
+        """,
+        params,
+    ).fetchone()
+    if not row:
+        return (0, 0, None)
+    return (int(row[0] or 0), int(row[1] or 0), int(row[2]) if row[2] else None)
+
+
+def _codex_usage_by_model(conn: sqlite3.Connection) -> list[CodexUsageBreakdown]:
+    rows = conn.execute(
+        """
+        SELECT
+            COALESCE(NULLIF(TRIM(model), ''), 'unspecified model') AS model_name,
+            COUNT(*) AS threads,
+            COALESCE(SUM(COALESCE(tokens_used, 0)), 0) AS tokens
+        FROM threads
+        WHERE lower(coalesce(model_provider, '')) = 'openai'
+        GROUP BY model_name
+        ORDER BY tokens DESC, threads DESC
+        LIMIT 10
+        """
+    ).fetchall()
+    return [
+        CodexUsageBreakdown(name=str(row[0]), threads=int(row[1] or 0), tokens=int(row[2] or 0))
+        for row in rows
+    ]
+
+
+def _codex_usage_by_source(conn: sqlite3.Connection) -> list[CodexUsageBreakdown]:
+    rows = conn.execute(
+        """
+        SELECT
+            source,
+            COUNT(*) AS threads,
+            COALESCE(SUM(COALESCE(tokens_used, 0)), 0) AS tokens
+        FROM threads
+        WHERE lower(coalesce(model_provider, '')) = 'openai'
+        GROUP BY source
+        ORDER BY tokens DESC, threads DESC
+        """
+    ).fetchall()
+
+    grouped: dict[str, CodexUsageBreakdown] = {}
+    for row in rows:
+        name = _codex_source_name(row[0])
+        item = grouped.setdefault(name, CodexUsageBreakdown(name=name))
+        item.threads += int(row[1] or 0)
+        item.tokens += int(row[2] or 0)
+
+    return sorted(grouped.values(), key=lambda item: (-item.tokens, -item.threads))[:10]
+
+
+def _coerce_percent(value: Any, default: float = 0) -> float:
+    """Return a percent clamped to [0, 100]."""
+    try:
+        percent = float(value)
+    except (TypeError, ValueError):
+        percent = default
+    return max(0, min(100, percent))
+
+
+def _parse_codex_rate_limit_window(raw: Any) -> CodexPlanWindow | None:
+    """Normalize a Codex app-server RateLimitWindow object."""
+    if not isinstance(raw, dict):
+        return None
+
+    used_percent = _coerce_percent(raw.get("usedPercent"))
+    remaining_percent = max(0, 100 - used_percent)
+
+    resets_at_raw = raw.get("resetsAt")
+    resets_at: int | None = None
+    resets_at_iso: str | None = None
+    resets_in_minutes: float | None = None
+    if resets_at_raw is not None:
+        try:
+            resets_at = int(resets_at_raw)
+            resets_at_dt = datetime.fromtimestamp(resets_at, UTC)
+            resets_at_iso = resets_at_dt.isoformat()
+            resets_in_minutes = max(
+                0,
+                (resets_at_dt - datetime.now(UTC)).total_seconds() / 60,
+            )
+        except (TypeError, ValueError, OSError):
+            resets_at = None
+
+    window_duration_raw = raw.get("windowDurationMins")
+    try:
+        window_duration = int(window_duration_raw) if window_duration_raw is not None else None
+    except (TypeError, ValueError):
+        window_duration = None
+
+    return CodexPlanWindow(
+        usedPercent=used_percent,
+        remainingPercent=remaining_percent,
+        windowDurationMins=window_duration,
+        resetsAt=resets_at,
+        resetsAtIso=resets_at_iso,
+        resetsInMinutes=resets_in_minutes,
+    )
+
+
+def _parse_codex_limit_snapshot(raw: Any) -> CodexPlanLimitSnapshot | None:
+    """Normalize a Codex app-server RateLimitSnapshot object."""
+    if not isinstance(raw, dict):
+        return None
+
+    return CodexPlanLimitSnapshot(
+        limitId=raw.get("limitId"),
+        limitName=raw.get("limitName"),
+        primary=_parse_codex_rate_limit_window(raw.get("primary")),
+        secondary=_parse_codex_rate_limit_window(raw.get("secondary")),
+        credits=raw.get("credits") if isinstance(raw.get("credits"), dict) else None,
+        individualLimit=(
+            raw.get("individualLimit") if isinstance(raw.get("individualLimit"), dict) else None
+        ),
+        planType=raw.get("planType"),
+        rateLimitReachedType=raw.get("rateLimitReachedType"),
+    )
+
+
+def _select_codex_limit_snapshot(
+    default_limit: CodexPlanLimitSnapshot | None,
+    limits_by_id: dict[str, CodexPlanLimitSnapshot],
+) -> CodexPlanLimitSnapshot | None:
+    """Pick the Codex bucket from a multi-bucket response."""
+    if "codex" in limits_by_id:
+        return limits_by_id["codex"]
+
+    for limit in limits_by_id.values():
+        if (limit.limitId or "").lower() == "codex":
+            return limit
+
+    return default_limit
+
+
+def _parse_codex_rate_limits_response(raw: dict[str, Any]) -> CodexPlanUsageResponse:
+    """Convert `account/rateLimits/read` into the dashboard API shape."""
+    default_limit = _parse_codex_limit_snapshot(raw.get("rateLimits"))
+    raw_limits_by_id = raw.get("rateLimitsByLimitId") or {}
+    limits_by_id: dict[str, CodexPlanLimitSnapshot] = {}
+
+    if isinstance(raw_limits_by_id, dict):
+        for key, value in raw_limits_by_id.items():
+            parsed = _parse_codex_limit_snapshot(value)
+            if parsed:
+                limits_by_id[str(key)] = parsed
+
+    codex_limit = _select_codex_limit_snapshot(default_limit, limits_by_id)
+
+    return CodexPlanUsageResponse(
+        available=codex_limit is not None,
+        codexLimit=codex_limit,
+        limitsById=limits_by_id,
+        rateLimitResetCredits=(
+            raw.get("rateLimitResetCredits")
+            if isinstance(raw.get("rateLimitResetCredits"), dict)
+            else None
+        ),
+        updatedAt=datetime.now(UTC).isoformat(),
+        message=None if codex_limit else "Codex rate-limit bucket was not present.",
+    )
+
+
+def _read_codex_app_server_rate_limits() -> dict[str, Any]:
+    """Read ChatGPT Codex rate limits from the local Codex app-server."""
+    payload_messages = [
+        {
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "clientInfo": {"name": "aos-dashboard", "version": "0.1.0"},
+                "capabilities": {
+                    "experimentalApi": True,
+                    "requestAttestation": False,
+                },
+            },
+        },
+        {"method": "initialized"},
+        {"id": 2, "method": "account/rateLimits/read"},
+    ]
+
+    process = subprocess.Popen(
+        [CODEX_APP_SERVER_BIN, "app-server", "--listen", "stdio://"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+    )
+    stdout_buffer = ""
+    stderr_buffer = b""
+    try:
+        if process.stdin is None or process.stdout is None or process.stderr is None:
+            raise RuntimeError("Codex app-server pipes were not available")
+
+        for message in payload_messages:
+            process.stdin.write((json.dumps(message) + "\n").encode())
+            process.stdin.flush()
+
+        deadline = time.monotonic() + CODEX_APP_SERVER_TIMEOUT_SECONDS
+        streams = [process.stdout, process.stderr]
+        while time.monotonic() < deadline:
+            timeout = max(0, min(0.2, deadline - time.monotonic()))
+            readable, _, _ = select.select(streams, [], [], timeout)
+            if not readable and process.poll() is not None:
+                break
+
+            for stream in readable:
+                chunk = os.read(stream.fileno(), 65536)
+                if not chunk:
+                    continue
+                if stream is process.stderr:
+                    stderr_buffer += chunk
+                    continue
+
+                stdout_buffer += chunk.decode(errors="replace")
+                while "\n" in stdout_buffer:
+                    line, stdout_buffer = stdout_buffer.split("\n", 1)
+                    response = _extract_codex_rate_limit_response_line(line)
+                    if response is not None:
+                        return response
+
+        if stdout_buffer.strip():
+            response = _extract_codex_rate_limit_response_line(stdout_buffer)
+            if response is not None:
+                return response
+
+        if process.poll() not in (None, 0):
+            raise RuntimeError(f"Codex app-server exited with {process.returncode}")
+        raise subprocess.TimeoutExpired(
+            [CODEX_APP_SERVER_BIN, "app-server", "--listen", "stdio://"],
+            CODEX_APP_SERVER_TIMEOUT_SECONDS,
+            output=stdout_buffer,
+            stderr=stderr_buffer,
+        )
+    finally:
+        try:
+            if process.stdin:
+                process.stdin.close()
+        except OSError:
+            pass
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                process.kill()
+
+
+def _extract_codex_rate_limit_response_line(line: str) -> dict[str, Any] | None:
+    """Return the id=2 rate-limit result from one app-server JSON line."""
+    if not line.strip():
+        return None
+    try:
+        message = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if message.get("id") != 2:
+        return None
+    if "error" in message:
+        error = message.get("error") or {}
+        raise RuntimeError(str(error.get("message") or "Codex app-server returned an error"))
+    response = message.get("result")
+    if not isinstance(response, dict):
+        raise RuntimeError("Codex app-server returned an invalid rate-limit response")
+    return response
+
+
+def _cached_codex_plan_response() -> CodexPlanUsageResponse | None:
+    """Return a fresh cached Codex plan response if available."""
+    response = _codex_plan_cache.get("response")
+    timestamp = _codex_plan_cache.get("timestamp")
+    if not isinstance(response, CodexPlanUsageResponse) or not isinstance(timestamp, datetime):
+        return None
+
+    age_seconds = int((datetime.now(UTC) - timestamp).total_seconds())
+    if age_seconds > CODEX_PLAN_CACHE_TTL_SECONDS:
+        return None
+
+    return response.model_copy(update={"isCached": True, "cacheAgeSeconds": max(age_seconds, 0)})
+
+
 @router.get("", response_model=UsageResponse)
 async def get_usage() -> UsageResponse:
     """
@@ -484,6 +888,9 @@ async def get_usage() -> UsageResponse:
         weekly_model_tokens = aggregate_model_tokens_from_jsonl(days=7)
         if weekly_model_tokens:
             weekly_model_tokens_source = "jsonl-fallback"
+            weekly_total, weekly_sonnet, weekly_opus = calculate_weekly_tokens(
+                [entry.model_dump() for entry in weekly_model_tokens]
+            )
 
     # Compute how many days behind today the stats-cache reports — useful for
     # surfacing "the upstream cache stopped updating" to the UI.
@@ -596,6 +1003,109 @@ async def get_usage() -> UsageResponse:
         weeklySonnetTokens=weekly_sonnet,
         weeklyOpusTokens=weekly_opus,
     )
+
+
+@router.get("/codex-cli", response_model=CodexCliUsageResponse)
+def get_codex_cli_usage() -> CodexCliUsageResponse:
+    """Get local Codex CLI/Desktop token usage from Codex thread state."""
+    db_path = CODEX_STATE_DB_PATH.expanduser().resolve()
+    if not db_path.exists():
+        return CodexCliUsageResponse(
+            available=False,
+            source="codex-state-db",
+            message="Codex state DB not found. Run Codex CLI/Desktop with ChatGPT login first.",
+        )
+
+    now_ts = int(datetime.now(UTC).timestamp())
+    five_hour_cutoff = now_ts - (5 * 60 * 60)
+    weekly_cutoff = now_ts - (7 * 24 * 60 * 60)
+
+    try:
+        with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as conn:
+            five_hour_threads, five_hour_tokens, _ = _codex_usage_totals(conn, five_hour_cutoff)
+            weekly_threads, weekly_tokens, _ = _codex_usage_totals(conn, weekly_cutoff)
+            total_threads, total_tokens, latest_updated_at = _codex_usage_totals(conn)
+            updated_at = (
+                datetime.fromtimestamp(latest_updated_at, UTC).isoformat()
+                if latest_updated_at
+                else None
+            )
+
+            return CodexCliUsageResponse(
+                available=True,
+                fiveHourTokens=five_hour_tokens,
+                fiveHourThreads=five_hour_threads,
+                weeklyTokens=weekly_tokens,
+                weeklyThreads=weekly_threads,
+                totalTokens=total_tokens,
+                totalThreads=total_threads,
+                byModel=_codex_usage_by_model(conn),
+                bySource=_codex_usage_by_source(conn),
+                updatedAt=updated_at,
+            )
+    except sqlite3.Error as exc:
+        logger.warning("Failed to read Codex state DB", exc_info=True)
+        return CodexCliUsageResponse(
+            available=False,
+            source="codex-state-db",
+            message=f"Codex state DB could not be read ({exc.__class__.__name__}).",
+        )
+
+
+@router.get("/codex-plan", response_model=CodexPlanUsageResponse)
+def get_codex_plan_usage(
+    refresh: Annotated[
+        bool,
+        Query(
+            description="Bypass the short-lived app-server cache and read fresh limits.",
+        ),
+    ] = False,
+) -> CodexPlanUsageResponse:
+    """Get ChatGPT subscription Codex remaining plan limits from Codex app-server."""
+    if not refresh:
+        cached = _cached_codex_plan_response()
+        if cached:
+            return cached
+
+    try:
+        raw_response = _read_codex_app_server_rate_limits()
+        response = _parse_codex_rate_limits_response(raw_response)
+        if response.available:
+            _codex_plan_cache["response"] = response
+            _codex_plan_cache["timestamp"] = datetime.now(UTC)
+        return response
+    except FileNotFoundError:
+        return CodexPlanUsageResponse(
+            available=False,
+            message="Codex CLI binary was not found. Install Codex and sign in with ChatGPT.",
+        )
+    except subprocess.TimeoutExpired:
+        stale_response = _codex_plan_cache.get("response")
+        if isinstance(stale_response, CodexPlanUsageResponse):
+            return stale_response.model_copy(
+                update={
+                    "isCached": True,
+                    "message": "Using cached Codex plan data after app-server timeout.",
+                }
+            )
+        return CodexPlanUsageResponse(
+            available=False,
+            message="Codex app-server timed out while reading ChatGPT plan limits.",
+        )
+    except Exception as exc:
+        logger.warning("Failed to read Codex app-server rate limits", exc_info=True)
+        stale_response = _codex_plan_cache.get("response")
+        if isinstance(stale_response, CodexPlanUsageResponse):
+            return stale_response.model_copy(
+                update={
+                    "isCached": True,
+                    "message": "Using cached Codex plan data after app-server error.",
+                }
+            )
+        return CodexPlanUsageResponse(
+            available=False,
+            message=f"Codex plan limits unavailable ({exc.__class__.__name__}).",
+        )
 
 
 @router.get("/raw")

--- a/src/backend/models/analytics.py
+++ b/src/backend/models/analytics.py
@@ -148,6 +148,7 @@ class CostBreakdown(BaseModel):
 
     category: str  # e.g., "agent_name", "model", "session"
     value: str  # e.g., "web-ui-specialist", "claude-sonnet-4-6"
+    provider: str | None = None  # e.g., "codex_cli", "anthropic"
     cost: float
     tokens: int
     percentage: float = 0.0

--- a/src/backend/services/analytics_service.py
+++ b/src/backend/services/analytics_service.py
@@ -1,6 +1,7 @@
 """Analytics service for dashboard metrics."""
 
 import logging
+import os
 import random
 from collections import defaultdict
 from datetime import UTC, timedelta
@@ -8,6 +9,7 @@ from datetime import UTC, timedelta
 from sqlalchemy import and_, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from config import get_settings
 from db.models import AuditLogModel, SessionActivityModel, SessionModel, TaskModel
 from models.analytics import (
     ActivityHeatmap,
@@ -58,15 +60,32 @@ def _spread_session_hours(created_at, last_activity):
         cur += timedelta(hours=1)
 
 
+UNKNOWN_MODEL_NAME = "unknown (no model info)"
+
+
 def _normalize_model_name(model: str) -> str:
     """Normalize model name for display."""
     if not model or model == "unknown":
-        return "unknown (no model info)"
+        return UNKNOWN_MODEL_NAME
     if model.startswith("<") and model.endswith(">"):
         # e.g. "<synthetic>" → "synthetic (system-generated)"
         inner = model.strip("<>")
         return f"{inner} (system-generated)"
     return model
+
+
+def _has_attributed_model_usage(session) -> bool:
+    """Return False for zero-usage sessions without model metadata."""
+    model_name = _normalize_model_name(session.model or "unknown")
+    total_tokens = session.total_input_tokens + session.total_output_tokens
+    return not (
+        model_name == UNKNOWN_MODEL_NAME and total_tokens == 0 and session.estimated_cost == 0
+    )
+
+
+def _runtime_provider() -> str:
+    """Return the configured runtime provider used for local session analytics."""
+    return os.getenv("LLM_PROVIDER") or get_settings().llm_provider
 
 
 def _get_time_delta(time_range: TimeRange) -> timedelta:
@@ -616,6 +635,8 @@ class AnalyticsService:
         # Group by model
         by_model: dict[str, list] = defaultdict(list)
         for s in range_sessions:
+            if not _has_attributed_model_usage(s):
+                continue
             by_model[_normalize_model_name(s.model or "unknown")].append(s)
 
         agents = []
@@ -674,10 +695,13 @@ class AnalyticsService:
         total_cost = sum(s.estimated_cost for s in range_sessions)
         total_tokens = sum(s.total_input_tokens + s.total_output_tokens for s in range_sessions)
         total_sessions = len(range_sessions)
+        provider = _runtime_provider()
 
         # By model
         model_costs: dict[str, dict] = defaultdict(lambda: {"cost": 0.0, "tokens": 0})
         for s in range_sessions:
+            if not _has_attributed_model_usage(s):
+                continue
             model = _normalize_model_name(s.model or "unknown")
             model_costs[model]["cost"] += s.estimated_cost
             model_costs[model]["tokens"] += s.total_input_tokens + s.total_output_tokens
@@ -689,6 +713,7 @@ class AnalyticsService:
                 CostBreakdown(
                     category="model",
                     value=model,
+                    provider=provider,
                     cost=round(data["cost"], 4),
                     tokens=data["tokens"],
                     percentage=round(pct, 1),

--- a/src/dashboard/src/components/CostMonitor.tsx
+++ b/src/dashboard/src/components/CostMonitor.tsx
@@ -17,6 +17,7 @@ const API_BASE = import.meta.env.VITE_API_URL || '/api'
 interface CostBreakdown {
   category: string
   value: string
+  provider?: string | null
   cost: number
   tokens: number
   percentage: number
@@ -29,6 +30,20 @@ interface CostAnalytics {
   by_agent: CostBreakdown[]
   by_model: CostBreakdown[]
   projected_monthly: number
+}
+
+interface ClaudePlanLimit {
+  name: string
+  displayName: string
+  utilization: number
+}
+
+interface ClaudeUsageSnapshot {
+  weeklyTotalTokens?: number
+  weeklyModelTokens?: Array<{ date: string; tokensByModel: Record<string, number> }>
+  weeklyModelTokensSource?: 'stats-cache' | 'jsonl-fallback' | 'empty'
+  planLimits?: ClaudePlanLimit[]
+  oauthAvailable?: boolean
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -78,6 +93,34 @@ function getModelFamily(model: string): string {
   return lower
 }
 
+function isLLMProvider(value: string | null | undefined): value is LLMProvider {
+  return Boolean(value && value in PROVIDER_CONFIG)
+}
+
+function getClaudeWeeklyTokens(usage: ClaudeUsageSnapshot | null): number {
+  if (!usage) return 0
+  if (usage.weeklyTotalTokens && usage.weeklyTotalTokens > 0) {
+    return usage.weeklyTotalTokens
+  }
+  return (usage.weeklyModelTokens ?? []).reduce((total, day) => (
+    total + Object.values(day.tokensByModel).reduce((sum, tokens) => sum + tokens, 0)
+  ), 0)
+}
+
+function getClaudePlanLabel(usage: ClaudeUsageSnapshot | null): string {
+  if (!usage) return 'Unavailable'
+  const sevenDay = usage.planLimits?.find((limit) => limit.name === 'sevenDay')
+  if (sevenDay) return `7d ${Math.round(sevenDay.utilization)}%`
+  return usage.oauthAvailable ? 'Live' : 'Local'
+}
+
+function getClaudeSourceLabel(usage: ClaudeUsageSnapshot | null): string {
+  if (!usage) return 'No data'
+  if (usage.weeklyModelTokensSource === 'jsonl-fallback') return 'JSONL'
+  if (usage.weeklyModelTokensSource === 'stats-cache') return 'Cache'
+  return 'No data'
+}
+
 /** Group by_model entries into provider-level usage. */
 function groupByProvider(byModel: CostBreakdown[]): Record<string, ProviderUsage> {
   const result: Record<string, ProviderUsage> = {}
@@ -86,7 +129,7 @@ function groupByProvider(byModel: CostBreakdown[]): Record<string, ProviderUsage
   for (const entry of byModel) {
     if (isIgnoredModel(entry.value)) continue
 
-    const provider = identifyProvider(entry.value)
+    const provider = isLLMProvider(entry.provider) ? entry.provider : identifyProvider(entry.value)
     const key = provider === 'unknown' ? `unknown:${entry.value}` : provider
     const family = getModelFamily(entry.value)
     const existing = result[key]
@@ -121,6 +164,12 @@ function groupByProvider(byModel: CostBreakdown[]): Record<string, ProviderUsage
 async function fetchCostAnalytics(): Promise<CostAnalytics> {
   const res = await fetch(`${API_BASE}/analytics/costs?time_range=all`)
   if (!res.ok) throw new Error('Failed to fetch cost analytics')
+  return res.json()
+}
+
+async function fetchClaudeUsage(): Promise<ClaudeUsageSnapshot> {
+  const res = await fetch(`${API_BASE}/usage`)
+  if (!res.ok) throw new Error('Failed to fetch Claude Code usage')
   return res.json()
 }
 
@@ -175,6 +224,24 @@ interface ProviderCardProps {
   usage: ProviderUsage
 }
 
+interface SourceRowProps {
+  label: string
+  value: string
+  meta: string
+}
+
+function SourceRow({ label, value, meta }: SourceRowProps) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-gray-100 dark:border-gray-700 px-3 py-2">
+      <div>
+        <div className="text-sm font-medium text-gray-900 dark:text-white">{label}</div>
+        <div className="text-xs text-gray-500 dark:text-gray-400">{meta}</div>
+      </div>
+      <div className="text-sm font-semibold text-gray-900 dark:text-white">{value}</div>
+    </div>
+  )
+}
+
 function ProviderCard({ usage }: ProviderCardProps) {
   const colors = PROVIDER_COLORS[usage.provider]
   const config = PROVIDER_CONFIG[usage.provider]
@@ -207,6 +274,7 @@ function ProviderCard({ usage }: ProviderCardProps) {
 
 export function CostMonitor() {
   const [data, setData] = useState<CostAnalytics | null>(null)
+  const [claudeUsage, setClaudeUsage] = useState<ClaudeUsageSnapshot | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -217,8 +285,12 @@ export function CostMonitor() {
     try {
       setLoading(true)
       setError(null)
-      const result = await fetchCostAnalytics()
+      const [result, claude] = await Promise.all([
+        fetchCostAnalytics(),
+        fetchClaudeUsage().catch(() => null),
+      ])
       setData(result)
+      setClaudeUsage(claude)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load')
     } finally {
@@ -240,6 +312,10 @@ export function CostMonitor() {
   const totalTokens = data?.total_tokens ?? 0
   const totalCost = data?.total_cost ?? 0
   const actualCost = externalSummary?.total_cost_usd ?? null
+  const runtimeProviders = sortedProviders
+    .map(([, usage]) => usage.displayName)
+    .join(', ') || 'No data'
+  const claudeWeeklyTokens = getClaudeWeeklyTokens(claudeUsage)
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
@@ -285,6 +361,25 @@ export function CostMonitor() {
               </span>
             )}
           </div>
+        </div>
+      </div>
+
+      {/* Source Split */}
+      <div className="mb-4">
+        <h4 className="text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider mb-3">
+          By Source
+        </h4>
+        <div className="space-y-2">
+          <SourceRow
+            label="AOS Runtime"
+            value={formatTokens(totalTokens)}
+            meta={`${runtimeProviders} · ${formatCost(totalCost)}`}
+          />
+          <SourceRow
+            label="Claude Code"
+            value={claudeUsage ? formatTokens(claudeWeeklyTokens) : loading ? '...' : '0'}
+            meta={`${getClaudePlanLabel(claudeUsage)} · ${getClaudeSourceLabel(claudeUsage)}`}
+          />
         </div>
       </div>
 

--- a/src/dashboard/src/components/__tests__/CostMonitor.test.tsx
+++ b/src/dashboard/src/components/__tests__/CostMonitor.test.tsx
@@ -32,6 +32,21 @@ function mockCostResponse(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function mockClaudeUsageResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        weeklyTotalTokens: 0,
+        weeklyModelTokens: [],
+        weeklyModelTokensSource: 'empty',
+        planLimits: [],
+        oauthAvailable: false,
+        ...overrides,
+      }),
+  }
+}
+
 describe('CostMonitor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -55,7 +70,7 @@ describe('CostMonitor', () => {
     render(<CostMonitor />)
 
     await waitFor(() => {
-      expect(screen.getByText('0')).toBeInTheDocument()
+      expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(1)
       expect(screen.getByText('FREE')).toBeInTheDocument()
     })
   })
@@ -75,8 +90,62 @@ describe('CostMonitor', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Anthropic Claude')).toBeInTheDocument()
-      // 1.5K appears in both Total and Provider card
-      expect(screen.getAllByText('1.5K')).toHaveLength(2)
+      expect(screen.getAllByText('1.5K').length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it('renders Claude Code usage as a separate source', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/usage')) {
+        return Promise.resolve(mockClaudeUsageResponse({
+          weeklyTotalTokens: 42000,
+          weeklyModelTokensSource: 'jsonl-fallback',
+          planLimits: [{ name: 'sevenDay', displayName: 'All models', utilization: 50 }],
+          oauthAvailable: true,
+        }))
+      }
+      return Promise.resolve(mockCostResponse({
+        total_cost: 0,
+        total_tokens: 1500,
+        by_model: [
+          { category: 'model', value: 'claude-opus-4-8', provider: 'codex_cli', cost: 0, tokens: 1500, percentage: 100 },
+        ],
+      }))
+    })
+
+    render(<CostMonitor />)
+
+    await waitFor(() => {
+      expect(screen.getByText('AOS Runtime')).toBeInTheDocument()
+      expect(screen.getByText('Claude Code')).toBeInTheDocument()
+      expect(screen.getByText('42.0K')).toBeInTheDocument()
+      expect(screen.getByText('7d 50% · JSONL')).toBeInTheDocument()
+    })
+  })
+
+  it('uses explicit provider metadata before model-name inference', async () => {
+    mockFetch.mockResolvedValue(
+      mockCostResponse({
+        total_cost: 0,
+        total_tokens: 1500,
+        by_model: [
+          {
+            category: 'model',
+            value: 'claude-opus-4-8',
+            provider: 'codex_cli',
+            cost: 0,
+            tokens: 1500,
+            percentage: 100,
+          },
+        ],
+      }),
+    )
+
+    render(<CostMonitor />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex CLI')).toBeInTheDocument()
+      expect(screen.queryByText('Anthropic Claude')).not.toBeInTheDocument()
     })
   })
 
@@ -94,8 +163,7 @@ describe('CostMonitor', () => {
     render(<CostMonitor />)
 
     await waitFor(() => {
-      // 1.0M appears in both Total and Provider card
-      expect(screen.getAllByText('1.0M')).toHaveLength(2)
+      expect(screen.getAllByText('1.0M').length).toBeGreaterThanOrEqual(2)
     })
   })
 

--- a/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
+++ b/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
@@ -1,28 +1,133 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useState } from 'react'
 import { BarChart3, RefreshCw, AlertCircle, CheckCircle2, XCircle, Clock } from 'lucide-react'
 import { useClaudeUsageStore } from '../../stores/claudeUsage'
-import { UsageProgressBar } from './UsageProgressBar'
+import type { PlanLimitInfo } from '../../types/claudeUsage'
+import { apiClient } from '../../services/apiClient'
 
 const REFRESH_INTERVAL = 5 * 60 * 1000 // 5 minutes
 
+interface CodexUsageBreakdown {
+  name: string
+  tokens: number
+  threads: number
+}
+
+interface CodexCliUsageResponse {
+  available: boolean
+  fiveHourTokens: number
+  fiveHourThreads: number
+  weeklyTokens: number
+  weeklyThreads: number
+  totalTokens: number
+  totalThreads: number
+  byModel: CodexUsageBreakdown[]
+  message?: string | null
+}
+
+interface CodexPlanWindow {
+  usedPercent: number
+  remainingPercent: number
+  windowDurationMins: number | null
+  resetsAt: number | null
+  resetsAtIso: string | null
+  resetsInMinutes: number | null
+}
+
+interface CodexPlanLimitSnapshot {
+  limitId: string | null
+  limitName: string | null
+  primary: CodexPlanWindow | null
+  secondary: CodexPlanWindow | null
+  planType: string | null
+  rateLimitReachedType: string | null
+}
+
+interface CodexPlanUsageResponse {
+  available: boolean
+  codexLimit: CodexPlanLimitSnapshot | null
+  rateLimitResetCredits: { availableCount?: number } | null
+  isCached: boolean
+  cacheAgeSeconds: number | null
+  message?: string | null
+}
+
+interface CodexUsageSummary {
+  available: boolean
+  fiveHourTokens: number
+  fiveHourThreads: number
+  weeklyTokens: number
+  weeklyThreads: number
+  totalTokens: number
+  totalThreads: number
+  modelCount: number
+  message?: string | null
+}
+
 export function ClaudeUsageDashboard() {
   const { usage, isLoading, error, lastFetched, fetchUsage, clearError } = useClaudeUsageStore()
+  const [codexUsage, setCodexUsage] = useState<CodexUsageSummary | null>(null)
+  const [codexPlan, setCodexPlan] = useState<CodexPlanUsageResponse | null>(null)
+  const [isCodexLoading, setIsCodexLoading] = useState(false)
+
+  const fetchCodexUsage = useCallback(async (forceRefresh = false) => {
+    setIsCodexLoading(true)
+    try {
+      const cacheBuster = `t=${Date.now()}`
+      const planPath = forceRefresh
+        ? `/api/usage/codex-plan?refresh=true&${cacheBuster}`
+        : `/api/usage/codex-plan?${cacheBuster}`
+      const [planResult, localResult] = await Promise.allSettled([
+        apiClient.get<CodexPlanUsageResponse>(planPath, {
+          timeout: 15_000,
+        }),
+        apiClient.get<CodexCliUsageResponse>('/api/usage/codex-cli', {
+          timeout: 10_000,
+        }),
+      ])
+
+      setCodexPlan(planResult.status === 'fulfilled' ? planResult.value : null)
+
+      if (localResult.status === 'fulfilled') {
+        const data = localResult.value
+        setCodexUsage({
+          available: data.available,
+          fiveHourTokens: data.fiveHourTokens,
+          fiveHourThreads: data.fiveHourThreads,
+          weeklyTokens: data.weeklyTokens,
+          weeklyThreads: data.weeklyThreads,
+          totalTokens: data.totalTokens,
+          totalThreads: data.totalThreads,
+          modelCount: data.byModel.filter((model) => model.tokens > 0).length,
+          message: data.message,
+        })
+      } else {
+        setCodexUsage(null)
+      }
+    } finally {
+      setIsCodexLoading(false)
+    }
+  }, [])
+
+  const refreshAllUsage = useCallback((forceCodexRefresh = false) => {
+    fetchUsage()
+    fetchCodexUsage(forceCodexRefresh)
+  }, [fetchUsage, fetchCodexUsage])
 
   // Fetch on mount and set up auto-refresh
   useEffect(() => {
-    fetchUsage()
+    refreshAllUsage()
 
     const interval = setInterval(() => {
-      fetchUsage()
+      refreshAllUsage()
     }, REFRESH_INTERVAL)
 
     return () => clearInterval(interval)
-  }, [fetchUsage])
+  }, [refreshAllUsage])
 
   const handleRefresh = useCallback(() => {
     clearError()
-    fetchUsage()
-  }, [fetchUsage, clearError])
+    refreshAllUsage(true)
+  }, [refreshAllUsage, clearError])
 
   // Format number with K/M suffix
   const formatTokenCount = (count: number) => {
@@ -42,7 +147,7 @@ export function ClaudeUsageDashboard() {
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
             <BarChart3 className="w-5 h-5" />
-            Claude Code Usage
+            Plan Usage Limits
           </h3>
           <button
             onClick={handleRefresh}
@@ -67,7 +172,7 @@ export function ClaudeUsageDashboard() {
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
             <BarChart3 className="w-5 h-5" />
-            Claude Code Usage
+            Plan Usage Limits
           </h3>
           <RefreshCw className="w-4 h-4 animate-spin text-gray-400" />
         </div>
@@ -88,7 +193,7 @@ export function ClaudeUsageDashboard() {
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
             <BarChart3 className="w-5 h-5" />
-            Claude Code Usage
+            Plan Usage Limits
           </h3>
         </div>
         <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -103,6 +208,12 @@ export function ClaudeUsageDashboard() {
   const allModelsLimit = usage.planLimits.find(l => l.name === 'sevenDay')
   const sonnetLimit = usage.planLimits.find(l => l.name === 'sevenDaySonnet')
   const opusLimit = usage.planLimits.find(l => l.name === 'sevenDayOpus')
+  const codexLimit = codexPlan?.available ? codexPlan.codexLimit : null
+  const codexFiveHourLimit = codexLimit?.primary ?? null
+  const codexWeeklyLimit = codexLimit?.secondary ?? null
+  const codexWeeklyTokens = codexUsage?.weeklyTokens ?? 0
+  const combinedWeeklyTokens = usage.weeklyTotalTokens + codexWeeklyTokens
+  const secondaryLimits = [sonnetLimit, opusLimit].filter(Boolean) as PlanLimitInfo[]
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 h-full flex flex-col">
@@ -113,23 +224,45 @@ export function ClaudeUsageDashboard() {
           Plan Usage Limits
         </h3>
         <div className="flex items-center gap-2">
-          {/* OAuth Status Indicator */}
+          {codexPlan?.available ? (
+            <span
+              className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400"
+              title={codexPlan.isCached ? 'Cached Codex plan data' : 'ChatGPT Codex plan data'}
+            >
+              <CheckCircle2 className="w-3 h-3" />
+              Codex {codexPlan.isCached ? 'Cached' : 'Live'}
+            </span>
+          ) : isCodexLoading ? (
+            <span className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400">
+              <RefreshCw className="w-3 h-3 animate-spin" />
+              Codex
+            </span>
+          ) : (
+            <span
+              className="flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400"
+              title={codexPlan?.message || 'Codex plan limits unavailable'}
+            >
+              <XCircle className="w-3 h-3" />
+              Codex Offline
+            </span>
+          )}
+          {/* Claude OAuth Status Indicator */}
           {usage.oauthAvailable ? (
             usage.isCached ? (
               <span className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400" title={`Cached data (${usage.cacheAgeMinutes ?? 0}m ago)`}>
                 <Clock className="w-3 h-3" />
-                Cached
+                Claude Cached
               </span>
             ) : (
               <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400" title="Real-time data from Anthropic API">
                 <CheckCircle2 className="w-3 h-3" />
-                Live
+                Claude Live
               </span>
             )
           ) : (
             <span className="flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400" title={usage.oauthError || 'OAuth not available'}>
               <XCircle className="w-3 h-3" />
-              Offline
+              Claude Offline
             </span>
           )}
           {lastFetched && (
@@ -159,61 +292,6 @@ export function ClaudeUsageDashboard() {
                 <span>Using cached data ({usage.cacheAgeMinutes}m ago) - API temporarily unavailable</span>
               </div>
             )}
-
-            {/* Current Session (5-hour limit) */}
-            {sessionLimit && (
-              <div className="pb-3 border-b border-gray-100 dark:border-gray-700">
-                <UsageProgressBar
-                  label={sessionLimit.displayName}
-                  percentUsed={sessionLimit.utilization}
-                  resetInHours={sessionLimit.resetsInHours ?? 0}
-                  resetInMinutes={sessionLimit.resetsInMinutes ?? 0}
-                />
-              </div>
-            )}
-
-            {/* Weekly Limits */}
-            <div>
-              <h4 className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-3">
-                Weekly Limits
-              </h4>
-
-              <div className="space-y-3">
-                {/* All Models (7-day limit) */}
-                {allModelsLimit && (
-                  <UsageProgressBar
-                    label={allModelsLimit.displayName}
-                    percentUsed={allModelsLimit.utilization}
-                    resetInHours={allModelsLimit.resetsInHours ?? 0}
-                    resetInMinutes={allModelsLimit.resetsInMinutes ?? 0}
-                  />
-                )}
-
-                {/* Sonnet Only (7-day Sonnet limit) */}
-                {sonnetLimit && (
-                  <UsageProgressBar
-                    label={sonnetLimit.displayName}
-                    percentUsed={sonnetLimit.utilization}
-                    resetInHours={sonnetLimit.resetsInHours ?? 0}
-                    resetInMinutes={sonnetLimit.resetsInMinutes ?? 0}
-                    showInfo
-                    tooltip="Separate limit for Sonnet model usage"
-                  />
-                )}
-
-                {/* Opus Only (7-day Opus limit) */}
-                {opusLimit && (
-                  <UsageProgressBar
-                    label={opusLimit.displayName}
-                    percentUsed={opusLimit.utilization}
-                    resetInHours={opusLimit.resetsInHours ?? 0}
-                    resetInMinutes={opusLimit.resetsInMinutes ?? 0}
-                    showInfo
-                    tooltip="Separate limit for Opus model usage"
-                  />
-                )}
-              </div>
-            </div>
           </>
         ) : (
           /* Fallback - OAuth not available, show local stats */
@@ -224,21 +302,105 @@ export function ClaudeUsageDashboard() {
                 {usage.oauthError || 'Plan limits unavailable'}
               </span>
             </div>
-            <p>Showing local token statistics only.</p>
+            <p>Claude plan limits unavailable; Codex plan limits are checked separately.</p>
           </div>
         )}
+
+        <div>
+          <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+            ChatGPT Codex & Claude Plan Limits
+          </h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+            {sessionLimit && (
+              <UsageRadialMetric
+                label="Claude Session"
+                value={`${Math.round(sessionLimit.utilization)}%`}
+                detail={`${formatResetTime(sessionLimit)} reset`}
+                percent={sessionLimit.utilization}
+                tone={getLimitTone(sessionLimit.utilization)}
+              />
+            )}
+            {allModelsLimit && (
+              <UsageRadialMetric
+                label="Claude Weekly"
+                value={`${Math.round(allModelsLimit.utilization)}%`}
+                detail={`${formatResetTime(allModelsLimit)} reset`}
+                percent={allModelsLimit.utilization}
+                tone={getLimitTone(allModelsLimit.utilization)}
+              />
+            )}
+            {codexFiveHourLimit ? (
+              <UsageRadialMetric
+                label="Codex 5h"
+                value={`${Math.round(codexFiveHourLimit.remainingPercent)}% left`}
+                detail={formatCodexPlanDetail(codexFiveHourLimit, codexLimit?.planType)}
+                percent={codexFiveHourLimit.remainingPercent}
+                tone={getRemainingTone(codexFiveHourLimit.remainingPercent)}
+                centerText={`${Math.round(codexFiveHourLimit.remainingPercent)}%`}
+              />
+            ) : (
+              <UsageRadialMetric
+                label="Codex 5h"
+                value={isCodexLoading ? '...' : 'Unavailable'}
+                detail={formatCodexPlanUnavailable(codexPlan, isCodexLoading)}
+                percent={0}
+                tone="yellow"
+                centerText={isCodexLoading ? '...' : 'N/A'}
+              />
+            )}
+            {codexWeeklyLimit ? (
+              <UsageRadialMetric
+                label="Codex Weekly"
+                value={`${Math.round(codexWeeklyLimit.remainingPercent)}% left`}
+                detail={formatCodexPlanDetail(codexWeeklyLimit, codexLimit?.planType)}
+                percent={codexWeeklyLimit.remainingPercent}
+                tone={getRemainingTone(codexWeeklyLimit.remainingPercent)}
+                centerText={`${Math.round(codexWeeklyLimit.remainingPercent)}%`}
+              />
+            ) : (
+              <UsageRadialMetric
+                label="Codex Weekly"
+                value={isCodexLoading ? '...' : 'Unavailable'}
+                detail={formatCodexPlanUnavailable(codexPlan, isCodexLoading)}
+                percent={0}
+                tone="yellow"
+                centerText={isCodexLoading ? '...' : 'N/A'}
+              />
+            )}
+          </div>
+
+          {codexPlan?.available && codexPlan.rateLimitResetCredits?.availableCount !== undefined && (
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Codex reset credits: {codexPlan.rateLimitResetCredits.availableCount}
+            </p>
+          )}
+
+          {secondaryLimits.length > 0 && (
+            <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {secondaryLimits.map((limit) => (
+                <LimitPill key={limit.name} limit={limit} />
+              ))}
+            </div>
+          )}
+        </div>
 
         {/* Weekly Summary (always shown) */}
         <div className="pt-3 border-t border-gray-100 dark:border-gray-700">
           <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
-            Weekly Token Usage (Local)
+            Local Token Usage (diagnostic)
           </h4>
-          <div className="grid grid-cols-3 gap-2 text-center">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center">
             <div>
               <p className="text-lg font-semibold text-gray-900 dark:text-white">
-                {formatTokenCount(usage.weeklyTotalTokens)}
+                {formatTokenCount(combinedWeeklyTokens)}
               </p>
               <p className="text-xs text-gray-500 dark:text-gray-400">Total</p>
+            </div>
+            <div>
+              <p className="text-lg font-semibold text-purple-600 dark:text-purple-400">
+                {isCodexLoading ? '...' : formatTokenCount(codexWeeklyTokens)}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Codex</p>
             </div>
             <div>
               <p className="text-lg font-semibold text-blue-600 dark:text-blue-400">
@@ -257,4 +419,171 @@ export function ClaudeUsageDashboard() {
       </div>
     </div>
   )
+}
+
+type UsageTone = 'blue' | 'yellow' | 'red' | 'purple'
+
+const RADIAL_STROKE_CLASS: Record<UsageTone, string> = {
+  blue: 'stroke-primary-500',
+  yellow: 'stroke-yellow-500',
+  red: 'stroke-red-500',
+  purple: 'stroke-purple-500',
+}
+
+const RADIAL_TEXT_CLASS: Record<UsageTone, string> = {
+  blue: 'text-primary-600 dark:text-primary-400',
+  yellow: 'text-yellow-600 dark:text-yellow-400',
+  red: 'text-red-600 dark:text-red-400',
+  purple: 'text-purple-600 dark:text-purple-400',
+}
+
+function UsageRadialMetric({
+  label,
+  value,
+  detail,
+  percent,
+  tone,
+  centerText,
+}: {
+  label: string
+  value: string
+  detail: string
+  percent: number
+  tone: UsageTone
+  centerText?: string
+}) {
+  const radius = 28
+  const circumference = 2 * Math.PI * radius
+  const safePercent = Math.max(0, Math.min(100, percent))
+  const dashLength = (safePercent / 100) * circumference
+
+  return (
+    <div className="rounded-md bg-gray-50 dark:bg-gray-900/40 px-3 py-2.5">
+      <div className="flex items-center gap-3">
+        <div className="relative h-16 w-16 flex-shrink-0">
+          <svg className="h-16 w-16 -rotate-90" viewBox="0 0 72 72" aria-hidden="true">
+            <circle
+              cx="36"
+              cy="36"
+              r={radius}
+              className="fill-none stroke-gray-200 dark:stroke-gray-700"
+              strokeWidth="7"
+            />
+            <circle
+              cx="36"
+              cy="36"
+              r={radius}
+              className={`fill-none ${RADIAL_STROKE_CLASS[tone]} transition-all duration-300`}
+              strokeWidth="7"
+              strokeLinecap="round"
+              strokeDasharray={`${dashLength} ${circumference - dashLength}`}
+            />
+          </svg>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className={`text-xs font-semibold ${RADIAL_TEXT_CLASS[tone]}`}>
+              {centerText ?? `${Math.round(safePercent)}%`}
+            </span>
+          </div>
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400">{label}</p>
+          <p className="truncate text-base font-semibold text-gray-900 dark:text-white">
+            {value}
+          </p>
+          <p className="truncate text-xs text-gray-500 dark:text-gray-400" title={detail}>
+            {detail}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function LimitPill({ limit }: { limit: PlanLimitInfo }) {
+  const tone = getLimitTone(limit.utilization)
+  return (
+    <div className="flex items-center justify-between rounded-md bg-gray-50 dark:bg-gray-900/40 px-3 py-2">
+      <div className="min-w-0">
+        <p className="truncate text-xs font-medium text-gray-700 dark:text-gray-300">
+          {limit.displayName}
+        </p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {formatResetTime(limit)} reset
+        </p>
+      </div>
+      <span className={`text-sm font-semibold ${RADIAL_TEXT_CLASS[tone]}`}>
+        {Math.round(limit.utilization)}%
+      </span>
+    </div>
+  )
+}
+
+function formatResetTime(limit: PlanLimitInfo): string {
+  const hours = Math.floor(limit.resetsInHours ?? 0)
+  const mins = Math.floor(limit.resetsInMinutes ?? 0)
+
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24)
+    const remainingHours = hours % 24
+    return `${days}d ${remainingHours}h`
+  }
+
+  if (hours > 0) return `${hours}h ${mins}m`
+  return `${mins}m`
+}
+
+function getLimitTone(percentUsed: number): UsageTone {
+  if (percentUsed >= 90) return 'red'
+  if (percentUsed >= 70) return 'yellow'
+  return 'blue'
+}
+
+function getRemainingTone(percentRemaining: number): UsageTone {
+  if (percentRemaining <= 10) return 'red'
+  if (percentRemaining <= 30) return 'yellow'
+  return 'purple'
+}
+
+function formatCodexPlanDetail(window: CodexPlanWindow, planType?: string | null): string {
+  const pieces = [
+    `${Math.round(window.usedPercent)}% used`,
+    `${formatCodexWindowReset(window)} reset`,
+  ]
+  if (planType) {
+    pieces.unshift(formatPlanName(planType))
+  }
+  return pieces.join(' / ')
+}
+
+function formatCodexWindowReset(window: CodexPlanWindow): string {
+  const minutes = Math.floor(window.resetsInMinutes ?? 0)
+
+  if (minutes <= 0) return 'soon'
+  if (minutes >= 60 * 24) {
+    const days = Math.floor(minutes / (60 * 24))
+    const hours = Math.floor((minutes % (60 * 24)) / 60)
+    return `${days}d ${hours}h`
+  }
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60)
+    const remainingMinutes = minutes % 60
+    return `${hours}h ${remainingMinutes}m`
+  }
+  return `${minutes}m`
+}
+
+function formatPlanName(planType: string): string {
+  if (!planType) return ''
+  return planType.charAt(0).toUpperCase() + planType.slice(1)
+}
+
+function formatCodexPlanUnavailable(
+  codexPlan: CodexPlanUsageResponse | null,
+  isLoading: boolean
+): string {
+  if (isLoading) return 'Loading ChatGPT Codex plan'
+  if (!codexPlan) return 'ChatGPT Codex plan unavailable'
+  if (!codexPlan.available) return codexPlan.message || 'ChatGPT Codex plan unavailable'
+
+  return 'ChatGPT Codex plan unavailable'
 }

--- a/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { ClaudeUsageDashboard } from '../ClaudeUsageDashboard'
 import type { ClaudeUsageResponse } from '../../../types/claudeUsage'
+
+const mockApiGet = vi.hoisted(() => vi.fn())
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
@@ -11,6 +13,12 @@ vi.mock('lucide-react', () => ({
   CheckCircle2: (props: Record<string, unknown>) => <svg data-testid="icon-check" {...props} />,
   XCircle: (props: Record<string, unknown>) => <svg data-testid="icon-x" {...props} />,
   Clock: (props: Record<string, unknown>) => <svg data-testid="icon-clock" {...props} />,
+}))
+
+vi.mock('../../../services/apiClient', () => ({
+  apiClient: {
+    get: mockApiGet,
+  },
 }))
 
 // Store mock state
@@ -51,9 +59,55 @@ const makeUsageResponse = (overrides?: Partial<ClaudeUsageResponse>): ClaudeUsag
   ...overrides,
 })
 
+const defaultCodexPlan = {
+  available: true,
+  codexLimit: {
+    limitId: 'codex',
+    limitName: null,
+    primary: {
+      usedPercent: 56,
+      remainingPercent: 44,
+      windowDurationMins: 300,
+      resetsAt: 1783174155,
+      resetsAtIso: '2026-07-04T12:49:15+00:00',
+      resetsInMinutes: 120,
+    },
+    secondary: {
+      usedPercent: 40,
+      remainingPercent: 60,
+      windowDurationMins: 10080,
+      resetsAt: 1783706099,
+      resetsAtIso: '2026-07-10T16:34:59+00:00',
+      resetsInMinutes: 8640,
+    },
+    planType: 'plus',
+    rateLimitReachedType: null,
+  },
+  rateLimitResetCredits: { availableCount: 1 },
+  isCached: false,
+  cacheAgeSeconds: null,
+}
+
+const defaultCodexCli = {
+  available: true,
+  fiveHourTokens: 0,
+  fiveHourThreads: 0,
+  weeklyTokens: 0,
+  weeklyThreads: 0,
+  totalTokens: 0,
+  totalThreads: 0,
+  byModel: [],
+}
+
 describe('ClaudeUsageDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockApiGet.mockImplementation((url: string) => {
+      if (url.includes('/api/usage/codex-plan')) {
+        return Promise.resolve(defaultCodexPlan)
+      }
+      return Promise.resolve(defaultCodexCli)
+    })
     mockUsage = null
     mockIsLoading = false
     mockError = null
@@ -73,7 +127,7 @@ describe('ClaudeUsageDashboard', () => {
     mockError = 'Network error'
     render(<ClaudeUsageDashboard />)
     expect(screen.getByText('Network error')).toBeInTheDocument()
-    expect(screen.getByText('Claude Code Usage')).toBeInTheDocument()
+    expect(screen.getByText('Plan Usage Limits')).toBeInTheDocument()
   })
 
   it('shows loading skeleton when loading with no data', () => {
@@ -100,19 +154,19 @@ describe('ClaudeUsageDashboard', () => {
   it('shows "Live" indicator when oauth is available and not cached', () => {
     mockUsage = makeUsageResponse({ oauthAvailable: true, isCached: false })
     render(<ClaudeUsageDashboard />)
-    expect(screen.getByText('Live')).toBeInTheDocument()
+    expect(screen.getByText('Claude Live')).toBeInTheDocument()
   })
 
   it('shows "Cached" indicator when data is cached', () => {
     mockUsage = makeUsageResponse({ oauthAvailable: true, isCached: true, cacheAgeMinutes: 5 })
     render(<ClaudeUsageDashboard />)
-    expect(screen.getByText('Cached')).toBeInTheDocument()
+    expect(screen.getByText('Claude Cached')).toBeInTheDocument()
   })
 
   it('shows "Offline" indicator when oauth is not available', () => {
     mockUsage = makeUsageResponse({ oauthAvailable: false })
     render(<ClaudeUsageDashboard />)
-    expect(screen.getByText('Offline')).toBeInTheDocument()
+    expect(screen.getByText('Claude Offline')).toBeInTheDocument()
   })
 
   it('shows weekly token usage section', () => {
@@ -122,17 +176,79 @@ describe('ClaudeUsageDashboard', () => {
       weeklyOpusTokens: 500000,
     })
     render(<ClaudeUsageDashboard />)
-    expect(screen.getByText('Weekly Token Usage (Local)')).toBeInTheDocument()
+    expect(screen.getByText('Local Token Usage (diagnostic)')).toBeInTheDocument()
     expect(screen.getByText('1.5M')).toBeInTheDocument()
     expect(screen.getByText('1.0M')).toBeInTheDocument()
     expect(screen.getByText('500.0K')).toBeInTheDocument()
   })
 
-  it('shows plan limit progress bars when oauth is available', () => {
+  it('shows radial plan usage metrics when oauth is available', () => {
     mockUsage = makeUsageResponse()
     render(<ClaudeUsageDashboard />)
-    expect(screen.getByText('Current Session')).toBeInTheDocument()
-    expect(screen.getByText('All Models (7d)')).toBeInTheDocument()
+    expect(screen.getByText('Claude Session')).toBeInTheDocument()
+    expect(screen.getByText('Claude Weekly')).toBeInTheDocument()
+  })
+
+  it('shows ChatGPT Codex subscription remaining limits', async () => {
+    mockUsage = makeUsageResponse({ weeklyTotalTokens: 200000 })
+
+    render(<ClaudeUsageDashboard />)
+
+    expect(await screen.findByText('Codex 5h')).toBeInTheDocument()
+    expect(screen.getByText('Codex Weekly')).toBeInTheDocument()
+    expect(screen.getByText('44% left')).toBeInTheDocument()
+    expect(screen.getByText('60% left')).toBeInTheDocument()
+    expect(screen.getByText('Codex reset credits: 1')).toBeInTheDocument()
+  })
+
+  it('shows local codex token usage as diagnostics', async () => {
+    mockUsage = makeUsageResponse({ weeklyTotalTokens: 200000 })
+    mockApiGet.mockImplementation((url: string) => {
+      if (url.includes('/api/usage/codex-plan')) {
+        return Promise.resolve(defaultCodexPlan)
+      }
+      return Promise.resolve({
+        available: true,
+        fiveHourTokens: 12000,
+        fiveHourThreads: 1,
+        weeklyTokens: 50000,
+        weeklyThreads: 3,
+        totalTokens: 80000,
+        totalThreads: 5,
+        byModel: [
+          { name: 'gpt-5.5', tokens: 42000, threads: 2 },
+          { name: 'codex-auto-review', tokens: 8000, threads: 1 },
+        ],
+      })
+    })
+
+    render(<ClaudeUsageDashboard />)
+
+    expect(await screen.findByText('50.0K')).toBeInTheDocument()
+    expect(screen.getByText('Codex')).toBeInTheDocument()
+  })
+
+  it('bypasses codex plan cache when refresh is clicked', async () => {
+    mockUsage = makeUsageResponse()
+
+    render(<ClaudeUsageDashboard />)
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith(
+        expect.stringContaining('/api/usage/codex-plan?'),
+        expect.objectContaining({ timeout: 15_000 })
+      )
+    })
+
+    mockApiGet.mockClear()
+    fireEvent.click(screen.getByTitle('Refresh'))
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith(
+        expect.stringContaining('/api/usage/codex-plan?refresh=true&'),
+        expect.objectContaining({ timeout: 15_000 })
+      )
+    })
   })
 
   it('shows oauth error message when oauth is not available', () => {
@@ -143,7 +259,9 @@ describe('ClaudeUsageDashboard', () => {
     })
     render(<ClaudeUsageDashboard />)
     expect(screen.getByText('Token expired')).toBeInTheDocument()
-    expect(screen.getByText('Showing local token statistics only.')).toBeInTheDocument()
+    expect(
+      screen.getByText('Claude plan limits unavailable; Codex plan limits are checked separately.')
+    ).toBeInTheDocument()
   })
 
   it('formats small token counts without suffix', () => {

--- a/src/dashboard/src/pages/AnalyticsPage.test.tsx
+++ b/src/dashboard/src/pages/AnalyticsPage.test.tsx
@@ -35,19 +35,11 @@ vi.mock('recharts', () => ({
 
 // Store mocks - imported later for vi.mocked() usage
 const mockFetchProjects = vi.fn()
-const mockFetchUsage = vi.fn()
 
 vi.mock('../stores/projects', () => ({
   useProjectsStore: vi.fn(() => ({
     projects: [],
     fetchProjects: mockFetchProjects,
-  })),
-}))
-
-vi.mock('../stores/claudeUsage', () => ({
-  useClaudeUsageStore: vi.fn(() => ({
-    usage: null,
-    fetchUsage: mockFetchUsage,
   })),
 }))
 
@@ -88,7 +80,7 @@ vi.mock('../lib/utils', () => ({
 
 import { AnalyticsPage } from './AnalyticsPage'
 import { useProjectsStore } from '../stores/projects'
-import { useClaudeUsageStore } from '../stores/claudeUsage'
+import { useExternalUsageStore } from '../stores/externalUsage'
 import { useAuthStore } from '../stores/auth'
 
 // ─────────────────────────────────────────────────────────────
@@ -135,8 +127,8 @@ const mockDashboardData = {
     avg_cost_per_task: 0.0625,
     by_agent: [],
     by_model: [
-      { category: 'model', value: 'gemini-2.0-flash', cost: 8.00, tokens: 300000, percentage: 64 },
-      { category: 'model', value: 'claude-3.5', cost: 4.50, tokens: 200000, percentage: 36 },
+      { category: 'model', value: 'gemini-2.0-flash', provider: 'google', cost: 8.00, tokens: 300000, percentage: 64 },
+      { category: 'model', value: 'claude-3.5', provider: 'anthropic', cost: 4.50, tokens: 200000, percentage: 36 },
     ],
     projected_monthly: 37.50,
   },
@@ -317,6 +309,10 @@ describe('AnalyticsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     setupFetchMock()
+    vi.mocked(useExternalUsageStore).mockReturnValue({
+      summary: { total_cost_usd: 5.25, providers: [], records: [], period_start: '', period_end: '' },
+      fetchSummary: mockFetchExternalSummary,
+    } as unknown as ReturnType<typeof useExternalUsageStore>)
   })
 
   // ── Basic rendering ──
@@ -392,6 +388,43 @@ describe('AnalyticsPage', () => {
 
     expect(screen.getByText('Test Agent')).toBeInTheDocument()
     expect(screen.getByText('general')).toBeInTheDocument()
+  })
+
+  it('hides zero-usage unknown model rows from model performance views', async () => {
+    setupFetchMock({
+      dashboardData: {
+        ...mockDashboardData,
+        agents: {
+          ...mockDashboardData.agents,
+          agents: [
+            ...mockDashboardData.agents.agents,
+            {
+              agent_id: 'unknown (no model info)',
+              agent_name: 'unknown (no model info)',
+              category: 'model',
+              total_tasks: 3,
+              completed_tasks: 3,
+              failed_tasks: 0,
+              success_rate: 100,
+              avg_duration_ms: 0,
+              total_tokens: 0,
+              total_cost: 0,
+            },
+          ],
+        },
+      },
+    })
+
+    await act(async () => {
+      render(<AnalyticsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Model Performance')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Test Agent')).toBeInTheDocument()
+    expect(screen.queryByText('unknown (no model info)')).not.toBeInTheDocument()
   })
 
   it('renders project comparison section', async () => {
@@ -1099,97 +1132,119 @@ describe('AnalyticsPage', () => {
     })
   })
 
-  // ── Claude Usage / Model Token Breakdown ──
+  // ── AOS LLM Usage / Model Token Breakdown ──
 
-  it('renders model token breakdown chart when claude usage data exists', async () => {
-    vi.mocked(useClaudeUsageStore).mockReturnValue({
-      usage: {
-        weeklyModelTokens: [
-          { date: '2026-02-15', tokensByModel: { 'claude-3.5': 10000, 'gemini-2.0': 20000 } },
-          { date: '2026-02-16', tokensByModel: { 'claude-3.5': 15000, 'gemini-2.0': 25000 } },
+  it('renders AOS model token breakdown from analytics costs', async () => {
+    await act(async () => {
+      render(<AnalyticsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('AOS LLM Usage by Model')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('gemini-2.0-flash')).toBeInTheDocument()
+    expect(screen.getByText('claude-3.5')).toBeInTheDocument()
+    expect(screen.getByText('Google Gemini')).toBeInTheDocument()
+    expect(screen.getByText('Anthropic Claude')).toBeInTheDocument()
+    expect(screen.getByText('AOS 집계: 2 providers')).toBeInTheDocument()
+    expect(screen.queryByText('No AOS LLM token data available')).not.toBeInTheDocument()
+  })
+
+  it('prefers explicit provider metadata over model-name inference', async () => {
+    setupFetchMock({
+      dashboardData: {
+        ...mockDashboardData,
+        costs: {
+          ...mockDashboardData.costs,
+          by_model: [
+            {
+              category: 'model',
+              value: 'claude-opus-4-8',
+              provider: 'codex_cli',
+              cost: 4,
+              tokens: 123456,
+              percentage: 100,
+            },
+          ],
+        },
+      },
+    })
+
+    await act(async () => {
+      render(<AnalyticsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('claude-opus-4-8')).toBeInTheDocument()
+    })
+
+    expect(screen.getAllByText('Codex CLI').length).toBeGreaterThan(0)
+    expect(screen.getByText('AOS 집계: Codex CLI')).toBeInTheDocument()
+    expect(screen.queryByText('Anthropic Claude')).not.toBeInTheDocument()
+  })
+
+  it('includes external usage records in the AOS model token breakdown', async () => {
+    vi.mocked(useExternalUsageStore).mockReturnValue({
+      summary: {
+        providers: [],
+        total_cost_usd: 0.25,
+        period_start: '2026-02-01T00:00:00Z',
+        period_end: '2026-02-02T00:00:00Z',
+        records: [
+          {
+            id: 'rec-1',
+            provider: 'openai',
+            timestamp: '2026-02-01T12:00:00Z',
+            bucket_width: '1d',
+            input_tokens: 10,
+            output_tokens: 20,
+            total_tokens: 30,
+            cost_usd: 0.25,
+            request_count: 1,
+            model: 'gpt-4.1',
+            user_id: null,
+            user_email: null,
+            project_id: null,
+            code_suggestions: null,
+            code_acceptances: null,
+            acceptance_rate: null,
+            collected_at: '2026-02-01T12:00:00Z',
+          },
         ],
       },
-      fetchUsage: mockFetchUsage,
-    } as unknown as ReturnType<typeof useClaudeUsageStore>)
+      fetchSummary: mockFetchExternalSummary,
+    } as unknown as ReturnType<typeof useExternalUsageStore>)
 
     await act(async () => {
       render(<AnalyticsPage />)
     })
 
     await waitFor(() => {
-      expect(screen.getByText('Model Token Breakdown (7 Days)')).toBeInTheDocument()
+      expect(screen.getByText('gpt-4.1')).toBeInTheDocument()
     })
 
-    // Should show bar charts, not the empty state
-    expect(screen.queryByText('No model token data available')).not.toBeInTheDocument()
+    expect(screen.getByText('OpenAI')).toBeInTheDocument()
+    expect(screen.getByText('AOS 집계: 3 providers')).toBeInTheDocument()
   })
 
-  it('shows empty state when no claude usage data', async () => {
-    vi.mocked(useClaudeUsageStore).mockReturnValue({
-      usage: null,
-      fetchUsage: mockFetchUsage,
-    } as unknown as ReturnType<typeof useClaudeUsageStore>)
-
-    await act(async () => {
-      render(<AnalyticsPage />)
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText('No model token data available')).toBeInTheDocument()
-    })
-  })
-
-  it('shows empty state when weeklyModelTokens is null', async () => {
-    vi.mocked(useClaudeUsageStore).mockReturnValue({
-      usage: { weeklyModelTokens: null },
-      fetchUsage: mockFetchUsage,
-    } as unknown as ReturnType<typeof useClaudeUsageStore>)
-
-    await act(async () => {
-      render(<AnalyticsPage />)
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText('No model token data available')).toBeInTheDocument()
-    })
-  })
-
-  it('shows empty state when weeklyModelTokens is an empty array', async () => {
-    // Regression: an empty array is truthy in JS, so the previous gate
-    // rendered an empty <BarChart> instead of the empty-state UI.
-    vi.mocked(useClaudeUsageStore).mockReturnValue({
-      usage: { weeklyModelTokens: [] },
-      fetchUsage: mockFetchUsage,
-    } as unknown as ReturnType<typeof useClaudeUsageStore>)
-
-    await act(async () => {
-      render(<AnalyticsPage />)
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText('No model token data available')).toBeInTheDocument()
-    })
-  })
-
-  it('shows a "session logs" badge when token data came from JSONL fallback', async () => {
-    vi.mocked(useClaudeUsageStore).mockReturnValue({
-      usage: {
-        weeklyModelTokens: [
-          { date: '2026-04-30', tokensByModel: { 'claude-opus-4-7': 1000 } },
-        ],
-        weeklyModelTokensSource: 'jsonl-fallback',
-        statsCacheAgeDays: 27,
+  it('shows empty state when analytics has no model token data', async () => {
+    setupFetchMock({
+      dashboardData: {
+        ...mockDashboardData,
+        costs: {
+          ...mockDashboardData.costs,
+          by_model: [],
+        },
       },
-      fetchUsage: mockFetchUsage,
-    } as unknown as ReturnType<typeof useClaudeUsageStore>)
+    })
 
     await act(async () => {
       render(<AnalyticsPage />)
     })
 
     await waitFor(() => {
-      // The badge surfaces both the source ("session logs") and the staleness.
-      expect(screen.getByText(/세션 로그 기반/)).toBeInTheDocument()
+      expect(screen.getByText('No AOS LLM token data available')).toBeInTheDocument()
     })
   })
 
@@ -1314,7 +1369,7 @@ describe('AnalyticsPage', () => {
     expect(mockFetchProjects).toHaveBeenCalled()
   })
 
-  it('calls fetchUsage on mount', async () => {
+  it('calls fetchExternalSummary on mount', async () => {
     await act(async () => {
       render(<AnalyticsPage />)
     })
@@ -1323,7 +1378,7 @@ describe('AnalyticsPage', () => {
       expect(screen.getByText('Analytics Dashboard')).toBeInTheDocument()
     })
 
-    expect(mockFetchUsage).toHaveBeenCalled()
+    expect(mockFetchExternalSummary).toHaveBeenCalled()
   })
 
   // ── Eval stats colors based on thresholds ──

--- a/src/dashboard/src/pages/AnalyticsPage.tsx
+++ b/src/dashboard/src/pages/AnalyticsPage.tsx
@@ -48,8 +48,10 @@ import {
 import { cn } from '../lib/utils'
 import { computeHeatmapAlpha } from '../lib/heatmap'
 import { useProjectsStore, Project } from '../stores/projects'
-import { useClaudeUsageStore } from '../stores/claudeUsage'
-import { useExternalUsageStore } from '../stores/externalUsage'
+import {
+  useExternalUsageStore,
+  type ExternalUsageSummaryResponse,
+} from '../stores/externalUsage'
 import { useAuthStore } from '../stores/auth'
 import { ProjectMultiSelect } from '../components/analytics/ProjectMultiSelect'
 import type { TaskAnalysisHistory } from '../stores/agents'
@@ -106,6 +108,7 @@ interface AgentPerformance {
 interface CostBreakdown {
   category: string
   value: string
+  provider?: string | null
   cost: number
   tokens: number
   percentage: number
@@ -139,6 +142,16 @@ interface AnalyticsDashboard {
   agents: { agents: AgentPerformance[]; time_range: TimeRange }
   costs: CostAnalytics
   activity: ActivityHeatmap
+}
+
+interface ModelTokenBreakdown {
+  model: string
+  provider: string
+  providerLabel: string
+  tokens: number
+  cost: number
+  percentage: number
+  color: string
 }
 
 // Multi-Project Comparison Types
@@ -208,6 +221,26 @@ const CHART_COLORS = [
   '#EC4899', // pink
   '#06B6D4', // cyan
 ]
+
+const PROVIDER_COLORS: Record<string, string> = {
+  codex_cli: '#8B5CF6',
+  anthropic: '#F97316',
+  openai: '#10B981',
+  google: '#3B82F6',
+  github_copilot: '#111827',
+  ollama: '#64748B',
+  unknown: '#6B7280',
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  codex_cli: 'Codex CLI',
+  anthropic: 'Anthropic Claude',
+  openai: 'OpenAI',
+  google: 'Google Gemini',
+  github_copilot: 'GitHub Copilot',
+  ollama: 'Ollama',
+  unknown: 'Unknown',
+}
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
@@ -315,9 +348,6 @@ export function AnalyticsPage() {
     ? projects
     : projects.filter((p: Project) => p.is_active !== false)
 
-  // Get Claude usage data from store
-  const { usage: claudeUsage, fetchUsage } = useClaudeUsageStore()
-
   // Get external (actual API billing) usage data
   const { summary: externalSummary, fetchSummary: fetchExternalSummary } = useExternalUsageStore()
 
@@ -325,11 +355,6 @@ export function AnalyticsPage() {
   useEffect(() => {
     fetchProjects()
   }, [fetchProjects])
-
-  // Fetch Claude usage on mount
-  useEffect(() => {
-    fetchUsage()
-  }, [fetchUsage])
 
   // Fetch external usage on mount
   useEffect(() => {
@@ -420,6 +445,9 @@ export function AnalyticsPage() {
   }
 
   if (!data) return null
+
+  const modelTokenBreakdown = buildModelTokenBreakdown(data.costs.by_model, externalSummary)
+  const modelPerformanceData = filterAttributedModelPerformance(data.agents.agents)
 
   return (
     <div className="flex-1 p-6 overflow-y-auto">
@@ -664,49 +692,78 @@ export function AnalyticsPage() {
           </ResponsiveContainer>
         </ChartCard>
 
-        {/* Model Token Breakdown (Weekly) */}
+        {/* AOS LLM Model Token Breakdown */}
         <ChartCard
-          title="Model Token Breakdown (7 Days)"
+          title="AOS LLM Usage by Model"
           icon={Users}
-          headerExtra={renderTokenSourceBadge(claudeUsage)}
+          headerExtra={renderAosModelSourceBadge(modelTokenBreakdown)}
         >
-          {claudeUsage?.weeklyModelTokens && claudeUsage.weeklyModelTokens.length > 0 ? (
-            <ResponsiveContainer width="100%" height={250}>
-              <BarChart data={transformModelTokensData(claudeUsage.weeklyModelTokens)}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
-                <XAxis
-                  dataKey="date"
-                  tick={{ fontSize: 12 }}
-                  className="text-gray-500"
-                />
-                <YAxis
-                  tick={{ fontSize: 12 }}
-                  className="text-gray-500"
-                  tickFormatter={formatTokenCount}
-                />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'var(--tooltip-bg, #fff)',
-                    borderColor: 'var(--tooltip-border, #e5e7eb)',
-                  }}
-                  formatter={(value) => [formatTokenCount(Number(value)), 'Tokens']}
-                />
-                <Legend />
-                {extractModelNames(claudeUsage.weeklyModelTokens).map((modelName, index) => (
-                  <Bar
-                    key={modelName}
-                    dataKey={modelName}
-                    stackId="tokens"
-                    fill={CHART_COLORS[index % CHART_COLORS.length]}
+          {modelTokenBreakdown.length > 0 ? (
+            <div className="space-y-3">
+              <ResponsiveContainer width="100%" height={210}>
+                <BarChart
+                  data={modelTokenBreakdown}
+                  layout="vertical"
+                  margin={{ top: 4, right: 24, left: 24, bottom: 4 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                  <XAxis
+                    type="number"
+                    tick={{ fontSize: 12 }}
+                    className="text-gray-500"
+                    tickFormatter={formatTokenCount}
                   />
+                  <YAxis
+                    type="category"
+                    dataKey="model"
+                    width={120}
+                    tick={{ fontSize: 11 }}
+                    className="text-gray-500"
+                    tickFormatter={(value) => truncateModelLabel(String(value))}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--tooltip-bg, #fff)',
+                      borderColor: 'var(--tooltip-border, #e5e7eb)',
+                      borderRadius: '12px',
+                      padding: '8px 12px',
+                    }}
+                    formatter={(value) => [formatTokenCount(Number(value)), 'Tokens']}
+                    labelFormatter={(label) => String(label)}
+                  />
+                  <Bar dataKey="tokens" radius={[0, 4, 4, 0]}>
+                    {modelTokenBreakdown.map((entry) => (
+                      <Cell key={`${entry.provider}:${entry.model}`} fill={entry.color} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2 border-t border-gray-100 dark:border-gray-700 pt-3">
+                {modelTokenBreakdown.slice(0, 6).map((entry) => (
+                  <div key={`${entry.provider}:${entry.model}`} className="min-w-0 flex items-center gap-2 text-xs">
+                    <span
+                      className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                      style={{ backgroundColor: entry.color }}
+                    />
+                    <span className="truncate text-gray-900 dark:text-white" title={entry.model}>
+                      {entry.model}
+                    </span>
+                    <span className="text-gray-400">·</span>
+                    <span className="text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      {entry.providerLabel}
+                    </span>
+                    <span className="ml-auto text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                      {formatTokenCount(entry.tokens)}
+                    </span>
+                  </div>
                 ))}
-              </BarChart>
-            </ResponsiveContainer>
+              </div>
+            </div>
           ) : (
             <div className="h-[250px] flex items-center justify-center text-gray-500 dark:text-gray-400">
               <div className="text-center">
                 <Zap className="w-12 h-12 mx-auto mb-2 opacity-50" />
-                <p>No model token data available</p>
+                <p>No AOS LLM token data available</p>
               </div>
             </div>
           )}
@@ -756,7 +813,7 @@ export function AnalyticsPage() {
         {/* Model Performance */}
         <ChartCard title="Model Performance" icon={Users}>
           <ResponsiveContainer width="100%" height={250}>
-            <BarChart data={data.agents.agents} layout="vertical">
+            <BarChart data={modelPerformanceData} layout="vertical">
               <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
               <XAxis type="number" domain={[0, 100]} tick={{ fontSize: 12 }} />
               <YAxis
@@ -898,7 +955,7 @@ export function AnalyticsPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-              {data.agents.agents.map((agent) => {
+              {modelPerformanceData.map((agent) => {
                 const agentEval = evalStats?.by_agent?.find(
                   (a) => a.agent_id === agent.agent_id ||
                     a.agent_id === agent.agent_name.toLowerCase().replace(/\s+/g, '-')
@@ -1535,76 +1592,109 @@ function transformMultiSeriesData(
   return Array.from(dateMap.values())
 }
 
-/**
- * Render a small status badge above the Model Token Breakdown chart that
- * tells the user *why* the data looks the way it does — silent fallback is
- * confusing, especially when stats-cache.json has gone stale upstream.
- */
-function renderTokenSourceBadge(
-  usage: import('../types/claudeUsage').ClaudeUsageResponse | null
-): React.ReactNode {
-  if (!usage) return null
-  const source = usage.weeklyModelTokensSource
-  const ageDays = usage.statsCacheAgeDays ?? null
+function buildModelTokenBreakdown(
+  models: CostBreakdown[],
+  externalSummary: ExternalUsageSummaryResponse | null,
+): ModelTokenBreakdown[] {
+  const grouped = new Map<string, ModelTokenBreakdown>()
 
-  if (source === 'jsonl-fallback') {
-    const ageHint = ageDays != null && ageDays > 0 ? ` (Claude 캐시 ${ageDays}일 stale)` : ''
-    return (
-      <span
-        className="text-[11px] px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200 whitespace-nowrap"
-        title={`stats-cache.json이 갱신되지 않아 세션 JSONL에서 직접 집계했습니다${ageHint}.`}
-      >
-        세션 로그 기반{ageHint}
-      </span>
-    )
-  }
+  const addEntry = (
+    modelName: string | null | undefined,
+    providerValue: string | null | undefined,
+    tokens: number,
+    cost: number,
+  ) => {
+    if (tokens <= 0) return
+    const model = modelName?.trim() || 'unknown'
+    const provider = normalizeProvider(providerValue, model)
+    const key = `${provider}:${model}`
+    const existing = grouped.get(key)
 
-  if (ageDays != null && ageDays >= 2) {
-    return (
-      <span
-        className="text-[11px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300 whitespace-nowrap"
-        title="Claude Code의 stats-cache.json이 며칠째 갱신되지 않았습니다."
-      >
-        캐시 {ageDays}일 stale
-      </span>
-    )
-  }
-
-  return null
-}
-
-/**
- * Transform model tokens data for stacked bar chart
- * Converts from DailyModelTokens[] to Recharts format
- */
-function transformModelTokensData(
-  data: { date: string; tokensByModel: Record<string, number> }[]
-): Record<string, string | number>[] {
-  return data.map((day) => {
-    const dateKey = new Date(day.date).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    })
-    return {
-      date: dateKey,
-      ...day.tokensByModel,
+    if (existing) {
+      existing.tokens += tokens
+      existing.cost += cost
+      return
     }
+
+    grouped.set(key, {
+      model,
+      provider,
+      providerLabel: PROVIDER_LABELS[provider] ?? provider,
+      tokens,
+      cost,
+      percentage: 0,
+      color: PROVIDER_COLORS[provider] ?? PROVIDER_COLORS.unknown,
+    })
+  }
+
+  models.forEach((model) => {
+    addEntry(model.value, model.provider, model.tokens, model.cost)
+  })
+
+  externalSummary?.records.forEach((record) => {
+    addEntry(record.model, record.provider, record.total_tokens, record.cost_usd)
+  })
+
+  const entries = Array.from(grouped.values())
+  const totalTokens = entries.reduce((sum, entry) => sum + entry.tokens, 0)
+  return entries
+    .map((entry) => ({
+      ...entry,
+      percentage: totalTokens > 0 ? Math.round((entry.tokens / totalTokens) * 1000) / 10 : 0,
+    }))
+    .sort((a, b) => b.tokens - a.tokens)
+}
+
+function filterAttributedModelPerformance(agents: AgentPerformance[]): AgentPerformance[] {
+  return agents.filter((agent) => {
+    const modelName = agent.agent_name.trim().toLowerCase()
+    return !(
+      modelName === 'unknown (no model info)'
+      && agent.total_tokens === 0
+      && agent.total_cost === 0
+    )
   })
 }
 
-/**
- * Extract all unique model names from weekly model tokens data
- */
-function extractModelNames(
-  data: { date: string; tokensByModel: Record<string, number> }[]
-): string[] {
-  const modelNamesSet = new Set<string>()
-  data.forEach((day) => {
-    Object.keys(day.tokensByModel).forEach((modelName) => {
-      modelNamesSet.add(modelName)
-    })
-  })
-  return Array.from(modelNamesSet)
+function normalizeProvider(provider: string | null | undefined, modelName: string): string {
+  const explicit = provider?.trim().toLowerCase()
+  if (explicit) {
+    if (explicit === 'codex') return 'codex_cli'
+    if (explicit === 'claude') return 'anthropic'
+    if (explicit === 'gemini' || explicit === 'vertex' || explicit === 'google_gemini') {
+      return 'google'
+    }
+    return explicit
+  }
+
+  const model = modelName.toLowerCase()
+  if (model.includes('codex')) return 'codex_cli'
+  if (model.includes('claude')) return 'anthropic'
+  if (model.includes('gpt') || model.includes('openai')) return 'openai'
+  if (model.includes('gemini') || model.includes('vertex')) return 'google'
+  if (model.includes('ollama') || model.includes('llama') || model.includes('mistral')) {
+    return 'ollama'
+  }
+  return 'unknown'
+}
+
+function renderAosModelSourceBadge(models: ModelTokenBreakdown[]): React.ReactNode {
+  if (models.length === 0) return null
+  const providers = Array.from(new Set(models.map((model) => model.providerLabel)))
+  const label = providers.length === 1 ? providers[0] : `${providers.length} providers`
+
+  return (
+    <span
+      className="text-[11px] px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200 whitespace-nowrap"
+      title="AOS analytics costs.by_model 기준의 모델별 LLM 사용량입니다."
+    >
+      AOS 집계: {label}
+    </span>
+  )
+}
+
+function truncateModelLabel(modelName: string): string {
+  return modelName.length > 18 ? `${modelName.slice(0, 17)}...` : modelName
 }
 
 export default AnalyticsPage

--- a/tests/backend/api/test_usage_jsonl.py
+++ b/tests/backend/api/test_usage_jsonl.py
@@ -8,6 +8,7 @@ that cache, leaving the Model Token Breakdown chart empty).
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -49,6 +50,42 @@ def _assistant_entry(*, ts: datetime, model: str, **usage_kwargs: int) -> dict:
             },
         },
     }
+
+
+def _write_codex_state_db(path: Path, rows: list[dict]) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE threads (
+                model_provider TEXT,
+                model TEXT,
+                source TEXT,
+                tokens_used INTEGER,
+                updated_at INTEGER
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO threads (
+                model_provider,
+                model,
+                source,
+                tokens_used,
+                updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    row.get("model_provider"),
+                    row.get("model"),
+                    row.get("source"),
+                    row.get("tokens_used"),
+                    row.get("updated_at"),
+                )
+                for row in rows
+            ],
+        )
 
 
 def test_aggregates_tokens_per_day_per_model(isolated_jsonl_env: Path) -> None:
@@ -266,6 +303,9 @@ async def test_response_marks_jsonl_fallback_when_stats_cache_empty(
     assert response.weeklyModelTokensSource == "jsonl-fallback"
     assert response.statsCacheAgeDays == 30
     assert any(r.tokensByModel.get("claude-opus-4-7", 0) == 42 for r in response.weeklyModelTokens)
+    assert response.weeklyTotalTokens == 42
+    assert response.weeklyOpusTokens == 42
+    assert response.weeklySonnetTokens == 0
 
 
 @pytest.mark.anyio
@@ -300,3 +340,221 @@ async def test_response_marks_stats_cache_when_data_is_fresh(
     response = await usage_mod.get_usage()
     assert response.weeklyModelTokensSource == "stats-cache"
     assert response.statsCacheAgeDays == 0
+
+
+def test_codex_cli_usage_reads_local_state_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex local token usage is read from the Codex state DB."""
+    now_ts = int(datetime.now(UTC).timestamp())
+    db_path = tmp_path / "state_5.sqlite"
+    _write_codex_state_db(
+        db_path,
+        [
+            {
+                "model_provider": "openai",
+                "model": "gpt-5.5",
+                "source": "vscode",
+                "tokens_used": 100,
+                "updated_at": now_ts - 60,
+            },
+            {
+                "model_provider": "openai",
+                "model": "codex-auto-review",
+                "source": json.dumps({"subagent": {"other": "guardian"}}),
+                "tokens_used": 50,
+                "updated_at": now_ts - (2 * 24 * 60 * 60),
+            },
+            {
+                "model_provider": "openai",
+                "model": "gpt-5.5",
+                "source": "exec",
+                "tokens_used": 25,
+                "updated_at": now_ts - (10 * 24 * 60 * 60),
+            },
+            {
+                "model_provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "source": "claude",
+                "tokens_used": 999,
+                "updated_at": now_ts,
+            },
+        ],
+    )
+    monkeypatch.setattr(usage_mod, "CODEX_STATE_DB_PATH", db_path)
+
+    response = usage_mod.get_codex_cli_usage()
+
+    assert response.available is True
+    assert response.fiveHourTokens == 100
+    assert response.fiveHourThreads == 1
+    assert response.weeklyTokens == 150
+    assert response.weeklyThreads == 2
+    assert response.totalTokens == 175
+    assert response.totalThreads == 3
+    assert response.byModel[0].name == "gpt-5.5"
+    assert response.byModel[0].tokens == 125
+    assert {source.name for source in response.bySource} >= {"vscode", "subagent", "exec"}
+    assert response.limitStatus == "not_exposed"
+
+
+def test_codex_cli_usage_handles_missing_state_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing Codex DB returns an unavailable payload instead of raising."""
+    monkeypatch.setattr(usage_mod, "CODEX_STATE_DB_PATH", tmp_path / "missing.sqlite")
+
+    response = usage_mod.get_codex_cli_usage()
+
+    assert response.available is False
+    assert response.weeklyTokens == 0
+    assert "not found" in (response.message or "")
+
+
+def test_codex_plan_usage_reads_chatgpt_subscription_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex plan usage comes from app-server rate limits, not the local token DB."""
+    monkeypatch.setattr(
+        usage_mod,
+        "_codex_plan_cache",
+        {"response": None, "timestamp": None},
+    )
+
+    def _fake_read_rate_limits() -> dict:
+        return {
+            "rateLimits": {
+                "limitId": "codex",
+                "limitName": None,
+                "primary": {
+                    "usedPercent": 56,
+                    "windowDurationMins": 300,
+                    "resetsAt": 1783174155,
+                },
+                "secondary": {
+                    "usedPercent": 40,
+                    "windowDurationMins": 10080,
+                    "resetsAt": 1783706099,
+                },
+                "credits": {"hasCredits": False, "balance": "0"},
+                "individualLimit": None,
+                "planType": "plus",
+                "rateLimitReachedType": None,
+            },
+            "rateLimitsByLimitId": {
+                "codex": {
+                    "limitId": "codex",
+                    "primary": {
+                        "usedPercent": 56,
+                        "windowDurationMins": 300,
+                        "resetsAt": 1783174155,
+                    },
+                    "secondary": {
+                        "usedPercent": 40,
+                        "windowDurationMins": 10080,
+                        "resetsAt": 1783706099,
+                    },
+                    "credits": {"hasCredits": False, "balance": "0"},
+                    "individualLimit": None,
+                    "planType": "plus",
+                    "rateLimitReachedType": None,
+                }
+            },
+            "rateLimitResetCredits": {"availableCount": 1},
+        }
+
+    monkeypatch.setattr(usage_mod, "_read_codex_app_server_rate_limits", _fake_read_rate_limits)
+
+    response = usage_mod.get_codex_plan_usage()
+
+    assert response.available is True
+    assert response.source == "codex-app-server"
+    assert response.codexLimit is not None
+    assert response.codexLimit.planType == "plus"
+    assert response.codexLimit.primary is not None
+    assert response.codexLimit.primary.usedPercent == 56
+    assert response.codexLimit.primary.remainingPercent == 44
+    assert response.codexLimit.secondary is not None
+    assert response.codexLimit.secondary.remainingPercent == 60
+    assert response.rateLimitResetCredits == {"availableCount": 1}
+
+
+def test_codex_plan_usage_handles_missing_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing Codex binary returns an unavailable payload."""
+    monkeypatch.setattr(
+        usage_mod,
+        "_codex_plan_cache",
+        {"response": None, "timestamp": None},
+    )
+
+    def _missing_read() -> dict:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(usage_mod, "_read_codex_app_server_rate_limits", _missing_read)
+
+    response = usage_mod.get_codex_plan_usage()
+
+    assert response.available is False
+    assert "not found" in (response.message or "")
+
+
+def test_codex_plan_refresh_bypasses_cached_limit_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manual refresh must not keep showing a stale 0% remaining Codex window."""
+    monkeypatch.setattr(
+        usage_mod,
+        "_codex_plan_cache",
+        {"response": None, "timestamp": None},
+    )
+
+    snapshots = [
+        {
+            "rateLimits": {
+                "limitId": "codex",
+                "primary": {"usedPercent": 100, "windowDurationMins": 300},
+                "secondary": {"usedPercent": 47, "windowDurationMins": 10080},
+                "planType": "plus",
+            },
+            "rateLimitsByLimitId": None,
+            "rateLimitResetCredits": {"availableCount": 1},
+        },
+        {
+            "rateLimits": {
+                "limitId": "codex",
+                "primary": {"usedPercent": 73, "windowDurationMins": 300},
+                "secondary": {"usedPercent": 43, "windowDurationMins": 10080},
+                "planType": "plus",
+            },
+            "rateLimitsByLimitId": None,
+            "rateLimitResetCredits": {"availableCount": 1},
+        },
+    ]
+    calls = {"count": 0}
+
+    def _read_rate_limits() -> dict:
+        index = min(calls["count"], len(snapshots) - 1)
+        calls["count"] += 1
+        return snapshots[index]
+
+    monkeypatch.setattr(usage_mod, "_read_codex_app_server_rate_limits", _read_rate_limits)
+
+    first = usage_mod.get_codex_plan_usage()
+    cached = usage_mod.get_codex_plan_usage()
+    refreshed = usage_mod.get_codex_plan_usage(refresh=True)
+
+    assert first.codexLimit is not None
+    assert first.codexLimit.primary is not None
+    assert first.codexLimit.primary.remainingPercent == 0
+    assert cached.codexLimit is not None
+    assert cached.codexLimit.primary is not None
+    assert cached.codexLimit.primary.remainingPercent == 0
+    assert cached.isCached is True
+    assert refreshed.codexLimit is not None
+    assert refreshed.codexLimit.primary is not None
+    assert refreshed.codexLimit.primary.remainingPercent == 27
+    assert refreshed.codexLimit.secondary is not None
+    assert refreshed.codexLimit.secondary.remainingPercent == 57
+    assert calls["count"] == 2

--- a/tests/backend/test_analytics_service.py
+++ b/tests/backend/test_analytics_service.py
@@ -364,6 +364,80 @@ class TestGetTrendsFromSessions:
         assert any(p.value == 1 for p in result.tasks)
 
 
+class TestGetAgentPerformanceFromSessions:
+    """Tests for AnalyticsService.get_agent_performance_from_sessions()."""
+
+    def _patch_sessions(self, sessions):
+        mock_monitor = MagicMock()
+        mock_monitor.discover_sessions.return_value = sessions
+        return patch(
+            "services.claude_session_monitor.get_monitor",
+            return_value=mock_monitor,
+        )
+
+    def test_excludes_zero_usage_sessions_without_model_metadata(self):
+        sessions = [
+            _make_mock_session(model="unknown", input_tokens=0, output_tokens=0, estimated_cost=0),
+            _make_mock_session(model="", input_tokens=0, output_tokens=0, estimated_cost=0),
+            _make_mock_session(
+                model="claude-fable-5",
+                input_tokens=1000,
+                output_tokens=500,
+                estimated_cost=0.1,
+            ),
+        ]
+
+        with self._patch_sessions(sessions):
+            result = AnalyticsService.get_agent_performance_from_sessions(TimeRange.ALL)
+
+        assert [agent.agent_name for agent in result.agents] == ["claude-fable-5"]
+
+
+class TestGetCostAnalyticsFromSessions:
+    """Tests for AnalyticsService.get_cost_analytics_from_sessions()."""
+
+    def _patch_sessions(self, sessions):
+        mock_monitor = MagicMock()
+        mock_monitor.discover_sessions.return_value = sessions
+        return patch(
+            "services.claude_session_monitor.get_monitor",
+            return_value=mock_monitor,
+        )
+
+    def test_model_breakdown_uses_runtime_provider_metadata(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
+        sessions = [
+            _make_mock_session(
+                model="claude-opus-4-8",
+                input_tokens=1000,
+                output_tokens=500,
+                estimated_cost=0.0,
+            )
+        ]
+
+        with self._patch_sessions(sessions):
+            result = AnalyticsService.get_cost_analytics_from_sessions(TimeRange.ALL)
+
+        assert result.by_model[0].value == "claude-opus-4-8"
+        assert result.by_model[0].provider == "codex_cli"
+
+    def test_model_breakdown_excludes_zero_usage_sessions_without_model_metadata(self):
+        sessions = [
+            _make_mock_session(model="unknown", input_tokens=0, output_tokens=0, estimated_cost=0),
+            _make_mock_session(
+                model="claude-opus-4-8",
+                input_tokens=1000,
+                output_tokens=500,
+                estimated_cost=0.1,
+            ),
+        ]
+
+        with self._patch_sessions(sessions):
+            result = AnalyticsService.get_cost_analytics_from_sessions(TimeRange.ALL)
+
+        assert [model.value for model in result.by_model] == ["claude-opus-4-8"]
+
+
 # ---------------------------------------------------------------------------
 # Async database method tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 로컬 Codex(ChatGPT) 사용량을 기존 Claude 사용량 대시보드에 통합
- 백엔드에 Codex 로컬 토큰 회계(`/api/usage/codex-cli`)와 ChatGPT 플랜 잔여 한도(`/api/usage/codex-plan`) 두 소스를 분리 노출
- 비용 분석에 `provider` 축을 추가해 provider별 사용량/비용 구분

## Changes
### Backend
- `api/usage.py`
  - `GET /api/usage/codex-cli`: Codex `state_5.sqlite`(로컬 스레드 토큰 회계)를 **read-only**로 읽어 5시간/주간/전체 토큰·스레드, 모델별·소스별 breakdown 반환
  - `GET /api/usage/codex-plan`: Codex `app-server`(stdio JSON-RPC)의 `account/rateLimits/read`로 ChatGPT 구독 잔여 플랜 한도(primary/secondary 윈도우) 조회, 5초 TTL 캐시 + 타임아웃 시 stale 캐시 폴백
  - 설계 주석 명시: 로컬 토큰 카운터 ≠ 계정 플랜 % (서로 다른 소스이므로 엔드포인트 분리)
  - env 오버라이드 지원: `CODEX_STATE_DB_PATH`, `CODEX_APP_SERVER_BIN`, `CODEX_APP_SERVER_TIMEOUT_SECONDS`, `CODEX_PLAN_CACHE_TTL_SECONDS`
- `models/analytics.py`: `CostBreakdown`에 `provider` 필드 추가
- `services/analytics_service.py`: 모델 미귀속 zero-usage 세션을 by-model/cost 집계에서 제외, 런타임 provider 표기

### Frontend
- `ClaudeUsageDashboard.tsx`: Codex 5시간/주간 한도 카드 + combined weekly tokens 통합, 캐시버스터/강제 refresh 처리
- `CostMonitor.tsx`: provider별 소스 표기 및 Claude 주간 토큰 합산 표시
- `AnalyticsPage.tsx`: provider 식별(`isLLMProvider`) 및 breakdown 표기 연동

## Test Plan
- [x] 백엔드: `pytest tests/backend/api/test_usage_jsonl.py tests/backend/test_analytics_service.py` → **81 passed**
- [x] 프론트: `vitest run CostMonitor/ClaudeUsageDashboard/AnalyticsPage` → **90 passed**
- [x] tsc(루트 tsconfig)·eslint·ruff: pre-commit 훅 통과
- [x] 시크릿 스캔: 하드코딩된 자격증명 없음
- [ ] 리뷰어: Codex 미설치 환경에서 graceful degradation(`available:false` + 안내 메시지) 동작 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)