### PR TITLE
docs(usage): Codex(ChatGPT) 사용량 통합 문서 동기화 (#141 후속)

### DIFF
--- a/docs/api/monitoring.md
+++ b/docs/api/monitoring.md
@@ -12,6 +12,8 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/usage` | Claude Code 사용량 (Plan Limits + 토큰 통계) |
+| GET | `/api/usage/codex-cli` | Codex(ChatGPT) 로컬 CLI/Desktop 토큰 사용량 (state DB 기반) |
+| GET | `/api/usage/codex-plan` | Codex(ChatGPT) 구독 잔여 플랜 한도 (app-server 기반) |
 | GET | `/api/usage/raw` | Raw stats-cache.json 데이터 |
 | GET | `/api/usage/oauth-test` | OAuth 토큰 진단 |
 | GET | `/api/usage/claude-config` | Claude 설정 조회 |
@@ -24,6 +26,25 @@
 - `isCached`: 캐시 데이터 사용 여부
 
 **환경 변수**: `CLAUDE_OAUTH_TOKEN`, `CLAUDE_STATS_CACHE_PATH`, `CLAUDE_USAGE_CACHE_PATH` ([배포 가이드](../deployment.md#claude-code-usage-환경-변수) 참조)
+
+### Codex (ChatGPT) Usage
+
+로컬 토큰 카운터(`codex-cli`)와 계정 플랜 잔여 %(codex-plan)는 서로 다른 데이터 소스라 엔드포인트를 분리한다. 둘 다 Codex 미설치/미로그인 시 `available:false` + 안내 `message`로 graceful degradation.
+
+**`GET /api/usage/codex-cli` 응답** (camelCase):
+- `available`, `source`(`codex-state-db`)
+- `fiveHourTokens`/`fiveHourThreads`, `weeklyTokens`/`weeklyThreads`, `totalTokens`/`totalThreads`
+- `byModel`, `bySource`: `{name, tokens, threads}` breakdown
+- `updatedAt`, `limitStatus`(`not_exposed`), `message`
+- 데이터 소스: 로컬 Codex `state_5.sqlite`를 **read-only**(`mode=ro`)로 열어 5시간/주간/전체 윈도우 집계. 플랜 % 는 로컬 state DB에 없음.
+
+**`GET /api/usage/codex-plan?refresh=<bool>` 응답** (camelCase):
+- `available`, `source`(`codex-app-server`)
+- `codexLimit`: `{limitId, limitName, primary, secondary, planType, ...}` (primary/secondary = `CodexPlanWindow`: `usedPercent`/`remainingPercent`/`resetsAtIso`/`resetsInMinutes` 등)
+- `limitsById`, `isCached`, `cacheAgeSeconds`, `updatedAt`, `message`
+- 데이터 소스: Codex `app-server`(stdio JSON-RPC `account/rateLimits/read`). 5초 TTL 캐시(`refresh=true`로 우회), 타임아웃/에러 시 stale 캐시 폴백(`isCached:true`).
+
+**환경 변수**: `CODEX_STATE_DB_PATH`, `CODEX_APP_SERVER_BIN`, `CODEX_APP_SERVER_TIMEOUT_SECONDS`, `CODEX_PLAN_CACHE_TTL_SECONDS` ([배포 가이드](../deployment.md#claude-code-usage-환경-변수) 참조)
 
 | Method | Path | 설명 |
 |--------|------|------|

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -298,9 +298,9 @@ import { cn } from '@/lib/utils';
 | 컴포넌트 | 설명 |
 |----------|------|
 | `ContextWindowMeter` | Context 창 사용량 게이지 |
-| `CostMonitor` | 비용 모니터링 패널 |
+| `CostMonitor` | 비용 모니터링 패널 (provider별 소스 표기, Claude 주간 토큰 합산) |
 | `UsageProgressBar` | 사용량 진행바 |
-| `ClaudeUsageDashboard` | Claude 사용량 대시보드 |
+| `ClaudeUsageDashboard` | Claude 사용량 대시보드 (Codex 5시간/주간 한도 카드 + combined weekly tokens 통합) |
 | `DailyCostTrend` | 일간 비용 추이 차트 |
 | `LLMAccountsSettings` | LLM 계정/API 키 설정 |
 | `MemberUsageTable` | 멤버별 사용량 테이블 |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -254,6 +254,15 @@ Plan Usage Limits 대시보드에서 사용하는 설정입니다. 로컬 개발
 | `CLAUDE_STATS_CACHE_PATH` | Claude Code stats-cache.json 경로 | `~/.claude/stats-cache.json` |
 | `CLAUDE_USAGE_CACHE_PATH` | Usage API 응답 캐시 경로 | `~/.claude/aos-usage-cache.json` |
 
+Codex(ChatGPT) 사용량 통합(`/api/usage/codex-cli`, `/api/usage/codex-plan`) 설정:
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `CODEX_STATE_DB_PATH` | Codex 로컬 state DB 경로 (read-only) | `~/.codex/state_5.sqlite` |
+| `CODEX_APP_SERVER_BIN` | Codex app-server 실행 파일 | `codex` |
+| `CODEX_APP_SERVER_TIMEOUT_SECONDS` | app-server 플랜 한도 조회 타임아웃 | `8` |
+| `CODEX_PLAN_CACHE_TTL_SECONDS` | 플랜 한도 응답 캐시 TTL | `5` |
+
 > **Note**: `CLAUDE_OAUTH_TOKEN`은 non-macOS 환경(Linux 서버, Docker 등)에서 필수입니다. macOS에서는 설정하지 않으면 Keychain에서 자동 추출됩니다.
 
 ### 모니터링 환경 변수

--- a/docs/features.md
+++ b/docs/features.md
@@ -1523,3 +1523,32 @@ async def web_search(query: str, max_results: int = 5) -> dict[str, Any]:
 - 웹 검색 도구는 도구 토글에서 선택
 
 **테스트 커버리지** (`tests/backend/test_playground_*.py`): rag_k 전파, 히스토리 병합, 도구 호출, force-final, 레거시 호환.
+
+---
+
+## 56. Codex (ChatGPT) Usage 통합
+
+Claude 사용량 대시보드에 Codex(ChatGPT) 사용량을 통합. 로컬 토큰 카운터와 계정 플랜 한도는 데이터 소스가 달라 두 엔드포인트로 분리:
+
+```python
+class CodexCliUsageResponse(BaseModel):   # 로컬 Codex state DB (read-only)
+    available: bool
+    fiveHourTokens / weeklyTokens / totalTokens: int
+    byModel / bySource: list[CodexUsageBreakdown]
+    limitStatus: str = "not_exposed"      # 플랜 %는 로컬 DB에 없음
+
+class CodexPlanUsageResponse(BaseModel):  # Codex app-server (JSON-RPC)
+    available: bool
+    codexLimit: CodexPlanLimitSnapshot | None  # primary/secondary 윈도우
+    isCached: bool                        # stale 캐시 폴백 여부
+```
+
+**기능**:
+- `GET /api/usage/codex-cli`: 로컬 `state_5.sqlite`(read-only)에서 5시간/주간/전체 토큰·스레드, 모델별·소스별 breakdown
+- `GET /api/usage/codex-plan?refresh=<bool>`: Codex `app-server`(stdio JSON-RPC `account/rateLimits/read`)에서 ChatGPT 구독 잔여 플랜 한도(primary/secondary 윈도우). 5초 TTL 캐시, 타임아웃 시 stale 캐시 폴백
+- Codex 미설치/미로그인 시 `available:false` + 안내 메시지 (graceful degradation)
+- 비용 분석: `CostBreakdown.provider`(예: `codex_cli`, `anthropic`)로 런타임 provider 표기, 모델 미귀속 zero-usage 세션은 by-model/cost 집계에서 제외
+
+**환경 변수**: `CODEX_STATE_DB_PATH`, `CODEX_APP_SERVER_BIN`, `CODEX_APP_SERVER_TIMEOUT_SECONDS`, `CODEX_PLAN_CACHE_TTL_SECONDS`
+
+**Dashboard UI**: `ClaudeUsageDashboard`(Codex 5시간/주간 한도 카드 + 주간 토큰 통합), `CostMonitor`(provider별 소스 표기), `AnalyticsPage`(provider 식별 및 breakdown)


### PR DESCRIPTION
## Summary
- PR #141(Codex 사용량 통합) 머지 후 `mandatory-docs.md` 규칙에 따라 관련 `docs/` 문서를 코드와 동기화
- 코드 변경 없음 — 문서만 갱신

## Changes
- `docs/api/monitoring.md`: Usage 테이블에 `GET /api/usage/codex-cli`·`/api/usage/codex-plan` 추가 + "Codex (ChatGPT) Usage" 서브섹션(camelCase 응답 형상, read-only state DB / app-server 소스, 5초 TTL 캐시·stale 폴백, env 4종)
- `docs/features.md`: `## 56. Codex (ChatGPT) Usage 통합` 신설 (두 엔드포인트, graceful degradation, `CostBreakdown.provider`·zero-usage 세션 제외, Dashboard UI)
- `docs/dashboard.md`: `CostMonitor`·`ClaudeUsageDashboard` 설명에 Codex 통합 반영 (신규 컴포넌트 없음 — light-touch)
- `docs/deployment.md`: Codex usage env 4종(`CODEX_STATE_DB_PATH` 등) 표 추가 (monitoring.md 앵커 참조 정합성 보강)

## Test Plan
- [x] 문서-소스 대조: `mode=ro`, `limitStatus="not_exposed"`, env 이름·기본값 등 실제 `src/backend/api/usage.py`와 일치 확인
- [x] Surgical: 요청되지 않은 섹션 무변경 (architecture.md/ontology.md는 근거와 함께 미변경)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)