### PR TITLE
docs(external-usage): 로컬 CLI 통합·토큰 지표 전환 문서 동기화 (#143 후속)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -69,7 +69,7 @@ import { cn } from '@/lib/utils';
 | `ProjectManagementPage` | `/project-management` | DB 기반 프로젝트 레지스트리 관리 (CRUD, soft-delete, 복원) |
 | `OrganizationsPage` | `/organizations` | 조직 관리 (Overview/Members/Settings 3탭, 소스 유저 매핑) |
 | `WorkflowsPage` | `/workflows` | 워크플로우 자동화 (CI/CD 파이프라인 관리) |
-| `ExternalUsagePage` | `/external-usage` | 외부 LLM 프로바이더 사용량 모니터링 (비용, 토큰, 프로바이더별 현황) |
+| `ExternalUsagePage` | `/external-usage` | 외부 LLM 프로바이더 + 로컬 CLI(Claude/Codex) 사용량 통합 모니터링 (비용·토큰, 누적/트렌드 지표는 토큰 기준, 프로바이더별 현황) |
 | `AdminPage` | `/admin` | 관리자 페이지 (사용자 관리, 메뉴 설정, 시스템 정보, External Sources) |
 | `SessionsPage` | `/sessions` | 세션 활동 뷰 (ClaudeCodeActivity 래핑) |
 | `SettingsPage` | `/settings` | 시스템 설정 (Claude Code OAuth 인증, 터미널 감지) |
@@ -301,9 +301,9 @@ import { cn } from '@/lib/utils';
 | `CostMonitor` | 비용 모니터링 패널 (provider별 소스 표기, Claude 주간 토큰 합산) |
 | `UsageProgressBar` | 사용량 진행바 |
 | `ClaudeUsageDashboard` | Claude 사용량 대시보드 (Codex 5시간/주간 한도 카드 + combined weekly tokens 통합) |
-| `DailyCostTrend` | 일간 비용 추이 차트 |
+| `DailyCostTrend` | 일간 사용량 추이 차트 ("Daily Usage Trend", 누적 지표 토큰 기준, `codex_cli` 시리즈 포함) |
 | `LLMAccountsSettings` | LLM 계정/API 키 설정 |
-| `MemberUsageTable` | 멤버별 사용량 테이블 |
+| `MemberUsageTable` | 멤버별 사용량 테이블 ("Total Usage": 비용 우선, 없으면 토큰 폴백 정렬, `codex_cli` 포함) |
 
 ### Terminal Components
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1264,7 +1264,7 @@ class ExternalUsageService:
 - 7/30/90일 기간 선택
 - 프로바이더 연결 상태 헬스체크
 
-**Dashboard UI**: `ExternalUsagePage` - 프로바이더별 비용/토큰 현황, 트렌드 차트
+**Dashboard UI**: `ExternalUsagePage` - 외부 API 집계 + 로컬 CLI(Claude/Codex) 사용량을 클라이언트에서 합성(`/api/usage` + `/api/usage/codex-cli`, 조회 실패 시 external usage만으로 폴백)하여 함께 표시. `codex_cli`를 정식 프로바이더로 포함. 로컬 CLI엔 비용이 없어(`cost_usd=0`) 트렌드/멤버 테이블의 누적 지표는 비용 → 토큰 기준으로 전환(외부 API 프로바이더 비용은 계속 표기)
 
 ---
 


### PR DESCRIPTION
## Summary
- PR #143(External Usage에 로컬 CLI 사용량 통합) 머지 후 `mandatory-docs.md`에 따라 `docs/` 동기화
- 코드 변경 없음 — 문서 2개만 갱신

## Changes
- `docs/dashboard.md`
  - `ExternalUsagePage`: 외부 프로바이더 + 로컬 CLI(Claude/Codex) 통합, 누적/트렌드 지표 토큰 기준 명시
  - `DailyCostTrend`: "Daily Usage Trend"(토큰 기준, `codex_cli` 시리즈)
  - `MemberUsageTable`: "Total Usage"(비용 우선, 없으면 토큰 폴백 정렬, `codex_cli` 포함)
- `docs/features.md` #47: `ExternalUsagePage` Dashboard UI에 클라이언트 합성(`/api/usage` + `/api/usage/codex-cli`, 실패 시 폴백)·`codex_cli` 정식 프로바이더·비용→토큰 전환 반영

## 의도적 미변경 (drift 방지)
- `features.md`의 백엔드 `ExternalUsageService` 프로바이더 목록: 로컬 CLI는 프론트에서 합성할 뿐 백엔드가 수집하지 않으므로 `codex_cli`를 넣으면 허위 서술이 됨 → 무변경
- `docs/api/monitoring.md`: API 무변경(이미 문서화된 엔드포인트를 클라이언트에서 합성할 뿐) → 무변경

## Test Plan
- [x] 문서-소스 대조: `buildLocalUsageRecords`·`PROVIDER_ORDER`·`.catch(() => null)`·`total_tokens` 전환 실제 코드와 일치 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)