### PR TITLE
fix: Codex 리뷰 findings — usage 이중집계 + 인증 Playground fallback

### DIFF
--- a/src/backend/services/external_usage_service.py
+++ b/src/backend/services/external_usage_service.py
@@ -691,8 +691,11 @@ class ExternalUsageService:
             for provider, collector in target_collectors.items():
                 try:
                     records = await collector.collect(start_time, end_time)
+                    # Provider billing measures the SAME usage as the internal
+                    # ledger a second way. It must not enter the primary
+                    # summaries/records/total (that would double-count); it
+                    # reaches the UI only via `reconciliation` below.
                     provider_billing_records.extend(records)
-                    all_records.extend(records)
 
                     summary = UsageSummary(
                         provider=provider,
@@ -713,7 +716,6 @@ class ExternalUsageService:
                                 summary.member_breakdown.get(rec.user_id, 0.0) + rec.cost_usd
                             )
                     provider_billing_summaries.append(summary)
-                    summaries.append(summary)
                 except Exception:
                     continue
 

--- a/src/backend/services/playground_service.py
+++ b/src/backend/services/playground_service.py
@@ -26,6 +26,11 @@ from models.playground import (
     PlaygroundSessionCreate,
     PlaygroundToolTest,
 )
+from services.llm_runtime_resolver import (
+    LLMRuntimeRequest,
+    LLMRuntimeResolutionError,
+    resolve_llm_runtime,
+)
 from services.llm_service import LLMResponse, LLMService
 from services.playground_context import build_effective_system_prompt
 from utils.time import utcnow
@@ -158,8 +163,38 @@ def _is_inaccessible_model_error(error: Exception) -> bool:
     )
 
 
-def _safe_playground_fallback_model(current_model: str) -> str | None:
-    """Pick a conservative fallback for stale persisted Playground sessions."""
+def _safe_playground_fallback_model(
+    current_model: str,
+    usage_context: dict[str, Any] | None = None,
+) -> str | None:
+    """Pick a conservative fallback for stale persisted Playground sessions.
+
+    For an authenticated user the runtime resolver gates models by entitlement,
+    so the fallback must be a model the user is actually entitled to. The global
+    env default may not be in their entitlements and would only trigger a fresh
+    ``LLMRuntimeResolutionError`` — breaking the fallback. Resolve the user's
+    entitled default instead; return ``None`` (no doomed retry) when they have no
+    usable entitlement. Anonymous sessions keep the env-default behaviour.
+    """
+    access = usage_context.get("llm_access") if usage_context else None
+    if isinstance(access, LLMAccessResponse):
+        try:
+            resolution = resolve_llm_runtime(
+                access,
+                LLMRuntimeRequest(
+                    user_id=usage_context.get("user_id") if usage_context else None,
+                    source=LLMUsageSource.PLAYGROUND.value,
+                    requested_model_id=None,
+                    organization_id=(
+                        usage_context.get("organization_id") if usage_context else None
+                    ),
+                ),
+            )
+        except LLMRuntimeResolutionError:
+            return None
+        entitled = resolution.model_id
+        return entitled if entitled and entitled != current_model else None
+
     configured_default = LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER") or "codex_cli")
     fallback = configured_default or "codex-cli"
     return fallback if fallback and fallback != current_model else None
@@ -174,7 +209,7 @@ async def _invoke_with_model_fallback(
     try:
         return await invoke(model_id=session.model, **kwargs)
     except Exception as exc:
-        fallback_model = _safe_playground_fallback_model(session.model)
+        fallback_model = _safe_playground_fallback_model(session.model, kwargs.get("usage_context"))
         if not fallback_model or not _is_inaccessible_model_error(exc):
             raise
 

--- a/src/backend/services/playground_service.py
+++ b/src/backend/services/playground_service.py
@@ -154,7 +154,19 @@ def _playground_usage_context(
 
 
 def _is_inaccessible_model_error(error: Exception) -> bool:
-    """Detect provider errors caused by a model the current project cannot use."""
+    """Detect errors caused by a model the current caller cannot use.
+
+    Two distinct sources must trigger the stale-model fallback:
+    - provider-side errors (OpenAI/Anthropic "model_not_found", etc.), matched by
+      message, and
+    - the runtime resolver rejecting the requested model for the authenticated
+      user's entitlements. ``LLMService.invoke`` re-raises that
+      ``LLMRuntimeResolutionError`` raw, and its message ("No enabled LLM
+      entitlement for provider=...") matches none of the provider patterns — so
+      it must be recognized by type, or authenticated fallback never fires.
+    """
+    if isinstance(error, LLMRuntimeResolutionError):
+        return True
     message = str(error).lower()
     return (
         "model_not_found" in message

--- a/tests/backend/test_external_usage_service.py
+++ b/tests/backend/test_external_usage_service.py
@@ -266,9 +266,7 @@ async def test_get_summary_does_not_double_count_provider_billing(monkeypatch) -
 
     # Primary total reflects the ledger only — not ledger (1.0) + billing (1.0).
     assert response.total_cost_usd == pytest.approx(1.0)
-    openai_summaries = [
-        s for s in response.providers if s.provider == ExternalProvider.OPENAI
-    ]
+    openai_summaries = [s for s in response.providers if s.provider == ExternalProvider.OPENAI]
     assert len(openai_summaries) == 1
     assert openai_summaries[0].total_cost_usd == pytest.approx(1.0)
     # The records feed (re-aggregated by the dashboard) holds only the ledger row.

--- a/tests/backend/test_external_usage_service.py
+++ b/tests/backend/test_external_usage_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from models.external_usage import ExternalProvider
+from models.external_usage import ExternalProvider, UnifiedUsageRecord
 from services.external_usage_service import (
     ExternalUsageService,
     OpenAIUsageCollector,
@@ -209,3 +209,71 @@ async def test_get_summary_includes_reconciliation_totals(monkeypatch) -> None:
     assert response.reconciliation.provider_billing_total_tokens == 0
     assert response.reconciliation.comparisons[0].provider == ExternalProvider.CLAUDE_CLI
     assert response.reconciliation.comparisons[0].status == "ledger_only"
+
+
+async def test_get_summary_does_not_double_count_provider_billing(monkeypatch) -> None:
+    """Provider billing measures the SAME usage as the internal ledger a second
+    way, so it must feed reconciliation only — never the primary summaries /
+    records / total (regression: double-count when billing is enabled)."""
+    start = datetime(2026, 7, 1, tzinfo=UTC)
+    end = datetime(2026, 7, 2, tzinfo=UTC)
+    ledger_row = SimpleNamespace(
+        id="ledger-1",
+        provider="openai",
+        mode="api",
+        source="agent",
+        model="gpt-5",
+        input_tokens=100,
+        output_tokens=0,
+        total_tokens=100,
+        estimated_cost_usd=1.0,
+        status="success",
+        measurement_method="api",
+        user_id="user-1",
+        organization_id="org-1",
+        project_id="project-1",
+        started_at=start,
+    )
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = [ledger_row]
+    db = AsyncMock()
+    db.execute.return_value = result
+
+    # Provider billing reports the same OpenAI usage a second way.
+    billing_record = UnifiedUsageRecord(
+        id="billing-1",
+        provider=ExternalProvider.OPENAI,
+        timestamp=start,
+        input_tokens=100,
+        output_tokens=0,
+        total_tokens=100,
+        cost_usd=1.0,
+        request_count=1,
+        model="gpt-5",
+        user_id="user-1",
+    )
+    collector = AsyncMock()
+    collector.collect = AsyncMock(return_value=[billing_record])
+
+    monkeypatch.setenv("EXTERNAL_USAGE_INCLUDE_PROVIDER_BILLING", "true")
+
+    with patch.object(
+        ExternalUsageService,
+        "_build_collectors",
+        AsyncMock(return_value={ExternalProvider.OPENAI: collector}),
+    ):
+        response = await ExternalUsageService().get_summary(db, start, end)
+
+    # Primary total reflects the ledger only — not ledger (1.0) + billing (1.0).
+    assert response.total_cost_usd == pytest.approx(1.0)
+    openai_summaries = [
+        s for s in response.providers if s.provider == ExternalProvider.OPENAI
+    ]
+    assert len(openai_summaries) == 1
+    assert openai_summaries[0].total_cost_usd == pytest.approx(1.0)
+    # The records feed (re-aggregated by the dashboard) holds only the ledger row.
+    assert len(response.records) == 1
+    assert response.records[0].raw_data["ledger_id"] == "ledger-1"
+    # Billing still reaches the UI, but via reconciliation only.
+    assert response.reconciliation.provider_billing_enabled is True
+    assert response.reconciliation.provider_billing_total_cost_usd == pytest.approx(1.0)

--- a/tests/backend/test_playground_service.py
+++ b/tests/backend/test_playground_service.py
@@ -219,6 +219,66 @@ def test_safe_fallback_resolves_entitled_model_for_authenticated_user(monkeypatc
     assert _safe_playground_fallback_model("stale-model-xyz", usage_context) == expected
 
 
+@pytest.mark.asyncio
+async def test_execute_retries_on_resolver_entitlement_error_for_authenticated_user(
+    monkeypatch,
+) -> None:
+    """A raw LLMRuntimeResolutionError (resolver rejecting the stale model for the
+    user's entitlements) must trigger the fallback and retry with the entitled
+    model — not just the provider-side 'model_not_found' string."""
+    from services.llm_access_service import default_access_response
+    from services.llm_runtime_resolver import (
+        LLMRuntimeRequest,
+        LLMRuntimeResolutionError,
+        resolve_llm_runtime,
+    )
+
+    playground_service._sessions.clear()
+    monkeypatch.setattr(playground_service, "_load_sessions", lambda: None)
+    monkeypatch.setattr(playground_service, "_save_sessions", lambda: None)
+
+    def close_background_coro(coro):
+        coro.close()
+
+    monkeypatch.setattr(playground_service, "_fire_and_forget", close_background_coro)
+
+    access = default_access_response("user-1")
+    entitled = resolve_llm_runtime(
+        access,
+        LLMRuntimeRequest(
+            user_id="user-1",
+            source=LLMUsageSource.PLAYGROUND.value,
+            requested_model_id=None,
+        ),
+    ).model_id
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale", model="stale-model-xyz", user_id="user-1")
+    )
+
+    calls: list[str] = []
+
+    async def fake_invoke(**kwargs):
+        model_id = kwargs["model_id"]
+        calls.append(model_id)
+        if model_id == "stale-model-xyz":
+            raise LLMRuntimeResolutionError(
+                "No enabled LLM entitlement for provider=openai, mode=api"
+            )
+        return LLMResponse(content="ok", model=model_id, provider="codex_cli")
+
+    monkeypatch.setattr(LLMService, "invoke", fake_invoke)
+
+    execution = await PlaygroundService.execute(
+        session.id,
+        PlaygroundExecuteRequest(prompt="hi"),
+        llm_access=access,
+    )
+
+    assert calls == ["stale-model-xyz", entitled]
+    assert execution.status.value == "completed"
+    assert session.model == entitled
+
+
 def test_safe_fallback_returns_none_when_authenticated_user_has_no_entitlement() -> None:
     """An authenticated user with no usable entitlement gets None (no doomed
     retry) instead of an env default the resolver would reject."""

--- a/tests/backend/test_playground_service.py
+++ b/tests/backend/test_playground_service.py
@@ -195,6 +195,43 @@ async def test_execute_passes_llm_access_to_usage_context(monkeypatch) -> None:
     assert captured["usage_context"]["llm_access"] == access
 
 
+def test_safe_fallback_resolves_entitled_model_for_authenticated_user(monkeypatch) -> None:
+    """Authenticated fallback must resolve the user's entitled model, not the
+    global env default — the runtime resolver gates by entitlement, so an
+    unentitled env default would just re-raise and break the fallback."""
+    from services.llm_access_service import default_access_response
+    from services.llm_runtime_resolver import LLMRuntimeRequest, resolve_llm_runtime
+    from services.playground_service import _safe_playground_fallback_model
+
+    # env default deliberately differs from the CLI-first entitled default.
+    monkeypatch.setenv("LLM_PROVIDER", "google")
+    access = default_access_response("user-1")
+    usage_context = {"llm_access": access, "user_id": "user-1"}
+    expected = resolve_llm_runtime(
+        access,
+        LLMRuntimeRequest(
+            user_id="user-1",
+            source=LLMUsageSource.PLAYGROUND.value,
+            requested_model_id=None,
+        ),
+    ).model_id
+
+    assert _safe_playground_fallback_model("stale-model-xyz", usage_context) == expected
+
+
+def test_safe_fallback_returns_none_when_authenticated_user_has_no_entitlement() -> None:
+    """An authenticated user with no usable entitlement gets None (no doomed
+    retry) instead of an env default the resolver would reject."""
+    from models.llm_access import LLMAccessResponse
+    from services.playground_service import _safe_playground_fallback_model
+
+    access = LLMAccessResponse(user_id="user-1", api_fallback_enabled=False)
+    fallback = _safe_playground_fallback_model(
+        "stale-model-xyz", {"llm_access": access, "user_id": "user-1"}
+    )
+    assert fallback is None
+
+
 # ─────────────────────────────────────────────────────────────
 # LLMService message building + force-final
 # ─────────────────────────────────────────────────────────────
@@ -240,9 +277,7 @@ async def test_invoke_with_tools_force_final_on_budget_exhaustion() -> None:
 
     always_tool_response = MagicMock()
     always_tool_response.content = ""
-    always_tool_response.tool_calls = [
-        {"name": "web_search", "args": {"query": "x"}, "id": "t1"}
-    ]
+    always_tool_response.tool_calls = [{"name": "web_search", "args": {"query": "x"}, "id": "t1"}]
     always_tool_response.usage_metadata = {"input_tokens": 10, "output_tokens": 2}
 
     # Raw llm.ainvoke (used for the force-final round) returns a clean answer.


### PR DESCRIPTION
## Summary
PR #145(LLM usage 관리 통합) 머지 후 Codex 종료시점 리뷰가 발견한 2개 결함 수정.

## Changes
### 1. usage 이중 집계 (`external_usage_service.py`)
- `EXTERNAL_USAGE_INCLUDE_PROVIDER_BILLING=true`일 때 provider billing 요약/레코드가 내부 ledger와 함께 primary total(`summaries`/`all_records`/`total_cost_usd`)에 합산되어 **같은 사용량을 이중 집계**
- provider billing은 ledger와 동일 사용량의 다른 측정치 → `build_reconciliation_summary` 비교용이지 합산 대상 아님
- `all_records.extend(records)`·`summaries.append(summary)` 제거, `provider_billing_*`는 reconciliation 전용 유지
- 기본 `default=False`라 기본 배포엔 미발현(그래서 기존 CI/테스트 green)

### 2. 인증 Playground fallback 깨짐 (`playground_service.py`)
- stale/inaccessible 모델 재시도 시 `_safe_playground_fallback_model`이 **전역 env 기본 모델**을 선택 → runtime resolver가 entitlement로 모델을 게이팅하는 인증 유저에겐 권한 없는 모델로 fallback → 재-invoke가 `LLMRuntimeResolutionError`로 깨짐
- `llm_access`가 있으면 `resolve_llm_runtime(requested_model_id=None)`로 유저의 **entitled 기본 모델**을 fallback으로 사용, entitlement 없으면 `None`(실패할 재시도 회피). 익명 세션은 기존 동작 유지

## Test Plan
- [x] 회귀 테스트 3건 추가, 모두 **Red-Green 검증**(수정 되돌리면 FAIL 확인)
  - double-count: billing 활성 + 겹치는 provider → `total == ledger`(2.0 아님)
  - fallback: 인증 유저 → entitled 모델 사용 / 무권한 → None
- [x] `pytest test_playground_service test_external_usage_service`: 23 passed
- [x] ruff check + format: 통과
- [x] mypy: no issues

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)