### PR TITLE
fix(usage): Claude Plan Limits 실시간 갱신 안 되는 429 캐시 폴백 수정

### DIFF
--- a/docs/api/monitoring.md
+++ b/docs/api/monitoring.md
@@ -11,7 +11,7 @@
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/usage` | Claude Code 사용량 (Plan Limits + 토큰 통계) |
+| GET | `/api/usage` | Claude Code 사용량 (Plan Limits + 토큰 통계). `?refresh=true`로 캐시 우회 |
 | GET | `/api/usage/codex-cli` | Codex(ChatGPT) 로컬 CLI/Desktop 토큰 사용량 (state DB 기반) |
 | GET | `/api/usage/codex-plan` | Codex(ChatGPT) 구독 잔여 플랜 한도 (app-server 기반) |
 | GET | `/api/usage/raw` | Raw stats-cache.json 데이터 |
@@ -23,7 +23,8 @@
 - `planLimits`: Anthropic OAuth API 실시간 Plan Limits (session, weekly, model별)
 - `weeklyTotalTokens`, `weeklySonnetTokens`, `weeklyOpusTokens`: 로컬 stats-cache 기반 주간 토큰
 - `oauthAvailable`: OAuth 토큰 사용 가능 여부
-- `isCached`: 캐시 데이터 사용 여부
+- `isCached`: **라이브 API 실패로 stale 캐시를 폴백 중일 때만** `true` (경고 배너 트리거)
+- 캐싱: Anthropic OAuth usage 엔드포인트는 rate-limit(429)이 잦아, 서버가 5분 TTL 캐시(`CACHE_TTL_SECONDS`)를 우선 서빙하고 TTL 만료 시에만 API 호출. TTL 내 캐시는 라이브로 간주(`isCached:false`). `?refresh=true`(수동 새로고침 전용)로 우회. 429/에러 시 stale 캐시(≤1h)로 폴백하며 이때만 `isCached:true`.
 
 **환경 변수**: `CLAUDE_OAUTH_TOKEN`, `CLAUDE_STATS_CACHE_PATH`, `CLAUDE_USAGE_CACHE_PATH` ([배포 가이드](../deployment.md#claude-code-usage-환경-변수) 참조)
 

--- a/src/backend/api/usage.py
+++ b/src/backend/api/usage.py
@@ -841,7 +841,14 @@ def _cached_codex_plan_response() -> CodexPlanUsageResponse | None:
 
 
 @router.get("", response_model=UsageResponse)
-async def get_usage() -> UsageResponse:
+async def get_usage(
+    refresh: Annotated[
+        bool,
+        Query(
+            description="Bypass the short-lived server cache and fetch fresh limits from Anthropic.",
+        ),
+    ] = False,
+) -> UsageResponse:
     """
     Get Claude Code usage statistics.
 
@@ -956,17 +963,31 @@ async def get_usage() -> UsageResponse:
 
     token = get_oauth_token()
     if token:
-        # Try to fetch fresh data from Anthropic API
-        usage_data = await fetch_usage_from_anthropic(token)
+        # Serve the short-lived cache (5 min TTL) without hitting Anthropic's
+        # OAuth usage endpoint. That endpoint is aggressively rate-limited
+        # (429 rate_limit_error) when polled on every request, which forced a
+        # stale-cache fallback and made the dashboard look "not real-time".
+        # Fresh cache is treated as live (isCached stays False - no warning).
+        cached_fresh = None
+        if not refresh and _is_cache_valid():
+            cache = _load_usage_cache()
+            if cache and cache.get("data"):
+                cached_fresh = cache["data"]
 
-        if usage_data:
-            # Success - save to cache and use fresh data
+        if cached_fresh is not None:
             oauth_available = True
-            plan_limits = parse_usage_data(usage_data)
-            _save_usage_cache(usage_data)
+            plan_limits = parse_usage_data(cached_fresh)
         else:
+            # Cache expired (or manual refresh) - fetch fresh data from Anthropic
+            usage_data = await fetch_usage_from_anthropic(token)
+
+            if usage_data:
+                # Success - save to cache and use fresh data
+                oauth_available = True
+                plan_limits = parse_usage_data(usage_data)
+                _save_usage_cache(usage_data)
             # API failed - try to use cached data as fallback
-            if _is_cache_usable():
+            elif _is_cache_usable():
                 cache = _load_usage_cache()
                 if cache and cache.get("data"):
                     oauth_available = True

--- a/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
+++ b/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
@@ -108,9 +108,9 @@ export function ClaudeUsageDashboard() {
     }
   }, [])
 
-  const refreshAllUsage = useCallback((forceCodexRefresh = false) => {
-    fetchUsage()
-    fetchCodexUsage(forceCodexRefresh)
+  const refreshAllUsage = useCallback((forceRefresh = false) => {
+    fetchUsage(forceRefresh)
+    fetchCodexUsage(forceRefresh)
   }, [fetchUsage, fetchCodexUsage])
 
   // Fetch on mount and set up auto-refresh

--- a/src/dashboard/src/stores/claudeUsage.ts
+++ b/src/dashboard/src/stores/claudeUsage.ts
@@ -10,7 +10,7 @@ interface ClaudeUsageState {
   lastFetched: Date | null
 
   // Actions
-  fetchUsage: () => Promise<void>
+  fetchUsage: (forceRefresh?: boolean) => Promise<void>
   clearError: () => void
 }
 
@@ -21,7 +21,7 @@ export const useClaudeUsageStore = create<ClaudeUsageState>((set, get) => ({
   error: null,
   lastFetched: null,
 
-  fetchUsage: async () => {
+  fetchUsage: async (forceRefresh = false) => {
     // Avoid duplicate requests
     const { isLoading } = get()
     if (isLoading) return
@@ -29,7 +29,10 @@ export const useClaudeUsageStore = create<ClaudeUsageState>((set, get) => ({
     set({ isLoading: true, error: null })
 
     try {
-      const data = await apiClient.get<ClaudeUsageResponse>('/api/usage')
+      // Only a manual refresh bypasses the server's 5-min cache; auto-polls
+      // reuse it so the rate-limited Anthropic endpoint isn't hammered.
+      const path = forceRefresh ? '/api/usage?refresh=true' : '/api/usage'
+      const data = await apiClient.get<ClaudeUsageResponse>(path)
       set({
         usage: data,
         isLoading: false,

--- a/tests/backend/api/test_usage_jsonl.py
+++ b/tests/backend/api/test_usage_jsonl.py
@@ -227,9 +227,7 @@ def test_returns_empty_when_projects_dir_missing(
     """Non-existent projects dir is handled without raising."""
     missing = tmp_path / "does-not-exist"
     monkeypatch.setattr(usage_mod, "CLAUDE_PROJECTS_DIR", missing)
-    monkeypatch.setattr(
-        usage_mod, "JSONL_TOKEN_CACHE_PATH", tmp_path / "cache.json"
-    )
+    monkeypatch.setattr(usage_mod, "JSONL_TOKEN_CACHE_PATH", tmp_path / "cache.json")
 
     result = usage_mod.aggregate_model_tokens_from_jsonl(days=7)
     assert result == []
@@ -275,9 +273,7 @@ async def test_response_marks_jsonl_fallback_when_stats_cache_empty(
             {
                 "lastComputedDate": old_date,
                 "dailyActivity": [],
-                "dailyModelTokens": [
-                    {"date": old_date, "tokensByModel": {"claude-opus-4-7": 100}}
-                ],
+                "dailyModelTokens": [{"date": old_date, "tokensByModel": {"claude-opus-4-7": 100}}],
                 "modelUsage": {},
                 "totalSessions": 1,
                 "totalMessages": 1,
@@ -321,9 +317,7 @@ async def test_response_marks_stats_cache_when_data_is_fresh(
             {
                 "lastComputedDate": today,
                 "dailyActivity": [],
-                "dailyModelTokens": [
-                    {"date": today, "tokensByModel": {"claude-opus-4-7": 555}}
-                ],
+                "dailyModelTokens": [{"date": today, "tokensByModel": {"claude-opus-4-7": 555}}],
                 "modelUsage": {},
                 "totalSessions": 1,
                 "totalMessages": 1,
@@ -558,3 +552,98 @@ def test_codex_plan_refresh_bypasses_cached_limit_snapshot(
     assert refreshed.codexLimit.secondary is not None
     assert refreshed.codexLimit.secondary.remainingPercent == 57
     assert calls["count"] == 2
+
+
+# ── /api/usage: honour the short-lived cache to avoid Anthropic 429s ──
+
+
+def _fresh_usage_cache(monkeypatch: pytest.MonkeyPatch, utilization: float) -> None:
+    """Prime a valid (unexpired) in-memory usage cache with one plan limit."""
+    now = datetime.now(UTC)
+    monkeypatch.setattr(
+        usage_mod,
+        "_usage_cache",
+        {
+            "data": {"five_hour": {"utilization": utilization, "resets_at": None}},
+            "timestamp": now.isoformat(),
+            "expires_at": (now + timedelta(seconds=200)).isoformat(),
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_get_usage_serves_fresh_cache_without_calling_anthropic(
+    stale_stats_cache: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid server cache must be served without hitting the rate-limited API."""
+    today = datetime.now().date().isoformat()
+    stale_stats_cache.write_text(
+        json.dumps(
+            {
+                "lastComputedDate": today,
+                "dailyActivity": [],
+                "dailyModelTokens": [],
+                "modelUsage": {},
+                "totalSessions": 1,
+                "totalMessages": 1,
+            }
+        )
+    )
+    _fresh_usage_cache(monkeypatch, utilization=42.0)
+
+    calls = {"count": 0}
+
+    async def _spy(_token: str) -> dict:
+        calls["count"] += 1
+        return {"five_hour": {"utilization": 99.0, "resets_at": None}}
+
+    monkeypatch.setattr(usage_mod, "fetch_usage_from_anthropic", _spy)
+    monkeypatch.setattr(usage_mod, "get_oauth_token", lambda: "tok")
+
+    response = await usage_mod.get_usage()
+
+    assert calls["count"] == 0  # fresh cache served, no Anthropic call
+    assert response.oauthAvailable is True
+    assert response.isCached is False  # fresh cache is "live enough", no warning banner
+    assert any(
+        limit.name == "fiveHour" and limit.utilization == 42.0 for limit in response.planLimits
+    )
+
+
+@pytest.mark.anyio
+async def test_get_usage_refresh_bypasses_fresh_cache(
+    stale_stats_cache: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """refresh=True must skip the cache and fetch live data from Anthropic."""
+    today = datetime.now().date().isoformat()
+    stale_stats_cache.write_text(
+        json.dumps(
+            {
+                "lastComputedDate": today,
+                "dailyActivity": [],
+                "dailyModelTokens": [],
+                "modelUsage": {},
+                "totalSessions": 1,
+                "totalMessages": 1,
+            }
+        )
+    )
+    _fresh_usage_cache(monkeypatch, utilization=42.0)
+
+    calls = {"count": 0}
+
+    async def _spy(_token: str) -> dict:
+        calls["count"] += 1
+        return {"five_hour": {"utilization": 99.0, "resets_at": None}}
+
+    monkeypatch.setattr(usage_mod, "fetch_usage_from_anthropic", _spy)
+    monkeypatch.setattr(usage_mod, "get_oauth_token", lambda: "tok")
+
+    response = await usage_mod.get_usage(refresh=True)
+
+    assert calls["count"] == 1  # refresh bypasses cache and hits the API
+    assert any(
+        limit.name == "fiveHour" and limit.utilization == 99.0 for limit in response.planLimits
+    )


### PR DESCRIPTION
## 문제

Claude Usage 대시보드가 "Claude Cached / API temporarily unavailable" 배너와 함께 stale 데이터를 표시하며 실시간 갱신이 안 됨.

## 근본 원인 (증거 기반)

`/api/usage`(`get_usage`)가 5분 TTL 캐시(`_is_cache_valid`, `CACHE_TTL_SECONDS`)를 만들어두고도 **요청 경로에서 한 번도 호출하지 않아**(dead code), 매 요청마다 rate-limited된 Anthropic OAuth usage 엔드포인트(`/api/oauth/usage`)를 호출.

- 프론트 마운트 + 5분 폴링 + 수동 새로고침 + StrictMode 중복마운트로 요청이 몰릴 때 Anthropic이 **429 rate_limit_error** 반환 (`logs/backend.log`에 6회 버스트 확인 — 401 인증만료가 **아님**)
- 429 시 백엔드가 설계대로 stale 캐시 폴백 → `isCached:true` → "Claude Cached" 배너

## 수정

- **백엔드** (`api/usage.py`): `get_usage()`에 `refresh: bool` 쿼리 파라미터 추가. `not refresh and _is_cache_valid()`면 Anthropic 호출 없이 캐시 즉시 서빙 → 요청 버스트 흡수, 429 제거. (동일 파일의 `codex-plan` 패턴 미러)
- **isCached 의미 보존**: TTL 내 fresh 캐시 = 라이브급(`isCached:false`, 배너 없음), 라이브 API 실패로 stale 폴백할 때만 `isCached:true`
- **프론트** (`claudeUsage.ts`, `ClaudeUsageDashboard.tsx`): 수동 새로고침만 `?refresh=true` 전송, 자동 폴링은 서버 캐시 재사용
- **문서** (`docs/api/monitoring.md`): 캐싱·refresh 동작 문서화

## 테스트 계획

- [x] 단위 RED→GREEN: 신규 테스트 2개 (`test_get_usage_serves_fresh_cache_without_calling_anthropic`, `test_get_usage_refresh_bypasses_fresh_cache`) — 수정 전 `assert 1==0` 실패 → 수정 후 통과
- [x] 회귀: 백엔드 api 119 passed / 프론트 25 passed
- [x] 게이트: `tsc --noEmit` 0, ruff·mypy·eslint clean
- [x] 실서버 cold-cache 검증: `?refresh=true` 679ms(라이브) → plain poll 42ms(캐시, 16× 빠름), 429 카운트 불변

## 참고

같은 OAuth 토큰을 Claude Code CLI 자신도 같은 엔드포인트에 사용. 수정 후에도 배너가 가끔 뜨면 CLI 부하로 인한 정당한 429이지 회귀가 아님 (시스템이 올바르게 stale 폴백 표시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)