### PR TITLE
fix(usage): Plan Usage Limits 카드 텍스트 잘림 수정

### DIFF
--- a/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
+++ b/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
@@ -487,10 +487,10 @@ function UsageRadialMetric({
         </div>
         <div className="min-w-0">
           <p className="text-xs font-medium text-gray-500 dark:text-gray-400">{label}</p>
-          <p className="truncate text-base font-semibold text-gray-900 dark:text-white">
+          <p className="text-base font-semibold text-gray-900 dark:text-white">
             {value}
           </p>
-          <p className="truncate text-xs text-gray-500 dark:text-gray-400" title={detail}>
+          <p className="text-xs text-gray-500 dark:text-gray-400" title={detail}>
             {detail}
           </p>
         </div>


### PR DESCRIPTION
## Summary
Plan Usage Limits 카드(`ChatGPT Codex & Claude Plan Limits`)의 부제목이 잘리는 문제 수정.
`xl:grid-cols-4` 좁은 컬럼에서 `truncate`가 텍스트를 ellipsis로 잘라
"Plus / 22% used / 4..." 처럼 보였음.

## Changes
- `ClaudeUsageDashboard.tsx` `UsageRadialMetric`: value/detail의 `truncate` 제거
  → 텍스트가 wrap되어 전부 표시 (카드 높이만 늘어남). `title` 툴팁은 유지

## Test Plan
- [x] tsc --noEmit: 클린
- [x] eslint (수정 파일): 클린
- [x] vitest ClaudeUsageDashboard: 15 passed
- [x] vite build: ✓
- [ ] 리뷰어: 4열 레이아웃에서 detail 2줄 wrap 시 카드 정렬 육안 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)