### PR TITLE
fix(charts): 드래그 리사이즈 시 recharts ResponsiveContainer 무한 루프 수정

### DIFF
--- a/src/dashboard/src/components/ProjectConfigStats.tsx
+++ b/src/dashboard/src/components/ProjectConfigStats.tsx
@@ -98,7 +98,7 @@ export function ConfigChartCard() {
 
       {barData.length > 0 ? (
         <div className="w-full" style={{ height: chartHeight }}>
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" debounce={80}>
             <BarChart data={barData} layout="vertical" margin={{ left: 0, right: 10 }}>
               <XAxis type="number" tick={{ fontSize: 10 }} />
               <YAxis

--- a/src/dashboard/src/components/organizations/MemberDetailPanel.tsx
+++ b/src/dashboard/src/components/organizations/MemberDetailPanel.tsx
@@ -232,7 +232,7 @@ function UsageTrendTab({ detail }: { detail: MemberUsageDetail }) {
   }
 
   return (
-    <ResponsiveContainer width="100%" height={200}>
+    <ResponsiveContainer width="100%" height={200} debounce={80}>
       <AreaChart data={chartData} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
         <defs>
           <linearGradient id="grad-tokens" x1="0" y1="0" x2="0" y2="1">

--- a/src/dashboard/src/components/usage/DailyCostTrend.tsx
+++ b/src/dashboard/src/components/usage/DailyCostTrend.tsx
@@ -144,7 +144,7 @@ export default function DailyCostTrend({ records }: Props) {
       <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-4">
         Daily Estimated Cost Trend
       </h2>
-      <ResponsiveContainer width="100%" height={260}>
+      <ResponsiveContainer width="100%" height={260} debounce={80}>
         <AreaChart data={data} margin={{ top: 4, right: 16, left: 8, bottom: 0 }}>
           <defs>
             {activeProviders.map(p => (

--- a/src/dashboard/src/pages/AnalyticsPage.tsx
+++ b/src/dashboard/src/pages/AnalyticsPage.tsx
@@ -587,7 +587,7 @@ export function AnalyticsPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         {/* Task Trend */}
         <ChartCard title="Task Volume" icon={BarChart3}>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} debounce={80}>
             <LineChart data={formatTrendData(data.trends.tasks, timeRange)}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
               <XAxis
@@ -617,7 +617,7 @@ export function AnalyticsPage() {
 
         {/* Success Rate Trend */}
         <ChartCard title="Success Rate Trend" icon={TrendingUp}>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} debounce={80}>
             <LineChart data={formatTrendData(data.trends.success_rate, timeRange)}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
               <XAxis
@@ -659,7 +659,7 @@ export function AnalyticsPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         {/* Token Usage Trend */}
         <ChartCard title="Token Usage Trend" icon={Zap}>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} debounce={80}>
             <AreaChart data={formatTrendData(data.trends.tokens, timeRange)}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
               <XAxis
@@ -700,7 +700,7 @@ export function AnalyticsPage() {
         >
           {modelTokenBreakdown.length > 0 ? (
             <div className="space-y-3">
-              <ResponsiveContainer width="100%" height={210}>
+              <ResponsiveContainer width="100%" height={210} debounce={80}>
                 <BarChart
                   data={modelTokenBreakdown}
                   layout="vertical"
@@ -774,7 +774,7 @@ export function AnalyticsPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         {/* Cost by Model */}
         <ChartCard title="Cost by Model" icon={DollarSign}>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} debounce={80}>
             <PieChart>
               <Pie
                 data={data.costs.by_model}
@@ -812,7 +812,7 @@ export function AnalyticsPage() {
 
         {/* Model Performance */}
         <ChartCard title="Model Performance" icon={Users}>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} debounce={80}>
             <BarChart data={modelPerformanceData} layout="vertical">
               <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
               <XAxis type="number" domain={[0, 100]} tick={{ fontSize: 12 }} />
@@ -885,7 +885,7 @@ export function AnalyticsPage() {
               <RefreshCw className="w-6 h-6 animate-spin text-gray-400" />
             </div>
           ) : compareData ? (
-            <ResponsiveContainer width="100%" height={250}>
+            <ResponsiveContainer width="100%" height={250} debounce={80}>
               <LineChart data={transformMultiSeriesData(compareData)}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
                 <XAxis

--- a/src/dashboard/src/pages/ExternalUsagePage.tsx
+++ b/src/dashboard/src/pages/ExternalUsagePage.tsx
@@ -393,7 +393,7 @@ export function ExternalUsagePage() {
               No estimated cost data available
             </div>
           ) : (
-            <ResponsiveContainer width="100%" height={220}>
+            <ResponsiveContainer width="100%" height={220} debounce={80}>
               <PieChart>
                 <Pie
                   data={pieData}
@@ -425,7 +425,7 @@ export function ExternalUsagePage() {
               No model breakdown available
             </div>
           ) : (
-            <ResponsiveContainer width="100%" height={220}>
+            <ResponsiveContainer width="100%" height={220} debounce={80}>
               <BarChart data={modelData.slice(0, 8)} layout="vertical">
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis type="number" tick={{ fontSize: 11 }} tickFormatter={v => `$${v.toFixed(2)}`} />


### PR DESCRIPTION
## Summary
창을 마우스로 드래그하여 리사이즈할 때 대시보드가 **"Maximum update depth exceeded"**로 크래시하는 문제 수정.

## Root Cause
사용자 재현의 스택 트레이스가 결정적:
```
at ...recharts... forceStoreRerender → notifyNestedSubs → handleChangeWrapper
The above error occurred in the <ReportChartSize> component.
```
recharts `ResponsiveContainer`(내부 `ReportChartSize`)의 ResizeObserver→setState 재측정이 드래그 리사이즈(연속 이벤트)에서 무한 루프에 빠져 React 중첩 업데이트 한도를 초과.

## Changes
- 앱 소스의 **모든 `ResponsiveContainer`(12개)에 `debounce={80}`** 추가 → 리사이즈 알림을 스로틀링하여 동기적 재측정 폭주를 차단 (recharts 문서화된 표준 해법)
- 크래시 지점: `ConfigChartCard`(Dashboard, 유일하게 `height="100%"`로 가장 취약)
- 동일 버그 잠재인 `AnalyticsPage`(7)·`ExternalUsagePage`(2)·`DailyCostTrend`·`MemberDetailPanel`도 일괄 적용해 whack-a-mole 방지

## Test Plan
- [x] tsc --noEmit: 클린 (`debounce` prop 유효)
- [x] eslint: 클린
- [x] vitest: 111 passed (ProjectConfigStats 13 + AnalyticsPage/ExternalUsagePage/DailyCostTrend 98)
- [x] 차트 렌더 무결성: Dashboard "Configuration by Project" 정상 육안 확인
- [x] 리뷰어/사용자: 실제 마우스 드래그 리사이즈로 크래시 재현 안 됨 확인 (자동화의 discrete 리사이즈로는 연속 이벤트 재현 불가)

> 참고: 이 크래시는 truncate 수정(PR #148)과 무관한 별개 기존 recharts 이슈 (스택에 앱 코드 없음).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)