### PR TITLE
fix(usage): Anthropic usage API 간헐적 실패에 바운디드 재시도+계측 추가

### DIFF
--- a/src/backend/api/usage.py
+++ b/src/backend/api/usage.py
@@ -3,6 +3,7 @@
 Fetches real usage data from Anthropic OAuth API using macOS Keychain credentials.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -93,6 +94,19 @@ _usage_cache: dict[str, Any] = {
 }
 CACHE_TTL_SECONDS = 300  # 5 minutes - cache is valid for this long
 CACHE_STALE_SECONDS = 3600  # 1 hour - stale cache can still be used as fallback
+
+# The Anthropic OAuth usage endpoint occasionally flakes on transient network
+# errors / 5xx. Retry those a bounded number of times with a short backoff.
+# 4xx (notably 429 rate_limit_error) is deliberately NOT retried — retrying a
+# rate limit only deepens it.
+#
+# Worst-case budget = MAX_ATTEMPTS * TIMEOUT + sum(BACKOFF) = 3*6 + 1.5 = 19.5s.
+# This MUST stay under the dashboard's 30s request timeout
+# (src/dashboard/src/services/apiClient.ts) — otherwise the frontend aborts
+# first and the retries waste work on a request nobody awaits.
+USAGE_FETCH_MAX_ATTEMPTS = 3
+USAGE_FETCH_TIMEOUT_SECONDS = 6.0  # per-attempt HTTP timeout
+USAGE_FETCH_BACKOFF_SECONDS = (0.5, 1.0)  # backoff before retry #1, #2
 
 
 def _load_usage_cache() -> dict[str, Any] | None:
@@ -447,28 +461,55 @@ async def fetch_usage_from_anthropic(token: str) -> dict[str, Any] | None:
     """
     Fetch usage data from Anthropic OAuth Usage API.
 
+    Transient failures (network errors, timeouts, 5xx) are retried a bounded
+    number of times with a short backoff so a single blip degrades to the
+    cached fallback instead of a hard error. 4xx responses — notably
+    ``429 rate_limit_error`` and ``401`` auth failures — are NOT retried and
+    return ``None`` immediately so the caller can fall back to cached data.
+
     Returns API response or None if failed.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(
-                ANTHROPIC_USAGE_API,
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "anthropic-beta": "oauth-2025-04-20",
-                    "User-Agent": "claude-code/2.0.31",
-                },
-            )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "anthropic-beta": "oauth-2025-04-20",
+        "User-Agent": "claude-code/2.0.31",
+    }
+    last_error = "unknown error"
 
+    for attempt in range(USAGE_FETCH_MAX_ATTEMPTS):
+        try:
+            async with httpx.AsyncClient(timeout=USAGE_FETCH_TIMEOUT_SECONDS) as client:
+                response = await client.get(ANTHROPIC_USAGE_API, headers=headers)
+        except httpx.HTTPError as exc:
+            # Network error / timeout — transient, worth retrying.
+            last_error = f"{type(exc).__name__}: {exc}"
+        else:
             if response.status_code == 200:
-                return response.json()
-            else:
-                print(f"Anthropic API error: {response.status_code} - {response.text}")
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    logger.error("Anthropic usage API returned invalid JSON: %s", exc)
+                    return None
+            if response.status_code < 500:
+                # 4xx (429 rate limit, 401 auth, ...) — retrying won't help.
+                logger.warning(
+                    "Anthropic usage API returned %s (not retrying): %s",
+                    response.status_code,
+                    response.text[:200],
+                )
                 return None
+            # 5xx — transient server error, worth retrying.
+            last_error = f"HTTP {response.status_code}: {response.text[:200]}"
 
-    except Exception as e:
-        print(f"Error fetching from Anthropic API: {e}")
-        return None
+        if attempt < USAGE_FETCH_MAX_ATTEMPTS - 1:
+            await asyncio.sleep(USAGE_FETCH_BACKOFF_SECONDS[attempt])
+
+    logger.error(
+        "Anthropic usage API failed after %d attempts: %s",
+        USAGE_FETCH_MAX_ATTEMPTS,
+        last_error,
+    )
+    return None
 
 
 def parse_reset_time(resets_at: str | None) -> tuple[float, float]:

--- a/tests/backend/api/test_usage_fetch_retry.py
+++ b/tests/backend/api/test_usage_fetch_retry.py
@@ -1,0 +1,175 @@
+"""Tests for transient-failure handling in ``fetch_usage_from_anthropic``.
+
+The Anthropic OAuth usage endpoint (``/api/oauth/usage``) is aggressively
+rate-limited and occasionally flakes on transient network errors. When a fetch
+fails and the local cache is already past its stale window, the dashboard shows
+a hard "Failed to fetch from Anthropic API" with zero data.
+
+These tests pin the intended policy:
+
+* transient failures (network error / timeout / 5xx) are retried with a short
+  backoff, so a single blip is absorbed;
+* 4xx responses — notably ``429 rate_limit_error`` and ``401`` auth failures —
+  are NOT retried (retrying a rate limit only deepens it) and return ``None``
+  so the caller can fall back to cached data.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from api import usage as usage_mod
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``httpx.Response``."""
+
+    def __init__(self, status_code: int, json_data: dict[str, Any] | None = None, text: str = ""):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        if self._json is None:
+            raise ValueError("no json body")
+        return self._json
+
+
+class _ClientFactory:
+    """Fake ``httpx.AsyncClient`` factory recording every ``.get`` call.
+
+    ``fetch_usage_from_anthropic`` creates a fresh client per attempt, so the
+    factory doubles as the async context manager and shares one call counter
+    across all attempts. Each queued outcome is either a ``_FakeResponse`` to
+    return or an ``Exception`` to raise.
+    """
+
+    def __init__(self, outcomes: list[Any]):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, *args: Any, **kwargs: Any) -> _ClientFactory:
+        return self
+
+    async def __aenter__(self) -> _ClientFactory:
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool:
+        return False
+
+    async def get(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+        outcome = self.outcomes[self.calls]
+        self.calls += 1
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise the retry backoff so tests stay fast."""
+
+    async def _instant(_seconds: float) -> None:
+        return None
+
+    # Patch the real asyncio module (shared singleton) so it applies whether or
+    # not usage_mod has bound ``asyncio`` yet — keeps the Red failures on the
+    # assertions rather than a fixture-setup AttributeError.
+    monkeypatch.setattr(asyncio, "sleep", _instant)
+
+
+def _install_client(monkeypatch: pytest.MonkeyPatch, outcomes: list[Any]) -> _ClientFactory:
+    factory = _ClientFactory(outcomes)
+    monkeypatch.setattr(usage_mod.httpx, "AsyncClient", factory)
+    return factory
+
+
+async def test_success_returns_data_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {"five_hour": {"utilization": 39.0}}
+    factory = _install_client(monkeypatch, [_FakeResponse(200, json_data=data)])
+
+    result = await usage_mod.fetch_usage_from_anthropic("tok")
+
+    assert result == data
+    assert factory.calls == 1
+
+
+async def test_rate_limit_429_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Even though a 200 is queued behind it, a 429 must fail fast: retrying a
+    # rate limit only makes the throttling worse.
+    factory = _install_client(
+        monkeypatch,
+        [_FakeResponse(429, text="rate_limit_error"), _FakeResponse(200, json_data={"ok": True})],
+    )
+
+    result = await usage_mod.fetch_usage_from_anthropic("tok")
+
+    assert result is None
+    assert factory.calls == 1
+
+
+async def test_timeout_then_success_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {"seven_day": {"utilization": 86.0}}
+    factory = _install_client(
+        monkeypatch,
+        [httpx.ReadTimeout("timed out"), _FakeResponse(200, json_data=data)],
+    )
+
+    result = await usage_mod.fetch_usage_from_anthropic("tok")
+
+    assert result == data
+    assert factory.calls == 2
+
+
+async def test_server_error_5xx_then_success_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {"seven_day": {"utilization": 50.0}}
+    factory = _install_client(
+        monkeypatch,
+        [_FakeResponse(503, text="service unavailable"), _FakeResponse(200, json_data=data)],
+    )
+
+    result = await usage_mod.fetch_usage_from_anthropic("tok")
+
+    assert result == data
+    assert factory.calls == 2
+
+
+async def test_persistent_timeout_gives_up_after_bounded_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Retries are bounded — a permanently failing endpoint must not loop forever.
+    factory = _install_client(
+        monkeypatch,
+        [httpx.ConnectError("boom")] * 10,
+    )
+
+    result = await usage_mod.fetch_usage_from_anthropic("tok")
+
+    assert result is None
+    assert 1 < factory.calls <= 5
+
+
+async def test_retry_budget_stays_under_dashboard_timeout() -> None:
+    """Worst-case retry budget must finish before the dashboard aborts.
+
+    The frontend ``apiClient`` fetches ``/api/usage`` with its default 30s
+    timeout (``src/dashboard/src/services/apiClient.ts``). If the backend keeps
+    retrying past that, the dashboard aborts and shows a timeout anyway while the
+    server wastes work on a request nobody awaits. Keep a safety margin.
+    """
+    dashboard_timeout_seconds = 30.0
+    worst_case = (
+        usage_mod.USAGE_FETCH_MAX_ATTEMPTS * usage_mod.USAGE_FETCH_TIMEOUT_SECONDS
+        + sum(usage_mod.USAGE_FETCH_BACKOFF_SECONDS)
+    )
+    assert len(usage_mod.USAGE_FETCH_BACKOFF_SECONDS) >= usage_mod.USAGE_FETCH_MAX_ATTEMPTS - 1
+    assert worst_case <= dashboard_timeout_seconds - 5.0, (
+        f"retry budget {worst_case}s leaves too little margin under "
+        f"{dashboard_timeout_seconds}s dashboard timeout"
+    )


### PR DESCRIPTION
## Summary
- Plan Usage Limits 카드의 "Failed to fetch from Anthropic API / Claude Offline" 하드에러 근본 대응
- 원인: 순간적 upstream 실패(429/타임아웃) + 캐시가 stale 한도(1h) 초과 → 폴백 데이터 0건 하드에러 (프론트 자동 폴링으로 자가 치유되던 간헐 현상)

## Changes
- `fetch_usage_from_anthropic`: 네트워크/타임아웃/**5xx만** 바운디드 재시도(최대 3회, 0.5s·1.0s 백오프). **429/4xx는 즉시 None** — rate-limit 재시도는 오히려 악화시키므로
- `print` → `logger.warning/error` 계측: 다음 발생 시 실제 실패 코드(429 vs 401 vs 네트워크)를 로그로 확증
- 재시도 예산을 `USAGE_FETCH_TIMEOUT_SECONDS=6.0`으로 상수화 → 최악 `3×6+1.5=19.5s`로 프론트 `apiClient` 30s 타임아웃 아래 유지 (Codex 리뷰 지적 반영)
- 예산 불변식 회귀 테스트 추가로 attempts/backoff 드리프트 방지
- `CACHE_STALE_SECONDS`(stale 창)는 **의도적으로 미변경**: five_hour가 5h마다 리셋되어 오래된 캐시는 자신만만하게 틀린 사용률을 보여줌

## Test Plan
- [x] `pytest tests/backend/api/test_usage_fetch_retry.py` — 5 retry + 1 budget = Red→Green
- [x] `pytest ... test_usage_jsonl.py` 인접 회귀 — 22 passed
- [x] `ruff check` — All checks passed
- [x] `mypy api/usage.py` — no issues
- [ ] 백엔드 재시작 후 대시보드에서 Plan Usage Limits 정상 렌더 확인 (배포 시)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)