### PR TITLE
fix(sidebar): 사이드바 메뉴 복제 수정 — menu_order 중복 제거

### DIFF
--- a/src/dashboard/src/lib/__tests__/menuOrder.test.ts
+++ b/src/dashboard/src/lib/__tests__/menuOrder.test.ts
@@ -35,4 +35,30 @@ describe('syncMenuOrder', () => {
     syncMenuOrder(input)
     expect(input).toEqual(inputCopy)
   })
+
+  it('deduplicates repeated keys from a corrupted persisted order', () => {
+    // 서버에 저장된 menu_order가 중복 누적된 경우(사이드바 메뉴 복제 버그).
+    const corrupted = [
+      'dashboard',
+      'audit',
+      'notifications',
+      'audit',
+      'notifications',
+      'audit',
+      'analytics',
+      'playground',
+      'analytics',
+    ]
+    const result = syncMenuOrder(corrupted)
+
+    // 각 키는 정확히 한 번만 등장
+    expect(new Set(result).size).toBe(result.length)
+    // 첫 등장 순서 보존
+    expect(result.slice(0, 4)).toEqual(['dashboard', 'audit', 'notifications', 'analytics'])
+    // 모든 기본 메뉴 포함 + 중복 없음 → 길이는 DEFAULT_MENU_ORDER와 동일
+    expect(result.length).toBe(DEFAULT_MENU_ORDER.length)
+    for (const key of DEFAULT_MENU_ORDER) {
+      expect(result).toContain(key)
+    }
+  })
 })

--- a/src/dashboard/src/lib/menuOrder.ts
+++ b/src/dashboard/src/lib/menuOrder.ts
@@ -3,16 +3,23 @@ import { DEFAULT_MENU_ORDER } from '../components/admin/types'
 /**
  * 서버에서 받은 menu_order를 기본 메뉴 목록과 동기화한다.
  * - 서버에 있지만 더 이상 존재하지 않는 메뉴 키 → 제거
+ * - 서버 순서에 중복된 키 → 첫 등장만 유지 (오염된 menu_order로 인한 사이드바 메뉴 복제 방지)
  * - 기본 목록에 새로 추가된 메뉴 → 끝에 append
  *
  * 빈 배열이 들어오면 기본 순서를 그대로 반환한다.
  */
 export function syncMenuOrder(serverOrder: readonly string[]): string[] {
   const validKeys = new Set<string>(DEFAULT_MENU_ORDER)
-  const synced = serverOrder.filter((key) => validKeys.has(key))
-  const present = new Set(synced)
+  const seen = new Set<string>()
+  const synced: string[] = []
+  for (const key of serverOrder) {
+    if (validKeys.has(key) && !seen.has(key)) {
+      seen.add(key)
+      synced.push(key)
+    }
+  }
   for (const key of DEFAULT_MENU_ORDER) {
-    if (!present.has(key)) synced.push(key)
+    if (!seen.has(key)) synced.push(key)
   }
   return synced
 }


### PR DESCRIPTION
## 문제

Settings 등 화면에서 **좌측 사이드바 메뉴가 복제**됨 — "Audit Trail", "Notifications"가 수십 번 반복되고 "Analytics"/"Playground"도 두 번씩 나타남.

## 근본 원인

`syncMenuOrder(serverOrder)`가 서버 `menu_order`를 정규화할 때 **중복을 제거하지 않음**:

```ts
const synced = serverOrder.filter((key) => validKeys.has(key))  // 중복 그대로 유지
```

서버에 저장된 `menu_order`에 키가 중복 누적돼 있으면(예: 'audit' 20회), `filter`가 전부 유지 → `Sidebar`의 `filteredNavigation`이 같은 메뉴를 여러 번 렌더. `present` Set은 DEFAULT append 시 중복만 막고, filter된 serverOrder 자체는 dedup 안 함.

## 수정 (read-path 방어)

`syncMenuOrder`가 서버 순서의 중복 키를 **첫 등장만 유지**하도록 정규화. 서버 데이터가 어떤 이유로 오염됐어도 사이드바는 항상 고유 메뉴(16개)만 렌더.

```ts
const seen = new Set<string>()
for (const key of serverOrder) {
  if (validKeys.has(key) && !seen.has(key)) { seen.add(key); synced.push(key) }
}
```

## 검증

- vitest: menuOrder 6 + Sidebar 9 = **15 passed** (dedup 회귀 테스트 추가: 오염 배열 → 고유 16개)
- RED-GREEN: 수정 전 20개(중복) → 수정 후 16개(고유)
- tsc --noEmit exit 0, eslint clean

## 참고 (별개 근본 원인)

서버 `menu_order`가 왜 중복 누적됐는지(백엔드 write/저장 경로)는 별도 이슈. 이 PR은 프론트 read-path에서 견고하게 정규화해 표시 버그를 해결. 서버 데이터 정리/write-path 가드는 후속.