### PR TITLE
fix(usage): Sync Now가 Claude snapshot 스캔+sync 트리거 (신선도 해결)

### DIFF
--- a/docs/superpowers/plans/2026-07-05-external-usage-claude-cli-snapshot-followups.md
+++ b/docs/superpowers/plans/2026-07-05-external-usage-claude-cli-snapshot-followups.md
@@ -1,0 +1,62 @@
+# External Usage Claude CLI snapshot — 신선도 이슈
+
+- 날짜: 2026-07-05
+- 상태: **해결됨 (Option B 구현)** — External Usage `/sync`(Sync Now)가 Claude scan+sync를 트리거하도록 배선. 아래 원인/옵션은 이력으로 보존.
+- 구현: `api/claude_sessions.py:scan_and_sync_claude_snapshots()` 추가 → `api/external_usage.py`의 `/sync`가 summary 계산 전 best-effort 호출. 테스트 `tests/backend/test_claude_session_sync.py`.
+- 출처: Codex stop-time review 지적 "snapshot time filter can miss updated Claude sessions"
+- 관련: `docs/superpowers/specs/2026-07-05-external-usage-claude-cli-snapshot-source-design.md`, `docs/llm-key-systems.md`
+
+> 남은 잔여(선택): `/summary`도 최근 활동을 즉시 반영하려면 스캔 트리거가 필요하나, 매 조회 파일시스템 스캔 비용 때문에 보류. 현재는 Sync Now(명시적)로 갱신한다.
+
+## 이슈: External Usage Claude CLI 데이터가 stale/누락될 수 있음
+
+PR #151은 `claude_session_snapshots` 테이블을 External Usage의 CLAUDE_CLI 소스로 **읽기만** 한다(`_collect_claude_snapshots`). 문제는 그 테이블의 신선도다.
+
+### 근본 원인
+
+- `claude_session_snapshots`는 `api/claude_sessions.py:_sync_sessions_to_db`가 **Claude Sessions 페이지가 로드될 때만**, 그리고 `file_size`가 바뀐 파일만 upsert한다.
+- External Usage `/summary`(및 `_collect_claude_snapshots`)는 monitor 스캔(`discover_sessions`)이나 sync를 **트리거하지 않는다**. 그냥 테이블을 조회한다.
+- 따라서 사용자가 Claude Sessions 페이지를 최근에 열지 않았다면:
+  - 방금 cmux로 활동한 세션이 아직 DB에 없거나,
+  - 기존 행의 `session_last_activity`가 실제 transcript보다 뒤처져 있을 수 있다.
+- 그 결과 time filter(`session_last_activity ∈ [start, end]`)가 **최근 활동 세션을 누락**하거나 토큰이 실제보다 적게 집계된다.
+
+### 증상
+
+- External Usage의 Claude CLI 카드/Total이 실제 사용량보다 작게 표시.
+- 방금 쓴 Claude 사용량이 카드에 안 나타남(Sessions 페이지를 열기 전까지).
+- "Sync Now"(`/sync`) 버튼도 현재는 provider billing collector만 돌리고 Claude scan은 하지 않음 → 새로고침해도 Claude 최신화 안 됨.
+- ledger 소스(Codex 등)는 실시간 기록이라 이 stale 특성이 없음 → **provider 간 UX 비대칭**.
+
+## Fix 옵션
+
+- **A) `_collect_claude_snapshots` 전에 증분 스캔 트리거**
+  - monitor `discover_sessions()` + `_sync_sessions_to_db()`를 summary 조회 직전에 호출.
+  - monitor는 `SessionFileCache`(mtime+size)로 변경 파일만 재파싱하므로 전체 재파싱 아님(비용 수용 가능).
+  - 단, `/summary`가 매 호출마다 파일시스템 스캔(697+ 파일 stat) → 캐싱/rate-limit 고려 필요. `/summary`도 collect를 트리거하는 기존 함정(llm-key-systems.md 후속 #4)과 결이 같음.
+
+- **B) "Sync Now"(`/sync`)에서만 Claude scan+sync 트리거 (권장, 저위험)**
+  - 명시적 갱신 지점에만 monitor 스캔+sync 수행. 카드는 페이지 방문/Sync Now 시점 기준으로 최신화.
+  - 매 페이지 로드 스캔 비용 없음. UX상 "Sync Now"의 의미와 부합.
+
+- **C) monitor를 백그라운드 주기 poller로 승격**
+  - `~/.claude/projects/`를 주기 스캔해 snapshot 상시 최신화. 범위 큼(라이프사이클/리소스 관리), YAGNI.
+
+## 권장
+
+**B**(명시적 Sync Now 트리거)를 우선. 실시간성이 더 필요하면 **A**를 캐시/디바운스와 함께. C는 과함.
+
+## 착수 시 시작점
+
+| 파일 | 역할 |
+|---|---|
+| `src/backend/services/external_usage_service.py` | `_collect_claude_snapshots` 앞 또는 `/sync` 경로에서 스캔 트리거 |
+| `src/backend/api/external_usage.py` | `/sync` 엔드포인트에 Claude scan+sync 배선 |
+| `src/backend/services/claude_session_monitor.py` | `discover_sessions()` (스캔) |
+| `src/backend/api/claude_sessions.py` | `_sync_sessions_to_db()` (snapshot upsert) — 재사용 가능하도록 서비스로 추출 검토 |
+
+## 테스트 관점
+
+- 스캔 트리거 후 새 세션이 CLAUDE_CLI 집계에 반영되는지(통합).
+- `/summary`가 스캔을 반복 트리거하지 않는지(캐시/디바운스, 옵션 A 채택 시).
+- 스캔 실패가 summary를 깨뜨리지 않는지(best-effort 유지).

--- a/src/backend/api/claude_sessions.py
+++ b/src/backend/api/claude_sessions.py
@@ -185,6 +185,18 @@ async def _sync_sessions_to_db(sessions: list) -> None:
         logger.warning(f"Background session sync failed: {e}")
 
 
+async def scan_and_sync_claude_snapshots() -> int:
+    """Scan ~/.claude/projects and upsert Claude session snapshots.
+
+    Returns the number of discovered sessions. Used by External Usage /sync so
+    the CLAUDE_CLI card reflects the latest host sessions without requiring a
+    prior visit to the Claude Sessions page (snapshot freshness follow-up).
+    """
+    sessions = get_monitor().discover_sessions()
+    await _sync_sessions_to_db(sessions)
+    return len(sessions)
+
+
 @router.get("", response_model=ClaudeSessionResponse)
 async def list_sessions(
     status: SessionStatus | None = None,

--- a/src/backend/api/external_usage.py
+++ b/src/backend/api/external_usage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -33,6 +34,8 @@ except ImportError:
     get_current_user = None  # type: ignore[assignment]
     get_current_admin_or_manager_user = None  # type: ignore[assignment]
     get_db_session = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/external-usage", tags=["external-usage"])
 
@@ -128,6 +131,19 @@ if AUTH_AVAILABLE:
         start = (body and body.start_time) or _default_start()
         end = (body and body.end_time) or _default_end()
         providers = [body.provider] if (body and body.provider) else None
+
+        # Refresh Claude session snapshots first so the CLAUDE_CLI card reflects
+        # the latest host sessions. Snapshots are otherwise only synced when the
+        # Claude Sessions page is opened, so a stale table can drop recently
+        # active sessions from the window (snapshot freshness follow-up).
+        # Best-effort: a scan failure must not break the usage summary.
+        try:
+            from api.claude_sessions import scan_and_sync_claude_snapshots
+
+            await scan_and_sync_claude_snapshots()
+        except Exception:
+            logger.warning("claude_snapshot_refresh_failed", exc_info=True)
+
         result = await svc.get_summary(db, start, end, providers)
         return _sync_response(result, start, end)
 

--- a/tests/backend/test_claude_session_sync.py
+++ b/tests/backend/test_claude_session_sync.py
@@ -1,0 +1,49 @@
+"""Tests for the Claude snapshot refresh used by External Usage /sync."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_scan_and_sync_claude_snapshots_discovers_and_upserts() -> None:
+    """Refresh must scan sessions from the monitor and upsert them, returning the count.
+
+    This is what lets External Usage /sync pick up host Claude sessions without a
+    prior visit to the Claude Sessions page (freshness follow-up).
+    """
+    from api import claude_sessions
+
+    fake_sessions = [MagicMock(), MagicMock(), MagicMock()]
+    monitor = MagicMock()
+    monitor.discover_sessions = MagicMock(return_value=fake_sessions)
+
+    with (
+        patch.object(claude_sessions, "get_monitor", return_value=monitor),
+        patch.object(claude_sessions, "_sync_sessions_to_db", AsyncMock()) as sync_mock,
+    ):
+        count = await claude_sessions.scan_and_sync_claude_snapshots()
+
+    monitor.discover_sessions.assert_called_once()
+    sync_mock.assert_awaited_once_with(fake_sessions)
+    assert count == 3
+
+
+async def test_scan_and_sync_claude_snapshots_empty() -> None:
+    """No discovered sessions → sync still runs with [] and count is 0."""
+    from api import claude_sessions
+
+    monitor = MagicMock()
+    monitor.discover_sessions = MagicMock(return_value=[])
+
+    with (
+        patch.object(claude_sessions, "get_monitor", return_value=monitor),
+        patch.object(claude_sessions, "_sync_sessions_to_db", AsyncMock()) as sync_mock,
+    ):
+        count = await claude_sessions.scan_and_sync_claude_snapshots()
+
+    sync_mock.assert_awaited_once_with([])
+    assert count == 0


### PR DESCRIPTION
## 문제 (Codex stop-review 반복 지적)

External Usage의 Claude CLI는 `claude_session_snapshots`를 읽는데(#151), 이 테이블은 **Claude Sessions 페이지 방문 시에만** 갱신된다. 따라서 stale하면 `session_last_activity` 기준 time filter가 **최근 활동 세션을 누락**할 수 있다. `/summary`·`/sync`는 스캔을 트리거하지 않았다.

## 수정 (Option B)

- `api/claude_sessions.py`: 공개 함수 `scan_and_sync_claude_snapshots()` 추가 — monitor로 `~/.claude/projects` 스캔 후 snapshot upsert, 세션 수 반환.
- `api/external_usage.py`: `/sync`(Sync Now)가 summary 계산 **전** 이 함수를 best-effort 호출 → Sync Now 시점에 Claude 데이터 최신화. 스캔 실패는 summary를 깨뜨리지 않음.

매 `/summary` 조회 스캔은 파일시스템 비용 때문에 배제하고, 명시적 Sync Now에만 배선(문서 옵션 B).

## 검증

- **TDD**: `tests/backend/test_claude_session_sync.py` — scan_and_sync가 monitor.discover + upsert 호출·count 반환(정상/빈 입력). 15 passed (신규 2 + external usage 13).
- ruff + mypy clean.
- **실브라우저**: Sync Now 클릭 → 에러 없이 동작, 비용 $3738.24→$3738.82로 미세 갱신(실제 스캔 반영 증거), Claude CLI 66.1M 유지.

## 문서
`docs/.../snapshot-freshness-followup.md` 상태를 **해결됨(Option B)**으로 갱신(PR #154 대체). 잔여(선택): `/summary` 자동 스캔은 비용상 보류.