### PR TITLE
feat(llm): claude-sonnet-5 추가 + 모델 레지스트리 SSOT 수렴

### DIFF
--- a/docs/api/llm.md
+++ b/docs/api/llm.md
@@ -24,10 +24,10 @@ LLM 모델 레지스트리, 라우터, 자격증명, 프록시, Playground API�
 {
   "models": [
     {
-      "id": "claude-sonnet-4-6",
-      "display_name": "Claude Sonnet 4.6",
+      "id": "claude-sonnet-5",
+      "display_name": "Claude Sonnet 5",
       "provider": "anthropic",
-      "context_window": 200000,
+      "context_window": 1000000,
       "pricing": {"input": 0.003, "output": 0.015},
       "available": true,
       "is_default": true,
@@ -43,6 +43,13 @@ LLM 모델 레지스트리, 라우터, 자격증명, 프록시, Playground API�
 
 > **Note**: 이 API는 중앙 레지스트리(`models/llm_models.py`)에서 모델 정보를 제공합니다.
 > 새 모델 추가 시 해당 파일만 수정하면 전체 시스템에 반영됩니다.
+>
+> **`is_default` 마이그레이션 주의** (`USE_DATABASE=true` 배포): `sync_to_db`는
+> 이미 해당 provider의 default 행이 DB에 있으면, `_MODELS`에서 `is_default=True`로
+> 추가된 신규 모델을 `is_default=False`로 INSERT합니다(이중 default 방지). 즉 신규
+> 기본 모델 이관은 기존 배포에 자동 반영되지 않으며, admin이 Settings UI에서 직접
+> default를 전환해야 합니다. 인메모리 폴백(`USE_DATABASE` 미설정)에서는 `_MODELS`의
+> `is_default`가 그대로 적용됩니다.
 
 ---
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -378,7 +378,7 @@ import { cn } from '@/lib/utils';
 | `useNavigationStore` | `navigation.ts` | 네비게이션 상태 |
 | `useUIStore` | `uiStore.ts` | UI 상태 (테마, 모달, 토스트) |
 | `useMonitoringStore` | `monitoring.ts` | 프로젝트 모니터링 |
-| `useSettingsStore` | `settings.ts` | 설정 상태 |
+| `useSettingsStore` | `settings.ts` | 설정 상태 + LLM 모델 카탈로그 (`availableModels`, `fetchModels` — App 마운트 시 전역 1회 로드해 모든 페이지에서 공유, in-flight dedup, API 실패 시 `fallbackModels` 주입, 백엔드 `_MODELS` 미러) |
 | `useGitStore` | `git.ts` | Git 브랜치/머지 관리, Worktree 관리 (`GitWorktree`, `worktrees`, `selectedWorktreePath`, `fetchWorktrees`, `setSelectedWorktree`), Staging 강화 (`fetchFileDiff`, `fetchFileHunks`, `stageHunks`, `fetchStagedDiff`), Draft Commits (`DraftCommit`, `generateDraftCommits`, `clearDraftCommits`), Remote 관리 (`fetchRemotes`, `addRemote`, `removeRemote`, `updateRemote`), Commit 상세 (`fetchCommitFiles`, `fetchCommitDiff`) |
 | `useOrganizationsStore` | `organizations.ts` | 조직/멤버 관리, 멤버 사용량 (`fetchMemberUsage`, `fetchMemberUsageDetail`), 소스 유저 매핑 |
 | `useAuditStore` | `audit.ts` | 감사 로그 |

--- a/src/backend/api/llm_proxy.py
+++ b/src/backend/api/llm_proxy.py
@@ -44,8 +44,16 @@ COST_TABLE: list[tuple[str, float, float]] = [
     ("gpt-4o", 0.005, 0.015),
     ("o1-mini", 0.003, 0.012),
     ("o1", 0.015, 0.060),
+    ("claude-sonnet-5", 0.003, 0.015),
+    ("claude-opus-4-8", 0.005, 0.025),
+    # Opus price cut ($5/$25) applies from Opus 4.5 onward; these specific
+    # prefixes must precede the generic "claude-opus-4" (4-0/4-1 era $15/$75).
+    ("claude-opus-4-7", 0.005, 0.025),
+    ("claude-opus-4-6", 0.005, 0.025),
+    ("claude-opus-4-5", 0.005, 0.025),
     ("claude-opus-4", 0.015, 0.075),
     ("claude-sonnet-4", 0.003, 0.015),
+    ("claude-haiku-4-5", 0.001, 0.005),
     ("claude-haiku-4", 0.00025, 0.00125),
     ("gemini-2.0-flash", 0.00025, 0.001),
     ("gemini-1.5-pro", 0.00125, 0.005),

--- a/src/backend/models/claude_session.py
+++ b/src/backend/models/claude_session.py
@@ -220,12 +220,14 @@ class TasksResponse(BaseModel):
 
 # Cost per 1K tokens for different models
 MODEL_COSTS = {
-    "claude-opus-4-8": {"input": 0.015, "output": 0.075},
+    "claude-opus-4-8": {"input": 0.005, "output": 0.025},
+    "claude-sonnet-5": {"input": 0.003, "output": 0.015},
     "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
     "claude-haiku-4-5-20251001": {"input": 0.001, "output": 0.005},
     # Legacy model IDs for backward compatibility
-    "claude-opus-4-6": {"input": 0.015, "output": 0.075},
-    "claude-opus-4-5-20251101": {"input": 0.015, "output": 0.075},
+    "claude-opus-4-7": {"input": 0.005, "output": 0.025},
+    "claude-opus-4-6": {"input": 0.005, "output": 0.025},
+    "claude-opus-4-5-20251101": {"input": 0.005, "output": 0.025},
     "claude-sonnet-4-20250514": {"input": 0.003, "output": 0.015},
     "claude-3-5-sonnet-20241022": {"input": 0.003, "output": 0.015},
     "claude-3-5-haiku-20241022": {"input": 0.001, "output": 0.005},

--- a/src/backend/models/context_usage.py
+++ b/src/backend/models/context_usage.py
@@ -15,10 +15,14 @@ class LLMProvider(str, Enum):
     OLLAMA = "ollama"
 
 
-# Provider context window limits (tokens)
+# Legacy provider context window limits (tokens).
+# SSOT is LLMModelRegistry (models.llm_models); get_context_limit() consults
+# the registry first and only falls back here for model ids the registry
+# does not know (e.g. older gemini-1.5/gpt-3.5 ids).
 PROVIDER_CONTEXT_LIMITS = {
     LLMProvider.ANTHROPIC: {
         "claude-opus-4-8": 200_000,
+        "claude-sonnet-5": 200_000,
         "claude-sonnet-4-6": 200_000,
         "claude-haiku-4-5-20251001": 200_000,
         "default": 200_000,
@@ -119,7 +123,21 @@ class ContextUsage(BaseModel):
 
 
 def get_context_limit(provider: str, model: str) -> int:
-    """Get context window limit for a provider/model combination."""
+    """Get context window limit for a provider/model combination.
+
+    Resolution order:
+    1. LLMModelRegistry (SSOT — reflects code _MODELS and DB-loaded values).
+    2. Legacy PROVIDER_CONTEXT_LIMITS substring matching.
+    3. Provider default / 100_000 safe default.
+    """
+    # SSOT first: exact registry id match (used by AOS API-called sessions,
+    # where `model` comes from the registry, e.g. get_model_for_provider()).
+    from models.llm_models import LLMModelRegistry
+
+    registry_model = LLMModelRegistry.get_by_id(model)
+    if registry_model is not None:
+        return registry_model.context_window
+
     try:
         provider_enum = LLMProvider(provider.lower())
         limits = PROVIDER_CONTEXT_LIMITS.get(provider_enum, {})

--- a/src/backend/models/llm_models.py
+++ b/src/backend/models/llm_models.py
@@ -58,13 +58,24 @@ _MODELS: list[LLMModelConfig] = [
         supports_vision=True,
     ),
     LLMModelConfig(
+        id="claude-sonnet-5",
+        display_name="Claude Sonnet 5",
+        provider=LLMProvider.ANTHROPIC,
+        context_window=1000000,  # 1M tokens
+        input_price=0.003,  # $3.00/1M tokens
+        output_price=0.015,  # $15.00/1M tokens
+        is_default=True,  # Default Anthropic model
+        supports_tools=True,
+        supports_vision=True,
+    ),
+    LLMModelConfig(
         id="claude-sonnet-4-6",
         display_name="Claude Sonnet 4.6",
         provider=LLMProvider.ANTHROPIC,
         context_window=1000000,  # 1M tokens
         input_price=0.003,  # $3.00/1M tokens
         output_price=0.015,  # $15.00/1M tokens
-        is_default=True,  # Default Anthropic model
+        is_default=False,
         supports_tools=True,
         supports_vision=True,
     ),
@@ -378,7 +389,7 @@ class LLMModelRegistry:
         Returns:
             Dict with 'inserted' and 'updated' counts.
         """
-        from sqlalchemy import select
+        from sqlalchemy import select, update
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
         from db.models import LLMModelConfigModel
@@ -387,10 +398,55 @@ class LLMModelRegistry:
         result = await session.execute(select(LLMModelConfigModel.id))
         existing_ids = {row[0] for row in result.fetchall()}
 
+        # Providers that already have an ENABLED default row in DB.
+        # Guard: a NEW model with is_default=True must not create a second
+        # default for a provider whose DB default is admin-controlled.
+        # A disabled default row does not count — the new model should
+        # still become the provider default in that case.
+        result = await session.execute(
+            select(LLMModelConfigModel.provider).where(
+                LLMModelConfigModel.is_default.is_(True),
+                LLMModelConfigModel.is_enabled.is_(True),
+            )
+        )
+        providers_with_db_default = {row[0] for row in result.fetchall()}
+
         inserted = 0
         updated = 0
 
         for model in _MODELS:
+            is_default = model.is_default
+            if (
+                is_default
+                and model.id not in existing_ids
+                and model.provider.value in providers_with_db_default
+            ):
+                # Respect the existing DB default for this provider:
+                # insert the new model as non-default to avoid dual defaults.
+                is_default = False
+
+            if is_default and model.id not in existing_ids:
+                # This new model is about to be INSERTed as the provider
+                # default (the guard above passed, so any remaining default
+                # rows for this provider are disabled). Clear their
+                # is_default flag so a later admin re-enable of an old row
+                # cannot resurrect a second default for the provider.
+                # is_enabled=False is part of the WHERE on purpose: under
+                # READ COMMITTED an admin could re-enable the old default
+                # between the guard SELECT and this UPDATE, so the "only
+                # clear DISABLED defaults" invariant must live in the SQL
+                # itself, not just in the pre-check.
+                await session.execute(
+                    update(LLMModelConfigModel)
+                    .where(
+                        LLMModelConfigModel.provider == model.provider.value,
+                        LLMModelConfigModel.is_default.is_(True),
+                        LLMModelConfigModel.is_enabled.is_(False),
+                        LLMModelConfigModel.id != model.id,
+                    )
+                    .values(is_default=False)
+                )
+
             values = {
                 "id": model.id,
                 "display_name": model.display_name,
@@ -398,7 +454,7 @@ class LLMModelRegistry:
                 "context_window": model.context_window,
                 "input_price": model.input_price,
                 "output_price": model.output_price,
-                "is_default": model.is_default,
+                "is_default": is_default,
                 "is_enabled": model.is_enabled,
                 "supports_tools": model.supports_tools,
                 "supports_vision": model.supports_vision,

--- a/src/backend/services/agent_registry.py
+++ b/src/backend/services/agent_registry.py
@@ -4,6 +4,7 @@
 Lead Orchestrator가 적절한 에이전트를 선택할 때 사용합니다.
 """
 
+import os
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
@@ -11,7 +12,20 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from models.llm_models import LLMModelRegistry
 from utils.time import utcnow
+
+
+def _default_agent_model() -> str:
+    """Resolve the default agent model from the configured provider.
+
+    Evaluated at AgentMetadata instance creation time (default agents are
+    built lazily via _build_default_agents() at registry init, not at module
+    import), so LLM_PROVIDER changes and DB-loaded registry defaults present
+    at that moment are honored. See _build_default_agents() for the
+    once-per-process singleton limitation.
+    """
+    return LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli"))
 
 
 class AgentCategory(str, Enum):
@@ -57,7 +71,7 @@ class AgentMetadata(BaseModel):
     name: str
     description: str
     category: AgentCategory
-    model: str = "claude-sonnet-4-6"
+    model: str = Field(default_factory=_default_agent_model)
 
     # 능력 및 전문 영역
     capabilities: list[AgentCapability] = Field(default_factory=list)
@@ -113,210 +127,221 @@ class AgentMetadata(BaseModel):
 
 
 # 기본 에이전트 정의
-DEFAULT_AGENTS: list[AgentMetadata] = [
-    # 개발 전문가
-    AgentMetadata(
-        id="web-ui-specialist",
-        name="Web UI Specialist",
-        description="Web UI/UX 전문가. 컴포넌트 설계, 반응형 레이아웃, UX 최적화.",
-        category=AgentCategory.DEVELOPMENT,
-        capabilities=[
-            AgentCapability(
-                name="react-native-components",
-                description="React Native 컴포넌트 설계 및 구현",
-                keywords=["component", "ui", "view", "screen", "layout", "style"],
-                priority=10,
-            ),
-            AgentCapability(
-                name="navigation",
-                description="React Navigation 설정 및 최적화",
-                keywords=["navigation", "screen", "route", "tab", "drawer", "stack"],
-                priority=8,
-            ),
-            AgentCapability(
-                name="responsive-design",
-                description="반응형 레이아웃 및 다양한 화면 크기 지원",
-                keywords=["responsive", "adaptive", "dimension", "orientation"],
-                priority=6,
-            ),
-        ],
-        specializations=["React Native", "Expo", "TypeScript", "Tailwind"],
-        estimated_cost_per_task=0.05,
-        avg_execution_time_ms=15000,
-    ),
-    AgentMetadata(
-        id="backend-integration-specialist",
-        name="Backend Integration Specialist",
-        description="Firebase 및 API 통합 전문가. 데이터 동기화, 인증, 실시간 업데이트.",
-        category=AgentCategory.DEVELOPMENT,
-        capabilities=[
-            AgentCapability(
-                name="firebase-integration",
-                description="Firebase Auth, Firestore, Functions 통합",
-                keywords=["firebase", "firestore", "auth", "authentication", "realtime"],
-                priority=10,
-            ),
-            AgentCapability(
-                name="api-integration",
-                description="REST/GraphQL API 연동 및 데이터 처리",
-                keywords=["api", "rest", "graphql", "fetch", "axios", "endpoint"],
-                priority=9,
-            ),
-            AgentCapability(
-                name="data-sync",
-                description="오프라인 우선 데이터 동기화 전략",
-                keywords=["sync", "offline", "cache", "persistence"],
-                priority=7,
-            ),
-        ],
-        specializations=["Firebase", "REST API", "GraphQL", "AsyncStorage"],
-        estimated_cost_per_task=0.06,
-        avg_execution_time_ms=20000,
-    ),
-    AgentMetadata(
-        id="test-automation-specialist",
-        name="Test Automation Specialist",
-        description="테스트 자동화 전문가. Jest, RTL, 커버리지 분석, TDD.",
-        category=AgentCategory.DEVELOPMENT,
-        capabilities=[
-            AgentCapability(
-                name="unit-testing",
-                description="Jest를 사용한 단위 테스트 작성",
-                keywords=["test", "jest", "unit", "spec", "mock", "expect"],
-                priority=10,
-            ),
-            AgentCapability(
-                name="component-testing",
-                description="React Native Testing Library 컴포넌트 테스트",
-                keywords=["rtl", "render", "screen", "fireEvent", "component test"],
-                priority=9,
-            ),
-            AgentCapability(
-                name="coverage-analysis",
-                description="테스트 커버리지 분석 및 개선",
-                keywords=["coverage", "branch", "statement", "function"],
-                priority=7,
-            ),
-        ],
-        specializations=["Jest", "React Native Testing Library", "Coverage"],
-        estimated_cost_per_task=0.04,
-        avg_execution_time_ms=12000,
-    ),
-    # 오케스트레이션
-    AgentMetadata(
-        id="aos-orchestrator",
-        name="AOS Orchestrator",
-        description="멀티 에이전트 워크플로우 조정자. 태스크 분해, 에이전트 선택, 결과 집계.",
-        category=AgentCategory.ORCHESTRATION,
-        capabilities=[
-            AgentCapability(
-                name="task-decomposition",
-                description="복잡한 태스크를 서브태스크로 분해",
-                keywords=["decompose", "break down", "split", "subtask"],
-                priority=10,
-            ),
-            AgentCapability(
-                name="agent-selection",
-                description="태스크에 적합한 에이전트 선택",
-                keywords=["select", "assign", "delegate", "agent"],
-                priority=9,
-            ),
-            AgentCapability(
-                name="workflow-coordination",
-                description="병렬/순차 실행 워크플로우 조정",
-                keywords=["parallel", "sequential", "workflow", "coordinate"],
-                priority=8,
-            ),
-        ],
-        specializations=["Multi-Agent", "Workflow", "Orchestration"],
-        estimated_cost_per_task=0.08,
-        avg_execution_time_ms=30000,
-        max_concurrent_tasks=3,
-    ),
-    # 품질
-    AgentMetadata(
-        id="quality-validator",
-        name="Quality Validator",
-        description="코드 품질 검증자. 리뷰, 표준 준수 확인, 품질 게이트.",
-        category=AgentCategory.QUALITY,
-        capabilities=[
-            AgentCapability(
-                name="code-review",
-                description="코드 리뷰 및 개선 제안",
-                keywords=["review", "quality", "check", "validate", "verify"],
-                priority=10,
-            ),
-            AgentCapability(
-                name="standards-compliance",
-                description="코딩 표준 및 프로젝트 규칙 준수 확인",
-                keywords=["standard", "convention", "rule", "lint"],
-                priority=8,
-            ),
-        ],
-        specializations=["Code Review", "Quality Gates"],
-        estimated_cost_per_task=0.03,
-        avg_execution_time_ms=8000,
-    ),
-    AgentMetadata(
-        id="code-simplifier",
-        name="Code Simplifier",
-        description="코드 복잡도 분석 및 단순화 전문가. 리팩토링, 중복 제거.",
-        category=AgentCategory.QUALITY,
-        capabilities=[
-            AgentCapability(
-                name="complexity-analysis",
-                description="순환 복잡도 및 코드 복잡도 분석",
-                keywords=["complexity", "cyclomatic", "cognitive", "nesting"],
-                priority=10,
-            ),
-            AgentCapability(
-                name="refactoring",
-                description="코드 리팩토링 및 단순화",
-                keywords=["refactor", "simplify", "clean", "restructure"],
-                priority=9,
-            ),
-            AgentCapability(
-                name="deduplication",
-                description="중복 코드 식별 및 제거",
-                keywords=["duplicate", "redundant", "dry", "extract"],
-                priority=7,
-            ),
-        ],
-        specializations=["Refactoring", "Clean Code"],
-        estimated_cost_per_task=0.04,
-        avg_execution_time_ms=10000,
-    ),
-    # 성능
-    AgentMetadata(
-        id="performance-optimizer",
-        name="Performance Optimizer",
-        description="성능 최적화 전문가. 메모리, 렌더링, 번들 크기 최적화.",
-        category=AgentCategory.DEVELOPMENT,
-        capabilities=[
-            AgentCapability(
-                name="render-optimization",
-                description="React Native 렌더링 최적화",
-                keywords=["render", "rerender", "memo", "useMemo", "useCallback"],
-                priority=10,
-            ),
-            AgentCapability(
-                name="memory-optimization",
-                description="메모리 누수 감지 및 최적화",
-                keywords=["memory", "leak", "garbage", "profiler"],
-                priority=9,
-            ),
-            AgentCapability(
-                name="bundle-optimization",
-                description="번들 크기 분석 및 최적화",
-                keywords=["bundle", "size", "tree-shaking", "code-splitting"],
-                priority=7,
-            ),
-        ],
-        specializations=["Performance", "Optimization", "Profiling"],
-        estimated_cost_per_task=0.05,
-        avg_execution_time_ms=18000,
-    ),
-]
+def _build_default_agents() -> list[AgentMetadata]:
+    """Build the default agent metadata list (fresh instances).
+
+    Called at AgentRegistry initialization (i.e. the first
+    get_agent_registry() call), not at module import, so each agent's
+    ``model`` default is resolved against LLMModelRegistry state at that
+    moment -- including DB-loaded admin defaults when the registry singleton
+    is created after startup's load_from_db(). Limitation: the singleton is
+    built once per process; a DB default changed after that is not
+    retroactively applied to already-registered agents.
+    """
+    return [
+        # 개발 전문가
+        AgentMetadata(
+            id="web-ui-specialist",
+            name="Web UI Specialist",
+            description="Web UI/UX 전문가. 컴포넌트 설계, 반응형 레이아웃, UX 최적화.",
+            category=AgentCategory.DEVELOPMENT,
+            capabilities=[
+                AgentCapability(
+                    name="react-native-components",
+                    description="React Native 컴포넌트 설계 및 구현",
+                    keywords=["component", "ui", "view", "screen", "layout", "style"],
+                    priority=10,
+                ),
+                AgentCapability(
+                    name="navigation",
+                    description="React Navigation 설정 및 최적화",
+                    keywords=["navigation", "screen", "route", "tab", "drawer", "stack"],
+                    priority=8,
+                ),
+                AgentCapability(
+                    name="responsive-design",
+                    description="반응형 레이아웃 및 다양한 화면 크기 지원",
+                    keywords=["responsive", "adaptive", "dimension", "orientation"],
+                    priority=6,
+                ),
+            ],
+            specializations=["React Native", "Expo", "TypeScript", "Tailwind"],
+            estimated_cost_per_task=0.05,
+            avg_execution_time_ms=15000,
+        ),
+        AgentMetadata(
+            id="backend-integration-specialist",
+            name="Backend Integration Specialist",
+            description="Firebase 및 API 통합 전문가. 데이터 동기화, 인증, 실시간 업데이트.",
+            category=AgentCategory.DEVELOPMENT,
+            capabilities=[
+                AgentCapability(
+                    name="firebase-integration",
+                    description="Firebase Auth, Firestore, Functions 통합",
+                    keywords=["firebase", "firestore", "auth", "authentication", "realtime"],
+                    priority=10,
+                ),
+                AgentCapability(
+                    name="api-integration",
+                    description="REST/GraphQL API 연동 및 데이터 처리",
+                    keywords=["api", "rest", "graphql", "fetch", "axios", "endpoint"],
+                    priority=9,
+                ),
+                AgentCapability(
+                    name="data-sync",
+                    description="오프라인 우선 데이터 동기화 전략",
+                    keywords=["sync", "offline", "cache", "persistence"],
+                    priority=7,
+                ),
+            ],
+            specializations=["Firebase", "REST API", "GraphQL", "AsyncStorage"],
+            estimated_cost_per_task=0.06,
+            avg_execution_time_ms=20000,
+        ),
+        AgentMetadata(
+            id="test-automation-specialist",
+            name="Test Automation Specialist",
+            description="테스트 자동화 전문가. Jest, RTL, 커버리지 분석, TDD.",
+            category=AgentCategory.DEVELOPMENT,
+            capabilities=[
+                AgentCapability(
+                    name="unit-testing",
+                    description="Jest를 사용한 단위 테스트 작성",
+                    keywords=["test", "jest", "unit", "spec", "mock", "expect"],
+                    priority=10,
+                ),
+                AgentCapability(
+                    name="component-testing",
+                    description="React Native Testing Library 컴포넌트 테스트",
+                    keywords=["rtl", "render", "screen", "fireEvent", "component test"],
+                    priority=9,
+                ),
+                AgentCapability(
+                    name="coverage-analysis",
+                    description="테스트 커버리지 분석 및 개선",
+                    keywords=["coverage", "branch", "statement", "function"],
+                    priority=7,
+                ),
+            ],
+            specializations=["Jest", "React Native Testing Library", "Coverage"],
+            estimated_cost_per_task=0.04,
+            avg_execution_time_ms=12000,
+        ),
+        # 오케스트레이션
+        AgentMetadata(
+            id="aos-orchestrator",
+            name="AOS Orchestrator",
+            description="멀티 에이전트 워크플로우 조정자. 태스크 분해, 에이전트 선택, 결과 집계.",
+            category=AgentCategory.ORCHESTRATION,
+            capabilities=[
+                AgentCapability(
+                    name="task-decomposition",
+                    description="복잡한 태스크를 서브태스크로 분해",
+                    keywords=["decompose", "break down", "split", "subtask"],
+                    priority=10,
+                ),
+                AgentCapability(
+                    name="agent-selection",
+                    description="태스크에 적합한 에이전트 선택",
+                    keywords=["select", "assign", "delegate", "agent"],
+                    priority=9,
+                ),
+                AgentCapability(
+                    name="workflow-coordination",
+                    description="병렬/순차 실행 워크플로우 조정",
+                    keywords=["parallel", "sequential", "workflow", "coordinate"],
+                    priority=8,
+                ),
+            ],
+            specializations=["Multi-Agent", "Workflow", "Orchestration"],
+            estimated_cost_per_task=0.08,
+            avg_execution_time_ms=30000,
+            max_concurrent_tasks=3,
+        ),
+        # 품질
+        AgentMetadata(
+            id="quality-validator",
+            name="Quality Validator",
+            description="코드 품질 검증자. 리뷰, 표준 준수 확인, 품질 게이트.",
+            category=AgentCategory.QUALITY,
+            capabilities=[
+                AgentCapability(
+                    name="code-review",
+                    description="코드 리뷰 및 개선 제안",
+                    keywords=["review", "quality", "check", "validate", "verify"],
+                    priority=10,
+                ),
+                AgentCapability(
+                    name="standards-compliance",
+                    description="코딩 표준 및 프로젝트 규칙 준수 확인",
+                    keywords=["standard", "convention", "rule", "lint"],
+                    priority=8,
+                ),
+            ],
+            specializations=["Code Review", "Quality Gates"],
+            estimated_cost_per_task=0.03,
+            avg_execution_time_ms=8000,
+        ),
+        AgentMetadata(
+            id="code-simplifier",
+            name="Code Simplifier",
+            description="코드 복잡도 분석 및 단순화 전문가. 리팩토링, 중복 제거.",
+            category=AgentCategory.QUALITY,
+            capabilities=[
+                AgentCapability(
+                    name="complexity-analysis",
+                    description="순환 복잡도 및 코드 복잡도 분석",
+                    keywords=["complexity", "cyclomatic", "cognitive", "nesting"],
+                    priority=10,
+                ),
+                AgentCapability(
+                    name="refactoring",
+                    description="코드 리팩토링 및 단순화",
+                    keywords=["refactor", "simplify", "clean", "restructure"],
+                    priority=9,
+                ),
+                AgentCapability(
+                    name="deduplication",
+                    description="중복 코드 식별 및 제거",
+                    keywords=["duplicate", "redundant", "dry", "extract"],
+                    priority=7,
+                ),
+            ],
+            specializations=["Refactoring", "Clean Code"],
+            estimated_cost_per_task=0.04,
+            avg_execution_time_ms=10000,
+        ),
+        # 성능
+        AgentMetadata(
+            id="performance-optimizer",
+            name="Performance Optimizer",
+            description="성능 최적화 전문가. 메모리, 렌더링, 번들 크기 최적화.",
+            category=AgentCategory.DEVELOPMENT,
+            capabilities=[
+                AgentCapability(
+                    name="render-optimization",
+                    description="React Native 렌더링 최적화",
+                    keywords=["render", "rerender", "memo", "useMemo", "useCallback"],
+                    priority=10,
+                ),
+                AgentCapability(
+                    name="memory-optimization",
+                    description="메모리 누수 감지 및 최적화",
+                    keywords=["memory", "leak", "garbage", "profiler"],
+                    priority=9,
+                ),
+                AgentCapability(
+                    name="bundle-optimization",
+                    description="번들 크기 분석 및 최적화",
+                    keywords=["bundle", "size", "tree-shaking", "code-splitting"],
+                    priority=7,
+                ),
+            ],
+            specializations=["Performance", "Optimization", "Profiling"],
+            estimated_cost_per_task=0.05,
+            avg_execution_time_ms=18000,
+        ),
+    ]
 
 
 class AgentRegistry:
@@ -338,7 +363,7 @@ class AgentRegistry:
         self._initialized = True
 
         # 기본 에이전트 등록
-        for agent in DEFAULT_AGENTS:
+        for agent in _build_default_agents():
             self.register(agent)
 
     def register(self, metadata: AgentMetadata) -> None:

--- a/src/backend/services/external_usage_service.py
+++ b/src/backend/services/external_usage_service.py
@@ -581,8 +581,17 @@ class AnthropicUsageCollector(BaseUsageCollector):
         records: list[UnifiedUsageRecord] = []
 
         costs: dict[str, tuple[float, float]] = {
+            "claude-sonnet-5": (0.003, 0.015),
+            "claude-opus-4-8": (0.005, 0.025),
+            # Opus price cut ($5/$25) applies from Opus 4.5 onward; these
+            # specific prefixes must precede the generic "claude-opus-4"
+            # (4-0/4-1 era $15/$75). Dict order == match order (startswith).
+            "claude-opus-4-7": (0.005, 0.025),
+            "claude-opus-4-6": (0.005, 0.025),
+            "claude-opus-4-5": (0.005, 0.025),
             "claude-opus-4": (0.015, 0.075),
             "claude-sonnet-4": (0.003, 0.015),
+            "claude-haiku-4-5": (0.001, 0.005),
             "claude-haiku-4": (0.00025, 0.00125),
         }
 

--- a/src/dashboard/src/App.tsx
+++ b/src/dashboard/src/App.tsx
@@ -8,6 +8,7 @@ import { useOrchestrationStore } from './stores/orchestration'
 import { useNavigationStore, isPublicView } from './stores/navigation'
 import { useAuthStore } from './stores/auth'
 import { useMenuVisibilityStore } from './stores/menuVisibility'
+import { useSettingsStore } from './stores/settings'
 import { routes } from './routes'
 import { analytics } from './services/analytics'
 import {
@@ -82,6 +83,14 @@ export default function App() {
   // PostHog 초기화 (앱 마운트 시 1회)
   useEffect(() => {
     analytics.init()
+  }, [])
+
+  // LLM 모델 목록 로드 (앱 마운트 시 1회, 이미 로드/로딩 중이면 스킵)
+  useEffect(() => {
+    const { availableModels, modelsLoading, fetchModels } = useSettingsStore.getState()
+    if (availableModels.length === 0 && !modelsLoading) {
+      fetchModels()
+    }
   }, [])
 
   // 페이지뷰 추적

--- a/src/dashboard/src/stores/__tests__/settings.test.ts
+++ b/src/dashboard/src/stores/__tests__/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { useSettingsStore, getModelsForProvider } from '../settings'
-import type { LLMModel } from '../settings'
+import { useSettingsStore } from '../settings'
+import type { LLMModel, LLMProvider } from '../settings'
 
 const { mockApiPatch } = vi.hoisted(() => ({
   mockApiPatch: vi.fn(),
@@ -235,8 +235,121 @@ describe('settings store', () => {
       const state = useSettingsStore.getState()
       expect(state.modelsLoading).toBe(false)
       expect(state.modelsError).toBe('Network failure')
-      // availableModels should remain unchanged (empty from beforeEach reset)
-      expect(state.availableModels).toEqual([])
+      // Fallback models are injected when the API is unavailable
+      expect(state.availableModels.length).toBeGreaterThan(0)
+    })
+
+    it('injects fallback models (including claude-sonnet-5) when fetch fails and store is empty', async () => {
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+      await useSettingsStore.getState().fetchModels()
+
+      const state = useSettingsStore.getState()
+      const ids = state.availableModels.map((m) => m.id)
+      expect(ids).toContain('claude-opus-4-8')
+      expect(ids).toContain('claude-sonnet-5')
+      expect(ids).toContain('claude-sonnet-4-6')
+      expect(ids).toContain('claude-haiku-4-5-20251001')
+      expect(ids).toContain('gpt-4o-mini')
+      expect(ids).toContain('codex-cli')
+      expect(ids).toContain('gemini-3-flash-preview')
+
+      // Each injected model is a fully-formed LLMModel; claude-sonnet-5 is the
+      // backend default for anthropic (mirrored from _MODELS is_default=True)
+      const sonnet5 = state.availableModels.find((m) => m.id === 'claude-sonnet-5')
+      expect(sonnet5).toMatchObject({
+        display_name: 'claude-sonnet-5',
+        provider: 'anthropic',
+        available: true,
+        is_default: true,
+      })
+
+      // Non-default models keep is_default: false
+      const opus = state.availableModels.find((m) => m.id === 'claude-opus-4-8')
+      expect(opus?.is_default).toBe(false)
+    })
+
+    it('marks the backend per-provider defaults as is_default in fallback models', async () => {
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+      await useSettingsStore.getState().fetchModels()
+
+      const defaults = useSettingsStore
+        .getState()
+        .availableModels.filter((m) => m.is_default)
+        .map((m) => m.id)
+        .sort()
+      expect(defaults).toEqual(
+        ['claude-sonnet-5', 'codex-cli', 'exaone3.5:7.8b', 'gemini-3-flash-preview', 'gpt-4o-mini'].sort()
+      )
+    })
+
+    it('dedupes concurrent fetchModels calls while a request is in flight', async () => {
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      let resolveResponse!: (value: Response) => void
+      mockFetch.mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveResponse = resolve
+        })
+      )
+
+      const first = useSettingsStore.getState().fetchModels()
+      expect(useSettingsStore.getState().modelsLoading).toBe(true)
+
+      // Second call while the first is in flight must early-return without fetching
+      await useSettingsStore.getState().fetchModels()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      resolveResponse(
+        new Response(JSON.stringify({ models: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      await first
+
+      const state = useSettingsStore.getState()
+      expect(state.modelsLoading).toBe(false)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it("maps fallback 'local' provider models to 'ollama' so getModelsForProvider works", async () => {
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+      await useSettingsStore.getState().fetchModels()
+
+      const localModels = useSettingsStore.getState().getModelsForProvider('local')
+      expect(localModels.map((m) => m.id)).toContain('exaone3.5:7.8b')
+      expect(localModels.every((m) => m.provider === 'ollama')).toBe(true)
+    })
+
+    it('does NOT overwrite previously loaded models with fallbacks on fetch failure', async () => {
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      const apiModels: LLMModel[] = [
+        makeModel({ id: 'claude-sonnet-4-6', provider: 'anthropic', is_default: true }),
+      ]
+      useSettingsStore.setState({ availableModels: apiModels })
+
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+      await useSettingsStore.getState().fetchModels()
+
+      const state = useSettingsStore.getState()
+      expect(state.modelsError).toBe('Network failure')
+      expect(state.availableModels).toEqual(apiModels)
     })
 
     it('sets modelsError when response status is not ok (non-200)', async () => {
@@ -403,35 +516,54 @@ describe('settings store', () => {
 
 })
 
-describe('getModelsForProvider (legacy exported function)', () => {
-  it('returns anthropic models', () => {
-    const models = getModelsForProvider('anthropic')
-    expect(models).toContain('claude-opus-4-8')
-    expect(models).toContain('claude-sonnet-4-6')
+describe('fallback models via store actions (after fetch failure)', () => {
+  beforeEach(async () => {
+    useSettingsStore.setState({
+      backendUrl: 'http://localhost:8000',
+      availableModels: [],
+      modelsLoading: false,
+      modelsError: null,
+    })
+    const mockFetch = vi.fn().mockRejectedValueOnce(new Error('API down'))
+    vi.stubGlobal('fetch', mockFetch)
+    await useSettingsStore.getState().fetchModels()
   })
 
-  it('returns openai models', () => {
-    const models = getModelsForProvider('openai')
-    expect(models).toContain('gpt-4o-mini')
-    expect(models).toContain('gpt-4o')
-    expect(models).not.toContain('gpt-5.4')
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
-  it('returns codex cli models', () => {
-    const models = getModelsForProvider('codex_cli')
-    expect(models).toContain('codex-cli')
+  const idsFor = (provider: LLMProvider) =>
+    useSettingsStore.getState().getModelsForProvider(provider).map((m) => m.id)
+
+  it('returns anthropic fallback models including claude-sonnet-5', () => {
+    const ids = idsFor('anthropic')
+    expect(ids).toContain('claude-opus-4-8')
+    expect(ids).toContain('claude-sonnet-5')
+    expect(ids).toContain('claude-sonnet-4-6')
   })
 
-  it('returns google/gemini models', () => {
-    const models = getModelsForProvider('google')
-    expect(models).toContain('gemini-3-flash-preview')
-    expect(models).toContain('gemini-2.5-pro')
+  it('returns openai fallback models', () => {
+    const ids = idsFor('openai')
+    expect(ids).toContain('gpt-4o-mini')
+    expect(ids).toContain('gpt-4o')
+    expect(ids).not.toContain('gpt-5.4')
   })
 
-  it('returns local models', () => {
-    const models = getModelsForProvider('local')
-    expect(models).toContain('exaone3.5:7.8b')
-    expect(models).toContain('llama3:8b')
+  it('returns codex cli fallback models', () => {
+    expect(idsFor('codex_cli')).toContain('codex-cli')
+  })
+
+  it('returns google/gemini fallback models', () => {
+    const ids = idsFor('google')
+    expect(ids).toContain('gemini-3-flash-preview')
+    expect(ids).toContain('gemini-2.5-pro')
+  })
+
+  it('returns local fallback models (mapped to ollama provider)', () => {
+    const ids = idsFor('local')
+    expect(ids).toContain('exaone3.5:7.8b')
+    expect(ids).toContain('llama3:8b')
   })
 })
 

--- a/src/dashboard/src/stores/settings.ts
+++ b/src/dashboard/src/stores/settings.ts
@@ -94,19 +94,45 @@ interface SettingsState {
   getModelsForProvider: (provider: LLMProvider) => LLMModel[]
 }
 
-// Fallback models when API is unavailable
+// Fallback models when API is unavailable.
+// Mirrors the enabled models in backend `_MODELS` (src/backend/models/llm_models.py).
+// Disabled backend models (gpt-5.5, gpt-5.4 family) are intentionally excluded.
+// Keep this list AND fallbackDefaultModelIds below in sync when the backend changes.
 const fallbackModels: Record<LLMProvider, string[]> = {
-  anthropic: ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+  anthropic: ['claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
   google: ['gemini-3-flash-preview', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
   openai: ['gpt-4o-mini', 'gpt-4o', 'o3', 'o4-mini'],
   codex_cli: ['codex-cli'],
   local: ['exaone3.5:7.8b', 'llama3:8b', 'mistral:7b', 'codellama:7b'],
 }
 
-// Legacy function for backward compatibility
-export const getModelsForProvider = (provider: LLMProvider): string[] => {
-  return fallbackModels[provider] || []
-}
+// Per-provider default model ids, mirrored from backend `_MODELS` entries with
+// is_default=True (src/backend/models/llm_models.py). Update alongside fallbackModels.
+const fallbackDefaultModelIds: ReadonlySet<string> = new Set([
+  'claude-sonnet-5', // anthropic
+  'gemini-3-flash-preview', // google
+  'gpt-4o-mini', // openai
+  'codex-cli', // codex_cli
+  'exaone3.5:7.8b', // local (ollama)
+])
+
+// Build minimal LLMModel objects from fallbackModels for offline/API-failure use.
+// 'local' is mapped to 'ollama' to match the provider values returned by the API.
+const buildFallbackModels = (): LLMModel[] =>
+  (Object.entries(fallbackModels) as [LLMProvider, string[]][]).flatMap(
+    ([provider, ids]) =>
+      ids.map((id) => ({
+        id,
+        display_name: id,
+        provider: provider === 'local' ? 'ollama' : provider,
+        context_window: 0,
+        pricing: { input: 0, output: 0 },
+        available: true,
+        is_default: fallbackDefaultModelIds.has(id),
+        supports_tools: true,
+        supports_vision: false,
+      }))
+  )
 
 const defaultNotifications: NotificationSettings = {
   browserNotifications: true,
@@ -169,6 +195,9 @@ export const useSettingsStore = create<SettingsState>()(
 
       fetchModels: async () => {
         const state = get()
+        // In-flight dedup: skip if a fetch is already running
+        // (e.g. App mount and SettingsPage mount firing concurrently)
+        if (state.modelsLoading) return
         set({ modelsLoading: true, modelsError: null })
 
         try {
@@ -185,10 +214,14 @@ export const useSettingsStore = create<SettingsState>()(
           })
         } catch (error) {
           console.warn('Failed to fetch LLM models from API, using fallback:', error)
-          set({
+          set((current) => ({
+            // Keep previously loaded models; only inject fallbacks when empty
+            availableModels: current.availableModels.length > 0
+              ? current.availableModels
+              : buildFallbackModels(),
             modelsLoading: false,
             modelsError: error instanceof Error ? error.message : 'Failed to fetch models',
-          })
+          }))
         }
       },
 

--- a/tests/backend/test_agent_registry.py
+++ b/tests/backend/test_agent_registry.py
@@ -29,8 +29,8 @@ class TestAgentRegistry:
         AgentRegistry._instance = registry
 
         # 기본 에이전트를 복사해서 등록 (상태 격리)
-        from services.agent_registry import DEFAULT_AGENTS
-        for agent in DEFAULT_AGENTS:
+        from services.agent_registry import _build_default_agents
+        for agent in _build_default_agents():
             # 깊은 복사를 통해 새 인스턴스 생성
             agent_copy = AgentMetadata(
                 id=agent.id,
@@ -169,6 +169,71 @@ class TestAgentMetadata:
         # 상태를 BUSY로 변경
         agent.status = AgentStatus.BUSY
         assert agent.is_available() is False
+
+    def test_default_model_resolved_from_registry(self, monkeypatch):
+        """model 기본값은 하드코딩이 아닌 LLMModelRegistry 기반 동적 해석."""
+        from models.llm_models import LLMModelRegistry
+
+        # 코드 레벨 _MODELS 기준으로 검증 (다른 테스트의 DB 캐시 영향 차단)
+        monkeypatch.setattr(LLMModelRegistry, "_db_cache", None)
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        agent = AgentMetadata(
+            id="test-agent",
+            name="Test Agent",
+            description="Test",
+            category=AgentCategory.DEVELOPMENT,
+        )
+        assert agent.model == "claude-sonnet-5"
+
+        # 인스턴스 생성 시점 평가 확인 (import 시점 고정이 아님)
+        monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
+        agent2 = AgentMetadata(
+            id="test-agent-2",
+            name="Test Agent 2",
+            description="Test",
+            category=AgentCategory.DEVELOPMENT,
+        )
+        assert agent2.model == "codex-cli"
+
+    def test_build_default_agents_reflects_registry_default_change(self, monkeypatch):
+        """기본 에이전트는 빌드 시점의 레지스트리 default를 따른다 (import 시점 고정 아님).
+
+        DB 로드로 admin default가 바뀐 상황을 _db_cache 주입으로 시뮬레이션하고,
+        _build_default_agents()가 매 호출 시점의 default를 반영하는지 검증.
+        """
+        from models.llm_models import LLMModelConfig, LLMModelRegistry
+        from models.llm_models import LLMProvider as ModelProvider
+        from services.agent_registry import _build_default_agents
+
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+
+        def _set_db_default(default_id: str) -> None:
+            db_models = [
+                LLMModelConfig(
+                    id=model_id,
+                    display_name=model_id,
+                    provider=ModelProvider.ANTHROPIC,
+                    context_window=1_000_000,
+                    input_price=0.003,
+                    output_price=0.015,
+                    is_default=(model_id == default_id),
+                )
+                for model_id in ("claude-sonnet-5", "claude-opus-4-8")
+            ]
+            monkeypatch.setattr(LLMModelRegistry, "_db_cache", db_models)
+            monkeypatch.setattr(
+                LLMModelRegistry, "_db_index", {m.id: m for m in db_models}
+            )
+
+        # DB-loaded admin default = opus → 빌드 결과에 반영
+        _set_db_default("claude-opus-4-8")
+        agents = _build_default_agents()
+        assert agents and all(a.model == "claude-opus-4-8" for a in agents)
+
+        # default 변경 후 새로 빌드하면 변경이 반영됨
+        _set_db_default("claude-sonnet-5")
+        agents2 = _build_default_agents()
+        assert agents2 and all(a.model == "claude-sonnet-5" for a in agents2)
 
     def test_matches_capability(self):
         """능력 매칭 테스트."""

--- a/tests/backend/test_external_usage_service.py
+++ b/tests/backend/test_external_usage_service.py
@@ -10,6 +10,7 @@ import pytest
 
 from models.external_usage import ExternalProvider, UnifiedUsageRecord
 from services.external_usage_service import (
+    AnthropicUsageCollector,
     ExternalUsageService,
     OpenAIUsageCollector,
     summarize_claude_snapshot_records,
@@ -114,6 +115,54 @@ async def test_openai_collect_unknown_model_zero_cost() -> None:
         )
 
     assert records[0].cost_usd == 0.0
+
+
+def _anthropic_usage_payload(model: str, input_tok: int, output_tok: int) -> dict:
+    return {
+        "data": [
+            {
+                "bucket_end_time": "2026-06-01T00:00:00Z",
+                "items": [
+                    {
+                        "model": model,
+                        "input_tokens": input_tok,
+                        "output_tokens": output_tok,
+                        "num_requests": 5,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+async def test_anthropic_collect_opus_4_6_matches_post_price_cut_row() -> None:
+    """Opus 4.5+ price cut: opus-4-6 must hit $5/$25, not generic claude-opus-4 ($15/$75)."""
+    collector = AnthropicUsageCollector("sk-ant-admin-test")
+    with patch(
+        "services.external_usage_service.httpx.AsyncClient",
+        return_value=_mock_client(_anthropic_usage_payload("claude-opus-4-6", 1000, 1000)),
+    ):
+        records = await collector.collect(
+            datetime.now(tz=UTC) - timedelta(days=30), datetime.now(tz=UTC)
+        )
+
+    assert len(records) == 1
+    assert records[0].cost_usd == pytest.approx(0.005 + 0.025)
+
+
+async def test_anthropic_collect_opus_4_1_keeps_legacy_price() -> None:
+    """Opus 4.1 predates the price cut: must fall through to claude-opus-4 ($15/$75)."""
+    collector = AnthropicUsageCollector("sk-ant-admin-test")
+    with patch(
+        "services.external_usage_service.httpx.AsyncClient",
+        return_value=_mock_client(_anthropic_usage_payload("claude-opus-4-1", 1000, 1000)),
+    ):
+        records = await collector.collect(
+            datetime.now(tz=UTC) - timedelta(days=30), datetime.now(tz=UTC)
+        )
+
+    assert len(records) == 1
+    assert records[0].cost_usd == pytest.approx(0.015 + 0.075)
 
 
 async def test_openai_collect_none_model_zero_cost() -> None:

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -1,0 +1,352 @@
+"""Tests for claude-sonnet-5 registry entry, sync_to_db dual-default guard, and pricing."""
+
+import pytest
+from sqlalchemy import Update
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql.dml import Insert
+
+from models.llm_models import _MODELS, LLMModelRegistry, LLMProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_cache():
+    """Ensure the registry serves the in-memory _MODELS list (no DB cache)."""
+    original_cache = LLMModelRegistry._db_cache
+    original_index = LLMModelRegistry._db_index
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+    yield
+    LLMModelRegistry._db_cache = original_cache
+    LLMModelRegistry._db_index = original_index
+
+
+# ─────────────────────────────────────────────────────────────
+# (a) claude-sonnet-5 exists and is the anthropic code default
+# ─────────────────────────────────────────────────────────────
+
+
+class TestSonnet5RegistryEntry:
+    def test_sonnet5_exists_with_expected_spec(self):
+        model = LLMModelRegistry.get_by_id("claude-sonnet-5")
+        assert model is not None
+        assert model.provider == LLMProvider.ANTHROPIC
+        assert model.context_window == 1_000_000
+        assert model.input_price == 0.003  # $3/1M tokens (per-1k)
+        assert model.output_price == 0.015  # $15/1M tokens (per-1k)
+        assert model.supports_tools is True
+        assert model.supports_vision is True
+        assert model.is_enabled is True
+
+    def test_sonnet5_is_anthropic_code_default(self):
+        assert LLMModelRegistry.get_default("anthropic") == "claude-sonnet-5"
+
+    def test_anthropic_has_exactly_one_code_default(self):
+        defaults = [
+            m.id
+            for m in _MODELS
+            if m.provider == LLMProvider.ANTHROPIC and m.is_default
+        ]
+        assert defaults == ["claude-sonnet-5"]
+
+
+# ─────────────────────────────────────────────────────────────
+# (b) sync_to_db dual-default guard
+# ─────────────────────────────────────────────────────────────
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple] | None = None):
+        self._rows = rows or []
+
+    def fetchall(self) -> list[tuple]:
+        return self._rows
+
+    def scalars(self):  # for load_from_db at end of sync_to_db
+        return self
+
+    def all(self) -> list:
+        return []
+
+
+class _FakeSession:
+    """Captures statements; serves queued results for SELECT calls in order."""
+
+    def __init__(self, select_results: list[_FakeResult]):
+        self._select_results = select_results
+        self.inserts: list = []
+        self.updates: list = []
+        self.selects: list = []
+        self.committed = False
+
+    async def execute(self, stmt):
+        if isinstance(stmt, Insert):
+            self.inserts.append(stmt)
+            return _FakeResult()
+        if isinstance(stmt, Update):
+            self.updates.append(stmt)
+            return _FakeResult()
+        self.selects.append(stmt)
+        return self._select_results.pop(0)
+
+    async def commit(self):
+        self.committed = True
+
+
+def _insert_params(stmt) -> dict:
+    return stmt.compile(dialect=postgresql.dialect()).params
+
+
+def _find_insert(session: _FakeSession, model_id: str):
+    for stmt in session.inserts:
+        if _insert_params(stmt).get("id") == model_id:
+            return stmt
+    raise AssertionError(f"no insert captured for {model_id}")
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_new_default_demoted_when_db_default_exists():
+    """New is_default=True model must INSERT as is_default=False when the
+    provider already has a default row in DB (existing DB default respected)."""
+    session = _FakeSession(
+        select_results=[
+            # existing IDs: sonnet-5 is NEW, sonnet-4-6 already exists
+            _FakeResult([("claude-sonnet-4-6",), ("claude-opus-4-8",)]),
+            # providers that already have a DB default row
+            _FakeResult([("anthropic",)]),
+            # final load_from_db select
+            _FakeResult([]),
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    params = _insert_params(_find_insert(session, "claude-sonnet-5"))
+    assert params["is_default"] is False
+    assert session.committed is True
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_new_default_kept_when_no_db_default():
+    """New is_default=True model keeps is_default=True when the provider has
+    no default row in DB."""
+    session = _FakeSession(
+        select_results=[
+            _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
+            _FakeResult([]),  # no provider has a DB default
+            _FakeResult([]),  # final load_from_db select
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    params = _insert_params(_find_insert(session, "claude-sonnet-5"))
+    assert params["is_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_default_guard_ignores_disabled_db_defaults():
+    """The dual-default guard must only count ENABLED default rows: a provider
+    whose only DB default is disabled still accepts the new code default."""
+    session = _FakeSession(
+        select_results=[
+            _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
+            # Guard select returns no providers: the anthropic default row in
+            # DB is disabled, so the is_enabled filter excludes it.
+            _FakeResult([]),
+            _FakeResult([]),  # final load_from_db select
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    # The guard query itself must filter on BOTH is_default and is_enabled
+    guard_select = session.selects[1]
+    sql = str(guard_select.compile(dialect=postgresql.dialect()))
+    assert "is_default" in sql
+    assert "is_enabled" in sql
+
+    # And the new model keeps its code-level default flag
+    params = _insert_params(_find_insert(session, "claude-sonnet-5"))
+    assert params["is_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_clears_stale_disabled_default_before_new_default_insert():
+    """disable→sync→re-enable 시나리오: 구 default(예: sonnet-4-6)가 disabled인
+    상태에서 sync가 신규 default(sonnet-5)를 INSERT하면, 구 행의 is_default를
+    False로 클리어하는 UPDATE가 함께 발행되어야 한다 — 이후 admin이 구 행을
+    re-enable해도 provider default가 2개가 되지 않도록."""
+    session = _FakeSession(
+        select_results=[
+            _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
+            # anthropic의 유일한 default 행이 disabled → enabled 필터에 걸러져
+            # 가드 통과 (신규 모델이 default로 INSERT되는 경로)
+            _FakeResult([]),
+            _FakeResult([]),  # final load_from_db select
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    # 신규 모델은 default로 INSERT됨
+    params = _insert_params(_find_insert(session, "claude-sonnet-5"))
+    assert params["is_default"] is True
+
+    # anthropic provider의 잔존 default 행을 클리어하는 UPDATE 발행 확인
+    anthropic_clears = []
+    for stmt in session.updates:
+        compiled = stmt.compile(dialect=postgresql.dialect())
+        if (
+            "anthropic" in compiled.params.values()
+            and compiled.params.get("is_default") is False
+        ):
+            anthropic_clears.append(str(compiled))
+    assert anthropic_clears, "expected is_default-clearing UPDATE for anthropic"
+    sql = anthropic_clears[0]
+    assert "SET is_default" in sql
+    # 클리어 UPDATE는 is_default만 만지고 enable 상태는 건드리지 않는다
+    assert "is_enabled" not in sql.split("SET", 1)[1].split("WHERE", 1)[0]
+    # WHERE절이 is_enabled=False 조건을 포함해야 한다: 가드 SELECT와 이
+    # UPDATE 사이에 admin이 구 default를 re-enable하는 경쟁(READ COMMITTED)
+    # 에서도 "disabled default만 정리" 불변식이 SQL 자체로 보장되도록.
+    where_clause = sql.split("WHERE", 1)[1]
+    assert "is_enabled IS false" in where_clause
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_no_default_clear_when_enabled_db_default_exists():
+    """enabled DB default가 있으면 신규 모델은 demote되고 클리어 UPDATE도
+    발행되지 않는다 (admin default 행 보존)."""
+    session = _FakeSession(
+        select_results=[
+            _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
+            _FakeResult([("anthropic",)]),  # anthropic enabled default 존재
+            _FakeResult([]),
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    for stmt in session.updates:
+        compiled = stmt.compile(dialect=postgresql.dialect())
+        assert "anthropic" not in compiled.params.values(), (
+            "must not clear defaults for a provider with an enabled DB default"
+        )
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_on_conflict_preserves_admin_fields():
+    """ON CONFLICT DO UPDATE must not touch is_default / is_enabled."""
+    session = _FakeSession(
+        select_results=[
+            _FakeResult([("claude-sonnet-5",)]),  # sonnet-5 already exists
+            _FakeResult([("anthropic",)]),
+            _FakeResult([]),
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    stmt = _find_insert(session, "claude-sonnet-5")
+    sql = str(stmt.compile(dialect=postgresql.dialect()))
+    assert "DO UPDATE SET" in sql
+    update_clause = sql.split("DO UPDATE SET", 1)[1]
+    assert "is_default" not in update_clause
+    assert "is_enabled" not in update_clause
+
+
+# ─────────────────────────────────────────────────────────────
+# (c) llm_proxy pricing matches claude-sonnet-5 (non-zero)
+# ─────────────────────────────────────────────────────────────
+
+
+class TestLLMProxyCostTable:
+    def test_sonnet5_cost_is_nonzero(self):
+        from api.llm_proxy import _calc_cost
+
+        cost = _calc_cost("claude-sonnet-5", 1000, 1000)
+        assert cost == pytest.approx(0.003 + 0.015)
+        assert cost > 0.0
+
+    def test_opus_4_8_matches_before_legacy_opus_4(self):
+        from api.llm_proxy import _calc_cost
+
+        # Must hit the claude-opus-4-8 row ($5/$25), not claude-opus-4 ($15/$75)
+        assert _calc_cost("claude-opus-4-8", 1000, 1000) == pytest.approx(0.005 + 0.025)
+
+    def test_haiku_4_5_matches_before_legacy_haiku_4(self):
+        from api.llm_proxy import _calc_cost
+
+        # Must hit the claude-haiku-4-5 row ($1/$5), not claude-haiku-4
+        assert _calc_cost("claude-haiku-4-5-20251001", 1000, 1000) == pytest.approx(
+            0.001 + 0.005
+        )
+
+    def test_opus_4_5_and_later_match_post_price_cut_rows(self):
+        """Opus price cut ($5/$25) applies from 4.5 onward: the specific
+        4-5/4-6/4-7 prefixes must win over the generic claude-opus-4 row."""
+        from api.llm_proxy import _calc_cost
+
+        for model in ("claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7"):
+            assert _calc_cost(model, 1000, 1000) == pytest.approx(0.005 + 0.025), model
+
+    def test_opus_4_1_and_4_0_keep_legacy_price(self):
+        """Pre-4.5 Opus generations fall through to claude-opus-4 ($15/$75)."""
+        from api.llm_proxy import _calc_cost
+
+        for model in ("claude-opus-4-1", "claude-opus-4-0"):
+            assert _calc_cost(model, 1000, 1000) == pytest.approx(0.015 + 0.075), model
+
+
+# ─────────────────────────────────────────────────────────────
+# (d) get_context_limit converges on the registry (SSOT)
+# ─────────────────────────────────────────────────────────────
+
+
+class TestContextLimitRegistrySSOT:
+    def test_registry_models_resolve_registry_context_window(self):
+        from models.context_usage import get_context_limit
+
+        # 1M-context models must report the registry value, not the old
+        # 200K legacy dict entries
+        assert get_context_limit("anthropic", "claude-sonnet-5") == 1_000_000
+        assert get_context_limit("anthropic", "claude-sonnet-4-6") == 1_000_000
+        assert get_context_limit("anthropic", "claude-opus-4-8") == 1_000_000
+        assert get_context_limit("openai", "gpt-4o") == 128_000
+
+    def test_unknown_model_falls_back_to_legacy_dict(self):
+        from models.context_usage import get_context_limit
+
+        # Not in the registry → legacy substring matching still applies
+        assert get_context_limit("google", "gemini-1.5-pro") == 1_000_000
+        assert get_context_limit("openai", "gpt-3.5-turbo") == 16_385
+
+    def test_fully_unknown_model_uses_provider_default(self):
+        from models.context_usage import get_context_limit
+
+        assert get_context_limit("anthropic", "some-future-model") == 200_000
+        assert get_context_limit("not-a-provider", "whatever") == 100_000
+
+
+# ─────────────────────────────────────────────────────────────
+# (e) claude_session MODEL_COSTS (exact-id lookup table)
+# ─────────────────────────────────────────────────────────────
+
+
+class TestClaudeSessionModelCosts:
+    def test_opus_4_7_has_exact_entry_post_price_cut(self):
+        """MODEL_COSTS는 정확-ID 조회 테이블: opus-4-7 항목이 없으면
+        calculate_cost가 sonnet 폴백($3/$15)으로 과소 집계된다."""
+        from models.claude_session import calculate_cost
+
+        assert calculate_cost("claude-opus-4-7", 1000, 1000) == pytest.approx(0.030)
+
+    def test_opus_4_5_plus_family_all_priced_at_5_25(self):
+        from models.claude_session import calculate_cost
+
+        for model in (
+            "claude-opus-4-8",
+            "claude-opus-4-6",
+            "claude-opus-4-5-20251101",
+        ):
+            assert calculate_cost(model, 1000, 1000) == pytest.approx(0.030), model


### PR DESCRIPTION
## Summary
- LLM 모델 레지스트리(SSOT)에 `claude-sonnet-5` 추가하고 anthropic 기본값 이관 — 이제 새 모델 추가는 `llm_models.py` 한 곳만 수정하면 DB(sync_to_db)와 모든 대시보드 페이지에 전파됨
- 3개 가격 테이블의 Opus 4.5+ 가격 오류($15/\$75 → \$5/\$25) 정정 및 신규 family prefix 항목 추가 (prefix 매칭 순서 보장)
- 대시보드 모델 목록을 App 마운트 시 전역 1회 로드로 전환 — Settings 미방문 페이지에서도 모델 카탈로그 사용 가능, API 실패 시 fallback 미주입 버그 수정

## Changes
- **backend/models/llm_models.py**: `claude-sonnet-5`($3/\$15, 1M ctx) 추가, anthropic 코드 default 이관, `sync_to_db` 이중-default 가드(기존 DB의 admin default 보존, disabled default는 SQL `WHERE is_enabled IS FALSE`로 클리어)
- **backend/api/llm_proxy.py · services/external_usage_service.py**: opus-4-5/4-6/4-7/4-8, sonnet-5, haiku-4-5 구체 prefix를 generic 항목 앞에 추가
- **backend/models/claude_session.py**: MODEL_COSTS에 sonnet-5·opus-4-7 추가, Opus 4.5+/4.6/4.8 가격 정정
- **backend/services/agent_registry.py**: 하드코딩 `claude-sonnet-4-6` 제거 → `_build_default_agents()` lazy 빌더 + 레지스트리 기반 `default_factory`
- **backend/models/context_usage.py**: `get_context_limit`이 LLMModelRegistry 우선 조회, dict는 legacy 폴백
- **dashboard**: `fetchModels` App 마운트 전역 로드 + in-flight dedup + fallback 주입 수정 + 죽은 legacy export 제거, fallback 상수를 백엔드 `_MODELS` 미러로 동기화
- **docs**: `docs/api/llm.md`(is_default 마이그레이션 주의 포함), `docs/dashboard.md` 동기화

## Test Plan
- [x] 백엔드: ruff / mypy / pytest **1259 passed, 0 failed** (신규 테스트 ~30개: 레지스트리 스펙, 이중-default 가드 4시나리오, 가격 prefix 매칭, context limit SSOT)
- [x] 대시보드: tsc / eslint / build / vitest **4265 passed, 0 failed**
- [x] Codex 독립 리뷰 3라운드 — 최종 P1/P2 잔여 0건
- [ ] 배포 후: 기존 DB 배포는 Settings UI에서 anthropic default를 Sonnet 5로 수동 전환 (admin 필드 보존 설계 — docs/api/llm.md 참조)

참고: `test_rag_verification.py` 플레이크 1건은 로컬 `.env` 의존 pre-existing 이슈로 본 PR과 무관 (baseline 재현 확인).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)