### PR TITLE
feat(llm): admin 모델 관리 패널 + 하드 삭제/suppression 재등록 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ dev/harness-legacy-scan/
 
 # Harness intermediate artifacts (aos-feature-harness) — audit trail, not committed
 _workspace/
+_workspace_*/

--- a/docs/api/llm.md
+++ b/docs/api/llm.md
@@ -17,6 +17,8 @@ LLM 모델 레지스트리, 라우터, 자격증명, 프록시, Playground API�
 | GET | `/api/llm/models/default` | 기본 모델 조회 |
 | GET | `/api/llm/models/{model_id}` | 특정 모델 상세 |
 | PATCH | `/api/llm/models/{model_id}` | 모델 설정 수정 |
+| DELETE | `/api/llm/models/{model_id}` | 모델 하드 삭제 (config 행 삭제 + suppression 기록, admin 전용) |
+| DELETE | `/api/llm/models/suppressions/{model_id}` | suppression 해제 (admin 전용) |
 | GET | `/api/llm/providers` | 지원 프로바이더 목록 |
 
 **응답 형식** (GET /api/llm/models):
@@ -47,9 +49,17 @@ LLM 모델 레지스트리, 라우터, 자격증명, 프록시, Playground API�
 > **`is_default` 마이그레이션 주의** (`USE_DATABASE=true` 배포): `sync_to_db`는
 > 이미 해당 provider의 default 행이 DB에 있으면, `_MODELS`에서 `is_default=True`로
 > 추가된 신규 모델을 `is_default=False`로 INSERT합니다(이중 default 방지). 즉 신규
-> 기본 모델 이관은 기존 배포에 자동 반영되지 않으며, admin이 Settings UI에서 직접
-> default를 전환해야 합니다. 인메모리 폴백(`USE_DATABASE` 미설정)에서는 `_MODELS`의
+> 기본 모델 이관은 기존 배포에 자동 반영되지 않으며, admin이 Settings의 Model
+> Management 패널에서 직접 default를 전환해야 합니다. 인메모리 폴백(`USE_DATABASE` 미설정)에서는 `_MODELS`의
 > `is_default`가 그대로 적용됩니다.
+>
+> **모델 하드 삭제 & suppression**: `DELETE /api/llm/models/{model_id}`는 config 행을
+> 삭제하고 `llm_model_suppressions` 테이블에 id를 기록합니다. suppression에 기록된 id는
+> startup `sync_to_db`와 24h 모델 discovery **양쪽에서 skip**되어 재등록되지 않습니다(진짜 삭제).
+> 코드 `_MODELS`(가격/정산 SSOT)는 보존되며 suppression은 DB 레이어에서만 동작합니다.
+> `is_default` 모델 삭제는 409로 거부되므로 먼저 default를 다른 모델로 이관해야 합니다.
+> `DELETE /api/llm/models/suppressions/{model_id}`로 suppression을 해제하면 다음
+> `sync_to_db`/discovery 실행 시 모델이 자동 재등록됩니다(즉시 재등록 아님).
 
 ---
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -286,6 +286,7 @@ import { cn } from '@/lib/utils';
 | 컴포넌트 | 설명 |
 |----------|------|
 | `LLMRouterSettings` | LLM 라우터 설정 (프로바이더 관리, 통계 포함) |
+| `ModelManagementPanel` | admin 전용 모델 관리 패널 (provider별 그룹, Enable/Disable·Set default 토글, 비활성·비-default 행 하드 삭제(confirm)) |
 
 ### Version Control Components
 

--- a/src/backend/alembic/versions/a7d3f1b9c2e4_add_llm_model_suppressions.py
+++ b/src/backend/alembic/versions/a7d3f1b9c2e4_add_llm_model_suppressions.py
@@ -1,0 +1,41 @@
+"""add llm model suppressions
+
+Revision ID: a7d3f1b9c2e4
+Revises: f4c9d8e7a6b5
+Create Date: 2026-07-12
+
+Adds the llm_model_suppressions table used to implement a durable "hard delete"
+for LLM models. A suppressed model id is skipped by both re-registration paths
+(startup sync_to_db and the 24h model discovery), so a deleted model stays
+deleted. Idempotent SQL keeps shared-infra re-runs safe.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a7d3f1b9c2e4"
+down_revision: str | Sequence[str] | None = "f4c9d8e7a6b5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS llm_model_suppressions (
+            model_id VARCHAR(100) NOT NULL PRIMARY KEY,
+            provider VARCHAR(50) NOT NULL,
+            reason VARCHAR(500),
+            suppressed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_llm_model_suppressions_provider "
+        "ON llm_model_suppressions (provider)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS llm_model_suppressions")

--- a/src/backend/api/llm.py
+++ b/src/backend/api/llm.py
@@ -4,11 +4,13 @@
 DB가 활성화된 경우, 모델 목록은 llm_model_configs 테이블에서 로드됩니다.
 """
 
+import logging
 import os
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_current_user_optional
@@ -17,6 +19,8 @@ from db.models import UserModel
 from models.llm_models import LLMModelConfig, LLMModelRegistry, LLMProvider
 
 router = APIRouter(prefix="/llm", tags=["llm"])
+
+logger = logging.getLogger(__name__)
 
 USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
 
@@ -61,6 +65,22 @@ class ModelUpdateRequest(BaseModel):
     output_price: float | None = None
 
 
+class ModelDeleteResponse(BaseModel):
+    """Response for a hard model deletion (config removed + suppression recorded)."""
+
+    model_id: str
+    provider: str
+    suppressed_at: datetime
+    reason: str | None = None
+
+
+class SuppressionDeleteResponse(BaseModel):
+    """Response for un-suppressing a model (suppression row removed)."""
+
+    model_id: str
+    unsuppressed: bool
+
+
 def _model_to_response(model: LLMModelConfig) -> ModelResponse:
     """Convert LLMModelConfig to ModelResponse."""
     return ModelResponse(
@@ -80,13 +100,28 @@ def _model_to_response(model: LLMModelConfig) -> ModelResponse:
     )
 
 
+def _require_admin(current_user: UserModel | None) -> None:
+    """Authorize an admin-only action from an optional-auth dependency.
+
+    Distinguishes 401 (no/invalid token) from 403 (authenticated but inactive or
+    non-admin). ``is_active`` is enforced so a deactivated admin cannot retain
+    destructive privileges — mirroring the canonical ``get_current_user`` guard.
+    """
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if not current_user.is_active:
+        raise HTTPException(status_code=403, detail="User is inactive")
+    if not (current_user.role == "admin" or current_user.is_admin):
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
 @router.get("/models", response_model=ModelsListResponse)
 async def get_models(
     provider: str | None = Query(
         None, description="Filter by provider (codex_cli, anthropic, google, openai, ollama)"
     ),
     available_only: bool = Query(False, description="Only return models with available API keys"),
-    include_disabled: bool = Query(False, description="Include disabled models (admin only)"),
+    include_disabled: bool = Query(False, description="Include disabled models in the listing"),
 ) -> ModelsListResponse:
     """Get list of available LLM models.
 
@@ -153,15 +188,17 @@ async def update_model(
     if not USE_DATABASE:
         raise HTTPException(status_code=501, detail="USE_DATABASE=false: DB mode required")
 
-    # Auth check: distinguish 401 (no/invalid token) from 403 (authenticated but not admin)
-    if not current_user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    if not (current_user.role == "admin" or current_user.is_admin):
-        raise HTTPException(status_code=403, detail="Admin access required")
+    _require_admin(current_user)
 
     from db.models import LLMModelConfigModel
 
-    result = await db.execute(select(LLMModelConfigModel).where(LLMModelConfigModel.id == model_id))
+    # Lock the target row FOR UPDATE so a concurrent DELETE (which also locks it)
+    # serializes with this default transfer — the "unset others → promote target"
+    # sequence can't interleave with a delete of the target (which would leave 0
+    # rows updated and lose the provider default). Same lock ordering as DELETE.
+    result = await db.execute(
+        select(LLMModelConfigModel).where(LLMModelConfigModel.id == model_id).with_for_update()
+    )
     db_model = result.scalar_one_or_none()
 
     if not db_model:
@@ -204,6 +241,127 @@ async def update_model(
         raise HTTPException(status_code=500, detail="Registry reload failed")
 
     return _model_to_response(updated)
+
+
+# NOTE: the 2-segment `/models/suppressions/{model_id}` path is NOT swallowed by
+# the 1-segment `/models/{model_id}` matcher (a single path param never spans a
+# `/`), so route ordering between the two DELETEs is safe.
+@router.delete("/models/suppressions/{model_id}", response_model=SuppressionDeleteResponse)
+async def unsuppress_model(
+    model_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel | None = Depends(get_current_user_optional),
+) -> SuppressionDeleteResponse:
+    """Remove a model's suppression (admin only, DB mode required).
+
+    Un-suppression is backend/API only: it does NOT re-register the model
+    immediately. The next ``sync_to_db`` (startup) or discovery (24h) run will
+    re-insert it automatically.
+    """
+    if not USE_DATABASE:
+        raise HTTPException(status_code=501, detail="USE_DATABASE=false: DB mode required")
+    _require_admin(current_user)
+
+    from db.models import LLMModelSuppressionModel
+
+    result = await db.execute(
+        select(LLMModelSuppressionModel).where(LLMModelSuppressionModel.model_id == model_id)
+    )
+    suppression = result.scalar_one_or_none()
+    if not suppression:
+        raise HTTPException(status_code=404, detail=f"No suppression found for model '{model_id}'")
+
+    await db.execute(
+        delete(LLMModelSuppressionModel).where(LLMModelSuppressionModel.model_id == model_id)
+    )
+    await db.commit()
+
+    return SuppressionDeleteResponse(model_id=model_id, unsuppressed=True)
+
+
+@router.delete("/models/{model_id}", response_model=ModelDeleteResponse)
+async def delete_model(
+    model_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel | None = Depends(get_current_user_optional),
+) -> ModelDeleteResponse:
+    """Hard-delete a model (admin only, DB mode required).
+
+    Removes the model's DB config row and records a suppression so neither
+    startup sync nor discovery re-registers it. Refuses to delete a provider's
+    default model (409) — transfer the default first. The code ``_MODELS`` list
+    (pricing/settlement source of truth) is intentionally untouched.
+    """
+    if not USE_DATABASE:
+        raise HTTPException(status_code=501, detail="USE_DATABASE=false: DB mode required")
+    _require_admin(current_user)
+
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from db.models import LLMModelConfigModel, LLMModelSuppressionModel
+
+    # Lock the config row FOR UPDATE so a concurrent PATCH that promotes this
+    # model to default (UPDATE ... WHERE id==model_id) serializes behind us and
+    # the is_default guard below is judged from the locked row — closing the
+    # TOCTOU window where a newly-promoted default could be deleted.
+    result = await db.execute(
+        select(LLMModelConfigModel).where(LLMModelConfigModel.id == model_id).with_for_update()
+    )
+    db_model = result.scalar_one_or_none()
+    if not db_model:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found in DB")
+    if db_model.is_default:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Cannot delete default model '{model_id}'. "
+                "Transfer the provider default to another model first."
+            ),
+        )
+
+    provider = db_model.provider
+
+    # One transaction: record suppression (idempotent) + delete the config row.
+    await db.execute(
+        pg_insert(LLMModelSuppressionModel)
+        .values(model_id=model_id, provider=provider, reason="admin deletion")
+        .on_conflict_do_nothing(index_elements=["model_id"])
+    )
+    # Confirm the response data WITHIN this transaction, before commit, so a
+    # concurrent un-suppress that deletes the row right after our commit cannot
+    # null it out (a post-commit read-back would race → AttributeError/500).
+    result = await db.execute(
+        select(LLMModelSuppressionModel).where(LLMModelSuppressionModel.model_id == model_id)
+    )
+    suppression = result.scalar_one_or_none()
+    await db.execute(delete(LLMModelConfigModel).where(LLMModelConfigModel.id == model_id))
+    await db.commit()
+
+    # Never 500: if the suppression row was not readable (extremely rare — a
+    # concurrent un-suppress removed a pre-existing row mid-transaction), fall
+    # back to the values we just wrote so the response stays well-formed.
+    if suppression is not None:
+        suppressed_at_value = suppression.suppressed_at
+        reason_value = suppression.reason
+    else:
+        suppressed_at_value = datetime.now(UTC)
+        reason_value = "admin deletion"
+
+    # Reload registry cache so the deleted model disappears from GET /models.
+    # Belt-and-suspenders: if the reload does not reflect the removal (empty
+    # result, failure, or stale read), evict the id directly so a hard-deleted
+    # model never lingers in the cache. Response stays 200 (delete committed).
+    await LLMModelRegistry.load_from_db(db)
+    if LLMModelRegistry.get_by_id(model_id) is not None:
+        LLMModelRegistry.evict(model_id)
+        logger.warning("registry reload did not drop deleted model %s; evicted directly", model_id)
+
+    return ModelDeleteResponse(
+        model_id=model_id,
+        provider=provider,
+        suppressed_at=suppressed_at_value,
+        reason=reason_value,
+    )
 
 
 @router.get("/providers")
@@ -275,10 +433,7 @@ async def check_model_updates(
     """
     if not USE_DATABASE:
         raise HTTPException(status_code=501, detail="USE_DATABASE=false: DB mode required")
-    if not current_user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    if not (current_user.role == "admin" or current_user.is_admin):
-        raise HTTPException(status_code=403, detail="Admin access required")
+    _require_admin(current_user)
 
     from services.model_update_service import ModelUpdateService
 

--- a/src/backend/db/models/__init__.py
+++ b/src/backend/db/models/__init__.py
@@ -51,6 +51,7 @@ from db.models.llm import (
     DeploymentUsageCredentialModel,
     LLMCLIProfileModel,
     LLMModelConfigModel,
+    LLMModelSuppressionModel,
     LLMUsageLedgerModel,
     UserLLMCredentialModel,
     UserLLMEntitlementModel,
@@ -152,6 +153,7 @@ __all__ = [
     "ClaudeSessionSnapshotModel",
     # LLM
     "LLMModelConfigModel",
+    "LLMModelSuppressionModel",
     "UserLLMCredentialModel",
     "DeploymentUsageCredentialModel",
     "UserLLMEntitlementModel",

--- a/src/backend/db/models/llm.py
+++ b/src/backend/db/models/llm.py
@@ -46,6 +46,29 @@ class LLMModelConfigModel(Base):
     __table_args__ = (Index("ix_llm_model_provider_enabled", "provider", "is_enabled"),)
 
 
+class LLMModelSuppressionModel(Base):
+    """Suppressed LLM model ids that must never be (re-)registered in the DB.
+
+    A model id present here is skipped by BOTH re-registration paths — startup
+    ``sync_to_db`` and the 24h ``model_update_service`` discovery — implementing
+    a durable "hard delete". The code ``_MODELS`` list (settlement/pricing source
+    of truth) is intentionally left intact; suppression acts only at the DB layer.
+    """
+
+    __tablename__ = "llm_model_suppressions"
+
+    # PK is the model id: it is already globally unique in llm_model_configs.
+    # ``provider`` is kept for lookup/reporting only (not a foreign key).
+    model_id = Column(String(100), primary_key=True)
+    provider = Column(String(50), nullable=False, index=True)
+    reason = Column(String(500), nullable=True)
+    suppressed_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+
 class UserLLMCredentialModel(Base):
     """User's personal LLM API credentials (encrypted at rest)."""
 

--- a/src/backend/models/llm_models.py
+++ b/src/backend/models/llm_models.py
@@ -349,34 +349,61 @@ class LLMModelRegistry:
             result = await session.execute(select(LLMModelConfigModel))
             db_models = result.scalars().all()
 
-            if db_models:
-                loaded = []
-                for m in db_models:
-                    try:
-                        loaded.append(
-                            LLMModelConfig(
-                                id=m.id,
-                                display_name=m.display_name,
-                                provider=LLMProvider(m.provider),
-                                context_window=m.context_window,
-                                input_price=m.input_price,
-                                output_price=m.output_price,
-                                is_default=m.is_default,
-                                is_enabled=m.is_enabled,
-                                supports_tools=m.supports_tools,
-                                supports_vision=m.supports_vision,
-                            )
+            loaded = []
+            for m in db_models:
+                try:
+                    loaded.append(
+                        LLMModelConfig(
+                            id=m.id,
+                            display_name=m.display_name,
+                            provider=LLMProvider(m.provider),
+                            context_window=m.context_window,
+                            input_price=m.input_price,
+                            output_price=m.output_price,
+                            is_default=m.is_default,
+                            is_enabled=m.is_enabled,
+                            supports_tools=m.supports_tools,
+                            supports_vision=m.supports_vision,
                         )
-                    except Exception:
-                        continue  # Skip malformed rows
+                    )
+                except Exception:
+                    continue  # Skip malformed rows
 
+            if loaded:
                 cls._db_cache = loaded
                 cls._db_index = {m.id: m for m in loaded}
                 print(f"✅ LLMModelRegistry loaded {len(loaded)} models from DB")
+            elif cls._db_cache is not None:
+                # Empty but successful query while already in DB mode (e.g. the
+                # last models were deleted). Honor the now-empty table so the
+                # cache is not left stale — a successful empty result must clear
+                # the cache, distinct from an exception (handled below).
+                cls._db_cache = []
+                cls._db_index = {}
+                print("⚠️  llm_model_configs table is empty, cache cleared")
             else:
+                # First load on a fresh/empty DB (no cache yet): keep the
+                # in-memory _MODELS fallback rather than serving nothing.
                 print("⚠️  llm_model_configs table is empty, using in-memory fallback")
         except Exception as e:
+            # Exception (not an empty result): leave the existing cache/fallback
+            # untouched rather than clobbering it with a partial/failed read.
             print(f"⚠️  Failed to load models from DB: {e}. Using in-memory fallback.")
+
+    @classmethod
+    def evict(cls, model_id: str) -> None:
+        """Remove a single model id from the DB cache (immutable rebuild).
+
+        Belt-and-suspenders for the DELETE endpoint: if a post-delete
+        ``load_from_db`` fails to reflect the removal, the endpoint evicts the
+        id directly so a hard-deleted model never lingers in a stale cache.
+        Works even in in-memory fallback mode: when no DB cache exists yet, it
+        materializes one from ``_MODELS`` minus the evicted id, so a hard-deleted
+        model is not resurrected by the fallback path after a failed reload.
+        """
+        base = cls._db_cache if cls._db_cache is not None else _MODELS
+        cls._db_cache = [m for m in base if m.id != model_id]
+        cls._db_index = {m.id: m for m in cls._db_cache}
 
     @classmethod
     async def sync_to_db(cls, session: Any) -> dict[str, int]:
@@ -389,10 +416,28 @@ class LLMModelRegistry:
         Returns:
             Dict with 'inserted' and 'updated' counts.
         """
-        from sqlalchemy import select, update
+        from sqlalchemy import delete, select, update
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-        from db.models import LLMModelConfigModel
+        from db.models import LLMModelConfigModel, LLMModelSuppressionModel
+
+        # Suppressed ids must never be re-registered (durable hard-delete).
+        # Queried first so downstream inserts/defaults ignore these models.
+        result = await session.execute(select(LLMModelSuppressionModel.model_id))
+        suppressed_ids = {row[0] for row in result.fetchall()}
+
+        # Self-heal: hard-remove any config row that is currently suppressed.
+        # Closes the snapshot↔DELETE race — if a concurrent DELETE commits after
+        # another path snapshotted suppressions and then re-INSERTed a config,
+        # this bulk delete on the *next* sync removes the stray row, making the
+        # "deleted stays deleted" invariant self-correcting.
+        # synchronize_session=False: the WHERE uses a subquery that cannot be
+        # evaluated in Python, and this fresh session has no identity map to sync.
+        await session.execute(
+            delete(LLMModelConfigModel)
+            .where(LLMModelConfigModel.id.in_(select(LLMModelSuppressionModel.model_id)))
+            .execution_options(synchronize_session=False)
+        )
 
         # Get existing IDs to distinguish insert vs update
         result = await session.execute(select(LLMModelConfigModel.id))
@@ -415,6 +460,11 @@ class LLMModelRegistry:
         updated = 0
 
         for model in _MODELS:
+            # Skip suppressed models entirely: no upsert, no count, no default
+            # clearing. This is the startup re-INSERT guard (regression a).
+            if model.id in suppressed_ids:
+                continue
+
             is_default = model.is_default
             if (
                 is_default

--- a/src/backend/services/model_update_service.py
+++ b/src/backend/services/model_update_service.py
@@ -359,17 +359,36 @@ class ModelUpdateService:
         New models are inserted as disabled (is_enabled=False).
         Metadata updates are applied directly.
         """
-        from sqlalchemy import update
+        from sqlalchemy import delete, select, update
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
         from db.database import async_session_factory
-        from db.models import LLMModelConfigModel
+        from db.models import LLMModelConfigModel, LLMModelSuppressionModel
 
         applied = 0
 
         async with async_session_factory() as session:
+            # Suppressed ids must never be re-registered. Discovery legitimately
+            # reports a suppressed model as "new" (it is absent from the registry
+            # after deletion) — the guard lives here at the INSERT point, not in
+            # _diff_models, so the "new" count stays accurate (regression b).
+            result = await session.execute(select(LLMModelSuppressionModel.model_id))
+            suppressed_ids = {row[0] for row in result.fetchall()}
+
+            # Self-heal: hard-remove any config row that is currently suppressed,
+            # recovering from a snapshot↔DELETE race where a stray config was
+            # re-INSERTed. synchronize_session=False: subquery WHERE cannot be
+            # evaluated in Python and this fresh session has no identity map.
+            await session.execute(
+                delete(LLMModelConfigModel)
+                .where(LLMModelConfigModel.id.in_(select(LLMModelSuppressionModel.model_id)))
+                .execution_options(synchronize_session=False)
+            )
+
             # Insert new models as disabled
             for change in new_models:
+                if change.model_id in suppressed_ids:
+                    continue
                 info = change.new_value or {}
                 values = {
                     "id": change.model_id,

--- a/src/dashboard/src/components/llm-router/ModelManagementPanel.tsx
+++ b/src/dashboard/src/components/llm-router/ModelManagementPanel.tsx
@@ -1,0 +1,431 @@
+/**
+ * Model Management Panel (admin only)
+ * Lists all LLM models grouped by provider and lets admins enable/disable
+ * models or set a provider default. Backend enforces admin auth on PATCH.
+ */
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Boxes, Loader2, Star, ToggleLeft, ToggleRight, Trash2 } from 'lucide-react'
+import { useAuthStore, authFetch } from '../../stores/auth'
+import { useSettingsStore } from '../../stores/settings'
+import { cn } from '../../lib/utils'
+
+// ─────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────
+
+interface ManagedModel {
+  id: string
+  display_name: string
+  provider: string
+  context_window: number
+  pricing: { input: number; output: number }
+  available: boolean
+  is_default: boolean
+  supports_tools: boolean
+  supports_vision: boolean
+  is_enabled: boolean
+}
+
+type PatchBody = { is_enabled: boolean } | { is_default: true }
+
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: 'Anthropic (Claude)',
+  google: 'Google (Gemini)',
+  openai: 'OpenAI (GPT)',
+  codex_cli: 'Codex CLI',
+  ollama: 'Ollama (Local)',
+}
+
+const SESSION_ERROR = '세션이 만료되었습니다. 다시 로그인해 주세요.'
+const ADMIN_ERROR = 'Admin 권한이 없습니다.'
+const LOAD_ERROR = '모델 목록을 불러오지 못했습니다.'
+const UPDATE_ERROR = '모델 업데이트에 실패했습니다.'
+const DELETE_ERROR = '모델 삭제에 실패했습니다.'
+const DEFAULT_TOGGLE_HINT = 'default 모델은 먼저 다른 모델로 default를 이관하세요'
+
+// authFetch throws this exact message when a pre-request token refresh fails (auth.ts).
+const SESSION_EXPIRED_THROW = 'Session expired. Please login again.'
+
+// FastAPI errors return { detail: "..." }; read it defensively so a 409 can surface
+// the backend's explanation (e.g. "Cannot delete default model ...") verbatim.
+const readErrorDetail = async (res: Response): Promise<string | null> => {
+  try {
+    const data = await res.json()
+    return typeof data?.detail === 'string' ? data.detail : null
+  } catch {
+    return null
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────
+
+const ModelManagementPanel = memo(function ModelManagementPanel() {
+  const user = useAuthStore((s) => s.user)
+  const fetchModels = useSettingsStore((s) => s.fetchModels)
+  // Target the admin-configured backend (same source as settings.fetchModels), so changing
+  // the Backend URL in Settings re-points this panel too instead of a build-time base URL.
+  const backendUrl = useSettingsStore((s) => s.backendUrl)
+
+  const isAdmin = !!user && (user.is_admin || user.role === 'admin')
+
+  const [models, setModels] = useState<ManagedModel[]>([])
+  const [loading, setLoading] = useState(true)
+  // Split so a concurrent mutation's refetch never clears another mutation's error,
+  // and a load failure never clobbers an action error (independent providers mutate in parallel).
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set())
+  // Disabled models are noise by default (auto-discovered legacy models); hide them
+  // until the admin opts in via the header toggle.
+  const [showDisabled, setShowDisabled] = useState(false)
+
+  // Generation guards for out-of-order refetch races (independent providers mutate in
+  // parallel, so their refetches can complete out of order):
+  //  • loadGenRef      — the newest load() dispatched (drives "is this the latest request").
+  //  • committedGenRef — the newest generation whose success was committed to state.
+  const loadGenRef = useRef(0)
+  const committedGenRef = useRef(0)
+
+  const load = useCallback(async () => {
+    const gen = ++loadGenRef.current
+    // `loading` drives the full-panel spinner and is only ever cleared here, so it
+    // shows on the initial mount only — refetches (after a mutation) update the list
+    // in place, keeping other rows interactive and their per-row pending state visible.
+    // Only loadError is touched here so a refetch can't erase a mutation's actionError.
+    setLoadError(null)
+    try {
+      const res = await fetch(`${backendUrl}/api/llm/models?include_disabled=true`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      // Monotonic success commit: only a strictly newer result may overwrite the list, so a
+      // slow/stale GET can never clobber fresher committed state. A successful commit also
+      // clears any load error — a valid response is rescued even if a newer request failed
+      // first (that failure must not discard the only good data).
+      if (gen > committedGenRef.current) {
+        committedGenRef.current = gen
+        setModels(data.models ?? [])
+        setLoadError(null)
+      }
+    } catch {
+      // Surface the failure only for the newest in-flight request; a stale failure must
+      // never mask a successful commit from a concurrent refetch.
+      if (gen === loadGenRef.current) setLoadError(LOAD_ERROR)
+    } finally {
+      // Clear the initial-mount spinner once this request either committed a result
+      // (committedGenRef advanced to gen) or is the newest in-flight load to settle.
+      if (gen === committedGenRef.current || gen === loadGenRef.current) setLoading(false)
+    }
+  }, [backendUrl])
+
+  useEffect(() => {
+    if (!isAdmin) return
+    load()
+  }, [isAdmin, load])
+
+  const patchModel = useCallback(
+    async (id: string, body: PatchBody) => {
+      setPending((prev) => {
+        const next = new Set(prev)
+        next.add(id)
+        return next
+      })
+      setActionError(null)
+      try {
+        const res = await authFetch(`${backendUrl}/api/llm/models/${encodeURIComponent(id)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
+        // authFetch already retried token refresh: a remaining 401 means re-login,
+        // 403 means the account lacks admin (re-login won't help).
+        if (res.status === 401) {
+          setActionError(SESSION_ERROR)
+          return
+        }
+        if (res.status === 403) {
+          setActionError(ADMIN_ERROR)
+          return
+        }
+        if (!res.ok) {
+          setActionError(UPDATE_ERROR)
+          return
+        }
+        // Refetch the panel list (server unsets sibling defaults) + sync global catalog.
+        await load()
+        await fetchModels()
+      } catch (err) {
+        // authFetch throws (not returns) when a pre-request token refresh fails.
+        setActionError(
+          err instanceof Error && err.message === SESSION_EXPIRED_THROW
+            ? SESSION_ERROR
+            : UPDATE_ERROR
+        )
+      } finally {
+        setPending((prev) => {
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        })
+      }
+    },
+    [load, fetchModels, backendUrl]
+  )
+
+  const handleToggle = useCallback(
+    (model: ManagedModel) => patchModel(model.id, { is_enabled: !model.is_enabled }),
+    [patchModel]
+  )
+
+  const handleSetDefault = useCallback(
+    (model: ManagedModel) => patchModel(model.id, { is_default: true }),
+    [patchModel]
+  )
+
+  // Permanently delete a disabled, non-default model. The backend removes the config row
+  // and records a suppression so startup sync / discovery can't re-register it. Reuses the
+  // same pending/actionError plumbing as patchModel; only offered for disabled non-default
+  // rows (the backend 409s on a default model, so we never expose Delete there).
+  const deleteModel = useCallback(
+    async (model: ManagedModel) => {
+      if (
+        !window.confirm(
+          `Delete model "${model.id}"? It will be suppressed so startup sync and discovery cannot re-register it.`
+        )
+      ) {
+        return
+      }
+      setPending((prev) => {
+        const next = new Set(prev)
+        next.add(model.id)
+        return next
+      })
+      setActionError(null)
+      try {
+        const res = await authFetch(`${backendUrl}/api/llm/models/${encodeURIComponent(model.id)}`, {
+          method: 'DELETE',
+        })
+        if (res.status === 401) {
+          setActionError(SESSION_ERROR)
+          return
+        }
+        if (res.status === 403) {
+          setActionError(ADMIN_ERROR)
+          return
+        }
+        if (res.status === 409) {
+          // is_default rejection (or similar conflict) — surface the backend's explanation.
+          setActionError((await readErrorDetail(res)) ?? DELETE_ERROR)
+          return
+        }
+        if (!res.ok) {
+          setActionError(DELETE_ERROR)
+          return
+        }
+        // Refetch the panel list (row is gone) + sync the global catalog.
+        await load()
+        await fetchModels()
+      } catch (err) {
+        // authFetch throws (not returns) when a pre-request token refresh fails.
+        setActionError(
+          err instanceof Error && err.message === SESSION_EXPIRED_THROW
+            ? SESSION_ERROR
+            : DELETE_ERROR
+        )
+      } finally {
+        setPending((prev) => {
+          const next = new Set(prev)
+          next.delete(model.id)
+          return next
+        })
+      }
+    },
+    [load, fetchModels, backendUrl]
+  )
+
+  // Count only the models the toggle actually hides. A disabled *default* is an anomaly
+  // that stays visible regardless, so it must not inflate the count or force the toggle on.
+  const disabledCount = useMemo(
+    () => models.filter((m) => !m.is_enabled && !m.is_default).length,
+    [models]
+  )
+
+  // Group by provider, preserving the order in which providers appear in the response.
+  // When disabled models are hidden, drop them from their groups so a provider with only
+  // disabled models disappears entirely. Exception: a disabled *default* row is an anomaly
+  // that must stay visible so the admin can recover it (re-enable / re-assign default).
+  const groups = useMemo(() => {
+    const map = new Map<string, ManagedModel[]>()
+    for (const model of models) {
+      const visible = showDisabled || model.is_enabled || (model.is_default && !model.is_enabled)
+      if (!visible) continue
+      const existing = map.get(model.provider)
+      if (existing) existing.push(model)
+      else map.set(model.provider, [model])
+    }
+    return Array.from(map.entries())
+  }, [models, showDisabled])
+
+  // Providers with any in-flight mutation. "default" is a provider-level invariant,
+  // so any pending request in a provider must lock every default-change button there.
+  const pendingProviders = useMemo(() => {
+    const set = new Set<string>()
+    for (const model of models) {
+      if (pending.has(model.id)) set.add(model.provider)
+    }
+    return set
+  }, [models, pending])
+
+  if (!isAdmin) return null
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-white flex items-center gap-2">
+          <Boxes className="w-5 h-5" />
+          Model Management
+        </h3>
+        {disabledCount > 0 && (
+          <button
+            onClick={() => setShowDisabled((v) => !v)}
+            className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex-shrink-0"
+            aria-label={
+              showDisabled ? 'Hide disabled models' : `Show disabled models (${disabledCount})`
+            }
+          >
+            {showDisabled ? 'Hide disabled' : `Show disabled (${disabledCount})`}
+          </button>
+        )}
+      </div>
+
+      {loadError && (
+        <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 rounded-lg text-sm">
+          {loadError}
+        </div>
+      )}
+
+      {actionError && (
+        <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 rounded-lg text-sm">
+          {actionError}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 animate-spin text-primary-500" aria-label="Loading models" />
+        </div>
+      ) : groups.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-6">
+          No models available
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {groups.map(([provider, providerModels]) => (
+            <section key={provider}>
+              <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                {PROVIDER_LABELS[provider] ?? provider}
+              </div>
+              <div className="space-y-2">
+                {providerModels.map((model) => {
+                  const isPending = pending.has(model.id)
+                  // Only block disabling an *enabled* default (keeps the provider from
+                  // losing its only default); a disabled default can still be re-enabled.
+                  const toggleDisabled = (model.is_default && model.is_enabled) || isPending
+                  const setDefaultDisabled = isPending || pendingProviders.has(model.provider)
+                  return (
+                    <div
+                      key={model.id}
+                      className={cn(
+                        'flex items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700',
+                        !model.is_enabled && 'opacity-60'
+                      )}
+                    >
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-medium text-gray-900 dark:text-white text-sm truncate">
+                            {model.display_name}
+                          </span>
+                          {model.is_default && (
+                            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 rounded">
+                              <Star className="w-3 h-3" />
+                              Default
+                            </span>
+                          )}
+                          {!model.is_enabled && (
+                            <span className="px-1.5 py-0.5 text-xs bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400 rounded">
+                              Disabled
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-0.5 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                          <span className="font-mono truncate">{model.id}</span>
+                          <span>
+                            ${model.pricing.input}/${model.pricing.output} per 1K
+                          </span>
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        {model.is_enabled && !model.is_default && (
+                          <button
+                            onClick={() => handleSetDefault(model)}
+                            disabled={setDefaultDisabled}
+                            className="flex items-center gap-1 px-2 py-1 text-xs bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 rounded hover:bg-primary-200 dark:hover:bg-primary-900/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            aria-label={`Set ${model.id} as default`}
+                          >
+                            <Star className="w-3.5 h-3.5" />
+                            Set default
+                          </button>
+                        )}
+                        <button
+                          onClick={() => handleToggle(model)}
+                          disabled={toggleDisabled}
+                          title={
+                            model.is_default && model.is_enabled ? DEFAULT_TOGGLE_HINT : undefined
+                          }
+                          className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          aria-label={`${model.is_enabled ? 'Disable' : 'Enable'} ${model.id}`}
+                        >
+                          {model.is_enabled ? (
+                            <>
+                              <ToggleRight className="w-4 h-4" />
+                              Disable
+                            </>
+                          ) : (
+                            <>
+                              <ToggleLeft className="w-4 h-4" />
+                              Enable
+                            </>
+                          )}
+                        </button>
+                        {/* Delete is offered only for disabled non-default rows: enabled models
+                            must be disabled first, and the backend 409s on a default model. */}
+                        {!model.is_enabled && !model.is_default && (
+                          <button
+                            onClick={() => deleteModel(model)}
+                            disabled={isPending}
+                            className="flex items-center gap-1 px-2 py-1 text-xs bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 rounded hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            aria-label={`Delete ${model.id}`}
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                            Delete
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+})
+
+ModelManagementPanel.displayName = 'ModelManagementPanel'
+
+export { ModelManagementPanel }

--- a/src/dashboard/src/components/llm-router/__tests__/ModelManagementPanel.test.tsx
+++ b/src/dashboard/src/components/llm-router/__tests__/ModelManagementPanel.test.tsx
@@ -1,0 +1,905 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ModelManagementPanel } from '../ModelManagementPanel'
+
+// ─────────────────────────────────────────────────────────────
+// Mocks
+// ─────────────────────────────────────────────────────────────
+
+vi.mock('lucide-react', () => {
+  const icon = (name: string) => (props: Record<string, unknown>) => (
+    <svg data-testid={`icon-${name}`} {...props} />
+  )
+  return {
+    Boxes: icon('boxes'),
+    Loader2: icon('loader'),
+    Star: icon('star'),
+    ToggleLeft: icon('toggle-left'),
+    ToggleRight: icon('toggle-right'),
+    Trash2: icon('trash'),
+  }
+})
+
+type MockUser = { is_admin: boolean; role: string } | null
+
+const DEFAULT_BACKEND_URL = 'http://localhost:8000'
+
+let mockUser: MockUser = null
+let mockBackendUrl = DEFAULT_BACKEND_URL
+const authFetchMock = vi.fn()
+const fetchModelsMock = vi.fn()
+
+vi.mock('../../../stores/auth', () => ({
+  useAuthStore: (selector: (s: { user: MockUser }) => unknown) => selector({ user: mockUser }),
+  authFetch: (...args: unknown[]) => authFetchMock(...args),
+}))
+
+vi.mock('../../../stores/settings', () => ({
+  useSettingsStore: (selector: (s: { fetchModels: () => void; backendUrl: string }) => unknown) =>
+    selector({ fetchModels: fetchModelsMock, backendUrl: mockBackendUrl }),
+}))
+
+// ─────────────────────────────────────────────────────────────
+// Fixtures / helpers
+// ─────────────────────────────────────────────────────────────
+
+const model = (overrides?: Record<string, unknown>) => ({
+  id: 'claude-opus-4-8',
+  display_name: 'Claude Opus 4.8',
+  provider: 'anthropic',
+  context_window: 200000,
+  pricing: { input: 0.015, output: 0.075 },
+  available: true,
+  is_default: false,
+  supports_tools: true,
+  supports_vision: true,
+  is_enabled: true,
+  ...overrides,
+})
+
+type ModelFixture = ReturnType<typeof model>
+
+const listResponse = (models: ModelFixture[]) =>
+  ({ ok: true, json: async () => ({ models, total: models.length }) }) as Response
+
+/** Same list for every GET (mount + refetch). */
+const mockList = (models: ModelFixture[]) => {
+  vi.mocked(global.fetch).mockResolvedValue(listResponse(models))
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+const adminUser: MockUser = { is_admin: true, role: 'admin' }
+
+// ─────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────
+
+describe('ModelManagementPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUser = null
+    mockBackendUrl = DEFAULT_BACKEND_URL
+  })
+
+  it('renders nothing and fires no request for non-admin users', () => {
+    mockUser = { is_admin: false, role: 'user' }
+    const { container } = render(<ModelManagementPanel />)
+    expect(container).toBeEmptyDOMElement()
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalled()
+  })
+
+  it('loads and renders models grouped by provider for admins', async () => {
+    mockUser = adminUser
+    mockList([
+      model(),
+      model({ id: 'gemini-3-flash-preview', display_name: 'Gemini 3 Flash', provider: 'google' }),
+    ])
+
+    render(<ModelManagementPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Claude Opus 4.8')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Anthropic (Claude)')).toBeInTheDocument()
+    expect(screen.getByText('Google (Gemini)')).toBeInTheDocument()
+    expect(screen.getByText('Gemini 3 Flash')).toBeInTheDocument()
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+      expect.stringContaining('/api/llm/models?include_disabled=true')
+    )
+  })
+
+  it('toggles enable with the correct body and reflects the new state after refetch', async () => {
+    mockUser = adminUser
+    const m = model({ is_enabled: true, is_default: false })
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(listResponse([m])) // mount
+      .mockResolvedValueOnce(listResponse([{ ...m, is_enabled: false }])) // refetch after PATCH
+    authFetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Disable claude-opus-4-8')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Disable claude-opus-4-8'))
+
+    await waitFor(() => {
+      expect(authFetchMock).toHaveBeenCalled()
+    })
+    const [url, opts] = authFetchMock.mock.calls[0]
+    expect(String(url)).toContain('/api/llm/models/claude-opus-4-8')
+    expect(opts.method).toBe('PATCH')
+    expect(JSON.parse(opts.body)).toEqual({ is_enabled: false })
+
+    // Post-refetch the model is disabled → hidden by default; the toggle reveals it.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+    })
+    expect(screen.queryByLabelText('Enable claude-opus-4-8')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Enable claude-opus-4-8')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+    expect(fetchModelsMock).toHaveBeenCalled()
+  })
+
+  it('sends is_default PATCH, refetches, and moves the Default badge', async () => {
+    mockUser = adminUser
+    const opus = model({ id: 'claude-opus-4-8', display_name: 'Claude Opus 4.8', is_default: true })
+    const sonnet = model({
+      id: 'claude-sonnet-5',
+      display_name: 'Claude Sonnet 5',
+      is_default: false,
+    })
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(listResponse([opus, sonnet])) // mount: opus is default
+      .mockResolvedValueOnce(
+        listResponse([
+          { ...opus, is_default: false },
+          { ...sonnet, is_default: true },
+        ])
+      ) // refetch: sonnet became default
+
+    authFetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-sonnet-5 as default')).toBeInTheDocument()
+    })
+    // Current default (opus) exposes no "Set default" action.
+    expect(screen.queryByLabelText('Set claude-opus-4-8 as default')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Set claude-sonnet-5 as default'))
+
+    await waitFor(() => {
+      expect(authFetchMock).toHaveBeenCalled()
+    })
+    expect(JSON.parse(authFetchMock.mock.calls[0][1].body)).toEqual({ is_default: true })
+
+    // Default badge moved: sonnet now default (no action), opus demoted (action reappears).
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+    })
+    expect(screen.queryByLabelText('Set claude-sonnet-5 as default')).not.toBeInTheDocument()
+    expect(fetchModelsMock).toHaveBeenCalled()
+  })
+
+  it('hides disabled models by default and shows a toggle with the disabled count', async () => {
+    mockUser = adminUser
+    mockList([
+      model({ id: 'claude-opus-4-8', display_name: 'Claude Opus 4.8', is_enabled: true }),
+      model({
+        id: 'claude-legacy-2',
+        display_name: 'Claude Legacy 2',
+        is_enabled: false,
+        is_default: false,
+      }),
+    ])
+
+    render(<ModelManagementPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Claude Opus 4.8')).toBeInTheDocument()
+    })
+    // Disabled model is hidden; the toggle advertises how many are hidden.
+    expect(screen.queryByText('Claude Legacy 2')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+  })
+
+  it('reveals disabled models when the toggle is clicked and hides them again', async () => {
+    mockUser = adminUser
+    mockList([
+      model({ id: 'claude-opus-4-8', display_name: 'Claude Opus 4.8', is_enabled: true }),
+      model({
+        id: 'claude-legacy-2',
+        display_name: 'Claude Legacy 2',
+        is_enabled: false,
+        is_default: false,
+      }),
+    ])
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+    expect(screen.getByText('Claude Legacy 2')).toBeInTheDocument()
+
+    // Toggle flips to a hide affordance and collapses the disabled row again.
+    fireEvent.click(screen.getByLabelText('Hide disabled models'))
+    expect(screen.queryByText('Claude Legacy 2')).not.toBeInTheDocument()
+  })
+
+  it('hides a provider group whose models are all disabled', async () => {
+    mockUser = adminUser
+    mockList([
+      model({
+        id: 'claude-opus-4-8',
+        display_name: 'Claude Opus 4.8',
+        provider: 'anthropic',
+        is_enabled: true,
+      }),
+      model({
+        id: 'gemini-legacy',
+        display_name: 'Gemini Legacy',
+        provider: 'google',
+        is_enabled: false,
+        is_default: false,
+      }),
+    ])
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByText('Anthropic (Claude)')).toBeInTheDocument()
+    })
+    // The google group has only a disabled model → its header is hidden too.
+    expect(screen.queryByText('Google (Gemini)')).not.toBeInTheDocument()
+    expect(screen.queryByText('Gemini Legacy')).not.toBeInTheDocument()
+
+    // Revealing disabled models brings the whole group back.
+    fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+    expect(screen.getByText('Google (Gemini)')).toBeInTheDocument()
+    expect(screen.getByText('Gemini Legacy')).toBeInTheDocument()
+  })
+
+  it('always shows a disabled default (anomalous) row even while disabled models are hidden', async () => {
+    mockUser = adminUser
+    mockList([
+      model({
+        id: 'claude-opus-4-8',
+        display_name: 'Claude Opus 4.8',
+        provider: 'anthropic',
+        is_enabled: true,
+      }),
+      model({
+        id: 'gemini-broken-default',
+        display_name: 'Gemini Broken Default',
+        provider: 'google',
+        is_enabled: false,
+        is_default: true,
+      }),
+    ])
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByText('Claude Opus 4.8')).toBeInTheDocument()
+    })
+    // Anomalous disabled-default stays visible (recovery path) despite hidden mode.
+    expect(screen.getByText('Gemini Broken Default')).toBeInTheDocument()
+    expect(screen.getByText('Google (Gemini)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Enable gemini-broken-default')).not.toBeDisabled()
+    // The always-visible anomaly must not surface a toggle (nothing is actually hidden).
+    expect(screen.queryByLabelText(/Show disabled models/)).not.toBeInTheDocument()
+  })
+
+  it('excludes always-visible disabled-default rows from the toggle count', async () => {
+    mockUser = adminUser
+    mockList([
+      model({
+        id: 'claude-opus-4-8',
+        display_name: 'Claude Opus 4.8',
+        provider: 'anthropic',
+        is_enabled: true,
+      }),
+      model({
+        id: 'claude-legacy-2',
+        display_name: 'Claude Legacy 2',
+        provider: 'anthropic',
+        is_enabled: false,
+        is_default: false,
+      }),
+      model({
+        id: 'gemini-broken-default',
+        display_name: 'Gemini Broken Default',
+        provider: 'google',
+        is_enabled: false,
+        is_default: true,
+      }),
+    ])
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByText('Claude Opus 4.8')).toBeInTheDocument()
+    })
+    // Two rows are disabled, but the always-visible anomalous default is excluded → count is 1.
+    expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Show disabled models (2)')).not.toBeInTheDocument()
+  })
+
+  it('shows a session-expired message on 401', async () => {
+    mockUser = adminUser
+    mockList([model({ is_enabled: true, is_default: false })])
+    authFetchMock.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) })
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Disable claude-opus-4-8')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByLabelText('Disable claude-opus-4-8'))
+    await waitFor(() => {
+      expect(screen.getByText('세션이 만료되었습니다. 다시 로그인해 주세요.')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Admin 권한이 없습니다.')).not.toBeInTheDocument()
+  })
+
+  it('shows an admin-required message on 403', async () => {
+    mockUser = adminUser
+    mockList([model({ is_enabled: true, is_default: false })])
+    authFetchMock.mockResolvedValue({ ok: false, status: 403, json: async () => ({}) })
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Disable claude-opus-4-8')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByLabelText('Disable claude-opus-4-8'))
+    await waitFor(() => {
+      expect(screen.getByText('Admin 권한이 없습니다.')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('세션이 만료되었습니다. 다시 로그인해 주세요.')).not.toBeInTheDocument()
+  })
+
+  it('shows a session-expired message when authFetch throws (pre-request refresh failed)', async () => {
+    mockUser = adminUser
+    mockList([model({ is_enabled: true, is_default: false })])
+    // authFetch throws (does not resolve) when it cannot refresh an expired token.
+    authFetchMock.mockRejectedValue(new Error('Session expired. Please login again.'))
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Disable claude-opus-4-8')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByLabelText('Disable claude-opus-4-8'))
+    await waitFor(() => {
+      expect(screen.getByText('세션이 만료되었습니다. 다시 로그인해 주세요.')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('모델 업데이트에 실패했습니다.')).not.toBeInTheDocument()
+  })
+
+  it("keeps a failed mutation's error visible when a parallel mutation refetches", async () => {
+    mockUser = adminUser
+    const opus = model({
+      id: 'claude-opus-4-8',
+      display_name: 'Claude Opus 4.8',
+      provider: 'anthropic',
+      is_default: false,
+      is_enabled: true,
+    })
+    const gemini = model({
+      id: 'gemini-3-flash-preview',
+      display_name: 'Gemini 3 Flash',
+      provider: 'google',
+      is_default: false,
+      is_enabled: true,
+    })
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(listResponse([opus, gemini])) // mount
+      .mockResolvedValueOnce(listResponse([opus, gemini])) // B's refetch after success
+
+    // Both mutations run concurrently: A (opus) 403s, B (gemini) succeeds.
+    const aPatch = deferred<Response>()
+    const bPatch = deferred<Response>()
+    authFetchMock.mockImplementation((url: string) =>
+      String(url).includes('claude-opus-4-8') ? aPatch.promise : bPatch.promise
+    )
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+    })
+
+    // Start both (different providers → not locked) before either resolves.
+    fireEvent.click(screen.getByLabelText('Set claude-opus-4-8 as default'))
+    fireEvent.click(screen.getByLabelText('Set gemini-3-flash-preview as default'))
+
+    // A fails → its action error is shown.
+    aPatch.resolve({ ok: false, status: 403, json: async () => ({}) } as Response)
+    await waitFor(() => {
+      expect(screen.getByText('Admin 권한이 없습니다.')).toBeInTheDocument()
+    })
+
+    // B succeeds → its refetch runs setLoadError(null); A's actionError must survive it.
+    bPatch.resolve({ ok: true, status: 200, json: async () => ({}) } as Response)
+    await waitFor(() => {
+      expect(fetchModelsMock).toHaveBeenCalled()
+    })
+    expect(screen.getByText('Admin 권한이 없습니다.')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the list fails to load', async () => {
+    mockUser = adminUser
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'))
+
+    render(<ModelManagementPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('모델 목록을 불러오지 못했습니다.')).toBeInTheDocument()
+    })
+  })
+
+  it('disables the toggle only for an enabled default model', async () => {
+    mockUser = adminUser
+    mockList([model({ is_enabled: true, is_default: true })])
+
+    render(<ModelManagementPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Disable claude-opus-4-8')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Disable claude-opus-4-8')).toBeDisabled()
+    // Default models expose no "Set default" action.
+    expect(screen.queryByLabelText('Set claude-opus-4-8 as default')).not.toBeInTheDocument()
+  })
+
+  it('allows re-enabling a disabled default model (recovery from anomalous state)', async () => {
+    mockUser = adminUser
+    mockList([model({ is_enabled: false, is_default: true })])
+
+    render(<ModelManagementPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Enable claude-opus-4-8')).toBeInTheDocument()
+    })
+    // Disabled default must remain recoverable — the Enable action stays active.
+    expect(screen.getByLabelText('Enable claude-opus-4-8')).not.toBeDisabled()
+  })
+
+  it('locks sibling "Set default" buttons in the same provider while a mutation is pending', async () => {
+    mockUser = adminUser
+    const opus = model({
+      id: 'claude-opus-4-8',
+      display_name: 'Claude Opus 4.8',
+      provider: 'anthropic',
+      is_default: false,
+      is_enabled: true,
+    })
+    const sonnet = model({
+      id: 'claude-sonnet-5',
+      display_name: 'Claude Sonnet 5',
+      provider: 'anthropic',
+      is_default: false,
+      is_enabled: true,
+    })
+    mockList([opus, sonnet])
+    // Keep the PATCH in-flight so the pending lock stays asserted.
+    const patch = deferred<Response>()
+    authFetchMock.mockReturnValue(patch.promise)
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Set claude-sonnet-5 as default')).not.toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText('Set claude-opus-4-8 as default'))
+
+    // The sibling default button in the same provider must lock immediately.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-sonnet-5 as default')).toBeDisabled()
+    })
+
+    patch.resolve({ ok: true, status: 200, json: async () => ({}) })
+  })
+
+  it('discards a stale refetch when a newer mutation refetches first (P1 race)', async () => {
+    mockUser = adminUser
+    const opus = model({
+      id: 'claude-opus-4-8',
+      display_name: 'Claude Opus 4.8',
+      provider: 'anthropic',
+      is_default: false,
+      is_enabled: true,
+    })
+    const gemini = model({
+      id: 'gemini-3-flash-preview',
+      display_name: 'Gemini 3 Flash',
+      provider: 'google',
+      is_default: false,
+      is_enabled: true,
+    })
+
+    const older = deferred<Response>() // opus refetch (gen 2, started first)
+    const newer = deferred<Response>() // gemini refetch (gen 3, started second)
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(listResponse([opus, gemini])) // mount (gen 1)
+      .mockReturnValueOnce(older.promise) // gen 2
+      .mockReturnValueOnce(newer.promise) // gen 3
+    authFetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+    })
+
+    // Mutation A (anthropic) → refetch call 2 is deferred.
+    fireEvent.click(screen.getByLabelText('Set claude-opus-4-8 as default'))
+    await waitFor(() => {
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(2)
+    })
+
+    // Mutation B (google — different provider, not locked) → refetch call 3 is deferred.
+    fireEvent.click(screen.getByLabelText('Set gemini-3-flash-preview as default'))
+    await waitFor(() => {
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(3)
+    })
+
+    // Newest refetch resolves first → gemini becomes the default.
+    newer.resolve(
+      listResponse([
+        { ...opus, is_default: false },
+        { ...gemini, is_default: true },
+      ])
+    )
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Set gemini-3-flash-preview as default')).not.toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+
+    // Stale (older) refetch resolves late with contradictory data → must be discarded.
+    older.resolve(
+      listResponse([
+        { ...opus, is_default: true },
+        { ...gemini, is_default: false },
+      ])
+    )
+    // Both mutations have now run through to fetchModels(); state must still reflect the newer refetch.
+    await waitFor(() => {
+      expect(fetchModelsMock).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.queryByLabelText('Set gemini-3-flash-preview as default')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+  })
+
+  it('targets the configured backend URL for GET, PATCH and DELETE (P1)', async () => {
+    mockUser = adminUser
+    mockBackendUrl = 'http://other-host:9000'
+    const opus = model({ id: 'claude-opus-4-8', is_enabled: true, is_default: false })
+    const legacy = model({ id: 'claude-legacy-2', is_enabled: false, is_default: false })
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(listResponse([opus, legacy])) // mount GET
+      .mockResolvedValueOnce(listResponse([{ ...opus, is_default: true }, legacy])) // refetch after PATCH
+      .mockResolvedValueOnce(listResponse([{ ...opus, is_default: true }])) // refetch after DELETE (legacy gone)
+    authFetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+    })
+
+    // GET must hit the admin-configured backend, not a relative/proxy path.
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+      'http://other-host:9000/api/llm/models?include_disabled=true'
+    )
+
+    fireEvent.click(screen.getByLabelText('Set claude-opus-4-8 as default'))
+    await waitFor(() => {
+      expect(authFetchMock).toHaveBeenCalled()
+    })
+    // PATCH must target the same configured backend.
+    expect(String(authFetchMock.mock.calls[0][0])).toBe(
+      'http://other-host:9000/api/llm/models/claude-opus-4-8'
+    )
+    // Wait for the PATCH refetch to settle so the disabled legacy row is present to delete.
+    await waitFor(() => {
+      expect(fetchModelsMock).toHaveBeenCalled()
+    })
+
+    // DELETE must target the same configured backend too (delete shares the base URL).
+    fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fireEvent.click(screen.getByLabelText('Delete claude-legacy-2'))
+    await waitFor(() => {
+      expect(authFetchMock).toHaveBeenCalledTimes(2)
+    })
+    expect(String(authFetchMock.mock.calls[1][0])).toBe(
+      'http://other-host:9000/api/llm/models/claude-legacy-2'
+    )
+    expect(authFetchMock.mock.calls[1][1].method).toBe('DELETE')
+    // Fully drain the queue (DELETE → refetch → fetchModels) so no leftover
+    // mockResolvedValueOnce can leak into the next test's mount GET.
+    await waitFor(() => {
+      expect(fetchModelsMock).toHaveBeenCalledTimes(2)
+    })
+    confirmSpy.mockRestore()
+  })
+
+  it('commits a successful older refetch even after a newer refetch failed first (P2)', async () => {
+    mockUser = adminUser
+    const opus = model({
+      id: 'claude-opus-4-8',
+      display_name: 'Claude Opus 4.8',
+      provider: 'anthropic',
+      is_default: false,
+      is_enabled: true,
+    })
+    const gemini = model({
+      id: 'gemini-3-flash-preview',
+      display_name: 'Gemini 3 Flash',
+      provider: 'google',
+      is_default: false,
+      is_enabled: true,
+    })
+
+    const earlier = deferred<Response>() // opus refetch (started first → lower gen)
+    const later = deferred<Response>() // gemini refetch (started second → higher gen)
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(listResponse([opus, gemini])) // mount
+      .mockReturnValueOnce(earlier.promise) // opus refetch
+      .mockReturnValueOnce(later.promise) // gemini refetch
+    authFetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    render(<ModelManagementPanel />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+    })
+
+    // Mutation A (anthropic) → earlier refetch dispatched first.
+    fireEvent.click(screen.getByLabelText('Set claude-opus-4-8 as default'))
+    await waitFor(() => {
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(2)
+    })
+    // Mutation B (google — different provider, not locked) → later refetch dispatched second.
+    fireEvent.click(screen.getByLabelText('Set gemini-3-flash-preview as default'))
+    await waitFor(() => {
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(3)
+    })
+
+    // The newer refetch FAILS first → a load error appears.
+    later.resolve({ ok: false, status: 500, json: async () => ({}) } as Response)
+    await waitFor(() => {
+      expect(screen.getByText('모델 목록을 불러오지 못했습니다.')).toBeInTheDocument()
+    })
+
+    // The earlier refetch SUCCEEDS later with gemini promoted → its data must still commit,
+    // clearing the load error rather than being discarded as "superseded".
+    earlier.resolve(
+      listResponse([
+        { ...opus, is_default: false },
+        { ...gemini, is_default: true },
+      ])
+    )
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText('Set gemini-3-flash-preview as default')
+      ).not.toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Set claude-opus-4-8 as default')).toBeInTheDocument()
+    expect(screen.queryByText('모델 목록을 불러오지 못했습니다.')).not.toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────
+  // Delete (real deletion + suppression) — disabled non-default rows only
+  // ───────────────────────────────────────────────────────────
+  describe('delete disabled models', () => {
+    // Drain any leftover fetch `mockResolvedValueOnce` queue from an earlier test that
+    // threw before consuming its queued responses (vi.clearAllMocks does not reset the
+    // once-queue), so each delete test's mount GET reads exactly its own fixture.
+    beforeEach(() => {
+      vi.mocked(global.fetch).mockReset()
+    })
+
+    const enabledDefault = () =>
+      model({ id: 'claude-opus-4-8', display_name: 'Claude Opus 4.8', is_enabled: true, is_default: true })
+    const disabledLegacy = () =>
+      model({
+        id: 'claude-legacy-2',
+        display_name: 'Claude Legacy 2',
+        is_enabled: false,
+        is_default: false,
+      })
+
+    it('offers Delete only on revealed disabled non-default rows, never on enabled or default rows', async () => {
+      mockUser = adminUser
+      mockList([enabledDefault(), disabledLegacy()])
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+      })
+      // Enabled default exposes no Delete; the disabled row is hidden so its Delete is unmounted.
+      expect(screen.queryByLabelText('Delete claude-opus-4-8')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Delete claude-legacy-2')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+
+      // Revealed disabled non-default row now exposes Delete; the enabled default still does not.
+      expect(screen.getByLabelText('Delete claude-legacy-2')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Delete claude-opus-4-8')).not.toBeInTheDocument()
+    })
+
+    it('never offers Delete on an anomalous (always-visible) disabled-default row', async () => {
+      mockUser = adminUser
+      mockList([
+        model({ id: 'claude-opus-4-8', provider: 'anthropic', is_enabled: true, is_default: false }),
+        model({
+          id: 'gemini-broken-default',
+          display_name: 'Gemini Broken Default',
+          provider: 'google',
+          is_enabled: false,
+          is_default: true,
+        }),
+      ])
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByText('Gemini Broken Default')).toBeInTheDocument()
+      })
+      expect(screen.queryByLabelText('Delete gemini-broken-default')).not.toBeInTheDocument()
+    })
+
+    it('deletes after confirm, sends DELETE, then refetches and re-syncs the catalog', async () => {
+      mockUser = adminUser
+      const opus = enabledDefault()
+      const legacy = disabledLegacy()
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(listResponse([opus, legacy])) // mount
+        .mockResolvedValueOnce(listResponse([opus])) // refetch after delete: row gone
+      authFetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ model_id: 'claude-legacy-2', provider: 'anthropic' }),
+      })
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+      fireEvent.click(screen.getByLabelText('Delete claude-legacy-2'))
+
+      await waitFor(() => {
+        expect(authFetchMock).toHaveBeenCalled()
+      })
+      const [url, opts] = authFetchMock.mock.calls[0]
+      // DELETE targets the admin-configured backend (default backendUrl), same base as load/patch.
+      expect(String(url)).toBe(`${DEFAULT_BACKEND_URL}/api/llm/models/claude-legacy-2`)
+      expect(opts.method).toBe('DELETE')
+      expect(confirmSpy).toHaveBeenCalled()
+
+      // Refetch drops the row and the global catalog is re-synced.
+      await waitFor(() => {
+        expect(fetchModelsMock).toHaveBeenCalled()
+      })
+      expect(screen.queryByText('Claude Legacy 2')).not.toBeInTheDocument()
+      confirmSpy.mockRestore()
+    })
+
+    it('does not call the API when the delete confirm is dismissed', async () => {
+      mockUser = adminUser
+      mockList([enabledDefault(), disabledLegacy()])
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+      fireEvent.click(screen.getByLabelText('Delete claude-legacy-2'))
+
+      expect(confirmSpy).toHaveBeenCalled()
+      expect(authFetchMock).not.toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    it('shows a session-expired message when delete returns 401', async () => {
+      mockUser = adminUser
+      mockList([enabledDefault(), disabledLegacy()])
+      authFetchMock.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) })
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+      fireEvent.click(screen.getByLabelText('Delete claude-legacy-2'))
+
+      await waitFor(() => {
+        expect(screen.getByText('세션이 만료되었습니다. 다시 로그인해 주세요.')).toBeInTheDocument()
+      })
+      confirmSpy.mockRestore()
+    })
+
+    it('shows an admin-required message when delete returns 403', async () => {
+      mockUser = adminUser
+      mockList([enabledDefault(), disabledLegacy()])
+      authFetchMock.mockResolvedValue({ ok: false, status: 403, json: async () => ({}) })
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+      fireEvent.click(screen.getByLabelText('Delete claude-legacy-2'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Admin 권한이 없습니다.')).toBeInTheDocument()
+      })
+      confirmSpy.mockRestore()
+    })
+
+    it('surfaces the backend detail message when delete is rejected with 409', async () => {
+      mockUser = adminUser
+      mockList([enabledDefault(), disabledLegacy()])
+      authFetchMock.mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({ detail: "Cannot delete default model 'claude-legacy-2'." }),
+      })
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+      fireEvent.click(screen.getByLabelText('Delete claude-legacy-2'))
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Cannot delete default model 'claude-legacy-2'.")
+        ).toBeInTheDocument()
+      })
+      confirmSpy.mockRestore()
+    })
+
+    it('disables the Delete button while its request is in flight', async () => {
+      mockUser = adminUser
+      mockList([enabledDefault(), disabledLegacy()])
+      const del = deferred<Response>()
+      authFetchMock.mockReturnValue(del.promise)
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+      render(<ModelManagementPanel />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Show disabled models (1)')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByLabelText('Show disabled models (1)'))
+      fireEvent.click(screen.getByLabelText('Delete claude-legacy-2'))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Delete claude-legacy-2')).toBeDisabled()
+      })
+      del.resolve({ ok: true, status: 200, json: async () => ({}) })
+      confirmSpy.mockRestore()
+    })
+  })
+})

--- a/src/dashboard/src/components/llm-router/index.ts
+++ b/src/dashboard/src/components/llm-router/index.ts
@@ -1,2 +1,3 @@
 export { LLMRouterSettings } from './LLMRouterSettings'
 export { ModelUpdatePanel } from './ModelUpdatePanel'
+export { ModelManagementPanel } from './ModelManagementPanel'

--- a/src/dashboard/src/pages/SettingsPage.test.tsx
+++ b/src/dashboard/src/pages/SettingsPage.test.tsx
@@ -49,6 +49,7 @@ const defaultNotifications = {
 vi.mock('../components/llm-router', () => ({
   LLMRouterSettings: () => <div data-testid="llm-router-settings">LLMRouterSettings</div>,
   ModelUpdatePanel: () => <div data-testid="model-update-panel">ModelUpdatePanel</div>,
+  ModelManagementPanel: () => <div data-testid="model-management-panel">ModelManagementPanel</div>,
 }))
 vi.mock('../components/usage', () => ({
   LLMAccessSettings: () => <div data-testid="llm-access">LLMAccessSettings</div>,
@@ -166,6 +167,11 @@ describe('SettingsPage', () => {
   it('renders LLM Router settings component', async () => {
     await renderSettingsPage()
     expect(screen.getByTestId('llm-router-settings')).toBeInTheDocument()
+  })
+
+  it('renders Model Management panel', async () => {
+    await renderSettingsPage()
+    expect(screen.getByTestId('model-management-panel')).toBeInTheDocument()
   })
 
   it('renders LLM Accounts settings component', async () => {

--- a/src/dashboard/src/pages/SettingsPage.tsx
+++ b/src/dashboard/src/pages/SettingsPage.tsx
@@ -18,7 +18,7 @@ import {
   Shield,
   AlertTriangle,
 } from 'lucide-react'
-import { LLMRouterSettings, ModelUpdatePanel } from '../components/llm-router'
+import { LLMRouterSettings, ModelUpdatePanel, ModelManagementPanel } from '../components/llm-router'
 import { LLMAccessSettings, LLMAccountsSettings } from '../components/usage'
 
 export function SettingsPage() {
@@ -655,6 +655,9 @@ export function SettingsPage() {
             })()}
           </div>
         </div>
+
+        {/* Model Management (admin only) */}
+        <ModelManagementPanel />
 
         {/* Model Version Updates */}
         <ModelUpdatePanel />

--- a/tests/backend/api/test_llm_models_delete.py
+++ b/tests/backend/api/test_llm_models_delete.py
@@ -1,0 +1,343 @@
+"""DELETE endpoint tests for LLM model hard-delete + un-suppress.
+
+Contract (frontend builds against this):
+- DELETE /api/llm/models/{id}              → 200 ModelDeleteResponse | 401/403/404/409/501
+- DELETE /api/llm/models/suppressions/{id} → 200 SuppressionDeleteResponse | 401/403/404/501
+
+``api.llm.USE_DATABASE`` is a module constant read at call time; conftest sets it
+false, so 501 is exercised without patching and the other paths patch it True.
+The DB session and auth user are injected via FastAPI dependency overrides with
+lightweight fakes (no real DB in the test env).
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Select
+from sqlalchemy.dialects import postgresql
+
+from api.deps import get_current_user_optional
+from api.llm import router
+from db.database import get_db
+from models.llm_models import LLMModelRegistry
+
+_ADMIN = SimpleNamespace(id="admin-1", role="admin", is_admin=True, is_active=True)
+_NON_ADMIN = SimpleNamespace(id="user-1", role="user", is_admin=False, is_active=True)
+_INACTIVE_ADMIN = SimpleNamespace(id="admin-2", role="admin", is_admin=True, is_active=False)
+_SUPPRESSED_AT = datetime(2026, 7, 12, 4, 30, tzinfo=timezone.utc)
+
+
+def _insert_params(stmt) -> dict:
+    return stmt.compile(dialect=postgresql.dialect()).params
+
+
+def _find_insert(db: "_FakeDB"):
+    for stmt in db.executed:
+        if type(stmt).__name__ == "Insert":
+            return stmt
+    raise AssertionError("no Insert statement captured")
+
+
+# ─────────────────────────────────────────────────────────────
+# Fake DB session: returns queued results for SELECTs, no-ops writes
+# ─────────────────────────────────────────────────────────────
+
+
+class _Result:
+    def __init__(self, scalar=None, scalars_list=None):
+        self._scalar = scalar
+        self._scalars_list = scalars_list or []
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._scalars_list
+
+
+class _FakeDB:
+    def __init__(self, select_results: list[_Result]):
+        self._select_results = list(select_results)
+        self.executed: list = []
+        self.committed = False
+
+    async def execute(self, stmt):
+        self.executed.append(stmt)
+        if isinstance(stmt, Select):
+            return self._select_results.pop(0)
+        return _Result()  # Insert / Delete / Update
+
+    async def commit(self):
+        self.committed = True
+
+    def stmt_names(self) -> list[str]:
+        return [type(s).__name__ for s in self.executed]
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_cache():
+    """Isolate the module-global registry cache: tests here drive load_from_db,
+    which mutates _db_cache/_db_index."""
+    original_cache = LLMModelRegistry._db_cache
+    original_index = LLMModelRegistry._db_index
+    yield
+    LLMModelRegistry._db_cache = original_cache
+    LLMModelRegistry._db_index = original_index
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    test_app = FastAPI()
+    test_app.include_router(router)
+    return test_app
+
+
+@pytest_asyncio.fixture
+async def make_client(app: FastAPI):
+    async def _make(db: _FakeDB | None, user) -> AsyncClient:
+        if db is not None:
+            app.dependency_overrides[get_db] = lambda: db
+        app.dependency_overrides[get_current_user_optional] = lambda: user
+        return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+    yield _make
+    app.dependency_overrides.clear()
+
+
+# ─────────────────────────────────────────────────────────────
+# DELETE /api/llm/models/{model_id}
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_model_success(monkeypatch, make_client):
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    db_model = SimpleNamespace(id="gpt-5.4-nano", provider="openai", is_default=False)
+    suppression = SimpleNamespace(
+        model_id="gpt-5.4-nano",
+        provider="openai",
+        reason="admin deletion",
+        suppressed_at=_SUPPRESSED_AT,
+    )
+    # load_from_db reload returns the REMAINING models (deleted one absent),
+    # exercising the real reload path → registry.get_by_id(deleted) is None.
+    remaining = SimpleNamespace(
+        id="claude-sonnet-5",
+        display_name="Claude Sonnet 5",
+        provider="anthropic",
+        context_window=1_000_000,
+        input_price=0.003,
+        output_price=0.015,
+        is_default=True,
+        is_enabled=True,
+        supports_tools=True,
+        supports_vision=True,
+    )
+    db = _FakeDB(
+        select_results=[
+            _Result(scalar=db_model),                # SELECT config row (FOR UPDATE)
+            _Result(scalar=suppression),             # read-back suppression
+            _Result(scalars_list=[remaining]),       # load_from_db reload
+        ]
+    )
+    client = await make_client(db, _ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/gpt-5.4-nano")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["model_id"] == "gpt-5.4-nano"
+    assert body["provider"] == "openai"
+    assert body["reason"] == "admin deletion"
+    assert body["suppressed_at"].startswith("2026-07-12T04:30:00")
+    # A suppression Insert and a config Delete were issued, then committed.
+    assert "Insert" in db.stmt_names()
+    assert "Delete" in db.stmt_names()
+    assert db.committed is True
+    # The suppression row is recorded with the right id/provider/reason.
+    insert_params = _insert_params(_find_insert(db))
+    assert insert_params["model_id"] == "gpt-5.4-nano"
+    assert insert_params["provider"] == "openai"
+    assert insert_params["reason"] == "admin deletion"
+    # After reload, the hard-deleted model is gone from the registry cache.
+    assert LLMModelRegistry.get_by_id("gpt-5.4-nano") is None
+    assert LLMModelRegistry.get_by_id("claude-sonnet-5") is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_model_suppression_readback_none_stays_200(monkeypatch, make_client):
+    """P2: if the suppression row is not readable (a concurrent un-suppress
+    removed it mid-transaction), the endpoint must NOT 500 — it falls back to the
+    just-written values and still returns 200."""
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    db_model = SimpleNamespace(id="gpt-5.4-nano", provider="openai", is_default=False)
+    db = _FakeDB(
+        select_results=[
+            _Result(scalar=db_model),   # SELECT config FOR UPDATE
+            _Result(scalar=None),       # suppression readback → None (raced away)
+            _Result(scalars_list=[]),   # load_from_db
+        ]
+    )
+    client = await make_client(db, _ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/gpt-5.4-nano")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["model_id"] == "gpt-5.4-nano"
+    assert body["provider"] == "openai"
+    assert body["reason"] == "admin deletion"  # fallback to just-written value
+    assert body["suppressed_at"]  # well-formed fallback timestamp, not null
+    assert db.committed is True
+
+
+@pytest.mark.asyncio
+async def test_delete_model_not_found(monkeypatch, make_client):
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    db = _FakeDB(select_results=[_Result(scalar=None)])
+    client = await make_client(db, _ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/does-not-exist")
+
+    assert resp.status_code == 404
+    assert "not found in DB" in resp.json()["detail"]
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_delete_model_default_conflict(monkeypatch, make_client):
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    db_model = SimpleNamespace(id="claude-sonnet-5", provider="anthropic", is_default=True)
+    db = _FakeDB(select_results=[_Result(scalar=db_model)])
+    client = await make_client(db, _ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/claude-sonnet-5")
+
+    assert resp.status_code == 409
+    assert "default model" in resp.json()["detail"]
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_delete_model_unauthenticated(monkeypatch, make_client):
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    client = await make_client(_FakeDB([]), None)
+    async with client:
+        resp = await client.delete("/llm/models/gpt-5.4-nano")
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Not authenticated"
+
+
+@pytest.mark.asyncio
+async def test_delete_model_forbidden_non_admin(monkeypatch, make_client):
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    client = await make_client(_FakeDB([]), _NON_ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/gpt-5.4-nano")
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin access required"
+
+
+@pytest.mark.asyncio
+async def test_delete_model_forbidden_inactive_admin(monkeypatch, make_client):
+    # M1: a deactivated admin must not retain destructive privileges → 403.
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    client = await make_client(_FakeDB([]), _INACTIVE_ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/gpt-5.4-nano")
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "User is inactive"
+
+
+@pytest.mark.asyncio
+async def test_delete_model_requires_db_mode(make_client):
+    # USE_DATABASE stays false (conftest default) → 501 before any DB access.
+    client = await make_client(_FakeDB([]), _ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/gpt-5.4-nano")
+
+    assert resp.status_code == 501
+    assert "DB mode required" in resp.json()["detail"]
+
+
+# ─────────────────────────────────────────────────────────────
+# DELETE /api/llm/models/suppressions/{model_id}
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unsuppress_success(monkeypatch, make_client):
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    suppression = SimpleNamespace(model_id="gpt-5.4-nano", provider="openai")
+    db = _FakeDB(select_results=[_Result(scalar=suppression)])
+    client = await make_client(db, _ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/suppressions/gpt-5.4-nano")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"model_id": "gpt-5.4-nano", "unsuppressed": True}
+    assert "Delete" in db.stmt_names()
+    assert db.committed is True
+
+
+@pytest.mark.asyncio
+async def test_unsuppress_not_found(monkeypatch, make_client):
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    db = _FakeDB(select_results=[_Result(scalar=None)])
+    client = await make_client(db, _ADMIN)
+    async with client:
+        resp = await client.delete("/llm/models/suppressions/never-suppressed")
+
+    assert resp.status_code == 404
+    assert "No suppression found" in resp.json()["detail"]
+    assert db.committed is False
+
+
+# ─────────────────────────────────────────────────────────────
+# PATCH /api/llm/models/{model_id} — row lock must not break the happy path
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_model_success_with_row_lock(monkeypatch, make_client):
+    """P1: the target row is now selected FOR UPDATE. Confirm the lock does not
+    break the PATCH happy path — it stays a Select the session serves → 200."""
+    monkeypatch.setattr("api.llm.USE_DATABASE", True)
+    db_model = SimpleNamespace(id="gpt-4o", provider="openai", is_default=False)
+    reloaded = SimpleNamespace(
+        id="gpt-4o",
+        display_name="GPT-4o Renamed",
+        provider="openai",
+        context_window=128000,
+        input_price=0.005,
+        output_price=0.015,
+        is_default=False,
+        is_enabled=True,
+        supports_tools=True,
+        supports_vision=True,
+    )
+    db = _FakeDB(
+        select_results=[
+            _Result(scalar=db_model),          # SELECT config FOR UPDATE
+            _Result(scalars_list=[reloaded]),  # load_from_db reload
+        ]
+    )
+    client = await make_client(db, _ADMIN)
+    async with client:
+        resp = await client.patch("/llm/models/gpt-4o", json={"display_name": "GPT-4o Renamed"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == "gpt-4o"
+    assert body["display_name"] == "GPT-4o Renamed"
+    assert db.committed is True

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -1,7 +1,7 @@
 """Tests for claude-sonnet-5 registry entry, sync_to_db dual-default guard, and pricing."""
 
 import pytest
-from sqlalchemy import Update
+from sqlalchemy import Delete, Update
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql.dml import Insert
 
@@ -75,6 +75,7 @@ class _FakeSession:
         self._select_results = select_results
         self.inserts: list = []
         self.updates: list = []
+        self.deletes: list = []
         self.selects: list = []
         self.committed = False
 
@@ -84,6 +85,10 @@ class _FakeSession:
             return _FakeResult()
         if isinstance(stmt, Update):
             self.updates.append(stmt)
+            return _FakeResult()
+        if isinstance(stmt, Delete):
+            # Self-heal bulk delete: captured without consuming a select result.
+            self.deletes.append(stmt)
             return _FakeResult()
         self.selects.append(stmt)
         return self._select_results.pop(0)
@@ -109,6 +114,7 @@ async def test_sync_to_db_new_default_demoted_when_db_default_exists():
     provider already has a default row in DB (existing DB default respected)."""
     session = _FakeSession(
         select_results=[
+            _FakeResult([]),  # suppressed ids (none)
             # existing IDs: sonnet-5 is NEW, sonnet-4-6 already exists
             _FakeResult([("claude-sonnet-4-6",), ("claude-opus-4-8",)]),
             # providers that already have a DB default row
@@ -131,6 +137,7 @@ async def test_sync_to_db_new_default_kept_when_no_db_default():
     no default row in DB."""
     session = _FakeSession(
         select_results=[
+            _FakeResult([]),  # suppressed ids (none)
             _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
             _FakeResult([]),  # no provider has a DB default
             _FakeResult([]),  # final load_from_db select
@@ -149,6 +156,7 @@ async def test_sync_to_db_default_guard_ignores_disabled_db_defaults():
     whose only DB default is disabled still accepts the new code default."""
     session = _FakeSession(
         select_results=[
+            _FakeResult([]),  # suppressed ids (none)
             _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
             # Guard select returns no providers: the anthropic default row in
             # DB is disabled, so the is_enabled filter excludes it.
@@ -159,8 +167,9 @@ async def test_sync_to_db_default_guard_ignores_disabled_db_defaults():
 
     await LLMModelRegistry.sync_to_db(session)
 
-    # The guard query itself must filter on BOTH is_default and is_enabled
-    guard_select = session.selects[1]
+    # The guard query itself must filter on BOTH is_default and is_enabled.
+    # selects[0]=suppressed ids, [1]=existing ids, [2]=providers_with_db_default.
+    guard_select = session.selects[2]
     sql = str(guard_select.compile(dialect=postgresql.dialect()))
     assert "is_default" in sql
     assert "is_enabled" in sql
@@ -178,6 +187,7 @@ async def test_sync_to_db_clears_stale_disabled_default_before_new_default_inser
     re-enable해도 provider default가 2개가 되지 않도록."""
     session = _FakeSession(
         select_results=[
+            _FakeResult([]),  # suppressed ids (none)
             _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
             # anthropic의 유일한 default 행이 disabled → enabled 필터에 걸러져
             # 가드 통과 (신규 모델이 default로 INSERT되는 경로)
@@ -219,6 +229,7 @@ async def test_sync_to_db_no_default_clear_when_enabled_db_default_exists():
     발행되지 않는다 (admin default 행 보존)."""
     session = _FakeSession(
         select_results=[
+            _FakeResult([]),  # suppressed ids (none)
             _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
             _FakeResult([("anthropic",)]),  # anthropic enabled default 존재
             _FakeResult([]),
@@ -239,6 +250,7 @@ async def test_sync_to_db_on_conflict_preserves_admin_fields():
     """ON CONFLICT DO UPDATE must not touch is_default / is_enabled."""
     session = _FakeSession(
         select_results=[
+            _FakeResult([]),  # suppressed ids (none)
             _FakeResult([("claude-sonnet-5",)]),  # sonnet-5 already exists
             _FakeResult([("anthropic",)]),
             _FakeResult([]),
@@ -253,6 +265,139 @@ async def test_sync_to_db_on_conflict_preserves_admin_fields():
     update_clause = sql.split("DO UPDATE SET", 1)[1]
     assert "is_default" not in update_clause
     assert "is_enabled" not in update_clause
+
+
+# ─────────────────────────────────────────────────────────────
+# (a-suppression) startup re-INSERT guard: suppressed ids are skipped
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_skips_suppressed_model_id():
+    """Regression guard (a): a suppressed model id must NOT be re-INSERTed by
+    startup sync_to_db, even though it is still present in code _MODELS."""
+    session = _FakeSession(
+        select_results=[
+            _FakeResult([("claude-opus-4-8",)]),  # suppressed ids
+            _FakeResult([]),  # existing ids: table empty
+            _FakeResult([]),  # providers with a DB default
+            _FakeResult([]),  # final load_from_db select
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    inserted_ids = {_insert_params(s).get("id") for s in session.inserts}
+    # Suppressed model is NOT re-inserted...
+    assert "claude-opus-4-8" not in inserted_ids
+    # ...while other code models still sync normally.
+    assert "claude-sonnet-5" in inserted_ids
+
+
+@pytest.mark.asyncio
+async def test_sync_to_db_self_heals_suppressed_config_rows():
+    """P1-2 self-heal: sync_to_db must issue a bulk DELETE removing any config
+    row whose id is suppressed, recovering from a snapshot↔DELETE race that left
+    a stray config behind. Verified at the statement level (no real DB): the
+    DELETE targets llm_model_configs filtered by the suppressions subquery, with
+    synchronize_session=False so a real Postgres run cannot raise on the
+    non-evaluable subquery WHERE."""
+    session = _FakeSession(
+        select_results=[
+            _FakeResult([]),  # suppressed ids
+            _FakeResult([]),  # existing ids
+            _FakeResult([]),  # providers with DB default
+            _FakeResult([]),  # final load_from_db
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    assert session.deletes, "expected a self-heal DELETE on llm_model_configs"
+    compiled = session.deletes[0].compile(dialect=postgresql.dialect())
+    sql = str(compiled)
+    assert "DELETE FROM llm_model_configs" in sql
+    assert "llm_model_suppressions" in sql
+    assert session.deletes[0].get_execution_options().get("synchronize_session") is False
+
+
+# ─────────────────────────────────────────────────────────────
+# (P2) load_from_db: empty-success clears cache vs preserves fallback
+# ─────────────────────────────────────────────────────────────
+
+
+class _FakeLoadResult:
+    def __init__(self, rows: list):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self) -> list:
+        return self._rows
+
+
+class _FakeLoadSession:
+    def __init__(self, rows: list):
+        self._rows = rows
+
+    async def execute(self, stmt):
+        return _FakeLoadResult(self._rows)
+
+
+@pytest.mark.asyncio
+async def test_load_from_db_empty_clears_existing_db_cache():
+    """A successful EMPTY read while already in DB mode (cache is a list) must
+    clear the cache — otherwise a hard-deleted last model lingers stale."""
+    from models.llm_models import LLMModelConfig
+
+    LLMModelRegistry._db_cache = [
+        LLMModelConfig(
+            id="stale-model",
+            display_name="Stale",
+            provider=LLMProvider.OPENAI,
+            context_window=128000,
+            input_price=0.001,
+            output_price=0.002,
+        )
+    ]
+    LLMModelRegistry._db_index = {"stale-model": LLMModelRegistry._db_cache[0]}
+
+    await LLMModelRegistry.load_from_db(_FakeLoadSession(rows=[]))
+
+    assert LLMModelRegistry._db_cache == []
+    assert LLMModelRegistry.get_by_id("stale-model") is None
+
+
+@pytest.mark.asyncio
+async def test_load_from_db_empty_preserves_fallback_on_first_load():
+    """A successful EMPTY read on the FIRST load (no cache yet) must keep the
+    in-memory _MODELS fallback (cache stays None) so startup serves models even
+    before sync_to_db populates the table."""
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+
+    await LLMModelRegistry.load_from_db(_FakeLoadSession(rows=[]))
+
+    assert LLMModelRegistry._db_cache is None
+    # Fallback still serves the code registry.
+    assert LLMModelRegistry.get_by_id("claude-sonnet-5") is not None
+
+
+def test_evict_reflects_in_none_cache_fallback():
+    """P2: evict must drop the id even with no DB cache (fallback mode). It
+    materializes the cache from _MODELS minus the id, so a failed post-delete
+    reload cannot let the in-memory fallback keep serving a hard-deleted model."""
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+    # Present in the code registry before eviction.
+    assert LLMModelRegistry.get_by_id("gpt-5.4-nano") is not None
+
+    LLMModelRegistry.evict("gpt-5.4-nano")
+
+    assert LLMModelRegistry.get_by_id("gpt-5.4-nano") is None
+    # Other models remain reachable.
+    assert LLMModelRegistry.get_by_id("claude-sonnet-5") is not None
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/backend/test_model_update_suppression.py
+++ b/tests/backend/test_model_update_suppression.py
@@ -1,0 +1,133 @@
+"""Regression guard (b): model discovery must not re-INSERT suppressed models.
+
+After a hard delete, the model is absent from the registry, so ``_diff_models``
+legitimately reports it as "new". The suppression guard lives at the INSERT
+point in ``_apply_changes`` — this test drives a suppressed id through that path
+and asserts it is skipped while a genuinely new model still inserts.
+"""
+
+import pytest
+from sqlalchemy import Select
+from sqlalchemy.dialects import postgresql
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple] | None = None):
+        self._rows = rows or []
+
+    def fetchall(self) -> list[tuple]:
+        return self._rows
+
+    def scalars(self):  # for load_from_db select
+        return self
+
+    def all(self) -> list:
+        return []
+
+
+class _FakeSession:
+    """Serves the suppressed-ids SELECT; captures inserts/updates."""
+
+    def __init__(self, suppressed_rows: list[tuple]):
+        self._suppressed_rows = suppressed_rows
+        self.inserts: list = []
+        self.updates: list = []
+        self.deletes: list = []
+        self.committed = False
+
+    async def execute(self, stmt):
+        if isinstance(stmt, Select):
+            return _FakeResult(self._suppressed_rows)
+        # pg_insert Insert / core Update / core Delete
+        name = type(stmt).__name__
+        if name == "Insert":
+            self.inserts.append(stmt)
+        elif name == "Update":
+            self.updates.append(stmt)
+        elif name == "Delete":
+            self.deletes.append(stmt)
+        return _FakeResult()
+
+    async def commit(self):
+        self.committed = True
+
+
+class _CtxManager:
+    def __init__(self, session: _FakeSession):
+        self._session = session
+
+    async def __aenter__(self) -> _FakeSession:
+        return self._session
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+def _make_factory(session: _FakeSession):
+    def factory():
+        return _CtxManager(session)
+
+    return factory
+
+
+def _insert_params(stmt) -> dict:
+    return stmt.compile(dialect=postgresql.dialect()).params
+
+
+@pytest.mark.asyncio
+async def test_apply_changes_skips_suppressed_new_model(monkeypatch):
+    from services.model_update_service import ModelChange, ModelUpdateService
+
+    session = _FakeSession(suppressed_rows=[("gpt-5.4-nano",)])
+    # _apply_changes imports async_session_factory lazily from db.database,
+    # so patch it at the source module.
+    monkeypatch.setattr(
+        "db.database.async_session_factory",
+        _make_factory(session),
+    )
+
+    new_models = [
+        ModelChange(
+            model_id="gpt-5.4-nano",  # suppressed → must be skipped
+            change_type="new",
+            new_value={"display_name": "GPT-5.4 Nano", "provider": "openai"},
+        ),
+        ModelChange(
+            model_id="brand-new-model",  # not suppressed → must insert
+            change_type="new",
+            new_value={"display_name": "Brand New", "provider": "openai"},
+        ),
+    ]
+
+    await ModelUpdateService._apply_changes(new_models, [])
+
+    inserted_ids = {_insert_params(s).get("id") for s in session.inserts}
+    assert "gpt-5.4-nano" not in inserted_ids
+    assert "brand-new-model" in inserted_ids
+    assert session.committed is True
+
+
+@pytest.mark.asyncio
+async def test_apply_changes_self_heals_suppressed_config_rows(monkeypatch):
+    """P1-2 self-heal: _apply_changes must issue a bulk DELETE removing config
+    rows whose id is suppressed (race recovery). Verified at the statement level:
+    DELETE FROM llm_model_configs filtered by the suppressions subquery, with
+    synchronize_session=False so a real Postgres run won't raise."""
+    from services.model_update_service import ModelUpdateService
+
+    session = _FakeSession(suppressed_rows=[("gpt-5.4-nano",)])
+    monkeypatch.setattr(
+        "db.database.async_session_factory",
+        _make_factory(session),
+    )
+
+    await ModelUpdateService._apply_changes([], [])
+
+    assert session.deletes, "expected a self-heal DELETE on llm_model_configs"
+    compiled = session.deletes[0].compile(dialect=postgresql.dialect())
+    sql = str(compiled)
+    assert "DELETE FROM llm_model_configs" in sql
+    assert "llm_model_suppressions" in sql
+    assert (
+        session.deletes[0].get_execution_options().get("synchronize_session") is False
+    )


### PR DESCRIPTION
## Summary
- Settings에 admin 전용 **Model Management 패널** 신설 — provider별 모델 목록, Enable/Disable 토글, default 전환, disabled 모델 기본 숨김("Show disabled" 토글)
- **하드 삭제 + suppression(재등록 방지)**: `llm_model_suppressions` 테이블을 도입해, DB에서 지운 모델이 startup `sync_to_db`(코드 `_MODELS` 재INSERT)나 `model_update_service` 24h 자동 발견으로 되살아나지 않도록 차단
- 동시성·보안 하드닝: PATCH/DELETE 대상 행 `FOR UPDATE` 잠금, 자가치유 벌크 DELETE, mutation 4종 `is_active` 강제(`_require_admin`)

## Changes
**Backend**
- `db/models/llm.py`: `LLMModelSuppressionModel` (PK=model_id) + alembic `a7d3f1b9c2e4` (idempotent)
- `api/llm.py`: `DELETE /api/llm/models/{id}` (admin, `is_default`면 409, suppression 기록+config 삭제 단일 트랜잭션, registry reload+evict 폴백) / `DELETE /api/llm/models/suppressions/{id}` (un-suppress — 다음 sync에서 자동 재등록)
- `models/llm_models.py`·`services/model_update_service.py`: suppressed id skip + 자가치유 벌크 DELETE(`synchronize_session=False`) — race로 잘못 재INSERT돼도 다음 sync가 반드시 제거
- `_require_admin` 헬퍼: PATCH·check-updates의 pre-existing `is_active` 미검사 결함 동반 수정

**Frontend**
- `ModelManagementPanel.tsx` (신규): admin 게이트, provider 그룹, pending Set + 요청 세대 카운터(stale refetch 폐기), loadError/actionError 분리, 401/403/409/세션만료 구분 처리, disabled 비-default 행 전용 Delete 버튼(confirm)
- `SettingsPage.tsx`: 패널 배치 (Model Version Updates 위)

**Docs**: `docs/api/llm.md` (DELETE 2건+suppression 동작), `docs/dashboard.md`

## Test Plan
- [x] 백엔드: pytest **1277 passed** (ruff·mypy 0) — 회귀 가드 2종(sync 재INSERT/발견 insert 차단) Red-Green 검증, 상태코드 계약 5종(200/401/403/404/409), 비활성 admin 403
- [x] 프론트: vitest **4294 passed** (tsc·eslint 0, build OK) — 패널 커버리지 95.7% stmts
- [x] integration-qa 경계면 5/5 PASS, Codex 독립 리뷰 6라운드 수렴 **PASS** (TOCTOU·suppression race·stale 캐시 등 P1 3건 수정 검증)
- [x] 런타임 스모크: 테이블 생성, DELETE 무인증 401, 브라우저에서 disabled 26행 Delete 버튼 노출 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)