### PR TITLE
ci(backup): step-if secrets 컨텍스트 제거로 워크플로우 파싱 실패 수정

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -171,10 +171,14 @@ jobs:
     name: Verify Backup
     needs: backup
     runs-on: ubuntu-latest
+    # secrets 컨텍스트는 step-level if에서 사용 불가(워크플로우 전체 파싱 실패 유발)
+    # → job env로 옮겨 env 컨텍스트로 검사 (backup 잡과 동일 패턴)
+    env:
+      AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
     steps:
       - name: Download latest backup
-        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
+        if: env.AWS_KEY != ''
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -184,6 +188,7 @@ jobs:
           aws s3 cp "s3://${{ secrets.BACKUP_S3_BUCKET }}/backups/$LATEST" ./backup.sql.gz
 
       - name: Verify backup integrity
+        if: env.AWS_KEY != ''
         run: |
+          test -s ./backup.sql.gz
           gunzip -t ./backup.sql.gz && echo "Backup verified: OK"
-        continue-on-error: true

--- a/src/dashboard/src/pages/SettingsPage.tsx
+++ b/src/dashboard/src/pages/SettingsPage.tsx
@@ -206,8 +206,10 @@ export function SettingsPage() {
           나머지 카드는 남는 폭에 masonry(Pinterest)로 분산 배치한다. */}
       <div className="flex flex-col lg:flex-row gap-6 items-start">
         {/* LLM Access — 세로로 긴 전용 컬럼 */}
-        <div className="w-full lg:w-1/3 lg:shrink-0">
+        <div className="w-full lg:w-1/3 lg:shrink-0 space-y-6">
           <LLMAccessSettings />
+          {/* LLM Auto-Switch — LLM Access 바로 아래 배치 */}
+          <LLMRouterSettings />
         </div>
 
         {/* 나머지 카드 — 남는 폭에 masonry로 분산 */}
@@ -661,9 +663,6 @@ export function SettingsPage() {
 
         {/* Model Version Updates */}
         <ModelUpdatePanel />
-
-        {/* LLM Auto-Switch — masonry 컬럼 안(세로형)으로 남는 공간을 채운다 */}
-        <LLMRouterSettings />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 요약
`backup.yml` verify 잡의 step-level `if: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}`는 GitHub Actions에서 허용되지 않는 컨텍스트 사용이라 **워크플로우 파일 전체가 파싱 무효** 처리되고 있었습니다.

**영향**: ① 모든 push마다 0초 startup_failure 노이즈 (최소 2026-07-03부터), ② **매일 2AM 스케줄 DB 백업이 전혀 실행되지 않음**.

## 변경
- secrets를 verify 잡 job-level env(`AWS_KEY`)로 이동, `if: env.AWS_KEY != ''`로 검사 (backup 잡의 기존 패턴과 동일)
- Verify backup integrity 스텝 false-green 차단 (Codex 리뷰 반영): AWS 키 없으면 skip, `continue-on-error` 제거, `test -s`로 파일 존재·비어있지 않음 선검증

## 테스트 계획
- `actionlint` 구조 에러 0 (수정 전: line 177 "context secrets is not allowed here")
- 머지 후 push 시 backup.yml startup_failure가 더 이상 생기지 않는지 확인
- 다음 2AM UTC 스케줄 실행 확인 (또는 workflow_dispatch 수동 트리거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA8StbAbDyfjin6U8Wdwiy