### PR TITLE
refactor(auth): python-jose → PyJWT 마이그레이션 (ecdsa high 알림 근본 해결)

### DIFF
--- a/src/backend/api/v1/auth_middleware.py
+++ b/src/backend/api/v1/auth_middleware.py
@@ -19,9 +19,9 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
 
+import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -271,7 +271,7 @@ def verify_token(token: str, expected_type: str = "access") -> dict[str, Any]:
     """
     try:
         payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-    except JWTError as e:
+    except jwt.PyJWTError as e:
         logger.warning("JWT decode error: %s", str(e))
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -288,7 +288,7 @@ def verify_token(token: str, expected_type: str = "access") -> dict[str, Any]:
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Check expiration explicitly (belt-and-suspenders with jose library)
+    # Check expiration explicitly (belt-and-suspenders)
     exp = payload.get("exp", 0)
     if time.time() > exp:
         raise HTTPException(

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
     "apscheduler>=3.10.0",
     "croniter>=1.3.0",
     "python-multipart>=0.0.22",
-    "python-jose[cryptography]>=3.3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -41,7 +41,6 @@ dependencies = [
     { name = "pygithub" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "qdrant-client" },
     { name = "rank-bm25" },
@@ -100,7 +99,6 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "qdrant-client", specifier = ">=1.12.0" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
@@ -787,18 +785,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -2612,25 +2598,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
 ]
 
 [[package]]

--- a/tests/backend/api/test_agent_registry.py
+++ b/tests/backend/api/test_agent_registry.py
@@ -7,10 +7,11 @@ Minimum 20 test cases required.
 
 import time
 
+import jwt
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from api.v1.agent_registry import (
     router,
@@ -19,11 +20,13 @@ from api.v1.agent_registry import (
     _seed_default_agents,
 )
 from api.v1.auth_middleware import (
+    JWT_ALGORITHM,
     UserRole,
     create_access_token,
     create_token_pair,
     create_refresh_token,
     reset_user_store,
+    verify_token,
 )
 from api.v1.rate_limiter import get_rate_limiter
 
@@ -683,3 +686,58 @@ async def test_stats_response_structure(client):
     assert "avg_execution_time_ms" in data
     assert data["total_agents"] == 4
     assert data["by_category"]["development"] == 2
+
+
+# ─────────────────────────────────────────────────────────────
+# 36-38: Token verification unit tests (JWT encode/decode round-trip)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_access_token_round_trip():
+    """Test 36: A freshly issued access token decodes back to its payload."""
+    token = create_access_token("usr_admin_001", "admin", UserRole.ADMIN)
+
+    payload = verify_token(token, expected_type="access")
+
+    assert payload["sub"] == "usr_admin_001"
+    assert payload["username"] == "admin"
+    assert payload["role"] == "admin"
+    assert payload["token_type"] == "access"
+
+
+def test_verify_expired_token_raises_401():
+    """Test 37: An expired access token is rejected with 401."""
+    from datetime import timedelta
+
+    token = create_access_token(
+        "usr_admin_001",
+        "admin",
+        UserRole.ADMIN,
+        expires_delta=timedelta(seconds=-10),  # Already expired
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_token(token, expected_type="access")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_verify_token_wrong_signature_raises_401():
+    """Test 38: A token signed with a different key is rejected with 401."""
+    now = time.time()
+    payload = {
+        "sub": "usr_admin_001",
+        "username": "admin",
+        "role": "admin",
+        "token_type": "access",
+        "exp": now + 3600,
+        "iat": now,
+    }
+    forged_token = jwt.encode(
+        payload, "a-different-secret-key-that-is-32-bytes-plus", algorithm=JWT_ALGORITHM
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_token(forged_token, expected_type="access")
+
+    assert exc_info.value.status_code == 401


### PR DESCRIPTION
## 요약
마지막 남은 pip high Dependabot 알림(`ecdsa`)은 패치가 존재하지 않는 wontfix advisory로, `python-jose[cryptography]`의 transitive입니다. 사용처가 `auth_middleware.py` 1개 파일뿐이라 PyJWT(기존 직접 의존성)로 마이그레이션해 근본 해결합니다.

## 변경
- `from jose import JWTError, jwt` → `import jwt`, `except JWTError` → `except jwt.PyJWTError` — encode/decode 시그니처·에러 메시지·로직 불변
- pyproject에서 python-jose 제거, uv.lock 순수 삭제 33줄 (ecdsa 소멸)
- 회귀 테스트 3종 추가 (round-trip / 만료 401 / 위조 서명 401)

## 테스트 계획 (로컬 fresh 완료)
- Red-Green: 신규 테스트 3종이 마이그레이션 전(jose) GREEN → 후(pyjwt) GREEN
- 결정적 증거: jose가 venv에서 제거된 상태로 전체 스위트 실행 → 1280 passed
- ruff 0 / mypy 0 (252 files) / Codex 리뷰 지적 0건
- 잔존 rsa/pyasn1은 google-auth(langchain-google-genai) 체인 소속 — jose 무관

## 후속 관찰 (범위 외)
- `auth_middleware.py:33` 하드코딩 JWT_SECRET_KEY(기존 이슈) — 환경변수 이관 별도 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA8StbAbDyfjin6U8Wdwiy