### PR TITLE
test(usage): ClaudeUsageDashboard 테스트 격리 누수 수정 (재적용)

### DIFF
--- a/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react'
 import { ClaudeUsageDashboard } from '../ClaudeUsageDashboard'
 import type { ClaudeUsageResponse } from '../../../types/claudeUsage'
 
@@ -192,13 +192,18 @@ describe('ClaudeUsageDashboard', () => {
   it('shows ChatGPT Codex subscription remaining limits', async () => {
     mockUsage = makeUsageResponse({ weeklyTotalTokens: 200000 })
 
-    render(<ClaudeUsageDashboard />)
+    const { container } = render(<ClaudeUsageDashboard />)
+    const utils = within(container)
 
-    expect(await screen.findByText('Codex 5h')).toBeInTheDocument()
-    expect(screen.getByText('Codex Weekly')).toBeInTheDocument()
-    expect(screen.getByText('44% left')).toBeInTheDocument()
-    expect(screen.getByText('60% left')).toBeInTheDocument()
-    expect(screen.getByText('Codex reset credits: 1')).toBeInTheDocument()
+    // "Codex reset credits" renders only after the codex-plan fetch resolves,
+    // so awaiting it guarantees the async plan data has settled before we assert.
+    // Scoping to this render's container keeps the query immune to any dashboard
+    // leaked from a prior async test still lingering in document.body.
+    expect(await utils.findByText('Codex reset credits: 1')).toBeInTheDocument()
+    expect(utils.getByText('Codex 5h')).toBeInTheDocument()
+    expect(utils.getByText('Codex Weekly')).toBeInTheDocument()
+    expect(utils.getByText('44% left')).toBeInTheDocument()
+    expect(utils.getByText('60% left')).toBeInTheDocument()
   })
 
   it('shows local codex token usage as diagnostics', async () => {
@@ -222,10 +227,16 @@ describe('ClaudeUsageDashboard', () => {
       })
     })
 
-    render(<ClaudeUsageDashboard />)
+    const { container } = render(<ClaudeUsageDashboard />)
+    const utils = within(container)
 
-    expect(await screen.findByText('50.0K')).toBeInTheDocument()
-    expect(screen.getByText('Codex')).toBeInTheDocument()
+    // The diagnostic grid shows the codex weekly tokens (50000 → "50.0K") only
+    // after the codex-CLI fetch resolves. Opus is 50.0K by default, so once the
+    // codex value lands there are exactly two "50.0K" cells — waiting for that
+    // both settles the async fetch (no bleed into the next test) and verifies the
+    // codex diagnostic value. within(container) keeps it scoped to this render.
+    await waitFor(() => expect(utils.getAllByText('50.0K')).toHaveLength(2))
+    expect(utils.getByText('Codex')).toBeInTheDocument()
   })
 
   it('bypasses codex plan cache when refresh is clicked', async () => {


### PR DESCRIPTION
## 재적용 안내
PR #172로 머지됐으나, 동시 작업 세션의 force-push로 추정되는 이유로 머지 커밋이 origin/main에서 사라졌다(현재 main HEAD는 다른 세션의 uv.lock 커밋). 검증 완료된 동일 변경을 재적용한다.

## 근본 원인 (동일)
Dependabot minor/patch 범프 후 `ClaudeUsageDashboard.test.tsx`의 async codex 테스트가 정착되지 않은 fetch를 남긴 채 종료 → 다음 테스트까지 대시보드 DOM 누수 → `getByText('Codex')`가 여러 벌 매칭. CI에서 고확률 flaky(2회 실패 관측, 이후 우연히 green).

## 수정 (테스트 파일만, 제품/의존성 무변경)
- `screen`(전역) → `within(render container)` 스코핑: 렌더 밖 누수 대시보드에 **구조적으로** 면역
- 약한 settlement(`Codex 5h`, 양쪽 브랜치 렌더) → fetch 이후에만 나타나는 `Codex reset credits` await
- test 204는 `waitFor(2x '50.0K')`로 codex-CLI fetch 정착 + codex 진단값 검증

## 검증
- 원 변경은 PR #172에서 Codex 리뷰 clean + 전체 CI green 통과함(byte-identical)
- 로컬 vitest 15/15, tsc/eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsJ99e9xb1ZWkBG2F74fh6