### PR TITLE
fix(auth): v1 agent-registry JWT 시크릿 하드코딩 제거 (3단계 폴백)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,11 @@ LLM_USAGE_PREFLIGHT_QUOTA_ENABLED=false
 # Manual: python -c "import secrets; print(secrets.token_hex(32))"
 SESSION_SECRET_KEY=
 
+# Agent Registry (v1) JWT signing key — separate from SESSION_SECRET_KEY.
+# Unset: falls back to a stable key derived from SESSION_SECRET_KEY (safe across
+# workers); if that is also unset, an ephemeral random key is used (dev/CI only).
+# AGENT_REGISTRY_JWT_SECRET=
+
 # First-admin bootstrap: comma-separated emails granted admin role.
 # OAuth users are promoted on first login; email/password users on their
 # next login after registering (see docs/self-host-quickstart.md).

--- a/src/backend/api/v1/auth_middleware.py
+++ b/src/backend/api/v1/auth_middleware.py
@@ -12,8 +12,11 @@ Security features:
 - Constant-time password comparison to prevent timing attacks
 """
 
+import hashlib
 import hmac
 import logging
+import os
+import secrets
 import time
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -30,7 +33,21 @@ logger = logging.getLogger(__name__)
 # Configuration
 # ─────────────────────────────────────────────────────────────
 
-JWT_SECRET_KEY = "agent-registry-secret-key-change-in-production"
+_env_secret = os.getenv("AGENT_REGISTRY_JWT_SECRET", "")
+if _env_secret:
+    JWT_SECRET_KEY = _env_secret
+else:
+    _session_secret = os.getenv("SESSION_SECRET_KEY", "")
+    if _session_secret:
+        # 세션 시크릿에서 도메인 분리 파생 — 워커/레플리카 간 안정적이면서
+        # 세션 토큰 서명키와는 다른 키 (토큰 혼동 방지)
+        JWT_SECRET_KEY = hashlib.sha256(f"agent-registry:{_session_secret}".encode()).hexdigest()
+    else:
+        JWT_SECRET_KEY = secrets.token_hex(32)
+        logger.warning(
+            "AGENT_REGISTRY_JWT_SECRET/SESSION_SECRET_KEY not set; using ephemeral "
+            "random key (tokens invalidate on restart; NOT safe for multi-worker)"
+        )
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 REFRESH_TOKEN_EXPIRE_DAYS = 7

--- a/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react'
 import { ClaudeUsageDashboard } from '../ClaudeUsageDashboard'
 import type { ClaudeUsageResponse } from '../../../types/claudeUsage'
 
@@ -192,13 +192,18 @@ describe('ClaudeUsageDashboard', () => {
   it('shows ChatGPT Codex subscription remaining limits', async () => {
     mockUsage = makeUsageResponse({ weeklyTotalTokens: 200000 })
 
-    render(<ClaudeUsageDashboard />)
+    const { container } = render(<ClaudeUsageDashboard />)
+    const utils = within(container)
 
-    expect(await screen.findByText('Codex 5h')).toBeInTheDocument()
-    expect(screen.getByText('Codex Weekly')).toBeInTheDocument()
-    expect(screen.getByText('44% left')).toBeInTheDocument()
-    expect(screen.getByText('60% left')).toBeInTheDocument()
-    expect(screen.getByText('Codex reset credits: 1')).toBeInTheDocument()
+    // "Codex reset credits" renders only after the codex-plan fetch resolves,
+    // so awaiting it guarantees the async plan data has settled before we assert.
+    // Scoping to this render's container keeps the query immune to any dashboard
+    // leaked from a prior async test still lingering in document.body.
+    expect(await utils.findByText('Codex reset credits: 1')).toBeInTheDocument()
+    expect(utils.getByText('Codex 5h')).toBeInTheDocument()
+    expect(utils.getByText('Codex Weekly')).toBeInTheDocument()
+    expect(utils.getByText('44% left')).toBeInTheDocument()
+    expect(utils.getByText('60% left')).toBeInTheDocument()
   })
 
   it('shows local codex token usage as diagnostics', async () => {
@@ -222,10 +227,16 @@ describe('ClaudeUsageDashboard', () => {
       })
     })
 
-    render(<ClaudeUsageDashboard />)
+    const { container } = render(<ClaudeUsageDashboard />)
+    const utils = within(container)
 
-    expect(await screen.findByText('50.0K')).toBeInTheDocument()
-    expect(screen.getByText('Codex')).toBeInTheDocument()
+    // The diagnostic grid shows the codex weekly tokens (50000 → "50.0K") only
+    // after the codex-CLI fetch resolves. Opus is 50.0K by default, so once the
+    // codex value lands there are exactly two "50.0K" cells — waiting for that
+    // both settles the async fetch (no bleed into the next test) and verifies the
+    // codex diagnostic value. within(container) keeps it scoped to this render.
+    await waitFor(() => expect(utils.getAllByText('50.0K')).toHaveLength(2))
+    expect(utils.getByText('Codex')).toBeInTheDocument()
   })
 
   it('bypasses codex plan cache when refresh is clicked', async () => {

--- a/tests/backend/api/test_agent_registry.py
+++ b/tests/backend/api/test_agent_registry.py
@@ -741,3 +741,67 @@ def test_verify_token_wrong_signature_raises_401():
         verify_token(forged_token, expected_type="access")
 
     assert exc_info.value.status_code == 401
+
+
+def test_env_secret_signs_tokens_after_reload(monkeypatch):
+    """Test 39: AGENT_REGISTRY_JWT_SECRET is used to sign tokens after reload."""
+    import importlib
+
+    from api.v1 import auth_middleware
+
+    env_secret = "env-provided-jwt-signing-key-abc123def456xyz789"
+    monkeypatch.setenv("AGENT_REGISTRY_JWT_SECRET", env_secret)
+    try:
+        importlib.reload(auth_middleware)
+
+        # Module constant reflects the env-provided key.
+        assert auth_middleware.JWT_SECRET_KEY == env_secret
+
+        # A token issued by the reloaded module verifies against the env key.
+        token = auth_middleware.create_access_token(
+            "usr_admin_001", "admin", auth_middleware.UserRole.ADMIN
+        )
+        decoded = jwt.decode(
+            token, env_secret, algorithms=[auth_middleware.JWT_ALGORITHM]
+        )
+        assert decoded["sub"] == "usr_admin_001"
+        assert decoded["token_type"] == "access"
+    finally:
+        # Restore original module state to avoid polluting other tests.
+        monkeypatch.delenv("AGENT_REGISTRY_JWT_SECRET", raising=False)
+        importlib.reload(auth_middleware)
+
+
+def test_session_secret_derived_key_after_reload(monkeypatch):
+    """Test 40: SESSION_SECRET_KEY derives a stable JWT key when the dedicated
+    env var is unset (multi-worker safe, distinct from the session key)."""
+    import hashlib
+    import importlib
+
+    from api.v1 import auth_middleware
+
+    session_secret = "session-secret-key-for-derivation-test-000111"
+    monkeypatch.delenv("AGENT_REGISTRY_JWT_SECRET", raising=False)
+    monkeypatch.setenv("SESSION_SECRET_KEY", session_secret)
+    try:
+        importlib.reload(auth_middleware)
+
+        derived = hashlib.sha256(
+            f"agent-registry:{session_secret}".encode()
+        ).hexdigest()
+        # Derived key is stable and NOT the raw session secret (no confusion).
+        assert auth_middleware.JWT_SECRET_KEY == derived
+        assert auth_middleware.JWT_SECRET_KEY != session_secret
+
+        # A token issued by the reloaded module verifies against the derived key.
+        token = auth_middleware.create_access_token(
+            "usr_admin_001", "admin", auth_middleware.UserRole.ADMIN
+        )
+        decoded = jwt.decode(
+            token, derived, algorithms=[auth_middleware.JWT_ALGORITHM]
+        )
+        assert decoded["sub"] == "usr_admin_001"
+    finally:
+        # Restore original module state to avoid polluting other tests.
+        monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+        importlib.reload(auth_middleware)


### PR DESCRIPTION
## 요약
`api/v1/auth_middleware.py`의 JWT 서명키가 리터럴로 하드코딩되어 있어 저장소 열람만으로 유효 토큰 위조가 가능했습니다. env 기반 3단계 폴백으로 교체합니다.

## 설계
1. `AGENT_REGISTRY_JWT_SECRET` — 명시 설정 시 그대로 사용
2. `SESSION_SECRET_KEY` **sha256 도메인 분리 파생** — 배포가 이미 설정하는 세션 시크릿에서 파생하므로 추가 설정 없이 멀티 워커/레플리카 간 안정 (Codex P1 반영). 파생 키 ≠ 세션 서명키라 토큰 혼동 없음
3. 둘 다 없으면 프로세스별 랜덤 + 경고 — dev/CI 무설정 동작, secure-by-default

세션 키 직접 재사용은 의도적으로 배제했습니다 (같은 HS256 키로 두 토큰 체계 서명 시 토큰 혼동 위험).

## 테스트 계획 (로컬 fresh 완료)
- Red-Green: 하드코딩 임시 복원 → 신규 테스트 FAIL, 수정 복원 → PASS
- test_agent_registry.py 40 passed (신규 2종: env 키 반영, 세션 파생 키 검증 — reload+원상복구 패턴)
- ruff 0 / mypy 0 / Codex 리뷰 "JWT configuration change is reasonable" (지적 0건)

## 배포 노트
기존 배포에서 SESSION_SECRET_KEY가 설정돼 있으면 무변경 배포로 안정 동작합니다. 단 **하드코딩 키로 서명된 기존 agent-registry 토큰은 재발급 필요** (의도된 무효화).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA8StbAbDyfjin6U8Wdwiy