### PR TITLE
feat(llm): Claude CLI 실행 프로바이더(claude_cli) 추가 — codex_cli 대칭

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ LLM_USAGE_PREFLIGHT_QUOTA_ENABLED=false
 # CODEX_CLI_ARGS=exec --sandbox read-only --color never
 # CODEX_CLI_TIMEOUT_SECONDS=300
 
+# Claude CLI (Claude subscription-backed runtime, opt-in via profile/entitlement)
+# Run `claude` once and sign in before starting the backend.
+# CLAUDE_CLI_COMMAND=claude
+# CLAUDE_CLI_ARGS=-p --output-format text --permission-mode plan
+# CLAUDE_CLI_TIMEOUT_SECONDS=300
+
 # API fallback credentials (optional, usage-billed, disabled by default)
 # Enable only with an explicit fallback policy; internal usage still records to llm_usage_ledger.
 # OPENAI_API_KEY=your_openai_api_key_here

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -56,7 +56,7 @@ Agent Orchestration System (AOS)은 **LangGraph 기반 멀티 에이전트 오�
 | Runtime | 용도 | 비고 |
 |-----------|------|------|
 | **Codex CLI** | 기본 LLM 실행 | `codex_cli`, ChatGPT CLI 구독 로그인 사용 |
-| **Claude CLI** | Task Analyzer tmux 실행, Warp launch intent | `claude_cli`, 일부 경로 계측 |
+| **Claude CLI** | opt-in LLM 실행 (CLI profile/entitlement 선택 시) | `claude_cli`, Claude CLI 구독 로그인 사용. Task Analyzer tmux/Warp 계측 경로 포함 |
 | **Ollama** | 로컬 모델 실행 | API 과금 없음 |
 | **OpenAI / Anthropic / Google** | fallback 또는 OCR/vision 예외 경로 | `LLM_API_FALLBACK_ENABLED=true`와 entitlement 허용 필요 |
 

--- a/docs/api/llm.md
+++ b/docs/api/llm.md
@@ -117,7 +117,7 @@ CLI-first LLM profile과 user/org entitlement를 조회하고 관리합니다.
 | POST | `/api/llm-access/entitlements` | LLM entitlement 생성 (admin/manager) |
 | PATCH | `/api/llm-access/entitlements/{entitlement_id}` | LLM entitlement 수정 (admin/manager) |
 
-`/me`는 DB에 별도 설정이 없어도 `codex_cli` 기본 profile과 `mode=cli`, `source_scope=all` entitlement를 합성해서 반환합니다. `LLM_API_FALLBACK_ENABLED=false`가 기본이며, API fallback 허용 여부는 response의 `api_fallback_enabled`와 entitlement의 `allow_api_fallback`에 분리되어 표시됩니다.
+`/me`는 DB에 별도 설정이 없어도 `codex_cli` 기본 profile과 `mode=cli`, `source_scope=all` entitlement를 합성해서 반환합니다. `claude_cli`는 이 합성/자동 시딩 대상이 아니며, Settings의 CLI profile 생성 폼(provider 셀렉트)으로 명시적으로 생성해야 실행 경로로 선택됩니다(entitlement 자동 생성 규칙은 provider와 무관하게 동일 적용). `LLM_API_FALLBACK_ENABLED=false`가 기본이며, API fallback 허용 여부는 response의 `api_fallback_enabled`와 entitlement의 `allow_api_fallback`에 분리되어 표시됩니다.
 
 CLI profile은 command, args, working directory, auth status, metadata만 반환하며 CLI 로그인 토큰이나 API key 원문은 반환하지 않습니다. `organization_id`가 있고 `owner_user_id`가 없는 profile은 조직 공용 profile로 취급합니다.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,7 +301,7 @@ container = client.containers.run(
 | Provider | 용도 | 설명 |
 |----------|------|------|
 | **Codex CLI** | 기본 LLM runtime | `codex exec` 셸 호출, ChatGPT 구독 세션 사용 |
-| **Claude CLI** | Task Analyzer/Warp 일부 CLI runtime | tmux transcript 기반 사용량 계측 |
+| **Claude CLI** | opt-in LLM runtime | `claude -p` 셸 호출, Claude 구독 세션 사용. 자동 시딩 없이 명시적 profile/entitlement로만 선택 (Task Analyzer/Warp 사용량 계측 경로 포함) |
 | **Ollama** | 로컬 LLM | API 과금 없는 로컬 모델 실행 |
 | **OpenAI GPT** | fallback/API 예외 경로 | `LLM_API_FALLBACK_ENABLED=true`와 entitlement 허용 필요 |
 | **Google Gemini** | fallback/API 예외 경로 | OCR/vision 등 API가 필요한 예외 경로 |

--- a/docs/architecture/cli-subscription-llm.md
+++ b/docs/architecture/cli-subscription-llm.md
@@ -87,7 +87,7 @@ CLI runtime unavailable
 | Provider | Mode | 1차 범위 | 설명 |
 |---|---|---:|---|
 | `codex_cli` | `cli` | Yes | 기본 LLM runtime. `codex exec` 사용 |
-| `claude_cli` | `cli` | Partial | Task Analyzer tmux 실행과 Warp launch intent 계측 |
+| `claude_cli` | `cli` | Yes | opt-in 실행 runtime. `claude -p` 사용, 명시적 profile/entitlement로만 선택 (Task Analyzer tmux/Warp launch intent 계측 포함) |
 | `warp_ai` | `cli` | Tool only | Warp CLI `agent run` 도구 실행. ChatGPT/Claude CLI subscription과 분리 |
 | `ollama` | `local` | Existing | 로컬 runtime. API 과금 없음 |
 | `openai` | `api` | Fallback only | emergency / compatibility |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -303,7 +303,7 @@ import { cn } from '@/lib/utils';
 | `UsageProgressBar` | 사용량 진행바 |
 | `ClaudeUsageDashboard` | Claude 사용량 대시보드 (Codex 5시간/주간 한도 카드 + combined weekly tokens 통합) |
 | `DailyCostTrend` | 일간 비용 추이 차트 |
-| `LLMAccessSettings` | CLI profile, entitlement, API fallback 정책 설정 |
+| `LLMAccessSettings` | CLI profile, entitlement, API fallback 정책 설정 (profile 생성 폼 provider 셀렉트: Codex CLI 기본·Claude CLI, 전환 시 command/args 프리필 리셋) |
 | `LLMAccountsSettings` | Advanced fallback/compatibility API 키 설정 |
 | `AdminKeyManager` | provider billing reconciliation key 관리 |
 | `MemberUsageTable` | 멤버별 사용량 테이블 |

--- a/docs/features.md
+++ b/docs/features.md
@@ -38,7 +38,7 @@ TOOL_RISK_CONFIG = {
 class LLMModelConfig(BaseModel):
     id: str              # "claude-sonnet-4-6"
     display_name: str    # "Claude Sonnet 4"
-    provider: LLMProvider  # codex_cli, anthropic, google, openai, ollama
+    provider: LLMProvider  # codex_cli, claude_cli, anthropic, google, openai, ollama
     context_window: int  # Max context window size
     input_price: float   # USD per 1K tokens
     output_price: float  # USD per 1K tokens
@@ -1571,3 +1571,20 @@ Settings의 `ModelManagementPanel`(admin 전용)에서 LLM 모델을 provider별
 **Dashboard UI**: `ModelManagementPanel` — provider별 그룹, Enable/Disable·Set default 토글, 비활성·비-default 행만 하드 삭제(confirm 2단계), disabled 모델 기본 숨김 토글. URL은 `useSettingsStore.backendUrl` 기준 (런타임 백엔드 변경 반영)
 
 **DB**: `llm_model_suppressions` (마이그레이션 `a7d3f1b9c2e4`)
+
+---
+
+## 58. Claude CLI 실행 프로바이더
+
+Claude 구독(CLI 로그인) 세션으로 LLM 호출을 실행하는 opt-in 런타임 프로바이더. `codex_cli`와 대칭인 로컬 CLI 어댑터로, API 과금 없이 `claude -p`(print 모드)를 셸 호출한다.
+
+**기능**:
+- `services/claude_cli_chat_model.py`: `ClaudeCliChatModel(SimpleChatModel)` — `codex_cli_chat_model.py` 미러. 유일한 구조적 차이는 출력 채널(codex: `--output-last-message` 임시파일 read, claude: **stdout** 직접 read). `stdin=DEVNULL`로 비인터랙티브 강제
+- 레지스트리(`models/llm_models.py`): `claude-cli` 모델 — provider `claude_cli`, $0 구독 가격, context 200K, `supports_tools=False`. CLI라 API 키 불필요, 항상 available
+- 선택 경로: 자동 시딩/`/me` 합성 없음. **명시적 CLI profile + entitlement로만** 선택되며, 모델 미지정 시 resolver는 codex_cli 우선 (codex+claude 동시 보유 시 codex 우선)
+- `bind_tools()` no-op(graceful degradation), `with_structured_output()` → ainvoke-only JSON 어댑터
+- ledger `claude_cli` 행의 CLAUDE_CLI External Usage 카드 집계 제외는 그대로 유지 (카드 source는 `claude_session_snapshots`, 이중집계 방지)
+
+**환경 변수**: `CLAUDE_CLI_COMMAND`(기본 `claude`), `CLAUDE_CLI_ARGS`(기본 `-p --output-format text --permission-mode plan` — codex `--sandbox read-only`에 대응하는 읽기전용 장벽), `CLAUDE_CLI_TIMEOUT_SECONDS`(기본 300). profile의 command/args_json이 아닌 env가 런타임 SSOT (codex 동일)
+
+**Dashboard UI**: `ProfileCreateForm` provider 셀렉트(Codex CLI 기본, 전환 시 command/args 프리필 리셋), `PROVIDER_CONFIG`/`PROVIDER_LABELS`/`PROVIDER_COLORS` 등 provider 맵에 `claude_cli`("Claude CLI", orange) 추가 (`CostMonitor`, `MemberDetailPanel`, `AnalyticsPage`, `ModelManagementPanel`)

--- a/docs/llm-key-systems.md
+++ b/docs/llm-key-systems.md
@@ -28,6 +28,7 @@ AOS에는 **CLI 구독권 기반 런타임 관리**와 목적이 다른 LLM key 
 - **서비스/API**: `services/llm_access_service.py`, `api/llm_access.py`.
 - **UI**: Settings → `LLM Access`(`components/usage/LLMAccessSettings.tsx`, `stores/llmAccess.ts`).
 - **소비**: `services/llm_runtime_resolver.py`가 provider/mode/source별 실행 경로를 결정하고, `services/llm_usage_ledger_service.py`가 사용량을 `llm_usage_ledger`에 기록한다.
+- **실행 프로바이더**: CLI 런타임은 `codex_cli`(기본, 자동 시딩·`/me` 합성 대상)와 `claude_cli`(`services/claude_cli_chat_model.py`, `claude -p` stdout 어댑터) 2종. `claude_cli`는 자동 시딩 없이 **명시적 profile/entitlement로만** 선택되며, 모델 미지정 시 resolver는 codex_cli를 우선한다. env: `CLAUDE_CLI_COMMAND`(기본 `claude`) / `CLAUDE_CLI_ARGS`(기본 `-p --output-format text --permission-mode plan` — codex `--sandbox read-only`에 대응하는 읽기전용 장벽) / `CLAUDE_CLI_TIMEOUT_SECONDS`(기본 300). codex와 동일하게 profile의 command/args_json이 아니라 **env가 런타임 SSOT**다. ledger의 `claude_cli` 행이 CLAUDE_CLI External Usage 카드 집계에서 제외되는 기존 계약(아래 "핵심 함정")은 그대로 유지된다.
 - **정책**: 개인 Docker 배포는 개인 profile을 기본값으로 둘 수 있고, 다중 사용자 배포는 Organization 단위 entitlement와 quota로 분리한다.
 
 ## [1] 런타임 프로바이더 키
@@ -35,7 +36,7 @@ AOS에는 **CLI 구독권 기반 런타임 관리**와 목적이 다른 LLM key 
 AOS의 에이전트/오케스트레이터가 **기본 provider와 예외 fallback**을 결정할 때 사용.
 
 - **설정** (`config.py`): `LLM_PROVIDER`(기본 `codex_cli`, 로컬 우선), `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`, 모델 변수.
-- **소비**: `services/llm_service.py` `create_llm()` → provider별 LangChain 모델(`ChatOpenAI`/`ChatAnthropic`/`ChatGoogleGenerativeAI`/`ChatOllama`/`CodexCliChatModel`) 생성, settings 키 주입. 라우팅/페일오버 `services/llm_router_service.py`.
+- **소비**: `services/llm_service.py` `create_llm()` → provider별 LangChain 모델(`ChatOpenAI`/`ChatAnthropic`/`ChatGoogleGenerativeAI`/`ChatOllama`/`CodexCliChatModel`/`ClaudeCliChatModel`) 생성, settings 키 주입. 라우팅/페일오버 `services/llm_router_service.py`.
 - **범위**: env는 배포 기본값과 fallback 정책을 제공한다. 사용자/조직별 CLI 실행 권한은 `llm_cli_profiles`와 `user_llm_entitlements`가 담당한다.
 
 ## [2] 유저 채팅 프록시 키

--- a/src/backend/models/llm_models.py
+++ b/src/backend/models/llm_models.py
@@ -18,6 +18,7 @@ class LLMProvider(str, Enum):
     GOOGLE = "google"
     OPENAI = "openai"
     CODEX_CLI = "codex_cli"
+    CLAUDE_CLI = "claude_cli"
     OLLAMA = "ollama"
 
 
@@ -252,6 +253,20 @@ _MODELS: list[LLMModelConfig] = [
         id="codex-cli",
         display_name="Codex CLI",
         provider=LLMProvider.CODEX_CLI,
+        context_window=200000,
+        input_price=0.0,
+        output_price=0.0,
+        is_default=True,
+        supports_tools=False,
+        supports_vision=False,
+    ),
+    # ─────────────────────────────────────────────────────────
+    # Claude CLI (Claude subscription-backed local CLI)
+    # ─────────────────────────────────────────────────────────
+    LLMModelConfig(
+        id="claude-cli",
+        display_name="Claude CLI",
+        provider=LLMProvider.CLAUDE_CLI,
         context_window=200000,
         input_price=0.0,
         output_price=0.0,
@@ -648,6 +663,8 @@ class LLMModelRegistry:
             return bool(os.getenv("OPENAI_API_KEY"))
         elif provider == LLMProvider.CODEX_CLI:
             return True
+        elif provider == LLMProvider.CLAUDE_CLI:
+            return True  # CLI subscription runtime is always "available" (local)
         elif provider == LLMProvider.OLLAMA:
             return True  # Ollama is always "available" (local)
         return False

--- a/src/backend/services/claude_cli_chat_model.py
+++ b/src/backend/services/claude_cli_chat_model.py
@@ -1,0 +1,184 @@
+"""LangChain-compatible chat model backed by Claude CLI.
+
+This provider is intended for local subscription-backed Claude usage. It shells
+out to ``claude -p`` (print mode) instead of using Anthropic's usage-billed API.
+Mirrors ``codex_cli_chat_model.py``; the sole structural difference is the output
+channel: ``claude -p`` writes the assistant reply to **stdout** rather than to a
+``--output-last-message`` file.
+"""
+
+import asyncio
+import json
+import os
+import shlex
+import subprocess
+from typing import Any
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import SimpleChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from pydantic import BaseModel, Field
+
+
+def _message_role(message: BaseMessage) -> str:
+    """Map LangChain message types to compact prompt roles."""
+    msg_type = getattr(message, "type", "")
+    if msg_type == "system":
+        return "System"
+    if msg_type == "human":
+        return "User"
+    if msg_type == "ai":
+        return "Assistant"
+    if msg_type == "tool":
+        return "Tool"
+    return msg_type.title() or "Message"
+
+
+def _format_messages(messages: list[BaseMessage]) -> str:
+    """Format a chat transcript into a single Claude CLI prompt."""
+    parts: list[str] = [
+        "You are being used as a chat completion backend for Agent-System.",
+        "Return only the assistant response. Do not modify files or run commands.",
+    ]
+    for message in messages:
+        content = message.content
+        if isinstance(content, list):
+            content = json.dumps(content, ensure_ascii=False)
+        parts.append(f"\n## {_message_role(message)}\n{content}")
+    parts.append("\n## Assistant")
+    return "\n".join(parts)
+
+
+class _StructuredClaudeRunnable:
+    """Minimal structured-output adapter for code paths that call ainvoke()."""
+
+    def __init__(self, llm: "ClaudeCliChatModel", schema: Any):
+        self.llm = llm
+        self.schema = schema
+
+    async def ainvoke(self, messages: list[BaseMessage], *args: Any, **kwargs: Any) -> Any:
+        schema_text = self._schema_text()
+        structured_messages = list(messages)
+        structured_messages.append(
+            AIMessage(
+                content=(
+                    "Return valid JSON only. Do not wrap it in Markdown. "
+                    f"The JSON must match this schema:\n{schema_text}"
+                )
+            )
+        )
+        response = await self.llm.ainvoke(structured_messages, *args, **kwargs)
+        data = self._parse_json(str(response.content))
+        if isinstance(self.schema, type) and issubclass(self.schema, BaseModel):
+            return self.schema(**data)
+        return data
+
+    def _schema_text(self) -> str:
+        if isinstance(self.schema, type) and issubclass(self.schema, BaseModel):
+            return json.dumps(self.schema.model_json_schema(), ensure_ascii=False)
+        return json.dumps(self.schema, ensure_ascii=False)
+
+    @staticmethod
+    def _parse_json(content: str) -> dict[str, Any]:
+        start = content.find("{")
+        end = content.rfind("}") + 1
+        if start < 0 or end <= start:
+            raise ValueError("Claude CLI response did not contain a JSON object")
+        return json.loads(content[start:end])
+
+
+class ClaudeCliChatModel(SimpleChatModel):
+    """Simple chat model that invokes ``claude -p`` locally."""
+
+    model_name: str = "claude-cli"
+    command: str = Field(default_factory=lambda: os.getenv("CLAUDE_CLI_COMMAND", "claude"))
+    args: list[str] = Field(
+        default_factory=lambda: shlex.split(
+            os.getenv(
+                # --permission-mode plan is the read-only hard barrier symmetric
+                # to codex's --sandbox read-only (no writes/commands); operators
+                # may override via CLAUDE_CLI_ARGS.
+                "CLAUDE_CLI_ARGS",
+                "-p --output-format text --permission-mode plan",
+            )
+        )
+    )
+    timeout_seconds: int = Field(
+        default_factory=lambda: int(os.getenv("CLAUDE_CLI_TIMEOUT_SECONDS", "300"))
+    )
+
+    @property
+    def _llm_type(self) -> str:
+        return "claude_cli"
+
+    def bind_tools(self, tools: Any, *args: Any, **kwargs: Any) -> "ClaudeCliChatModel":
+        # Claude CLI does not expose LangChain tool-call messages. Returning self
+        # keeps existing execution paths functional without API tool billing.
+        return self
+
+    def with_structured_output(  # type: ignore[override]
+        self,
+        schema: dict[str, Any] | type,
+        *,
+        include_raw: bool = False,
+        **kwargs: Any,
+    ) -> _StructuredClaudeRunnable:
+        # Intentional override divergence: Claude CLI cannot return a full
+        # LangChain Runnable, so we hand back a minimal ainvoke-only adapter.
+        if include_raw:
+            raise NotImplementedError("Claude CLI structured output does not support include_raw")
+        return _StructuredClaudeRunnable(self, schema)
+
+    def _call(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> str:
+        prompt = _format_messages(messages)
+
+        cmd = [self.command, *self.args, prompt]
+        try:
+            result = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                # Detach stdin so Claude never blocks waiting on interactive input
+                # when invoked from a non-interactive backend (it sees EOF).
+                stdin=subprocess.DEVNULL,
+                timeout=self.timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Claude CLI command not found: {self.command}. Install Claude CLI and sign in."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Claude CLI timed out after {self.timeout_seconds} seconds"
+            ) from exc
+
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+            detail = stderr or stdout or f"exit code {result.returncode}"
+            raise RuntimeError(f"Claude CLI invocation failed: {detail}")
+
+        # claude -p writes the assistant reply to stdout (no output file).
+        return result.stdout.strip()
+
+    async def _acall(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> str:
+        return await asyncio.to_thread(
+            self._call,
+            messages,
+            stop=stop,
+            run_manager=run_manager,
+            **kwargs,
+        )

--- a/src/backend/services/llm_service.py
+++ b/src/backend/services/llm_service.py
@@ -329,6 +329,11 @@ class LLMService:
 
             llm = CodexCliChatModel(model_name=config["model"])
 
+        elif provider == "claude_cli":
+            from services.claude_cli_chat_model import ClaudeCliChatModel
+
+            llm = ClaudeCliChatModel(model_name=config["model"])
+
         elif provider == "ollama":
             from langchain_ollama import ChatOllama
 

--- a/src/dashboard/src/components/CostMonitor.tsx
+++ b/src/dashboard/src/components/CostMonitor.tsx
@@ -208,6 +208,12 @@ const PROVIDER_COLORS: Record<LLMProvider, { bg: string; border: string; text: s
     text: 'text-purple-600 dark:text-purple-400',
     bar: 'bg-purple-500',
   },
+  claude_cli: {
+    bg: 'bg-orange-50 dark:bg-orange-900/20',
+    border: 'border-orange-200 dark:border-orange-800',
+    text: 'text-orange-600 dark:text-orange-400',
+    bar: 'bg-orange-500',
+  },
   unknown: {
     bg: 'bg-gray-50 dark:bg-gray-900/20',
     border: 'border-gray-200 dark:border-gray-700',

--- a/src/dashboard/src/components/llm-router/ModelManagementPanel.tsx
+++ b/src/dashboard/src/components/llm-router/ModelManagementPanel.tsx
@@ -34,6 +34,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   google: 'Google (Gemini)',
   openai: 'OpenAI (GPT)',
   codex_cli: 'Codex CLI',
+  claude_cli: 'Claude CLI',
   ollama: 'Ollama (Local)',
 }
 

--- a/src/dashboard/src/components/organizations/MemberDetailPanel.tsx
+++ b/src/dashboard/src/components/organizations/MemberDetailPanel.tsx
@@ -52,6 +52,7 @@ const PROVIDER_BAR_COLORS: Record<LLMProvider, { bar: string; text: string }> = 
   google: { bar: 'bg-blue-500', text: 'text-blue-600 dark:text-blue-400' },
   openai: { bar: 'bg-purple-500', text: 'text-purple-600 dark:text-purple-400' },
   codex_cli: { bar: 'bg-purple-500', text: 'text-purple-600 dark:text-purple-400' },
+  claude_cli: { bar: 'bg-orange-500', text: 'text-orange-600 dark:text-orange-400' },
   ollama: { bar: 'bg-green-500', text: 'text-green-600 dark:text-green-400' },
   unknown: { bar: 'bg-gray-500', text: 'text-gray-600 dark:text-gray-400' },
 }

--- a/src/dashboard/src/components/usage/__tests__/LLMAccessSettings.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/LLMAccessSettings.test.tsx
@@ -584,6 +584,38 @@ describe('LLMAccessSettings', () => {
     })
   })
 
+  it('creates a Claude CLI profile when the provider select is switched', () => {
+    setMockAccessStoreState({
+      access,
+      isLoading: false,
+      error: null,
+      fetchAccess: mockFetchAccess,
+      updateEntitlement: mockUpdateEntitlement,
+      createProfile: mockCreateProfile,
+      updateProfile: mockUpdateProfile,
+      deleteProfile: mockDeleteProfile,
+      checkProfileHealth: mockCheckProfileHealth,
+    })
+    render(<LLMAccessSettings />)
+
+    // Switching the provider prefills the claude CLI command/args defaults.
+    fireEvent.change(screen.getByLabelText('New CLI profile provider'), {
+      target: { value: 'claude_cli' },
+    })
+    fireEvent.change(screen.getByLabelText('New CLI profile name'), {
+      target: { value: 'Team Claude CLI' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create CLI profile' }))
+
+    expect(mockCreateProfile).toHaveBeenCalledWith({
+      provider: 'claude_cli',
+      profile_name: 'Team Claude CLI',
+      command: 'claude',
+      args_json: ['-p', '--output-format', 'text'],
+      owner_user_id: 'user-1',
+    })
+  })
+
   it('loads organization memberships for managers', () => {
     render(<LLMAccessSettings />)
     expect(mockFetchUserMemberships).toHaveBeenCalledWith('admin-1')

--- a/src/dashboard/src/components/usage/llm-access/LLMAccessContent.tsx
+++ b/src/dashboard/src/components/usage/llm-access/LLMAccessContent.tsx
@@ -70,6 +70,7 @@ function LLMAccessLoadedContent({ model }: { model: LLMAccessSettingsModel }) {
           organizationMemberships={model.organizationMemberships}
           organizationMembers={model.organizationMembers}
           ownerUserId={model.profileForm.ownerUserId}
+          provider={model.profileForm.provider}
           command={model.profileForm.command}
           args={model.profileForm.args}
           workingDirectory={model.profileForm.workingDirectory}
@@ -77,6 +78,7 @@ function LLMAccessLoadedContent({ model }: { model: LLMAccessSettingsModel }) {
           onNameChange={model.profileForm.setName}
           onScopeChange={model.profileForm.setScope}
           onOwnerUserIdChange={model.profileForm.setOwnerUserId}
+          onProviderChange={model.profileForm.setProvider}
           onCommandChange={model.profileForm.setCommand}
           onArgsChange={model.profileForm.setArgs}
           onWorkingDirectoryChange={model.profileForm.setWorkingDirectory}

--- a/src/dashboard/src/components/usage/llm-access/ProfileCreateForm.tsx
+++ b/src/dashboard/src/components/usage/llm-access/ProfileCreateForm.tsx
@@ -2,7 +2,7 @@ import { Plus } from 'lucide-react'
 
 import type { OrganizationMember } from '@/stores/organizations'
 
-import { SANDBOX_PRESETS } from './utils'
+import { CLI_PROVIDER_OPTIONS, SANDBOX_PRESETS } from './utils'
 
 type TextInputFieldProps = {
   label: string
@@ -18,6 +18,7 @@ type ProfileCreateFormProps = {
   organizationMemberships: OrganizationMember[]
   organizationMembers: OrganizationMember[]
   ownerUserId: string
+  provider: string
   command: string
   args: string
   workingDirectory: string
@@ -25,6 +26,7 @@ type ProfileCreateFormProps = {
   onNameChange: (value: string) => void
   onScopeChange: (value: string) => void
   onOwnerUserIdChange: (value: string) => void
+  onProviderChange: (value: string) => void
   onCommandChange: (value: string) => void
   onArgsChange: (value: string) => void
   onWorkingDirectoryChange: (value: string) => void
@@ -51,6 +53,34 @@ function TextInputField({
         onChange={event => onChange(event.target.value)}
         className="mt-1 w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-700 shadow-sm dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
       />
+    </label>
+  )
+}
+
+function ProviderSelect({
+  provider,
+  onProviderChange,
+}: {
+  provider: string
+  onProviderChange: (value: string) => void
+}) {
+  return (
+    <label className="block min-w-0">
+      <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+        Provider
+      </span>
+      <select
+        aria-label="New CLI profile provider"
+        value={provider}
+        onChange={event => onProviderChange(event.target.value)}
+        className="mt-1 w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-700 shadow-sm dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+      >
+        {CLI_PROVIDER_OPTIONS.map(option => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
     </label>
   )
 }
@@ -175,9 +205,11 @@ function ProfileIdentityFields({
   organizationMemberships,
   organizationMembers,
   ownerUserId,
+  provider,
   onNameChange,
   onScopeChange,
   onOwnerUserIdChange,
+  onProviderChange,
 }: Pick<
   ProfileCreateFormProps,
   | 'name'
@@ -185,12 +217,15 @@ function ProfileIdentityFields({
   | 'organizationMemberships'
   | 'organizationMembers'
   | 'ownerUserId'
+  | 'provider'
   | 'onNameChange'
   | 'onScopeChange'
   | 'onOwnerUserIdChange'
+  | 'onProviderChange'
 >) {
   return (
     <>
+      <ProviderSelect provider={provider} onProviderChange={onProviderChange} />
       <TextInputField
         label="Profile name"
         ariaLabel="New CLI profile name"

--- a/src/dashboard/src/components/usage/llm-access/useLLMAccessSettingsModel.ts
+++ b/src/dashboard/src/components/usage/llm-access/useLLMAccessSettingsModel.ts
@@ -24,15 +24,19 @@ import { useSettingsStore, type LLMModel } from '@/stores/settings'
 import {
   buildCLIProfileCreatePayload,
   canManageLLMAccess,
+  CLI_PROVIDER_DEFAULTS,
   DEFAULT_CLI_ARGS,
   DEFAULT_CLI_COMMAND,
   uniqueOrganizationMemberships,
 } from './utils'
 
+const DEFAULT_CLI_PROVIDER = 'codex_cli'
+
 type ProfileFormState = {
   name: string
   scope: string
   ownerUserId: string
+  provider: string
   command: string
   args: string
   workingDirectory: string
@@ -40,6 +44,7 @@ type ProfileFormState = {
   setName: (value: string) => void
   setScope: (value: string) => void
   setOwnerUserId: (value: string) => void
+  setProvider: (value: string) => void
   setCommand: (value: string) => void
   setArgs: (value: string) => void
   setWorkingDirectory: (value: string) => void
@@ -85,15 +90,28 @@ function useProfileFormState(): ProfileFormState {
   const [name, setName] = useState('')
   const [scope, setScope] = useState('personal')
   const [ownerUserId, setOwnerUserId] = useState('shared')
+  const [provider, setProviderState] = useState(DEFAULT_CLI_PROVIDER)
   const [command, setCommand] = useState(DEFAULT_CLI_COMMAND)
   const [args, setArgs] = useState(DEFAULT_CLI_ARGS)
   const [workingDirectory, setWorkingDirectory] = useState('')
   const [sandboxPreset, setSandboxPreset] = useState('none')
 
+  // Switching provider resets command/args to that provider's CLI defaults so a
+  // claude_cli profile can't silently inherit codex's command; still editable after.
+  const setProvider = (value: string) => {
+    setProviderState(value)
+    const defaults = CLI_PROVIDER_DEFAULTS[value]
+    if (defaults) {
+      setCommand(defaults.command)
+      setArgs(defaults.args)
+    }
+  }
+
   return {
     name,
     scope,
     ownerUserId,
+    provider,
     command,
     args,
     workingDirectory,
@@ -101,6 +119,7 @@ function useProfileFormState(): ProfileFormState {
     setName,
     setScope,
     setOwnerUserId,
+    setProvider,
     setCommand,
     setArgs,
     setWorkingDirectory,
@@ -236,12 +255,10 @@ function createProfileFromForm({
   stores,
   profileForm,
   isManager,
-  activeProvider,
 }: {
   stores: StoreBindings
   profileForm: ProfileFormState
   isManager: boolean
-  activeProvider: string
 }) {
   const access = stores.accessStore.access
   const profileName = profileForm.name.trim()
@@ -256,7 +273,7 @@ function createProfileFromForm({
 
   void stores.accessStore.createProfile(
     buildCLIProfileCreatePayload({
-      activeProvider,
+      activeProvider: profileForm.provider,
       profileName,
       command,
       args: profileForm.args,
@@ -275,14 +292,12 @@ function createLLMAccessActions({
   usageScope,
   setUsageScope,
   isManager,
-  activeProvider,
 }: {
   stores: StoreBindings
   profileForm: ProfileFormState
   usageScope: string
   setUsageScope: (scope: string) => void
   isManager: boolean
-  activeProvider: string
 }) {
   return {
     handleRefresh: () => {
@@ -295,7 +310,6 @@ function createLLMAccessActions({
         stores,
         profileForm,
         isManager,
-        activeProvider,
       }),
     handleDefaultModelChange: (modelId: string) => {
       void stores.settingsStore.setDefaultModel(modelId)
@@ -346,7 +360,6 @@ export function useLLMAccessSettingsModel(): LLMAccessSettingsModel {
     usageScope,
     setUsageScope,
     isManager,
-    activeProvider: derivedState.activeProvider,
   })
 
   return {

--- a/src/dashboard/src/components/usage/llm-access/utils.ts
+++ b/src/dashboard/src/components/usage/llm-access/utils.ts
@@ -20,6 +20,21 @@ export const SANDBOX_PRESETS = [
 export const DEFAULT_CLI_COMMAND = 'codex'
 export const DEFAULT_CLI_ARGS = 'exec --color never'
 
+// CLI execution providers selectable when creating a profile. The `value` is the
+// backend enum literal (snake_case) sent verbatim as the profile `provider`.
+export const CLI_PROVIDER_OPTIONS = [
+  { value: 'codex_cli', label: 'Codex CLI' },
+  { value: 'claude_cli', label: 'Claude CLI' },
+] as const
+
+// Per-provider default command/args prefilled into the create form. Mirrors each
+// provider's backend env defaults (CODEX_CLI_* / CLAUDE_CLI_*) so a new profile is
+// coherent with its provider; the user can still override before creating.
+export const CLI_PROVIDER_DEFAULTS: Record<string, { command: string; args: string }> = {
+  codex_cli: { command: DEFAULT_CLI_COMMAND, args: DEFAULT_CLI_ARGS },
+  claude_cli: { command: 'claude', args: '-p --output-format text' },
+}
+
 export type SandboxPreset = (typeof SANDBOX_PRESETS)[number]
 
 export function formatCompactNumber(value: number | null | undefined): string {

--- a/src/dashboard/src/pages/AnalyticsPage.tsx
+++ b/src/dashboard/src/pages/AnalyticsPage.tsx
@@ -224,6 +224,7 @@ const CHART_COLORS = [
 
 const PROVIDER_COLORS: Record<string, string> = {
   codex_cli: '#8B5CF6',
+  claude_cli: '#F59E0B',
   anthropic: '#F97316',
   openai: '#10B981',
   google: '#3B82F6',
@@ -234,6 +235,7 @@ const PROVIDER_COLORS: Record<string, string> = {
 
 const PROVIDER_LABELS: Record<string, string> = {
   codex_cli: 'Codex CLI',
+  claude_cli: 'Claude CLI',
   anthropic: 'Anthropic Claude',
   openai: 'OpenAI',
   google: 'Google Gemini',

--- a/src/dashboard/src/stores/__tests__/llmAccess.test.ts
+++ b/src/dashboard/src/stores/__tests__/llmAccess.test.ts
@@ -153,6 +153,60 @@ describe('llmAccess store', () => {
     expect(useLLMAccessStore.getState().access?.entitlements[1].id).toBe('ent-2')
   })
 
+  it('creates a claude_cli profile and threads the provider through the auto entitlement', async () => {
+    mockGet.mockResolvedValueOnce(accessResponse)
+    await useLLMAccessStore.getState().fetchAccess()
+
+    const createdProfile = {
+      ...accessResponse.profiles[0],
+      id: 'profile-claude',
+      provider: 'claude_cli',
+      profile_name: 'Team Claude CLI',
+      command: 'claude',
+      args_json: ['-p', '--output-format', 'text'],
+      owner_user_id: 'user-1',
+    }
+    const createdEntitlement = {
+      ...accessResponse.entitlements[0],
+      id: 'ent-claude',
+      provider: 'claude_cli',
+      cli_profile_id: 'profile-claude',
+    }
+    mockPost
+      .mockResolvedValueOnce(createdProfile)
+      .mockResolvedValueOnce(createdEntitlement)
+
+    await useLLMAccessStore.getState().createProfile({
+      provider: 'claude_cli',
+      profile_name: 'Team Claude CLI',
+      command: 'claude',
+      args_json: ['-p', '--output-format', 'text'],
+      owner_user_id: 'user-1',
+    })
+
+    // The provider literal must reach the backend verbatim on both the profile
+    // create and the derived auto-entitlement (provider-generic store path).
+    expect(mockPost).toHaveBeenCalledWith('/api/llm-access/profiles', {
+      provider: 'claude_cli',
+      profile_name: 'Team Claude CLI',
+      command: 'claude',
+      args_json: ['-p', '--output-format', 'text'],
+      owner_user_id: 'user-1',
+    })
+    expect(mockPost).toHaveBeenCalledWith('/api/llm-access/entitlements', {
+      user_id: 'user-1',
+      organization_id: null,
+      provider: 'claude_cli',
+      mode: 'cli',
+      source_scope: 'all',
+      enabled: true,
+      cli_profile_id: 'profile-claude',
+      allow_api_fallback: false,
+    })
+    expect(useLLMAccessStore.getState().access?.profiles[1].provider).toBe('claude_cli')
+    expect(useLLMAccessStore.getState().access?.entitlements[1].provider).toBe('claude_cli')
+  })
+
   it('does not auto-create an entitlement when a persisted match already exists', async () => {
     const accessWithPersistedEntitlement = {
       ...accessResponse,

--- a/src/dashboard/src/stores/__tests__/orchestration.test.ts
+++ b/src/dashboard/src/stores/__tests__/orchestration.test.ts
@@ -113,6 +113,11 @@ describe('orchestration store', () => {
       expect(identifyProvider('Claude-3.5-Haiku')).toBe('anthropic')
     })
 
+    it('identifies the Claude CLI model without falling through to anthropic', () => {
+      expect(identifyProvider('claude-cli')).toBe('claude_cli')
+      expect(identifyProvider('Claude-CLI')).toBe('claude_cli')
+    })
+
     it('identifies Google models', () => {
       expect(identifyProvider('gemini-pro')).toBe('google')
       expect(identifyProvider('Gemini-1.5-Flash')).toBe('google')
@@ -144,6 +149,8 @@ describe('orchestration store', () => {
       expect(PROVIDER_CONFIG.anthropic).toBeDefined()
       expect(PROVIDER_CONFIG.ollama).toBeDefined()
       expect(PROVIDER_CONFIG.openai).toBeDefined()
+      expect(PROVIDER_CONFIG.codex_cli).toBeDefined()
+      expect(PROVIDER_CONFIG.claude_cli).toBeDefined()
       expect(PROVIDER_CONFIG.unknown).toBeDefined()
     })
 

--- a/src/dashboard/src/stores/__tests__/settings.test.ts
+++ b/src/dashboard/src/stores/__tests__/settings.test.ts
@@ -255,6 +255,7 @@ describe('settings store', () => {
       expect(ids).toContain('claude-haiku-4-5-20251001')
       expect(ids).toContain('gpt-4o-mini')
       expect(ids).toContain('codex-cli')
+      expect(ids).toContain('claude-cli')
       expect(ids).toContain('gemini-3-flash-preview')
 
       // Each injected model is a fully-formed LLMModel; claude-sonnet-5 is the
@@ -286,7 +287,14 @@ describe('settings store', () => {
         .map((m) => m.id)
         .sort()
       expect(defaults).toEqual(
-        ['claude-sonnet-5', 'codex-cli', 'exaone3.5:7.8b', 'gemini-3-flash-preview', 'gpt-4o-mini'].sort()
+        [
+          'claude-cli',
+          'claude-sonnet-5',
+          'codex-cli',
+          'exaone3.5:7.8b',
+          'gemini-3-flash-preview',
+          'gpt-4o-mini',
+        ].sort()
       )
     })
 
@@ -552,6 +560,10 @@ describe('fallback models via store actions (after fetch failure)', () => {
 
   it('returns codex cli fallback models', () => {
     expect(idsFor('codex_cli')).toContain('codex-cli')
+  })
+
+  it('returns claude cli fallback models', () => {
+    expect(idsFor('claude_cli')).toContain('claude-cli')
   })
 
   it('returns google/gemini fallback models', () => {

--- a/src/dashboard/src/stores/orchestration/types.ts
+++ b/src/dashboard/src/stores/orchestration/types.ts
@@ -93,7 +93,7 @@ export interface TokenUsage {
 }
 
 // Provider identification
-export type LLMProvider = 'google' | 'anthropic' | 'ollama' | 'openai' | 'codex_cli' | 'unknown'
+export type LLMProvider = 'google' | 'anthropic' | 'ollama' | 'openai' | 'codex_cli' | 'claude_cli' | 'unknown'
 
 export interface ProviderUsage {
   provider: LLMProvider
@@ -112,12 +112,17 @@ export const PROVIDER_CONFIG: Record<LLMProvider, { displayName: string; color: 
   ollama: { displayName: 'Ollama (Local)', color: 'green', icon: '🟢' },
   openai: { displayName: 'OpenAI GPT', color: 'purple', icon: '🟣' },
   codex_cli: { displayName: 'Codex CLI', color: 'purple', icon: '🟣' },
+  claude_cli: { displayName: 'Claude CLI', color: 'orange', icon: '🟠' },
   unknown: { displayName: 'Unknown', color: 'gray', icon: '⚪' },
 }
 
 // Helper function to identify provider from model name
 export function identifyProvider(model: string): LLMProvider {
   const modelLower = model.toLowerCase()
+
+  // Claude CLI model (must precede the generic `claude` check, which would
+  // otherwise swallow "claude-cli" into anthropic)
+  if (modelLower.includes('claude-cli')) return 'claude_cli'
 
   // Anthropic models
   if (modelLower.includes('claude')) return 'anthropic'

--- a/src/dashboard/src/stores/settings.ts
+++ b/src/dashboard/src/stores/settings.ts
@@ -3,7 +3,7 @@ import { persist } from 'zustand/middleware'
 import { apiClient } from '../services/apiClient'
 
 export type Theme = 'light' | 'dark' | 'system'
-export type LLMProvider = 'anthropic' | 'openai' | 'google' | 'codex_cli' | 'local'
+export type LLMProvider = 'anthropic' | 'openai' | 'google' | 'codex_cli' | 'claude_cli' | 'local'
 
 export type TerminalType = 'warp' | 'tmux' | 'terminal_app' | 'iterm2' | 'kitty' | 'alacritty' | 'ghostty' | 'wezterm' | 'cmux'
 
@@ -103,6 +103,7 @@ const fallbackModels: Record<LLMProvider, string[]> = {
   google: ['gemini-3-flash-preview', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
   openai: ['gpt-4o-mini', 'gpt-4o', 'o3', 'o4-mini'],
   codex_cli: ['codex-cli'],
+  claude_cli: ['claude-cli'],
   local: ['exaone3.5:7.8b', 'llama3:8b', 'mistral:7b', 'codellama:7b'],
 }
 
@@ -113,6 +114,7 @@ const fallbackDefaultModelIds: ReadonlySet<string> = new Set([
   'gemini-3-flash-preview', // google
   'gpt-4o-mini', // openai
   'codex-cli', // codex_cli
+  'claude-cli', // claude_cli
   'exaone3.5:7.8b', // local (ollama)
 ])
 

--- a/tests/backend/test_claude_cli_chat_model.py
+++ b/tests/backend/test_claude_cli_chat_model.py
@@ -1,0 +1,228 @@
+"""Unit tests for ClaudeCliChatModel.
+
+The Claude CLI binary is never invoked: ``subprocess.run`` is mocked. Unlike
+Codex (which writes to a ``--output-last-message`` file), ``claude -p`` returns
+its answer on **stdout**, so the mock supplies stdout directly and the full
+format→run→read→parse path is exercised without the real CLI.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from pydantic import BaseModel
+
+from services.claude_cli_chat_model import (
+    ClaudeCliChatModel,
+    _format_messages,
+    _message_role,
+)
+
+MODULE = "services.claude_cli_chat_model"
+
+
+def _run_side_effect(*, returncode: int = 0, stdout: str = "", stderr: str = ""):
+    """Build a subprocess.run replacement that emulates Claude CLI behaviour.
+
+    ``claude -p`` prints the assistant reply to stdout, so the mock simply
+    returns the given stdout/stderr/returncode.
+    """
+
+    def _side(cmd, **_kwargs):
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = stdout
+        result.stderr = stderr
+        return result
+
+    return _side
+
+
+def _model() -> ClaudeCliChatModel:
+    return ClaudeCliChatModel()
+
+
+# ── _message_role / _format_messages ─────────────────────────────────────────
+
+
+def test_message_role_maps_known_types() -> None:
+    assert _message_role(SystemMessage(content="x")) == "System"
+    assert _message_role(HumanMessage(content="x")) == "User"
+    assert _message_role(AIMessage(content="x")) == "Assistant"
+
+
+def test_format_messages_includes_roles_and_trailing_assistant() -> None:
+    prompt = _format_messages(
+        [SystemMessage(content="be terse"), HumanMessage(content="hi")]
+    )
+    assert "## System\nbe terse" in prompt
+    assert "## User\nhi" in prompt
+    # Must end by cueing the assistant turn so Claude completes the response.
+    assert prompt.rstrip().endswith("## Assistant")
+
+
+# ── _call: success paths ─────────────────────────────────────────────────────
+
+
+def test_call_reads_answer_from_stdout() -> None:
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=_run_side_effect(stdout="claude answer")):
+        out = _model()._call([HumanMessage(content="q")])
+    assert out == "claude answer"
+
+
+def test_call_strips_stdout_whitespace() -> None:
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=_run_side_effect(stdout="  spaced answer \n")):
+        out = _model()._call([HumanMessage(content="q")])
+    assert out == "spaced answer"
+
+
+def test_call_passes_prompt_as_trailing_argv() -> None:
+    # Contract: `claude -p --output-format text <prompt>` — prompt is the last
+    # positional arg, and the default args flow through verbatim.
+    mock_run = MagicMock(side_effect=_run_side_effect(stdout="ok"))
+    with patch(f"{MODULE}.subprocess.run", mock_run):
+        _model()._call([HumanMessage(content="hello")])
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == "claude"
+    assert cmd[1:3] == ["-p", "--output-format"]
+    assert cmd[3] == "text"
+    # The formatted prompt is the final argv element.
+    assert cmd[-1].rstrip().endswith("## Assistant")
+    assert "hello" in cmd[-1]
+
+
+def test_call_detaches_stdin_to_avoid_interactive_hang() -> None:
+    # Regression: without stdin=DEVNULL, Claude inherits the backend's stdin and
+    # blocks waiting for interactive input, hanging until the timeout fires.
+    import subprocess
+
+    mock_run = MagicMock(side_effect=_run_side_effect(stdout="ok"))
+    with patch(f"{MODULE}.subprocess.run", mock_run):
+        _model()._call([HumanMessage(content="q")])
+
+    assert mock_run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+
+# ── _call: error paths ───────────────────────────────────────────────────────
+
+
+def test_call_raises_on_nonzero_exit() -> None:
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=_run_side_effect(returncode=1, stderr="boom")):
+        with pytest.raises(RuntimeError, match="boom"):
+            _model()._call([HumanMessage(content="q")])
+
+
+def test_call_raises_when_command_not_found() -> None:
+    with patch(f"{MODULE}.subprocess.run", side_effect=FileNotFoundError()):
+        with pytest.raises(RuntimeError, match="not found"):
+            _model()._call([HumanMessage(content="q")])
+
+
+def test_call_raises_on_timeout() -> None:
+    import subprocess
+
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1)):
+        with pytest.raises(RuntimeError, match="timed out"):
+            _model()._call([HumanMessage(content="q")])
+
+
+# ── bind_tools (no-op) ───────────────────────────────────────────────────────
+
+
+def test_bind_tools_returns_self() -> None:
+    model = _model()
+    # Claude CLI cannot emit LangChain tool calls; binding must be a no-op so
+    # consumers that check ``response.tool_calls`` degrade gracefully.
+    assert model.bind_tools([{"name": "noop"}]) is model
+
+
+# ── with_structured_output ───────────────────────────────────────────────────
+
+
+class _Plan(BaseModel):
+    title: str
+    steps: int
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parses_pydantic() -> None:
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=_run_side_effect(stdout='{"title": "x", "steps": 3}')):
+        runnable = _model().with_structured_output(_Plan)
+        result = await runnable.ainvoke([HumanMessage(content="plan it")])
+    assert isinstance(result, _Plan)
+    assert result.title == "x"
+    assert result.steps == 3
+
+
+@pytest.mark.asyncio
+async def test_structured_output_strips_surrounding_markdown() -> None:
+    fenced = "Here you go:\n```json\n{\"title\": \"y\", \"steps\": 1}\n```\nThanks!"
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=_run_side_effect(stdout=fenced)):
+        runnable = _model().with_structured_output(_Plan)
+        result = await runnable.ainvoke([HumanMessage(content="plan it")])
+    assert result == _Plan(title="y", steps=1)
+
+
+@pytest.mark.asyncio
+async def test_structured_output_raises_without_json() -> None:
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=_run_side_effect(stdout="no json here")):
+        runnable = _model().with_structured_output(_Plan)
+        with pytest.raises(ValueError, match="did not contain a JSON object"):
+            await runnable.ainvoke([HumanMessage(content="plan it")])
+
+
+def test_structured_output_include_raw_unsupported() -> None:
+    with pytest.raises(NotImplementedError):
+        _model().with_structured_output(_Plan, include_raw=True)
+
+
+# ── async delegation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_acall_delegates_to_call() -> None:
+    with patch(f"{MODULE}.subprocess.run",
+               side_effect=_run_side_effect(stdout="async answer")):
+        out = await _model()._acall([HumanMessage(content="q")])
+    assert out == "async answer"
+
+
+# ── env configuration (CLAUDE_CLI_* boundary contract) ───────────────────────
+# The defaults are locked by test_call_passes_prompt_as_trailing_argv; these
+# assert the *override* half of the contract — a renamed/dropped env var would
+# otherwise silently ignore operator config without any failing test.
+
+
+def test_command_and_args_read_from_env(monkeypatch) -> None:
+    # default_factory reads env at instantiation, so set env BEFORE constructing.
+    monkeypatch.setenv("CLAUDE_CLI_COMMAND", "claude-custom")
+    monkeypatch.setenv("CLAUDE_CLI_ARGS", "-p --output-format json --verbose")
+
+    mock_run = MagicMock(side_effect=_run_side_effect(stdout="ok"))
+    with patch(f"{MODULE}.subprocess.run", mock_run):
+        ClaudeCliChatModel()._call([HumanMessage(content="q")])
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == "claude-custom"
+    # CLAUDE_CLI_ARGS is shlex-split and flows through verbatim before the prompt.
+    assert cmd[1:5] == ["-p", "--output-format", "json", "--verbose"]
+    assert cmd[-1].rstrip().endswith("## Assistant")
+
+
+def test_timeout_read_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("CLAUDE_CLI_TIMEOUT_SECONDS", "42")
+
+    mock_run = MagicMock(side_effect=_run_side_effect(stdout="ok"))
+    with patch(f"{MODULE}.subprocess.run", mock_run):
+        ClaudeCliChatModel()._call([HumanMessage(content="q")])
+
+    # The env-configured timeout must reach subprocess.run, not the 300s default.
+    assert mock_run.call_args.kwargs["timeout"] == 42

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -50,6 +50,41 @@ class TestSonnet5RegistryEntry:
 
 
 # ─────────────────────────────────────────────────────────────
+# (a2) claude-cli exists (codex_cli-symmetric subscription runtime)
+# ─────────────────────────────────────────────────────────────
+
+
+class TestClaudeCliRegistryEntry:
+    def test_claude_cli_exists_with_expected_spec(self):
+        model = LLMModelRegistry.get_by_id("claude-cli")
+        assert model is not None
+        assert model.display_name == "Claude CLI"
+        assert model.provider == LLMProvider.CLAUDE_CLI
+        assert model.context_window == 200_000
+        assert model.input_price == 0.0  # $0 subscription-backed runtime
+        assert model.output_price == 0.0
+        assert model.supports_tools is False  # CLI cannot emit LangChain tool calls
+        assert model.supports_vision is False
+        assert model.is_enabled is True
+
+    def test_claude_cli_is_provider_default(self):
+        # Only model under the claude_cli provider → it is the provider default.
+        assert LLMModelRegistry.get_default("claude_cli") == "claude-cli"
+
+    def test_claude_cli_provider_has_exactly_one_code_default(self):
+        defaults = [
+            m.id
+            for m in _MODELS
+            if m.provider == LLMProvider.CLAUDE_CLI and m.is_default
+        ]
+        assert defaults == ["claude-cli"]
+
+    def test_claude_cli_is_always_available(self):
+        # CLI subscription runtime needs no API key → always available (like codex_cli).
+        assert LLMModelRegistry.is_available("claude-cli") is True
+
+
+# ─────────────────────────────────────────────────────────────
 # (b) sync_to_db dual-default guard
 # ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 요약
"LLM Access는 codex만 가능한가?"에 대한 확장: Claude 구독 CLI를 **opt-in 실행 프로바이더**로 추가합니다. 명시적 profile/entitlement로만 선택되며(자동 시딩 없음), codex 폴백 등 기존 기본 동작은 불변입니다.

## 설계 핵심
| 결정 | 내용 |
|------|------|
| provider 문자열 | `claude_cli` — ledger 행의 external usage 집계 제외(PR #151 이중집계 방지 계약)가 그대로 방어선이 되어 스냅샷 수집과 충돌 없음 |
| 실행 | `claude -p --output-format text --permission-mode plan` (stdout 소비, stdin=DEVNULL). `--permission-mode plan`은 codex `--sandbox read-only`와 대칭인 하드 배리어 (보안 리뷰 반영) |
| 불변 | resolver의 codex 폴백, codex 자동 시딩, 가격표($0 구독), config 기본값 |
| 프론트 | Create CLI profile 폼에 provider 셀렉트 신설 (기존 폼은 provider 지정 불가로 claude 프로파일 생성 불가였음) |

## 검증 (하네스 전 Phase 통과)
- integration-qa **9/9 PASS** — 경계면 리터럴/모델 미러/entitlement 체인/env SSOT(codex 선례 동일) 
- 게이트: ruff 0 · mypy 0(253파일) · **pytest 1303 passed** · tsc 0 · eslint 0 · **vitest 4298 passed** · build 성공
- 코드 리뷰 APPROVE (CRITICAL~MEDIUM 0, LOW 4는 codex 대칭·비차단) · 보안 리뷰 CRITICAL/HIGH 0
- 문서 7종 동기화: features.md **58번 신설**, "Claude CLI=계측 전용" 상태 표 모순 3곳(architecture/cli-subscription-llm/USER_GUIDE) 수정

## Codex 최종 리뷰 판단
P2 1건(claude 바이너리 부재 시에도 모델 available) — **기각**: codex_cli도 동일한 기존 설계로, CLI 프로바이더의 모델 available은 "API 키 불필요" 의미이며 바이너리 상태는 LLM Access health probe 담당. 둘을 함께 바꾸는 것은 기존 codex API 동작 변경이라 별도 설계 과제로 기록.

## 사용법
Settings → LLM Access → Create CLI profile에서 Provider=Claude CLI 선택 → 생성 시 entitlement 자동 구성 → claude-cli 모델로 라우팅. 사전에 호스트에서 `claude` 로그인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA8StbAbDyfjin6U8Wdwiy