### PR TITLE
ci(deps): Dependabot에서 typescript를 eslint 그룹으로 이동 — typescript-eslint 동반 범프

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
           - "eslint-plugin-*"
           - "typescript-eslint"
           - "@typescript-eslint/*"
+          # typescript-eslint peer 상한(예: <6.1.0)에 묶여 있어 단독 범프 시 ERESOLVE로
+          # npm ci가 깨짐(PR #169). typescript-eslint와 같은 그룹에서 동반 범프한다.
+          - "typescript"
       testing:
         patterns:
           - "@testing-library/*"


### PR DESCRIPTION
## 요약
- `typescript`를 Dependabot `eslint` 그룹 패턴에 추가 (typescript-eslint와 동반 범프)

## 배경
PR #169에서 typescript 단독 6.0.3→7.0.2 범프가 typescript-eslint@8.63.0의 peer 상한(`>=4.8.4 <6.1.0`)과 충돌, `npm ci`가 ERESOLVE로 실패해 Frontend Lint/Type Check/Tests/Build 4개 잡이 설치 단계에서 전멸했다. 7.x는 `@dependabot ignore this major version`으로 보류됐지만, **TS 6.1 minor** 범프도 같은 상한에 걸려 `minor-and-patch` catch-all 그룹 PR을 통째로 깨뜨릴 수 있다.

## 효과
- 그룹 정의 순서상 `eslint`가 `minor-and-patch`보다 앞이므로 typescript는 이제 eslint 그룹에 배정됨 (Dependabot은 첫 매칭 그룹 우선)
- typescript와 typescript-eslint가 한 PR에서 함께 범프 → peer 범위 확장판과 동기화
- 둘 중 하나만 준비된 시점엔 eslint 그룹 PR만 실패하고, 다른 무해한 업데이트는 연좌되지 않음

## 검증
- PyYAML 파싱 OK, 그룹 순서/패턴 확인 (`"typescript"`는 정확 매치 — typescript-eslint 미포함)
- Codex 리뷰 통과 (지적사항 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHgEFY1rxS1gPQLwsbM7go