### PR TITLE
fix(test): MCP 배치 호출 타이밍 의존 flaky 테스트 제거

### DIFF
--- a/tests/backend/test_mcp_manager.py
+++ b/tests/backend/test_mcp_manager.py
@@ -393,7 +393,9 @@ class TestMCPManagerBatchCall:
         assert len(result.results) == 2
         # 두 번째는 서버가 없어서 실패
         assert result.results[1].success is False
-        assert result.total_execution_time_ms > 0
+        # 두 호출 모두 실패(가짜 command라 mock-server1도 시작 실패) — 결정론적 검증.
+        # total_execution_time_ms 는 1ms 미만이면 0으로 절삭되어 타이밍 의존 flaky 유발.
+        assert result.failure_count == 2
 
     @pytest.mark.asyncio
     async def test_call_tools_batch_respects_max_concurrent(self):


### PR DESCRIPTION
## 요약

CI를 깨뜨린 **타이밍 의존 flaky 테스트** 한 건을 결정론적 단언으로 교체합니다. `tests/backend/test_mcp_manager.py` 1줄 변경, 소스 코드는 손대지 않습니다.

## 근본 원인

`test_call_tools_batch_mixed_results`가 `assert result.total_execution_time_ms > 0`을 단언했으나, 이 값은 `mcp_manager.py`에서 `int((time.time() - start_time) * 1000)`로 **벽시계 시간을 ms로 절삭**합니다.

이 배치는 두 호출 모두 즉시 실패합니다:
- `mock-server1`: `command="mock"`(가짜 명령)이라 `subprocess.Popen`이 `FileNotFoundError` → "Failed to start server"
- `nonexistent`: 딕셔너리 조회 실패 → "Server not found"

Python 3.11 Linux의 `subprocess`는 단순 케이스에서 `posix_spawn`/`vfork`를 사용해 실패 exec가 서브밀리초로 끝납니다. 빠른 CI 러너에서 배치 전체가 1ms 미만 → `int(...)`가 `0`으로 절삭 → `assert 0 > 0` 실패.

## 변경

소스는 정직합니다(1ms 미만 작업의 `0ms`는 올바른 측정값). 버그는 `0`을 배제한 테스트 단언 쪽입니다. `>= 0`은 `int`라 구조상 항상 참이라 무의미하므로, **타이밍 비의존 결정론적 단언**으로 교체했습니다:

```python
-        assert result.total_execution_time_ms > 0
+        # 두 호출 모두 실패(가짜 command라 mock-server1도 시작 실패) — 결정론적 검증.
+        # total_execution_time_ms 는 1ms 미만이면 0으로 절삭되어 타이밍 의존 flaky 유발.
+        assert result.failure_count == 2
```

CI 실패 출력이 이미 `success_count=0, failure_count=2`를 보여주므로 이 값은 추측이 아니라 검증된 값입니다.

## 테스트 계획

- `pytest tests/backend/test_mcp_manager.py` → **26 passed** (fresh 실행)
- 새 단언은 타이밍 비의존이라 결정론적 — 빠른/느린 러너 무관하게 안정적

## 참고 (범위 밖)

- 이 테스트는 이름("mixed")과 달리 성공 경로를 실제로 검증하지 않습니다(`command="mock"`이 항상 시작 실패). 진짜 mixed로 만들려면 성공 서버 mock이 필요하나, Surgical-Changes 원칙상 이번 PR 범위에서 제외.
- 동일 패턴 1건 더 존재: `test_integration_automation.py:310`의 `assert result.total_duration_ms > 0`(현재 실패 아님, 미수정). 필요 시 별도 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETzF9B18pZrtP9zQSfb8JK
