### PR TITLE
fix(usage): Codex 사용량 창을 windowDurationMins 기준 자동 라벨링

### DIFF
--- a/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
+++ b/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
@@ -209,8 +209,11 @@ export function ClaudeUsageDashboard() {
   const sonnetLimit = usage.planLimits.find(l => l.name === 'sevenDaySonnet')
   const opusLimit = usage.planLimits.find(l => l.name === 'sevenDayOpus')
   const codexLimit = codexPlan?.available ? codexPlan.codexLimit : null
-  const codexFiveHourLimit = codexLimit?.primary ?? null
-  const codexWeeklyLimit = codexLimit?.secondary ?? null
+  // Codex 사용량 창은 슬롯 위치(primary/secondary)가 아니라 창 길이(windowDurationMins)로 라벨을 정한다.
+  // OpenAI가 5시간창을 제거하면서 앱서버가 주간창 하나만 primary 슬롯에 반환하는 등 슬롯 매핑이 유동적이기 때문.
+  const codexWindows = [codexLimit?.primary, codexLimit?.secondary].filter(
+    (window): window is CodexPlanWindow => window != null,
+  )
   const codexWeeklyTokens = codexUsage?.weeklyTokens ?? 0
   const combinedWeeklyTokens = usage.weeklyTotalTokens + codexWeeklyTokens
   const secondaryLimits = [sonnetLimit, opusLimit].filter(Boolean) as PlanLimitInfo[]
@@ -329,37 +332,21 @@ export function ClaudeUsageDashboard() {
                 tone={getLimitTone(allModelsLimit.utilization)}
               />
             )}
-            {codexFiveHourLimit ? (
-              <UsageRadialMetric
-                label="Codex 5h"
-                value={`${Math.round(codexFiveHourLimit.remainingPercent)}% left`}
-                detail={formatCodexPlanDetail(codexFiveHourLimit, codexLimit?.planType)}
-                percent={codexFiveHourLimit.remainingPercent}
-                tone={getRemainingTone(codexFiveHourLimit.remainingPercent)}
-                centerText={`${Math.round(codexFiveHourLimit.remainingPercent)}%`}
-              />
+            {codexWindows.length > 0 ? (
+              codexWindows.map((window, idx) => (
+                <UsageRadialMetric
+                  key={window.windowDurationMins ?? idx}
+                  label={formatCodexWindowLabel(window)}
+                  value={`${Math.round(window.remainingPercent)}% left`}
+                  detail={formatCodexPlanDetail(window, codexLimit?.planType)}
+                  percent={window.remainingPercent}
+                  tone={getRemainingTone(window.remainingPercent)}
+                  centerText={`${Math.round(window.remainingPercent)}%`}
+                />
+              ))
             ) : (
               <UsageRadialMetric
-                label="Codex 5h"
-                value={isCodexLoading ? '...' : 'Unavailable'}
-                detail={formatCodexPlanUnavailable(codexPlan, isCodexLoading)}
-                percent={0}
-                tone="yellow"
-                centerText={isCodexLoading ? '...' : 'N/A'}
-              />
-            )}
-            {codexWeeklyLimit ? (
-              <UsageRadialMetric
-                label="Codex Weekly"
-                value={`${Math.round(codexWeeklyLimit.remainingPercent)}% left`}
-                detail={formatCodexPlanDetail(codexWeeklyLimit, codexLimit?.planType)}
-                percent={codexWeeklyLimit.remainingPercent}
-                tone={getRemainingTone(codexWeeklyLimit.remainingPercent)}
-                centerText={`${Math.round(codexWeeklyLimit.remainingPercent)}%`}
-              />
-            ) : (
-              <UsageRadialMetric
-                label="Codex Weekly"
+                label="Codex"
                 value={isCodexLoading ? '...' : 'Unavailable'}
                 detail={formatCodexPlanUnavailable(codexPlan, isCodexLoading)}
                 percent={0}
@@ -542,6 +529,19 @@ function getRemainingTone(percentRemaining: number): UsageTone {
   if (percentRemaining <= 10) return 'red'
   if (percentRemaining <= 30) return 'yellow'
   return 'purple'
+}
+
+/**
+ * Codex 사용량 창 라벨을 창 길이(windowDurationMins) 기준으로 결정한다.
+ * 슬롯 위치(primary/secondary)는 OpenAI 정책 변화에 따라 유동적이므로 데이터 속성으로 라벨링한다.
+ * 300분→"Codex 5h", 10080분(7일)→"Codex Weekly", 그 외는 시간/일 단위로 일반화.
+ */
+function formatCodexWindowLabel(window: CodexPlanWindow): string {
+  const mins = window.windowDurationMins
+  if (mins == null) return 'Codex'
+  if (mins === 10080) return 'Codex Weekly'
+  if (mins < 60 * 24) return `Codex ${Math.round(mins / 60)}h`
+  return `Codex ${Math.round(mins / (60 * 24))}d`
 }
 
 function formatCodexPlanDetail(window: CodexPlanWindow, planType?: string | null): string {

--- a/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
@@ -200,10 +200,52 @@ describe('ClaudeUsageDashboard', () => {
     // Scoping to this render's container keeps the query immune to any dashboard
     // leaked from a prior async test still lingering in document.body.
     expect(await utils.findByText('Codex reset credits: 1')).toBeInTheDocument()
+    // primary(300분)→"Codex 5h", secondary(10080분)→"Codex Weekly"로 창 길이 기준 라벨링된다.
     expect(utils.getByText('Codex 5h')).toBeInTheDocument()
     expect(utils.getByText('Codex Weekly')).toBeInTheDocument()
     expect(utils.getByText('44% left')).toBeInTheDocument()
     expect(utils.getByText('60% left')).toBeInTheDocument()
+  })
+
+  it('labels a weekly-only codex window as "Codex Weekly" (5h window removed)', async () => {
+    // Real-world after OpenAI removed the 5-hour window: the app-server returns a
+    // single weekly window (windowDurationMins: 10080) in the *primary* slot and
+    // leaves secondary null. Labeling must follow window duration, not slot position,
+    // so the surviving window renders as "Codex Weekly" — never "Codex 5h".
+    mockUsage = makeUsageResponse({ weeklyTotalTokens: 200000 })
+    mockApiGet.mockImplementation((url: string) => {
+      if (url.includes('/api/usage/codex-plan')) {
+        return Promise.resolve({
+          available: true,
+          codexLimit: {
+            limitId: 'codex',
+            limitName: null,
+            primary: {
+              usedPercent: 75,
+              remainingPercent: 25,
+              windowDurationMins: 10080,
+              resetsAt: 1784488253,
+              resetsAtIso: '2026-07-19T19:10:53+00:00',
+              resetsInMinutes: 7542,
+            },
+            secondary: null,
+            planType: 'plus',
+            rateLimitReachedType: null,
+          },
+          rateLimitResetCredits: { availableCount: 1 },
+          isCached: true,
+          cacheAgeSeconds: 2,
+        })
+      }
+      return Promise.resolve(defaultCodexCli)
+    })
+
+    const { container } = render(<ClaudeUsageDashboard />)
+    const utils = within(container)
+
+    expect(await utils.findByText('Codex Weekly')).toBeInTheDocument()
+    expect(utils.getByText('25% left')).toBeInTheDocument()
+    expect(utils.queryByText('Codex 5h')).not.toBeInTheDocument()
   })
 
   it('shows local codex token usage as diagnostics', async () => {


### PR DESCRIPTION
## 배경 / 문제

OpenAI가 Codex(ChatGPT Plus)의 **5시간 사용량 창을 제거**하면서, 앱서버가 이제 주간창 하나만 `primary` 슬롯에 반환합니다 (`secondary`는 `null`).

기존 UI(`ClaudeUsageDashboard`)는 슬롯 위치에 고정 결합돼 있었습니다:
- `primary` → **"Codex 5h"** 라벨
- `secondary` → **"Codex Weekly"** 라벨

그 결과 라이브 데이터에서:
- 실제 **주간 데이터**(`windowDurationMins: 10080`, 25% 남음)가 "Codex 5h"로 **오라벨**
- `secondary(null)` 카드가 **"Unavailable"** 로 표시 (헤더는 "Codex Cached"인데 카드만 Unavailable → 오해 유발)

## 변경

슬롯 위치가 아니라 각 창의 **`windowDurationMins`(창 길이)로 라벨을 결정**하도록 리팩터링 (positional → semantic coupling 제거).

- `codexWindows = [primary, secondary].filter(non-null)` 로 존재하는 창만 렌더 (null 슬롯은 카드 미생성 → 유령 "Unavailable" 제거)
- `formatCodexWindowLabel()`: `300분 → "Codex 5h"`, `10080분 → "Codex Weekly"`, 그 외 시간/일 단위로 일반화
- **5시간창이 부활해도 코드 수정 없이 자동 대응** (앱서버가 primary=300 + secondary=10080 다시 주면 두 카드 자동 표시)

**화면 변화 (라이브 기준):** `Claude Session · Claude Weekly · Codex Weekly(25% 남음)` 3개 정확 표시, "Unavailable" 유령 카드 제거.

## 테스트 계획 (실행 증거)

- `tsc --noEmit`: 변경 파일 에러 0
- `eslint`: exit 0
- `vitest`: **16 passed** (기존 15 + 회귀 1)
- 회귀 테스트 추가: `primary=주간(10080)/secondary=null` mock → `"Codex Weekly"` 렌더 + `"25% left"` + `queryByText("Codex 5h")` **부재** 단언 (이번 오라벨 버그 재발 방지)
- 라이브 `/api/usage/codex-plan`(HTTP 200)로 `primary.windowDurationMins=10080, secondary=null` 실측 확인

## 범위

- 프론트 표시 로직만 변경. 백엔드 `api/usage.py`의 primary/secondary 파싱은 미변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ty6nrkdKrn8pfNtex4xDM8
