### PR TITLE
refactor(dashboard): LLM Auto-Switch를 LLM Access 컬럼 아래로 이동

### DIFF
--- a/src/dashboard/src/pages/SettingsPage.tsx
+++ b/src/dashboard/src/pages/SettingsPage.tsx
@@ -206,8 +206,10 @@ export function SettingsPage() {
           나머지 카드는 남는 폭에 masonry(Pinterest)로 분산 배치한다. */}
       <div className="flex flex-col lg:flex-row gap-6 items-start">
         {/* LLM Access — 세로로 긴 전용 컬럼 */}
-        <div className="w-full lg:w-1/3 lg:shrink-0">
+        <div className="w-full lg:w-1/3 lg:shrink-0 space-y-6">
           <LLMAccessSettings />
+          {/* LLM Auto-Switch — LLM Access 바로 아래 배치 */}
+          <LLMRouterSettings />
         </div>
 
         {/* 나머지 카드 — 남는 폭에 masonry로 분산 */}
@@ -661,9 +663,6 @@ export function SettingsPage() {
 
         {/* Model Version Updates */}
         <ModelUpdatePanel />
-
-        {/* LLM Auto-Switch — masonry 컬럼 안(세로형)으로 남는 공간을 채운다 */}
-        <LLMRouterSettings />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 설정 화면에서 LLM Auto-Switch(LLMRouterSettings)를 오른쪽 masonry 영역에서 왼쪽 LLM Access 전용 컬럼 바로 아래로 재배치
- 전용 컬럼에 `space-y-6`을 추가해 두 카드 간격을 masonry 카드 간격과 일치

## Test plan
- [ ] CI Dashboard 게이트 (tsc + lint + vitest + build) 통과 확인
- [ ] Settings 페이지에서 LLM Auto-Switch 카드가 LLM Access 아래에 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k6s2h4xJDTdWLCd7598V8