### PR TITLE
feat: Task Analyzer 실행 터미널에 Orca 어댑터 추가

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -312,7 +312,7 @@ import { cn } from '@/lib/utils';
 
 | 컴포넌트 | 설명 |
 |----------|------|
-| `TerminalSelector` | 실행 터미널 선택 (Warp/tmux 토글) |
+| `TerminalSelector` | 실행 터미널 선택 (Warp/tmux/Orca 토글) |
 
 ### Admin Components
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -875,6 +875,7 @@ class TerminalType(str, Enum):
 - `ITermAdapter`, `TerminalAppAdapter`: AppleScript 기반 실행
 - `KittyAdapter`, `AlacrittyAdapter`, `WezTermAdapter`: CLI 기반 실행
 - `GhosttyAdapter`: System Events 키스트로크 기반 실행
+- `OrcaAdapter`: `orca terminal create` CLI 기반 실행 (기존 체크아웃에 터미널 스폰, 미등록 저장소는 `orca repo add` 후 1회 재시도)
 
 ---
 

--- a/src/backend/services/terminal_service.py
+++ b/src/backend/services/terminal_service.py
@@ -697,9 +697,7 @@ async def _run_orca_json(args: list[str]) -> _OrcaResult:
         return _OrcaResult(False, None, str(e))
 
     try:
-        raw_out, raw_err = await asyncio.wait_for(
-            proc.communicate(), timeout=_ORCA_TIMEOUT_SECONDS
-        )
+        raw_out, raw_err = await asyncio.wait_for(proc.communicate(), timeout=_ORCA_TIMEOUT_SECONDS)
     except TimeoutError:
         logger.error("orca command timed out after %ss", _ORCA_TIMEOUT_SECONDS)
         await _terminate_orca_process(proc)

--- a/src/backend/services/terminal_service.py
+++ b/src/backend/services/terminal_service.py
@@ -17,6 +17,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -605,6 +606,20 @@ _ORCA_UNREGISTERED_ERROR_CODES = frozenset(
 )
 
 
+def _resolve_orca_command() -> str:
+    """Return the Orca CLI executable name for this platform.
+
+    On Linux a bare ``orca`` is the GNOME screen reader, not this app, so
+    the IDE ships its CLI as ``orca-ide``. ``ORCA_CLI_COMMAND`` overrides
+    both for non-standard installs. Resolved per call so environment and
+    platform changes are picked up without reimporting.
+    """
+    override = os.getenv("ORCA_CLI_COMMAND")
+    if override:
+        return override
+    return "orca" if sys.platform == "darwin" else "orca-ide"
+
+
 class _OrcaResult(NamedTuple):
     """Outcome of a single ``orca ... --json`` invocation."""
 
@@ -651,6 +666,19 @@ def _parse_orca_payload(stdout: str, stderr: str, returncode: int | None) -> _Or
     return _OrcaResult(False, code, message or f"orca command failed (exit {returncode})")
 
 
+async def _terminate_orca_process(proc: asyncio.subprocess.Process) -> None:
+    """Kill and reap a child that outlived its timeout.
+
+    Without this the abandoned ``orca`` process keeps running and can
+    create the terminal *after* the API already reported failure.
+    """
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        return  # already exited; nothing to reap
+    await proc.wait()
+
+
 async def _run_orca_json(args: list[str]) -> _OrcaResult:
     """Run an ``orca`` CLI command with ``--json`` and parse its response.
 
@@ -664,14 +692,21 @@ async def _run_orca_json(args: list[str]) -> _OrcaResult:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+    except OSError as e:
+        logger.error("Failed to launch orca: %s", e)
+        return _OrcaResult(False, None, str(e))
+
+    try:
         raw_out, raw_err = await asyncio.wait_for(
             proc.communicate(), timeout=_ORCA_TIMEOUT_SECONDS
         )
     except TimeoutError:
         logger.error("orca command timed out after %ss", _ORCA_TIMEOUT_SECONDS)
+        await _terminate_orca_process(proc)
         return _OrcaResult(False, None, f"orca command timed out after {_ORCA_TIMEOUT_SECONDS}s")
     except OSError as e:
-        logger.error("Failed to launch orca: %s", e)
+        logger.error("orca command failed while reading output: %s", e)
+        await _terminate_orca_process(proc)
         return _OrcaResult(False, None, str(e))
 
     stdout = raw_out.decode().strip() if raw_out else ""
@@ -687,7 +722,7 @@ class OrcaAdapter(TerminalAdapter):
     """
 
     async def is_available(self) -> bool:
-        return shutil.which("orca") is not None
+        return shutil.which(_resolve_orca_command()) is not None
 
     async def execute(
         self,
@@ -699,8 +734,9 @@ class OrcaAdapter(TerminalAdapter):
     ) -> dict:
         exec_script = _write_exec_script(project_path, command, branch_name, image_paths)
 
+        orca_cmd = _resolve_orca_command()
         create_args = [
-            "orca",
+            orca_cmd,
             "terminal",
             "create",
             "--worktree",
@@ -716,7 +752,9 @@ class OrcaAdapter(TerminalAdapter):
 
         # Recover once from an unregistered repo by adding it, then retrying.
         if not result.ok and _is_unregistered_worktree_error(result):
-            added = await _run_orca_json(["orca", "repo", "add", "--path", project_path, "--json"])
+            added = await _run_orca_json(
+                [orca_cmd, "repo", "add", "--path", project_path, "--json"]
+            )
             if added.ok:
                 result = await _run_orca_json(create_args)
             else:

--- a/src/backend/services/terminal_service.py
+++ b/src/backend/services/terminal_service.py
@@ -11,6 +11,7 @@ Other adapters implement terminal-specific execution via AppleScript or CLI.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import shlex
@@ -21,6 +22,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +41,7 @@ class TerminalType(str, Enum):
     GHOSTTY = "ghostty"
     WEZTERM = "wezterm"
     CMUX = "cmux"
+    ORCA = "orca"
 
 
 TERMINAL_INFO: dict[TerminalType, dict[str, str]] = {
@@ -68,6 +71,10 @@ TERMINAL_INFO: dict[TerminalType, dict[str, str]] = {
     TerminalType.CMUX: {
         "name": "cmux",
         "description": "AI-native terminal with workspaces",
+    },
+    TerminalType.ORCA: {
+        "name": "Orca",
+        "description": "AI-native workspace manager",
     },
 }
 
@@ -586,6 +593,151 @@ class CmuxAdapter(TerminalAdapter):
 
 
 # ---------------------------------------------------------------------------
+# Orca CLI helpers
+# ---------------------------------------------------------------------------
+
+_ORCA_TIMEOUT_SECONDS = 20
+
+# Orca only resolves worktree selectors for repos it has registered. These
+# error codes mean "register the repo first", which is recoverable once.
+_ORCA_UNREGISTERED_ERROR_CODES = frozenset(
+    {"selector_not_found", "worktree_not_found", "repo_not_found"}
+)
+
+
+class _OrcaResult(NamedTuple):
+    """Outcome of a single ``orca ... --json`` invocation."""
+
+    ok: bool
+    code: str | None
+    error: str | None
+
+
+def _is_unregistered_worktree_error(result: _OrcaResult) -> bool:
+    """Return True when the failure means the repo is unknown to Orca."""
+    if result.code in _ORCA_UNREGISTERED_ERROR_CODES:
+        return True
+    text = (result.error or "").lower()
+    return "not found" in text and ("worktree" in text or "repo" in text)
+
+
+def _parse_orca_payload(stdout: str, stderr: str, returncode: int | None) -> _OrcaResult:
+    """Parse an Orca JSON envelope into an ``_OrcaResult``.
+
+    Orca emits ``{"ok": true, "result": {...}}`` on success and
+    ``{"ok": false, "error": {"code": ..., "message": ...}}`` on failure,
+    always on stdout, exiting non-zero for the latter.
+    """
+    if not stdout:
+        detail = stderr or "no output"
+        return _OrcaResult(False, None, f"orca exited with {returncode}: {detail}")
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        logger.error("orca returned non-JSON output (exit %s)", returncode)
+        return _OrcaResult(False, None, f"failed to parse orca JSON response (exit {returncode})")
+
+    if payload.get("ok"):
+        return _OrcaResult(True, None, None)
+
+    error = payload.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        message = error.get("message") or code
+    else:
+        code = None
+        message = str(error) if error else None
+    return _OrcaResult(False, code, message or f"orca command failed (exit {returncode})")
+
+
+async def _run_orca_json(args: list[str]) -> _OrcaResult:
+    """Run an ``orca`` CLI command with ``--json`` and parse its response.
+
+    ``stdin`` is detached: CLIs inheriting uvicorn's stdin have hung or
+    failed with broken pipes in this codebase before.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        raw_out, raw_err = await asyncio.wait_for(
+            proc.communicate(), timeout=_ORCA_TIMEOUT_SECONDS
+        )
+    except TimeoutError:
+        logger.error("orca command timed out after %ss", _ORCA_TIMEOUT_SECONDS)
+        return _OrcaResult(False, None, f"orca command timed out after {_ORCA_TIMEOUT_SECONDS}s")
+    except OSError as e:
+        logger.error("Failed to launch orca: %s", e)
+        return _OrcaResult(False, None, str(e))
+
+    stdout = raw_out.decode().strip() if raw_out else ""
+    stderr = raw_err.decode().strip() if raw_err else ""
+    return _parse_orca_payload(stdout, stderr, proc.returncode)
+
+
+class OrcaAdapter(TerminalAdapter):
+    """Orca workspace manager via its CLI.
+
+    Spawns a terminal session inside the existing checkout with
+    ``orca terminal create``; no new worktree is created.
+    """
+
+    async def is_available(self) -> bool:
+        return shutil.which("orca") is not None
+
+    async def execute(
+        self,
+        project_path: str,
+        command: str,
+        title: str | None = None,
+        branch_name: str | None = None,
+        image_paths: list[str] | None = None,
+    ) -> dict:
+        exec_script = _write_exec_script(project_path, command, branch_name, image_paths)
+
+        create_args = [
+            "orca",
+            "terminal",
+            "create",
+            "--worktree",
+            f"path:{project_path}",
+            "--command",
+            f"bash {exec_script}",
+        ]
+        if title:
+            create_args += ["--title", title]
+        create_args.append("--json")
+
+        result = await _run_orca_json(create_args)
+
+        # Recover once from an unregistered repo by adding it, then retrying.
+        if not result.ok and _is_unregistered_worktree_error(result):
+            added = await _run_orca_json(["orca", "repo", "add", "--path", project_path, "--json"])
+            if added.ok:
+                result = await _run_orca_json(create_args)
+            else:
+                result = added
+
+        if result.ok:
+            return {
+                "success": True,
+                "terminal": TerminalType.ORCA.value,
+                "message": f"Created Orca terminal at {project_path}",
+            }
+
+        logger.error("orca terminal create failed: %s", result.error)
+        return {
+            "success": False,
+            "terminal": TerminalType.ORCA.value,
+            "error": f"Failed to create Orca terminal: {result.error}",
+        }
+
+
+# ---------------------------------------------------------------------------
 # Shared helper for AppleScript-based adapters
 # ---------------------------------------------------------------------------
 
@@ -640,6 +792,7 @@ class TerminalService:
             TerminalType.GHOSTTY: GhosttyAdapter(),
             TerminalType.WEZTERM: WezTermAdapter(),
             TerminalType.CMUX: CmuxAdapter(),
+            TerminalType.ORCA: OrcaAdapter(),
         }
 
     def get_adapter(self, terminal: TerminalType) -> TerminalAdapter:

--- a/src/dashboard/src/components/TerminalSelector.tsx
+++ b/src/dashboard/src/components/TerminalSelector.tsx
@@ -2,13 +2,13 @@
  * TerminalSelector Component
  *
  * Task Analyzer에서 실행 터미널을 선택하는 세그먼트 토글.
- * Warp / Tmux 중 선택 가능하며, 선택은 localStorage에 영속.
+ * Warp / Tmux / Orca 중 선택 가능하며, 선택은 localStorage에 영속.
  */
 
 import { memo } from 'react'
 import { cn } from '../lib/utils'
 import { useSettingsStore, type TerminalType } from '../stores/settings'
-import { Terminal, SquareTerminal } from 'lucide-react'
+import { Terminal, SquareTerminal, PanelsTopLeft } from 'lucide-react'
 
 interface TerminalOption {
   type: TerminalType
@@ -19,11 +19,13 @@ interface TerminalOption {
 const TERMINAL_OPTIONS: TerminalOption[] = [
   { type: 'warp', label: 'Warp', description: 'Warp 터미널에서 실행' },
   { type: 'tmux', label: 'tmux', description: 'tmux 세션에서 실행' },
+  { type: 'orca', label: 'Orca', description: 'Orca 워크스페이스에서 실행' },
 ]
 
 const ICONS: Record<string, typeof Terminal> = {
   warp: Terminal,
   tmux: SquareTerminal,
+  orca: PanelsTopLeft,
 }
 
 /** 터미널 타입 선택 세그먼트 토글. */

--- a/src/dashboard/src/stores/settings.ts
+++ b/src/dashboard/src/stores/settings.ts
@@ -5,7 +5,7 @@ import { apiClient } from '../services/apiClient'
 export type Theme = 'light' | 'dark' | 'system'
 export type LLMProvider = 'anthropic' | 'openai' | 'google' | 'codex_cli' | 'claude_cli' | 'local'
 
-export type TerminalType = 'warp' | 'tmux' | 'terminal_app' | 'iterm2' | 'kitty' | 'alacritty' | 'ghostty' | 'wezterm' | 'cmux'
+export type TerminalType = 'warp' | 'tmux' | 'terminal_app' | 'iterm2' | 'kitty' | 'alacritty' | 'ghostty' | 'wezterm' | 'cmux' | 'orca'
 
 export const TERMINAL_DISPLAY_NAMES: Record<TerminalType, string> = {
   warp: 'Warp',
@@ -17,6 +17,7 @@ export const TERMINAL_DISPLAY_NAMES: Record<TerminalType, string> = {
   ghostty: 'Ghostty',
   wezterm: 'WezTerm',
   cmux: 'cmux',
+  orca: 'Orca',
 }
 
 export interface NotificationSettings {

--- a/tests/backend/test_terminal_service_orca.py
+++ b/tests/backend/test_terminal_service_orca.py
@@ -1,0 +1,304 @@
+"""Unit tests for OrcaAdapter in terminal_service.
+
+The Orca CLI binary is never invoked: ``asyncio.create_subprocess_exec`` is
+mocked so the full argv-build → run → JSON-parse → recover path is exercised
+without spawning a real terminal in the user's Orca app.
+
+``_write_exec_script`` is also patched so no files are written to ``~/.aos``.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.terminal_service import (
+    OrcaAdapter,
+    TERMINAL_INFO,
+    TerminalService,
+    TerminalType,
+)
+
+MODULE = "services.terminal_service"
+
+FAKE_SCRIPT = Path("/tmp/aos-exec-test.sh")
+PROJECT_PATH = "/Users/tester/Work/demo"
+
+
+def _proc(stdout: str = "", stderr: str = "", returncode: int = 0) -> MagicMock:
+    """Build a mock asyncio subprocess whose communicate() returns given output."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout.encode(), stderr.encode()))
+    return proc
+
+
+def _ok_json() -> str:
+    return json.dumps({"id": "x", "ok": True, "result": {"terminalId": "t-1"}})
+
+
+def _err_json(code: str, message: str | None = None) -> str:
+    return json.dumps(
+        {"id": "x", "ok": False, "error": {"code": code, "message": message or code}}
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_available_true_when_cli_on_path() -> None:
+    with patch(f"{MODULE}.shutil.which", return_value="/usr/local/bin/orca"):
+        assert await OrcaAdapter().is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_is_available_false_when_cli_missing() -> None:
+    with patch(f"{MODULE}.shutil.which", return_value=None):
+        assert await OrcaAdapter().is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# execute: success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_success_builds_expected_argv() -> None:
+    exec_mock = AsyncMock(return_value=_proc(stdout=_ok_json()))
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "do the thing")
+
+    assert result["success"] is True
+    assert result["terminal"] == TerminalType.ORCA.value
+    assert result.get("error") is None
+
+    args, kwargs = exec_mock.call_args
+    assert list(args[:3]) == ["orca", "terminal", "create"]
+    # --worktree / --command values must be single argv elements (no shell quoting)
+    assert args[args.index("--worktree") + 1] == f"path:{PROJECT_PATH}"
+    assert args[args.index("--command") + 1] == f"bash {FAKE_SCRIPT}"
+    assert "--json" in args
+    assert "--title" not in args
+    # stdin must be detached: inherited stdin breaks CLIs under uvicorn.
+    assert kwargs["stdin"] is asyncio.subprocess.DEVNULL
+    assert kwargs["stdout"] is asyncio.subprocess.PIPE
+    assert kwargs["stderr"] is asyncio.subprocess.PIPE
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_title_flag() -> None:
+    exec_mock = AsyncMock(return_value=_proc(stdout=_ok_json()))
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd", title="RUNNER")
+
+    assert result["success"] is True
+    args = exec_mock.call_args[0]
+    assert args[args.index("--title") + 1] == "RUNNER"
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_branch_and_images_to_script_builder() -> None:
+    exec_mock = AsyncMock(return_value=_proc(stdout=_ok_json()))
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT) as script_mock,
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        await OrcaAdapter().execute(
+            PROJECT_PATH, "cmd", branch_name="feat/x", image_paths=["/tmp/a.png"]
+        )
+
+    script_mock.assert_called_once_with(PROJECT_PATH, "cmd", "feat/x", ["/tmp/a.png"])
+
+
+# ---------------------------------------------------------------------------
+# execute: failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_failure_on_error_payload() -> None:
+    exec_mock = AsyncMock(
+        return_value=_proc(stdout=_err_json("runtime_unreachable", "runtime is down"), returncode=1)
+    )
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert result["terminal"] == TerminalType.ORCA.value
+    assert "runtime is down" in result["error"]
+    # non-recoverable error must not trigger a repo-add retry
+    assert exec_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_failure_on_nonzero_exit_without_json() -> None:
+    exec_mock = AsyncMock(return_value=_proc(stdout="", stderr="orca: fatal", returncode=1))
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert "orca: fatal" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_failure_on_unparsable_json() -> None:
+    exec_mock = AsyncMock(return_value=_proc(stdout="not json at all"))
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert "parse" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_failure_on_timeout() -> None:
+    exec_mock = AsyncMock(return_value=_proc(stdout=_ok_json()))
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+        patch(f"{MODULE}.asyncio.wait_for", side_effect=TimeoutError),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert "timed out" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_failure_when_cli_cannot_launch() -> None:
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(
+            f"{MODULE}.asyncio.create_subprocess_exec",
+            MagicMock(side_effect=OSError("no such file")),
+        ),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert "no such file" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# execute: repo-registration recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_registers_repo_and_retries_once() -> None:
+    exec_mock = AsyncMock(
+        side_effect=[
+            _proc(stdout=_err_json("selector_not_found"), returncode=1),  # create #1
+            _proc(stdout=_ok_json()),  # repo add
+            _proc(stdout=_ok_json()),  # create #2
+        ]
+    )
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is True
+    assert exec_mock.await_count == 3
+
+    repo_add_args = exec_mock.await_args_list[1][0]
+    assert list(repo_add_args[:3]) == ["orca", "repo", "add"]
+    assert repo_add_args[repo_add_args.index("--path") + 1] == PROJECT_PATH
+    assert "--json" in repo_add_args
+
+
+@pytest.mark.asyncio
+async def test_execute_retries_only_once_when_second_create_fails() -> None:
+    exec_mock = AsyncMock(
+        side_effect=[
+            _proc(stdout=_err_json("selector_not_found"), returncode=1),
+            _proc(stdout=_ok_json()),
+            _proc(stdout=_err_json("selector_not_found"), returncode=1),
+        ]
+    )
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert exec_mock.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_no_retry_when_repo_add_fails() -> None:
+    exec_mock = AsyncMock(
+        side_effect=[
+            _proc(stdout=_err_json("selector_not_found"), returncode=1),
+            _proc(stdout=_err_json("invalid_path", "path is not a git repo"), returncode=1),
+        ]
+    )
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert exec_mock.await_count == 2
+    assert "path is not a git repo" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_orca_registered_in_service() -> None:
+    adapter = TerminalService().get_adapter(TerminalType.ORCA)
+    assert isinstance(adapter, OrcaAdapter)
+
+
+def test_orca_accepted_by_api_string_coercion() -> None:
+    """POST /api/terminal/execute resolves the raw string via TerminalType()."""
+    assert TerminalType("orca") is TerminalType.ORCA
+
+
+def test_orca_terminal_info_present() -> None:
+    info = TERMINAL_INFO[TerminalType.ORCA]
+    assert info["name"] == "Orca"
+    assert info["description"]
+
+
+@pytest.mark.asyncio
+async def test_detect_available_includes_orca() -> None:
+    results = await TerminalService().detect_available()
+    types = [r["type"] for r in results]
+    assert TerminalType.ORCA.value in types

--- a/tests/backend/test_terminal_service_orca.py
+++ b/tests/backend/test_terminal_service_orca.py
@@ -19,6 +19,7 @@ from services.terminal_service import (
     TERMINAL_INFO,
     TerminalService,
     TerminalType,
+    _resolve_orca_command,
 )
 
 MODULE = "services.terminal_service"
@@ -27,11 +28,22 @@ FAKE_SCRIPT = Path("/tmp/aos-exec-test.sh")
 PROJECT_PATH = "/Users/tester/Work/demo"
 
 
+@pytest.fixture(autouse=True)
+def _pin_orca_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the CLI name so argv assertions hold on macOS and Linux alike.
+
+    Resolution itself is covered by the dedicated tests below, which
+    override this fixture's env var.
+    """
+    monkeypatch.setenv("ORCA_CLI_COMMAND", "orca")
+
+
 def _proc(stdout: str = "", stderr: str = "", returncode: int = 0) -> MagicMock:
     """Build a mock asyncio subprocess whose communicate() returns given output."""
     proc = MagicMock()
     proc.returncode = returncode
     proc.communicate = AsyncMock(return_value=(stdout.encode(), stderr.encode()))
+    proc.wait = AsyncMock(return_value=returncode)
     return proc
 
 
@@ -54,6 +66,18 @@ def _err_json(code: str, message: str | None = None) -> str:
 async def test_is_available_true_when_cli_on_path() -> None:
     with patch(f"{MODULE}.shutil.which", return_value="/usr/local/bin/orca"):
         assert await OrcaAdapter().is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_is_available_probes_resolved_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Availability must probe the platform-resolved binary, not a bare 'orca'."""
+    monkeypatch.delenv("ORCA_CLI_COMMAND", raising=False)
+    monkeypatch.setattr(f"{MODULE}.sys.platform", "linux")
+
+    with patch(f"{MODULE}.shutil.which", return_value=None) as which_mock:
+        assert await OrcaAdapter().is_available() is False
+
+    which_mock.assert_called_once_with("orca-ide")
 
 
 @pytest.mark.asyncio
@@ -177,8 +201,14 @@ async def test_execute_failure_on_unparsable_json() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_failure_on_timeout() -> None:
-    exec_mock = AsyncMock(return_value=_proc(stdout=_ok_json()))
+async def test_execute_failure_on_timeout_kills_and_reaps_child() -> None:
+    """A timed-out orca must be killed and reaped.
+
+    Otherwise the orphan keeps running and can open the terminal *after*
+    the API has already reported failure.
+    """
+    hung = _proc(stdout=_ok_json())
+    exec_mock = AsyncMock(return_value=hung)
 
     with (
         patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
@@ -189,6 +219,26 @@ async def test_execute_failure_on_timeout() -> None:
 
     assert result["success"] is False
     assert "timed out" in result["error"].lower()
+    hung.kill.assert_called_once_with()
+    hung.wait.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_timeout_tolerates_already_exited_child() -> None:
+    """kill() racing a natural exit must not surface as a new error."""
+    gone = _proc(stdout=_ok_json())
+    gone.kill.side_effect = ProcessLookupError
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", AsyncMock(return_value=gone)),
+        patch(f"{MODULE}.asyncio.wait_for", side_effect=TimeoutError),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is False
+    assert "timed out" in result["error"].lower()
+    gone.wait.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -274,6 +324,62 @@ async def test_execute_no_retry_when_repo_add_fails() -> None:
     assert result["success"] is False
     assert exec_mock.await_count == 2
     assert "path is not a git repo" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# CLI executable resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_orca_command_prefers_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCA_CLI_COMMAND", "/opt/orca/bin/orca-custom")
+    monkeypatch.setattr(f"{MODULE}.sys.platform", "linux")
+    assert _resolve_orca_command() == "/opt/orca/bin/orca-custom"
+
+
+def test_resolve_orca_command_on_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ORCA_CLI_COMMAND", raising=False)
+    monkeypatch.setattr(f"{MODULE}.sys.platform", "darwin")
+    assert _resolve_orca_command() == "orca"
+
+
+def test_resolve_orca_command_off_macos_avoids_screen_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On Linux a bare 'orca' is the GNOME screen reader, so use orca-ide."""
+    monkeypatch.delenv("ORCA_CLI_COMMAND", raising=False)
+    monkeypatch.setattr(f"{MODULE}.sys.platform", "linux")
+    assert _resolve_orca_command() == "orca-ide"
+
+
+@pytest.mark.asyncio
+async def test_execute_uses_resolved_command_for_create_and_repo_add(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both the create and the recovery repo-add argv use the resolved binary."""
+    monkeypatch.delenv("ORCA_CLI_COMMAND", raising=False)
+    monkeypatch.setattr(f"{MODULE}.sys.platform", "linux")
+
+    exec_mock = AsyncMock(
+        side_effect=[
+            _proc(stdout=_err_json("selector_not_found"), returncode=1),
+            _proc(stdout=_ok_json()),
+            _proc(stdout=_ok_json()),
+        ]
+    )
+
+    with (
+        patch(f"{MODULE}._write_exec_script", return_value=FAKE_SCRIPT),
+        patch(f"{MODULE}.asyncio.create_subprocess_exec", exec_mock),
+    ):
+        result = await OrcaAdapter().execute(PROJECT_PATH, "cmd")
+
+    assert result["success"] is True
+    assert [call[0][0] for call in exec_mock.await_args_list] == [
+        "orca-ide",
+        "orca-ide",
+        "orca-ide",
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Task Analyzer "Execute with Claude Code"의 실행 터미널로 Orca 지원 추가 (10번째 어댑터)
- cmux의 AppleScript keystroke 방식과 달리 `orca terminal create --json` CLI로 스폰해 성공/실패가 구조화 응답으로 확인됨
- Codex 리뷰 지적 2건 반영: 플랫폼별 CLI 해석(Linux `orca`=GNOME 스크린 리더 함정), 타임아웃 시 자식 프로세스 kill+reap

## Changes
- `src/backend/services/terminal_service.py`: `TerminalType.ORCA` + `OrcaAdapter` (기존 `_write_exec_script` 재사용, repo 미등록 시 `orca repo add` 1회 복구, `stdin=DEVNULL`, `ORCA_CLI_COMMAND` env → darwin `orca` → 그 외 `orca-ide` 해석)
- `src/dashboard/src/stores/settings.ts`: `TerminalType` 유니온 + `TERMINAL_DISPLAY_NAMES`에 orca 추가
- `src/dashboard/src/components/TerminalSelector.tsx`: Task Analyzer 토글에 Orca 옵션 추가
- `tests/backend/test_terminal_service_orca.py`: 어댑터 테스트 23건 (성공/실패/복구 재시도/타임아웃 kill/CLI 해석)
- `docs/dashboard.md`, `docs/features.md`: 터미널 목록 동기화

## Test Plan
- [x] BE: ruff / mypy(253 파일) / pytest 전체 1320 passed (기지 로컬 .env 이슈 1건 제외)
- [x] FE: tsc / eslint / vitest 4348 passed / build (커밋 스냅숏 격리 워크트리에서 실행)
- [x] Codex 리뷰(branch vs main) 통과 — 지적 2건 반영 완료
- [x] E2E: 대시보드에서 실행 → Orca 워크스페이스 내 터미널 생성 + Claude Code 기동 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HK65gDdM2psaW9DJnXZq6V