### PR TITLE
refactor(dashboard): raw fetch 호출을 apiClient로 일원화

### DIFF
--- a/src/dashboard/src/App.tsx
+++ b/src/dashboard/src/App.tsx
@@ -12,7 +12,7 @@ import { useMenuVisibilityStore } from './stores/menuVisibility'
 import { useSettingsStore } from './stores/settings'
 import { routes } from './routes'
 import { analytics } from './services/analytics'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 import {
   SidebarSkeleton,
   DashboardSkeleton,
@@ -104,13 +104,7 @@ export default function App() {
   useEffect(() => {
     const checkAuthStatus = async () => {
       try {
-        const response = await fetch(getApiUrl('/api/auth/status'))
-        if (response.ok) {
-          const data = await response.json()
-          setAuthStatus(data)
-        } else {
-          setAuthStatus({ oauth_enabled: false, google_enabled: false, github_enabled: false, email_enabled: true })
-        }
+        setAuthStatus(await apiClient.get('/api/auth/status'))
       } catch {
         setAuthStatus({ oauth_enabled: false, google_enabled: false, github_enabled: false, email_enabled: true })
       }

--- a/src/dashboard/src/components/CostMonitor.tsx
+++ b/src/dashboard/src/components/CostMonitor.tsx
@@ -7,7 +7,7 @@ import {
   identifyProvider,
 } from '../stores/orchestration'
 import { useExternalUsageStore } from '../stores/externalUsage'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -161,15 +161,11 @@ function groupByProvider(byModel: CostBreakdown[]): Record<string, ProviderUsage
 }
 
 async function fetchCostAnalytics(): Promise<CostAnalytics> {
-  const res = await fetch(getApiUrl('/api/analytics/costs?time_range=all'))
-  if (!res.ok) throw new Error('Failed to fetch cost analytics')
-  return res.json()
+  return apiClient.get<CostAnalytics>('/api/analytics/costs?time_range=all')
 }
 
 async function fetchClaudeUsage(): Promise<ClaudeUsageSnapshot> {
-  const res = await fetch(getApiUrl('/api/usage'))
-  if (!res.ok) throw new Error('Failed to fetch Claude Code usage')
-  return res.json()
+  return apiClient.get<ClaudeUsageSnapshot>('/api/usage')
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/components/ProcessMonitorWidget.tsx
+++ b/src/dashboard/src/components/ProcessMonitorWidget.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Cpu, Trash2, RefreshCw } from 'lucide-react'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 interface ProcessInfo {
   pid: number
@@ -30,9 +30,7 @@ export function ProcessMonitorWidget() {
   const fetchProcesses = useCallback(async () => {
     setLoading(true)
     try {
-      const res = await fetch(getApiUrl('/api/claude-sessions/processes'))
-      if (!res.ok) return
-      const data: ProcessListResponse = await res.json()
+      const data = await apiClient.get<ProcessListResponse>('/api/claude-sessions/processes')
       setProcesses(data.processes)
       setTotalCount(data.total_count)
       setForegroundCount(data.foreground_count)
@@ -55,12 +53,10 @@ export function ProcessMonitorWidget() {
     setCleaning(true)
     try {
       const url = includeAll
-        ? getApiUrl('/api/claude-sessions/processes/cleanup-stale?include_foreground=true')
-        : getApiUrl('/api/claude-sessions/processes/cleanup-stale')
-      const res = await fetch(url, { method: 'POST' })
-      if (res.ok) {
-        await fetchProcesses()
-      }
+        ? '/api/claude-sessions/processes/cleanup-stale?include_foreground=true'
+        : '/api/claude-sessions/processes/cleanup-stale'
+      await apiClient.post(url, undefined, { skipRetry: true })
+      await fetchProcesses()
     } catch {
       // Silently fail
     } finally {

--- a/src/dashboard/src/components/__tests__/CostMonitor.test.tsx
+++ b/src/dashboard/src/components/__tests__/CostMonitor.test.tsx
@@ -168,7 +168,12 @@ describe('CostMonitor', () => {
   })
 
   it('shows error when fetch fails', async () => {
-    mockFetch.mockResolvedValue({ ok: false })
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      json: () => Promise.resolve({ detail: 'Failed to fetch cost analytics' }),
+    })
 
     render(<CostMonitor />)
 

--- a/src/dashboard/src/components/__tests__/ProcessMonitorWidget.test.tsx
+++ b/src/dashboard/src/components/__tests__/ProcessMonitorWidget.test.tsx
@@ -66,7 +66,8 @@ describe('ProcessMonitorWidget', () => {
       render(<ProcessMonitorWidget />)
     })
     expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/claude-sessions/processes')
+      expect.stringContaining('/api/claude-sessions/processes'),
+      expect.objectContaining({ method: 'GET' })
     )
   })
 

--- a/src/dashboard/src/components/audit/AuditLogTable.tsx
+++ b/src/dashboard/src/components/audit/AuditLogTable.tsx
@@ -12,6 +12,7 @@ import {
   Filter,
   Loader2,
 } from 'lucide-react'
+import { apiClient } from '@/services/apiClient'
 
 // Types
 export interface AuditLogEntry {
@@ -141,10 +142,7 @@ export function AuditLogTable({ sessionId, projectId, includeGlobal = true, clas
       params.set('limit', String(pageSize))
       params.set('offset', String(page * pageSize))
 
-      const res = await fetch(`/api/audit?${params}`)
-      if (!res.ok) throw new Error('Failed to fetch audit logs')
-
-      const data: AuditLogResponse = await res.json()
+      const data = await apiClient.get<AuditLogResponse>(`/api/audit?${params}`)
       setLogs(data.logs)
       setTotal(data.total)
     } catch (e) {

--- a/src/dashboard/src/components/audit/__tests__/AuditLogTable.test.tsx
+++ b/src/dashboard/src/components/audit/__tests__/AuditLogTable.test.tsx
@@ -166,7 +166,9 @@ describe('AuditLogTable', () => {
       if (url.includes('/api/audit?') || url === '/api/audit') {
         return Promise.resolve({
           ok: false,
+          status: 500,
           statusText: 'Server Error',
+          json: () => Promise.resolve({ detail: 'Failed to fetch audit logs' }),
         })
       }
       return Promise.resolve({

--- a/src/dashboard/src/components/claude-sessions/ProcessCleanupPanel.tsx
+++ b/src/dashboard/src/components/claude-sessions/ProcessCleanupPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 interface ProcessInfo {
   pid: number
@@ -42,9 +42,7 @@ export function ProcessCleanupPanel() {
   const fetchProcesses = useCallback(async () => {
     setLoading(true)
     try {
-      const res = await fetch(getApiUrl('/api/claude-sessions/processes'))
-      if (!res.ok) throw new Error('Failed to fetch processes')
-      const data: ProcessListResponse = await res.json()
+      const data = await apiClient.get<ProcessListResponse>('/api/claude-sessions/processes')
       setProcesses(data.processes)
       setTotalCount(data.total_count)
       setForegroundCount(data.foreground_count)
@@ -64,11 +62,11 @@ export function ProcessCleanupPanel() {
     setCleaning(true)
     setMessage(null)
     try {
-      const res = await fetch(getApiUrl('/api/claude-sessions/processes/cleanup-stale'), {
-        method: 'POST',
-      })
-      if (!res.ok) throw new Error('Cleanup failed')
-      const data: ProcessKillResponse = await res.json()
+      const data = await apiClient.post<ProcessKillResponse>(
+        '/api/claude-sessions/processes/cleanup-stale',
+        undefined,
+        { skipRetry: true }
+      )
       setMessage({
         type: data.success ? 'success' : 'error',
         text: data.message,
@@ -86,12 +84,11 @@ export function ProcessCleanupPanel() {
     setCleaning(true)
     setMessage(null)
     try {
-      const res = await fetch(
-        getApiUrl('/api/claude-sessions/processes/cleanup-stale?include_foreground=true'),
-        { method: 'POST' },
+      const data = await apiClient.post<ProcessKillResponse>(
+        '/api/claude-sessions/processes/cleanup-stale?include_foreground=true',
+        undefined,
+        { skipRetry: true },
       )
-      if (!res.ok) throw new Error('Kill all failed')
-      const data: ProcessKillResponse = await res.json()
       setMessage({
         type: data.success ? 'success' : 'error',
         text: data.message,
@@ -111,13 +108,11 @@ export function ProcessCleanupPanel() {
     setCleaning(true)
     setMessage(null)
     try {
-      const res = await fetch(getApiUrl('/api/claude-sessions/processes/kill'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pids: Array.from(selectedPids) }),
-      })
-      if (!res.ok) throw new Error('Kill failed')
-      const data: ProcessKillResponse = await res.json()
+      const data = await apiClient.post<ProcessKillResponse>(
+        '/api/claude-sessions/processes/kill',
+        { pids: Array.from(selectedPids) },
+        { skipRetry: true }
+      )
       setMessage({
         type: data.success ? 'success' : 'error',
         text: data.message,

--- a/src/dashboard/src/components/claude-sessions/__tests__/ProcessCleanupPanel.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/ProcessCleanupPanel.test.tsx
@@ -84,7 +84,8 @@ describe('ProcessCleanupPanel', () => {
     render(<ProcessCleanupPanel />)
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/claude-sessions/processes')
+        expect.stringContaining('/api/claude-sessions/processes'),
+        expect.objectContaining({ method: 'GET' })
       )
     })
   })

--- a/src/dashboard/src/components/feedback/AgentEvalPanel.tsx
+++ b/src/dashboard/src/components/feedback/AgentEvalPanel.tsx
@@ -16,6 +16,7 @@ import {
   BarChart3,
 } from 'lucide-react'
 import { cn } from '../../lib/utils'
+import { apiClient } from '@/services/apiClient'
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -41,12 +42,8 @@ interface TaskEvalStats {
 // API
 // ─────────────────────────────────────────────────────────────
 
-const API_BASE = 'http://localhost:8000/api/feedback'
-
 async function fetchEvalStats(): Promise<TaskEvalStats> {
-  const res = await fetch(`${API_BASE}/task-evaluation/stats`)
-  if (!res.ok) throw new Error('Failed to fetch evaluation stats')
-  return res.json()
+  return apiClient.get<TaskEvalStats>('/api/feedback/task-evaluation/stats')
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/components/feedback/__tests__/AgentEvalPanel.test.tsx
+++ b/src/dashboard/src/components/feedback/__tests__/AgentEvalPanel.test.tsx
@@ -46,7 +46,7 @@ describe('AgentEvalPanel', () => {
     render(<AgentEvalPanel />)
 
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument()
+      expect(screen.getByText('Error: Network error')).toBeInTheDocument()
     })
   })
 
@@ -169,7 +169,8 @@ describe('AgentEvalPanel', () => {
     vi.mocked(global.fetch).mockResolvedValue({
       ok: false,
       status: 500,
-    } as Response)
+      json: () => Promise.resolve({ detail: 'Failed to fetch evaluation stats' }),
+    } as unknown as Response)
 
     render(<AgentEvalPanel />)
 

--- a/src/dashboard/src/components/llm-router/LLMRouterSettings.tsx
+++ b/src/dashboard/src/components/llm-router/LLMRouterSettings.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useState } from 'react'
 import { cn } from '../../lib/utils'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 import {
   Server,
   Plus,
@@ -87,59 +87,39 @@ interface RouterStats {
 // ─────────────────────────────────────────────────────────────
 
 async function fetchProviders(): Promise<LLMProvider[]> {
-  const res = await fetch(getApiUrl('/api/llm-router/providers'))
-  if (!res.ok) throw new Error('Failed to fetch providers')
-  return res.json()
+  return apiClient.get<LLMProvider[]>('/api/llm-router/providers')
 }
 
 async function fetchRouterConfig(): Promise<RouterConfig> {
-  const res = await fetch(getApiUrl('/api/llm-router/config'))
-  if (!res.ok) throw new Error('Failed to fetch config')
-  return res.json()
+  return apiClient.get<RouterConfig>('/api/llm-router/config')
 }
 
 async function updateRouterConfig(config: Partial<RouterConfig>): Promise<RouterConfig> {
-  const res = await fetch(getApiUrl('/api/llm-router/config'), {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(config),
-  })
-  if (!res.ok) throw new Error('Failed to update config')
-  return res.json()
+  return apiClient.patch<RouterConfig>('/api/llm-router/config', config)
 }
 
 async function checkHealth(): Promise<HealthCheck[]> {
-  const res = await fetch(getApiUrl('/api/llm-router/health'))
-  if (!res.ok) throw new Error('Failed to check health')
-  return res.json()
+  return apiClient.get<HealthCheck[]>('/api/llm-router/health')
 }
 
 async function fetchStats(): Promise<RouterStats> {
-  const res = await fetch(getApiUrl('/api/llm-router/stats'))
-  if (!res.ok) throw new Error('Failed to fetch stats')
-  return res.json()
+  return apiClient.get<RouterStats>('/api/llm-router/stats')
 }
 
 async function toggleProvider(providerId: string): Promise<{ enabled: boolean }> {
-  const res = await fetch(getApiUrl(`/api/llm-router/providers/${providerId}/toggle`), {
-    method: 'POST',
-  })
-  if (!res.ok) throw new Error('Failed to toggle provider')
-  return res.json()
+  return apiClient.post<{ enabled: boolean }>(
+    `/api/llm-router/providers/${providerId}/toggle`,
+    undefined,
+    { skipRetry: true }
+  )
 }
 
 async function deleteProvider(providerId: string): Promise<void> {
-  const res = await fetch(getApiUrl(`/api/llm-router/providers/${providerId}`), {
-    method: 'DELETE',
-  })
-  if (!res.ok) throw new Error('Failed to delete provider')
+  await apiClient.delete(`/api/llm-router/providers/${providerId}`)
 }
 
 async function initializeProviders(): Promise<void> {
-  const res = await fetch(getApiUrl('/api/llm-router/initialize'), {
-    method: 'POST',
-  })
-  if (!res.ok) throw new Error('Failed to initialize providers')
+  await apiClient.post('/api/llm-router/initialize', undefined, { skipRetry: true })
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/components/llm-router/__tests__/LLMRouterSettings.test.tsx
+++ b/src/dashboard/src/components/llm-router/__tests__/LLMRouterSettings.test.tsx
@@ -188,7 +188,8 @@ describe('LLMRouterSettings', () => {
     fireEvent.click(screen.getByText('Health Check'))
     await waitFor(() => {
       expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
-        expect.stringContaining('/llm-router/health')
+        expect.stringContaining('/llm-router/health'),
+        expect.objectContaining({ method: 'GET' })
       )
     })
   })

--- a/src/dashboard/src/components/notifications/NotificationRuleEditor.tsx
+++ b/src/dashboard/src/components/notifications/NotificationRuleEditor.tsx
@@ -24,7 +24,8 @@ import {
   Pencil,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
+import { ApiError } from '@/services/errors'
 import { useOrchestrationStore } from '@/stores/orchestration'
 
 // ─────────────────────────────────────────────────────────────
@@ -130,51 +131,32 @@ const PRIORITY_COLORS: Record<NotificationPriority, string> = {
 // ─────────────────────────────────────────────────────────────
 
 async function fetchRules(): Promise<NotificationRule[]> {
-  const res = await fetch(getApiUrl('/api/notifications/rules'))
-  if (!res.ok) throw new Error('Failed to fetch rules')
-  return res.json()
+  return apiClient.get<NotificationRule[]>('/api/notifications/rules')
 }
 
 async function fetchChannels(): Promise<ChannelStatus[]> {
-  const res = await fetch(getApiUrl('/api/notifications/channels'))
-  if (!res.ok) throw new Error('Failed to fetch channels')
-  const data = await res.json()
+  const data = await apiClient.get<{ channels: ChannelStatus[] }>('/api/notifications/channels')
   return data.channels
 }
 
 async function createRule(rule: Partial<NotificationRule>): Promise<NotificationRule> {
-  const res = await fetch(getApiUrl('/api/notifications/rules'), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(rule),
-  })
-  if (!res.ok) throw new Error('Failed to create rule')
-  return res.json()
+  return apiClient.post<NotificationRule>('/api/notifications/rules', rule, { skipRetry: true })
 }
 
 async function updateRule(ruleId: string, data: Partial<NotificationRule>): Promise<NotificationRule> {
-  const res = await fetch(`${getApiUrl('/api/notifications/rules')}/${ruleId}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  })
-  if (!res.ok) throw new Error('Failed to update rule')
-  return res.json()
+  return apiClient.put<NotificationRule>(`/api/notifications/rules/${ruleId}`, data)
 }
 
 async function deleteRule(ruleId: string): Promise<void> {
-  const res = await fetch(`${getApiUrl('/api/notifications/rules')}/${ruleId}`, {
-    method: 'DELETE',
-  })
-  if (!res.ok) throw new Error('Failed to delete rule')
+  await apiClient.delete(`/api/notifications/rules/${ruleId}`)
 }
 
 async function toggleRule(ruleId: string): Promise<{ enabled: boolean }> {
-  const res = await fetch(`${getApiUrl('/api/notifications/rules')}/${ruleId}/toggle`, {
-    method: 'POST',
-  })
-  if (!res.ok) throw new Error('Failed to toggle rule')
-  return res.json()
+  return apiClient.post<{ enabled: boolean }>(
+    `/api/notifications/rules/${ruleId}/toggle`,
+    undefined,
+    { skipRetry: true }
+  )
 }
 
 async function updateChannel(
@@ -190,19 +172,24 @@ async function updateChannel(
     smtp_use_tls?: boolean
   }
 ): Promise<void> {
-  const res = await fetch(`${getApiUrl('/api/notifications/channels')}/${channel}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  })
-  if (!res.ok) throw new Error('Failed to update channel')
+  await apiClient.put(`/api/notifications/channels/${channel}`, data)
 }
 
 async function testChannel(channel: NotificationChannel): Promise<{ success: boolean; error?: string }> {
-  const res = await fetch(`${getApiUrl('/api/notifications/channels')}/${channel}/test`, {
-    method: 'POST',
-  })
-  return res.json()
+  try {
+    return await apiClient.post<{ success: boolean; error?: string }>(
+      `/api/notifications/channels/${channel}/test`,
+      undefined,
+      { skipRetry: true }
+    )
+  } catch (e) {
+    // An HTTP error response still reports a failed test rather than throwing;
+    // network/timeout errors (status 0) keep propagating to the caller.
+    if (e instanceof ApiError && e.status !== 0) {
+      return { success: false, error: e.message }
+    }
+    throw e
+  }
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/components/notifications/__tests__/NotificationRuleEditor.test.tsx
+++ b/src/dashboard/src/components/notifications/__tests__/NotificationRuleEditor.test.tsx
@@ -311,11 +311,11 @@ describe('NotificationRuleEditor', () => {
     render(<NotificationRuleEditor />)
 
     await waitFor(() => {
-      expect(screen.getByText('Server error')).toBeInTheDocument()
+      expect(screen.getByText('Error: Server error')).toBeInTheDocument()
     })
 
     // Dismiss the error
-    const dismissButton = screen.getByText('Server error').closest('div')!.querySelector('button')!
+    const dismissButton = screen.getByText('Error: Server error').closest('div')!.querySelector('button')!
     fireEvent.click(dismissButton)
 
     await waitFor(() => {
@@ -520,7 +520,7 @@ describe('NotificationRuleEditor', () => {
 
     it('shows error when create rule fails', async () => {
       await renderAndWait(mockRules, mockChannels, [
-        { ok: false, json: () => Promise.resolve({}) } as Response,
+        { ok: false, json: () => Promise.resolve({ detail: 'Failed to create rule' }) } as Response,
       ])
 
       fireEvent.click(screen.getByText('Add Rule'))
@@ -662,7 +662,7 @@ describe('NotificationRuleEditor', () => {
 
     it('shows error when delete fails', async () => {
       await renderAndWait(mockRules, mockChannels, [
-        { ok: false, json: () => Promise.resolve({}) } as Response,
+        { ok: false, json: () => Promise.resolve({ detail: 'Failed to delete rule' }) } as Response,
       ])
 
       const ruleCards = screen.getByText('Alert on failures').closest('div[class*="p-4"]')!
@@ -703,7 +703,7 @@ describe('NotificationRuleEditor', () => {
 
     it('shows error when toggle fails', async () => {
       await renderAndWait(mockRules, mockChannels, [
-        { ok: false, json: () => Promise.resolve({}) } as Response,
+        { ok: false, json: () => Promise.resolve({ detail: 'Failed to toggle rule' }) } as Response,
       ])
 
       const ruleRow = screen.getByText('Alert on failures').closest('div[class*="p-4"]')!
@@ -821,7 +821,7 @@ describe('NotificationRuleEditor', () => {
 
     it('shows error when save edit fails', async () => {
       await renderAndWait(mockRules, mockChannels, [
-        { ok: false, json: () => Promise.resolve({}) } as Response,
+        { ok: false, json: () => Promise.resolve({ detail: 'Failed to update rule' }) } as Response,
       ])
 
       // Open edit mode
@@ -1220,7 +1220,7 @@ describe('NotificationRuleEditor', () => {
       fireEvent.click(screen.getByText('2. Test').closest('button')!)
 
       await waitFor(() => {
-        expect(screen.getByText('error: Network error')).toBeInTheDocument()
+        expect(screen.getByText('error: Error: Network error')).toBeInTheDocument()
       })
     })
 

--- a/src/dashboard/src/components/rag/RAGQueryPanel.tsx
+++ b/src/dashboard/src/components/rag/RAGQueryPanel.tsx
@@ -20,7 +20,7 @@ import {
   Info,
 } from 'lucide-react'
 import { cn } from '../../lib/utils'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -63,51 +63,31 @@ async function queryRAG(
   k: number = 5,
   filterPriority?: string
 ): Promise<QueryResult> {
-  const res = await fetch(getApiUrl(`/api/rag/projects/${projectId}/query`), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+  return apiClient.post<QueryResult>(
+    `/api/rag/projects/${projectId}/query`,
+    {
       query,
       k,
       filter_priority: filterPriority || null,
-    }),
-  })
-  if (!res.ok) {
-    const error = await res.json()
-    throw new Error(error.detail || 'Query failed')
-  }
-  return res.json()
+    },
+    { skipRetry: true }
+  )
 }
 
 async function getRAGStats(projectId: string): Promise<RAGStats> {
-  const res = await fetch(getApiUrl(`/api/rag/projects/${projectId}/stats`))
-  if (!res.ok) {
-    const error = await res.json()
-    throw new Error(error.detail || 'Failed to get stats')
-  }
-  return res.json()
+  return apiClient.get<RAGStats>(`/api/rag/projects/${projectId}/stats`)
 }
 
 async function deleteRAGIndex(projectId: string): Promise<void> {
-  const res = await fetch(getApiUrl(`/api/rag/projects/${projectId}/index`), {
-    method: 'DELETE',
-  })
-  if (!res.ok) {
-    const error = await res.json()
-    throw new Error(error.detail || 'Failed to delete index')
-  }
+  await apiClient.delete(`/api/rag/projects/${projectId}/index`)
 }
 
 async function reindexProject(projectId: string, forceReindex: boolean = true): Promise<void> {
-  const res = await fetch(getApiUrl(`/api/rag/projects/${projectId}/index`), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ force_reindex: forceReindex }),
-  })
-  if (!res.ok) {
-    const error = await res.json()
-    throw new Error(error.detail || 'Failed to index project')
-  }
+  await apiClient.post(
+    `/api/rag/projects/${projectId}/index`,
+    { force_reindex: forceReindex },
+    { skipRetry: true }
+  )
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/components/usage/ContextWindowMeter.tsx
+++ b/src/dashboard/src/components/usage/ContextWindowMeter.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useCallback } from 'react'
 import { cn } from '../../lib/utils'
 import { AlertCircle, AlertTriangle, Info } from 'lucide-react'
+import { apiClient } from '@/services/apiClient'
+import { ApiError } from '@/services/errors'
 
 export type ContextUsageLevel = 'normal' | 'warning' | 'critical'
 
@@ -65,17 +67,14 @@ export function ContextWindowMeter({
     setError(null)
 
     try {
-      const res = await fetch(`/api/sessions/${sessionId}/context-usage`)
-      if (!res.ok) {
-        if (res.status === 404) {
-          setUsage(null)
-          return
-        }
-        throw new Error('Failed to fetch context usage')
-      }
-      const data = await res.json()
+      const data = await apiClient.get<ContextUsage>(`/api/sessions/${sessionId}/context-usage`)
       setUsage(data)
     } catch (e) {
+      // A missing session is not an error state — it simply has no usage yet.
+      if (e instanceof ApiError && e.status === 404) {
+        setUsage(null)
+        return
+      }
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/src/dashboard/src/components/version-control/VersionHistory.tsx
+++ b/src/dashboard/src/components/version-control/VersionHistory.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useState } from 'react'
 import { cn } from '../../lib/utils'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 import {
   History,
   GitBranch,
@@ -71,25 +71,24 @@ interface VersionCompare {
 // ─────────────────────────────────────────────────────────────
 
 async function fetchHistory(configType: ConfigType, configId: string): Promise<VersionHistoryResponse> {
-  const res = await fetch(getApiUrl(`/api/config-versions/history/${configType}/${configId}`))
-  if (!res.ok) throw new Error('Failed to fetch history')
-  return res.json()
+  return apiClient.get<VersionHistoryResponse>(
+    `/api/config-versions/history/${configType}/${configId}`
+  )
 }
 
 async function compareVersions(versionIdA: string, versionIdB: string): Promise<VersionCompare> {
-  const res = await fetch(getApiUrl(`/api/config-versions/compare/${versionIdA}/${versionIdB}`))
-  if (!res.ok) throw new Error('Failed to compare versions')
-  return res.json()
+  return apiClient.get<VersionCompare>(`/api/config-versions/compare/${versionIdA}/${versionIdB}`)
 }
 
 async function rollbackToVersion(targetVersionId: string, reason?: string): Promise<{ success: boolean; message: string }> {
-  const res = await fetch(getApiUrl('/api/config-versions/rollback'), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ target_version_id: targetVersionId, reason }),
-  })
-  if (!res.ok) throw new Error('Failed to rollback')
-  return res.json()
+  return apiClient.post<{ success: boolean; message: string }>(
+    '/api/config-versions/rollback',
+    {
+      target_version_id: targetVersionId,
+      reason,
+    },
+    { skipRetry: true }
+  )
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/components/workflows/ArtifactBrowser.tsx
+++ b/src/dashboard/src/components/workflows/ArtifactBrowser.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { File, Download, Trash2, FileText, Image, Archive, RefreshCw } from 'lucide-react'
 import type { Artifact } from '../../types/workflow'
 import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 interface ArtifactBrowserProps {
   runId: string
@@ -32,11 +33,10 @@ export function ArtifactBrowser({ runId }: ArtifactBrowserProps) {
   const fetchArtifacts = async () => {
     setIsLoading(true)
     try {
-      const res = await fetch(getApiUrl(`/api/workflows/runs/${runId}/artifacts`))
-      if (res.ok) {
-        const data = await res.json()
-        setArtifacts(data.artifacts || [])
-      }
+      const data = await apiClient.get<{ artifacts?: Artifact[] }>(
+        `/api/workflows/runs/${runId}/artifacts`
+      )
+      setArtifacts(data.artifacts || [])
     } catch (e) {
       console.error('Failed to fetch artifacts:', e)
     }
@@ -45,10 +45,8 @@ export function ArtifactBrowser({ runId }: ArtifactBrowserProps) {
 
   const handleDelete = async (artifactId: string) => {
     try {
-      const res = await fetch(getApiUrl(`/api/workflows/artifacts/${artifactId}`), { method: 'DELETE' })
-      if (res.ok) {
-        setArtifacts(prev => prev.filter(a => a.id !== artifactId))
-      }
+      await apiClient.delete(`/api/workflows/artifacts/${artifactId}`)
+      setArtifacts(prev => prev.filter(a => a.id !== artifactId))
     } catch (e) {
       console.error('Failed to delete artifact:', e)
     }

--- a/src/dashboard/src/components/workflows/TemplateGallery.tsx
+++ b/src/dashboard/src/components/workflows/TemplateGallery.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react'
 import { useProjectsStore } from '../../stores/projects'
 import { useWorkflowStore } from '../../stores/workflows'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 export interface Template {
   id: string
@@ -78,11 +78,10 @@ export function TemplateGallery({ onSelect, onClose }: TemplateGalleryProps) {
       const params = new URLSearchParams()
       if (category) params.set('category', category)
       if (search) params.set('search', search)
-      const res = await fetch(getApiUrl(`/api/workflows/templates?${params}`))
-      if (res.ok) {
-        const data = await res.json()
-        setTemplates(data.templates || [])
-      }
+      const data = await apiClient.get<{ templates?: Template[] }>(
+        `/api/workflows/templates?${params}`
+      )
+      setTemplates(data.templates || [])
     } catch (e) {
       console.error('Failed to fetch templates:', e)
     }

--- a/src/dashboard/src/pages/AnalyticsPage.test.tsx
+++ b/src/dashboard/src/pages/AnalyticsPage.test.tsx
@@ -53,10 +53,14 @@ vi.mock('../stores/externalUsage', () => ({
 }))
 
 vi.mock('../stores/auth', () => ({
-  useAuthStore: vi.fn((selector?: (s: unknown) => unknown) => {
-    const state = { user: { id: 'u1', is_admin: false } }
-    return selector ? selector(state) : state
-  }),
+  // `getState` is required by the apiClient auth interceptor.
+  useAuthStore: Object.assign(
+    vi.fn((selector?: (s: unknown) => unknown) => {
+      const state = { user: { id: 'u1', is_admin: false } }
+      return selector ? selector(state) : state
+    }),
+    { getState: () => ({ accessToken: null }) }
+  ),
 }))
 
 // Mock ProjectMultiSelect component - captures props for testing
@@ -242,7 +246,10 @@ function setupFetchMock(overrides?: {
 
     if (urlStr.includes('/analytics/dashboard')) {
       if (overrides?.dashboardError) {
-        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response)
+        return Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ detail: 'Failed to fetch analytics' }),
+        } as Response)
       }
       return Promise.resolve({
         ok: true,
@@ -479,7 +486,7 @@ describe('AnalyticsPage', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument()
+      expect(screen.getByText('Error: Network error')).toBeInTheDocument()
     })
 
     expect(screen.getByText('Retry')).toBeInTheDocument()
@@ -537,7 +544,7 @@ describe('AnalyticsPage', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText('Server down')).toBeInTheDocument()
+      expect(screen.getByText('Error: Server down')).toBeInTheDocument()
     })
 
     // Click Retry

--- a/src/dashboard/src/pages/AnalyticsPage.tsx
+++ b/src/dashboard/src/pages/AnalyticsPage.tsx
@@ -55,7 +55,7 @@ import {
 import { useAuthStore } from '../stores/auth'
 import { ProjectMultiSelect } from '../components/analytics/ProjectMultiSelect'
 import type { TaskAnalysisHistory } from '../stores/agents'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -252,18 +252,14 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 async function fetchDashboard(timeRange: TimeRange, projectId?: string): Promise<AnalyticsDashboard> {
   const params = new URLSearchParams({ time_range: timeRange })
   if (projectId) params.append('project_id', projectId)
-  const res = await fetch(getApiUrl(`/api/analytics/dashboard?${params}`))
-  if (!res.ok) throw new Error('Failed to fetch analytics')
-  return res.json()
+  return apiClient.get<AnalyticsDashboard>(`/api/analytics/dashboard?${params}`)
 }
 
 async function fetchTaskEvalStats(projectId?: string): Promise<TaskEvalStats> {
   const params = new URLSearchParams()
   if (projectId) params.set('project_id', projectId)
   const qs = params.toString()
-  const res = await fetch(getApiUrl(`/api/feedback/task-evaluation/stats${qs ? `?${qs}` : ''}`))
-  if (!res.ok) throw new Error('Failed to fetch evaluation stats')
-  return res.json()
+  return apiClient.get<TaskEvalStats>(`/api/feedback/task-evaluation/stats${qs ? `?${qs}` : ''}`)
 }
 
 async function fetchTaskEvalList(
@@ -274,16 +270,12 @@ async function fetchTaskEvalList(
   const params = new URLSearchParams({ limit: String(limit) })
   if (agentId) params.set('agent_id', agentId)
   if (projectId) params.set('project_id', projectId)
-  const res = await fetch(getApiUrl(`/api/feedback/task-evaluation/list?${params}`))
-  if (!res.ok) throw new Error('Failed to fetch evaluation list')
-  return res.json()
+  return apiClient.get<TaskEvaluation[]>(`/api/feedback/task-evaluation/list?${params}`)
 }
 
 async function fetchAnalysisDetail(analysisId: string): Promise<TaskAnalysisHistory | null> {
   try {
-    const res = await fetch(getApiUrl(`/api/agents/orchestrate/analyses/${analysisId}`))
-    if (!res.ok) return null
-    return res.json()
+    return await apiClient.get<TaskAnalysisHistory>(`/api/agents/orchestrate/analyses/${analysisId}`)
   } catch {
     return null
   }
@@ -310,9 +302,7 @@ async function fetchMultiProjectTrends(
 ): Promise<MultiProjectTrendsResponse> {
   const params = new URLSearchParams({ metric, time_range: timeRange })
   projectIds.forEach((id) => params.append('project_ids', id))
-  const res = await fetch(getApiUrl(`/api/analytics/trends/compare?${params}`))
-  if (!res.ok) throw new Error('Failed to fetch multi-project trends')
-  return res.json()
+  return apiClient.get<MultiProjectTrendsResponse>(`/api/analytics/trends/compare?${params}`)
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/pages/LoginPage.test.tsx
+++ b/src/dashboard/src/pages/LoginPage.test.tsx
@@ -8,10 +8,14 @@ const mockSetUser = vi.fn()
 const mockSetView = vi.fn()
 
 vi.mock('../stores/auth', () => ({
-  useAuthStore: () => ({
-    setTokens: mockSetTokens,
-    setUser: mockSetUser,
-  }),
+  // `getState` is required by the apiClient auth interceptor.
+  useAuthStore: Object.assign(
+    () => ({
+      setTokens: mockSetTokens,
+      setUser: mockSetUser,
+    }),
+    { getState: () => ({ accessToken: null }) }
+  ),
   getGoogleAuthUrl: () => 'https://google.com/auth',
   getGitHubAuthUrl: () => 'https://github.com/auth',
   loginWithEmail: vi.fn(),

--- a/src/dashboard/src/pages/LoginPage.tsx
+++ b/src/dashboard/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { getGoogleAuthUrl, getGitHubAuthUrl, loginWithEmail, useAuthStore } from '../stores/auth'
 import { useNavigationStore } from '../stores/navigation'
-import { getApiUrl } from '@/config/api'
+import { apiClient } from '@/services/apiClient'
 
 export function LoginPage() {
   const [email, setEmail] = useState('')
@@ -22,10 +22,7 @@ export function LoginPage() {
   useEffect(() => {
     const fetchAuthStatus = async () => {
       try {
-        const response = await fetch(getApiUrl('/api/auth/status'))
-        if (response.ok) {
-          setAuthStatus(await response.json())
-        }
+        setAuthStatus(await apiClient.get('/api/auth/status'))
       } catch {
         // Default: show email only
         setAuthStatus({ oauth_enabled: false, google_enabled: false, github_enabled: false, email_enabled: true })

--- a/src/dashboard/src/services/__tests__/apiClient.test.ts
+++ b/src/dashboard/src/services/__tests__/apiClient.test.ts
@@ -252,4 +252,49 @@ describe('ApiClient', () => {
       expect((err as ApiError).code).toBe(ApiErrorCode.NETWORK_ERROR)
     }
   })
+
+  // ── 11. FormData body ─────────────────────────────────────
+
+  it('sends FormData untouched and omits Content-Type', async () => {
+    mockFetch(async () => jsonResponse({ ok: true }))
+
+    const formData = new FormData()
+    formData.append('image', new File(['data'], 'shot.png', { type: 'image/png' }))
+
+    await client.post('/api/agents/ocr', formData)
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ]
+    expect(init.body).toBe(formData)
+    // Browser must set multipart boundary itself
+    const headerNames = Object.keys(init.headers as Record<string, string>)
+    expect(headerNames.some((name) => name.toLowerCase() === 'content-type')).toBe(false)
+  })
+
+  it('still JSON-encodes plain object bodies and keeps Content-Type', async () => {
+    mockFetch(async () => jsonResponse({ ok: true }))
+
+    await client.post('/api/agents', { name: 'Agent A' })
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ]
+    expect(init.body).toBe(JSON.stringify({ name: 'Agent A' }))
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+
+  // ── 12. Text response type ────────────────────────────────
+
+  it('returns the raw body when responseType is text', async () => {
+    mockFetch(async () => new Response('id,name\n1,Agent A', { status: 200 }))
+
+    const result = await client.get<string>('/api/feedback/dataset/export', {
+      responseType: 'text',
+    })
+
+    expect(result).toBe('id,name\n1,Agent A')
+  })
 })

--- a/src/dashboard/src/services/apiClient.ts
+++ b/src/dashboard/src/services/apiClient.ts
@@ -31,6 +31,8 @@ export interface RequestConfig {
   timeout?: number
   /** Disable retry for this specific request */
   skipRetry?: boolean
+  /** How to parse a successful response body (default: 'json') */
+  responseType?: 'json' | 'text'
 }
 
 export interface RequestInterceptor {
@@ -53,6 +55,23 @@ function isNetworkError(err: unknown): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * FormData is passed through untouched so the browser can set the
+ * multipart boundary itself; everything else is JSON-encoded.
+ */
+function serializeBody(data: unknown): string | FormData | undefined {
+  if (data === undefined) return undefined
+  if (data instanceof FormData) return data
+  return JSON.stringify(data)
+}
+
+/** Drop Content-Type (case-insensitive) so the browser derives it from FormData. */
+function omitContentType(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'content-type')
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -99,7 +118,7 @@ class ApiClient {
       url,
       method: 'POST',
       headers: {},
-      body: data !== undefined ? JSON.stringify(data) : undefined,
+      body: serializeBody(data),
     })
   }
 
@@ -109,7 +128,7 @@ class ApiClient {
       url,
       method: 'PUT',
       headers: {},
-      body: data !== undefined ? JSON.stringify(data) : undefined,
+      body: serializeBody(data),
     })
   }
 
@@ -119,7 +138,7 @@ class ApiClient {
       url,
       method: 'PATCH',
       headers: {},
-      body: data !== undefined ? JSON.stringify(data) : undefined,
+      body: serializeBody(data),
     })
   }
 
@@ -131,10 +150,12 @@ class ApiClient {
 
   private async request<T>(reqConfig: RequestConfig): Promise<T> {
     // Merge default headers
+    const mergedHeaders = { ...this.config.headers, ...reqConfig.headers }
     const mergedConfig: RequestConfig = {
       ...reqConfig,
       url: `${this.config.baseURL}${reqConfig.url}`,
-      headers: { ...this.config.headers, ...reqConfig.headers },
+      headers:
+        reqConfig.body instanceof FormData ? omitContentType(mergedHeaders) : mergedHeaders,
       timeout: reqConfig.timeout ?? this.config.timeout,
     }
 
@@ -220,6 +241,10 @@ class ApiClient {
       // 204 No Content
       if (processed.status === 204) {
         return undefined as T
+      }
+
+      if (config.responseType === 'text') {
+        return (await processed.text()) as T
       }
 
       return (await processed.json()) as T

--- a/src/dashboard/src/stores/__tests__/agents.test.ts
+++ b/src/dashboard/src/stores/__tests__/agents.test.ts
@@ -692,10 +692,8 @@ describe('agents store', () => {
     }
 
     it('uses multipart/form-data when images are attached via store state', async () => {
-      // analyzeTask with images uses raw fetch, not apiClient
-      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify(mockAnalysisResult))
-      )
+      // analyzeTask with images posts FormData through apiClient
+      mockApiClient.post.mockResolvedValueOnce(mockAnalysisResult)
       // fetchAnalysisHistory after success uses apiClient.get
       mockApiClient.get.mockResolvedValueOnce({ items: [], total: 0, has_more: false })
 
@@ -704,38 +702,33 @@ describe('agents store', () => {
 
       await useAgentsStore.getState().analyzeTask('Analyze this UI')
 
-      const callUrl = fetchSpy.mock.calls[0][0] as string
+      const [callUrl, callBody, callOpts] = mockApiClient.post.mock.calls[0]
       expect(callUrl).toContain('analyze-with-images')
-      const callOpts = fetchSpy.mock.calls[0][1] as RequestInit
-      expect(callOpts.body).toBeInstanceOf(FormData)
-      expect(callOpts.signal).toBeInstanceOf(AbortSignal)
+      expect(callBody).toBeInstanceOf(FormData)
+      expect(callOpts).toEqual(expect.objectContaining({ timeout: expect.any(Number) }))
     })
 
     it('uses multipart/form-data when images are passed as argument', async () => {
-      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify(mockAnalysisResult))
-      )
+      mockApiClient.post.mockResolvedValueOnce(mockAnalysisResult)
       mockApiClient.get.mockResolvedValueOnce({ items: [], total: 0, has_more: false })
 
       const images = [new File(['imgdata'], 'test.png', { type: 'image/png' })]
 
       await useAgentsStore.getState().analyzeTask('Test task', undefined, images)
 
-      const callUrl = fetchSpy.mock.calls[0][0] as string
+      const callUrl = mockApiClient.post.mock.calls[0][0]
       expect(callUrl).toContain('analyze-with-images')
     })
 
     it('includes context in FormData when images present and context provided', async () => {
-      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify(mockAnalysisResult))
-      )
+      mockApiClient.post.mockResolvedValueOnce(mockAnalysisResult)
       mockApiClient.get.mockResolvedValueOnce({ items: [], total: 0, has_more: false })
 
       const images = [new File(['imgdata'], 'test.png', { type: 'image/png' })]
 
       await useAgentsStore.getState().analyzeTask('Test', { project_id: 'p1' }, images)
 
-      const formData = fetchSpy.mock.calls[0][1]?.body as FormData
+      const formData = mockApiClient.post.mock.calls[0][1] as FormData
       expect(formData.get('task')).toBe('Test')
       expect(formData.get('context')).toBe(JSON.stringify({ project_id: 'p1' }))
     })
@@ -788,13 +781,11 @@ describe('agents store', () => {
   })
 
   // ── extractTextFromImage ──────────────────────────────
-  // Note: extractTextFromImage uses raw fetch, not apiClient
+  // Note: extractTextFromImage posts FormData through apiClient
 
   describe('extractTextFromImage', () => {
     it('returns extracted text on success', async () => {
-      vi.spyOn(global, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify({ success: true, text: 'Hello world' }))
-      )
+      mockApiClient.post.mockResolvedValueOnce({ success: true, text: 'Hello world' })
 
       const file = new File(['imgdata'], 'test.png', { type: 'image/png' })
       const result = await useAgentsStore.getState().extractTextFromImage(file)
@@ -803,37 +794,34 @@ describe('agents store', () => {
     })
 
     it('sends image via FormData', async () => {
-      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify({ success: true, text: 'text' }))
-      )
+      mockApiClient.post.mockResolvedValueOnce({ success: true, text: 'text' })
 
       const file = new File(['imgdata'], 'test.png', { type: 'image/png' })
       await useAgentsStore.getState().extractTextFromImage(file)
 
-      expect(fetchSpy).toHaveBeenCalledWith(
+      expect(mockApiClient.post).toHaveBeenCalledWith(
         expect.stringContaining('/agents/ocr'),
-        expect.objectContaining({ method: 'POST' })
+        expect.any(FormData),
+        { skipRetry: true }
       )
-      const body = fetchSpy.mock.calls[0][1]?.body as FormData
+      const body = mockApiClient.post.mock.calls[0][1] as FormData
       expect(body.get('image')).toBe(file)
     })
 
     it('returns null when HTTP response is not ok', async () => {
-      vi.spyOn(global, 'fetch').mockResolvedValue(
-        new Response(null, { status: 500, statusText: 'Server Error' })
-      )
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockApiClient.post.mockRejectedValueOnce(new Error('Server Error'))
 
       const file = new File(['imgdata'], 'test.png', { type: 'image/png' })
       const result = await useAgentsStore.getState().extractTextFromImage(file)
 
       expect(result).toBeNull()
+      expect(consoleSpy).toHaveBeenCalledWith('OCR request failed:', expect.any(Error))
     })
 
     it('returns null when result.success is false', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      vi.spyOn(global, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify({ success: false, error: 'OCR failed' }))
-      )
+      mockApiClient.post.mockResolvedValueOnce({ success: false, error: 'OCR failed' })
 
       const file = new File(['imgdata'], 'test.png', { type: 'image/png' })
       const result = await useAgentsStore.getState().extractTextFromImage(file)
@@ -844,7 +832,7 @@ describe('agents store', () => {
 
     it('returns null on network error', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'))
+      mockApiClient.post.mockRejectedValueOnce(new Error('Network error'))
 
       const file = new File(['imgdata'], 'test.png', { type: 'image/png' })
       const result = await useAgentsStore.getState().extractTextFromImage(file)

--- a/src/dashboard/src/stores/__tests__/feedback.test.ts
+++ b/src/dashboard/src/stores/__tests__/feedback.test.ts
@@ -23,10 +23,6 @@ import { apiClient } from '../../services/apiClient'
 
 const mockApiClient = vi.mocked(apiClient)
 
-// Mock global.fetch for exportDataset (only method that still uses raw fetch)
-const mockFetch = vi.fn()
-global.fetch = mockFetch
-
 // Mock crypto.randomUUID
 vi.stubGlobal('crypto', { randomUUID: () => 'mock-uuid' })
 
@@ -52,7 +48,6 @@ describe('feedback store', () => {
   beforeEach(() => {
     resetStore()
     vi.clearAllMocks()
-    mockFetch.mockReset()
   })
 
   // ── Initial State ──────────────────────────────────────
@@ -313,24 +308,32 @@ describe('feedback store', () => {
   })
 
   // ── exportDataset ──────────────────────────────────────
-  // Note: exportDataset still uses raw fetch (not apiClient)
+  // Note: exportDataset reads a text response through apiClient
 
   describe('exportDataset', () => {
     it('exports dataset as text', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve('{"line":"1"}\n{"line":"2"}'),
-      })
+      mockApiClient.get.mockResolvedValueOnce('{"line":"1"}\n{"line":"2"}')
 
       const result = await useFeedbackStore.getState().exportDataset({ format: 'jsonl' })
 
       expect(result).toContain('line')
-      const url = mockFetch.mock.calls[0][0] as string
+      const url = mockApiClient.get.mock.calls[0][0]
       expect(url).toContain('format=jsonl')
     })
 
+    it('requests a text response', async () => {
+      mockApiClient.get.mockResolvedValueOnce('data')
+
+      await useFeedbackStore.getState().exportDataset()
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('/api/feedback/dataset/export'),
+        { responseType: 'text' }
+      )
+    })
+
     it('returns null on error', async () => {
-      mockFetch.mockResolvedValueOnce({ ok: false, statusText: 'Error' })
+      mockApiClient.get.mockRejectedValueOnce(new Error('Error'))
 
       const result = await useFeedbackStore.getState().exportDataset()
 
@@ -455,66 +458,65 @@ describe('exportDataset - all options', () => {
   beforeEach(() => {
     resetStore()
     vi.clearAllMocks()
-    mockFetch.mockReset()
   })
 
   it('includes include_negative=true in URL', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('data') })
+    mockApiClient.get.mockResolvedValueOnce('data')
 
     await useFeedbackStore.getState().exportDataset({ include_negative: true })
 
-    const url = mockFetch.mock.calls[0][0] as string
+    const url = mockApiClient.get.mock.calls[0][0]
     expect(url).toContain('include_negative=true')
   })
 
   it('includes include_negative=false in URL', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('data') })
+    mockApiClient.get.mockResolvedValueOnce('data')
 
     await useFeedbackStore.getState().exportDataset({ include_negative: false })
 
-    const url = mockFetch.mock.calls[0][0] as string
+    const url = mockApiClient.get.mock.calls[0][0]
     expect(url).toContain('include_negative=false')
   })
 
   it('includes include_implicit=true in URL', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('data') })
+    mockApiClient.get.mockResolvedValueOnce('data')
 
     await useFeedbackStore.getState().exportDataset({ include_implicit: true })
 
-    const url = mockFetch.mock.calls[0][0] as string
+    const url = mockApiClient.get.mock.calls[0][0]
     expect(url).toContain('include_implicit=true')
   })
 
   it('includes agent_filter joined by comma in URL', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('data') })
+    mockApiClient.get.mockResolvedValueOnce('data')
 
     await useFeedbackStore.getState().exportDataset({ agent_filter: ['agent-a', 'agent-b'] })
 
-    const url = mockFetch.mock.calls[0][0] as string
+    const url = mockApiClient.get.mock.calls[0][0]
     expect(url).toContain('agent_filter=agent-a%2Cagent-b')
   })
 
   it('does NOT include agent_filter when array is empty', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('data') })
+    mockApiClient.get.mockResolvedValueOnce('data')
 
     await useFeedbackStore.getState().exportDataset({ agent_filter: [] })
 
-    const url = mockFetch.mock.calls[0][0] as string
+    const url = mockApiClient.get.mock.calls[0][0]
     expect(url).not.toContain('agent_filter')
   })
 
   it('includes start_date and end_date in URL', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('data') })
+    mockApiClient.get.mockResolvedValueOnce('data')
 
     await useFeedbackStore.getState().exportDataset({ start_date: '2025-01-01', end_date: '2025-12-31' })
 
-    const url = mockFetch.mock.calls[0][0] as string
+    const url = mockApiClient.get.mock.calls[0][0]
     expect(url).toContain('start_date=2025-01-01')
     expect(url).toContain('end_date=2025-12-31')
   })
 
   it('includes all options together', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('combined') })
+    mockApiClient.get.mockResolvedValueOnce('combined')
 
     const result = await useFeedbackStore.getState().exportDataset({
       format: 'csv',
@@ -526,7 +528,7 @@ describe('exportDataset - all options', () => {
     })
 
     expect(result).toBe('combined')
-    const url = mockFetch.mock.calls[0][0] as string
+    const url = mockApiClient.get.mock.calls[0][0]
     expect(url).toContain('format=csv')
     expect(url).toContain('include_negative=true')
     expect(url).toContain('include_implicit=false')

--- a/src/dashboard/src/stores/__tests__/orchestration.test.ts
+++ b/src/dashboard/src/stores/__tests__/orchestration.test.ts
@@ -17,6 +17,7 @@ import {
   PROVIDER_CONFIG,
 } from '../orchestration'
 import { apiClient } from '../../services/apiClient'
+import { ApiError } from '../../services/errors'
 
 const mockApiClient = vi.mocked(apiClient)
 
@@ -886,10 +887,7 @@ describe('orchestration store', () => {
   describe('connect', () => {
     // Helper: start connect and manually trigger WS onopen
     async function connectAndOpen(sessionId = 'sess-new') {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ session_id: sessionId }),
-      })
+      mockApiClient.post.mockResolvedValueOnce({ session_id: sessionId })
 
       const connectPromise = useOrchestrationStore.getState().connect()
       await connectPromise
@@ -907,9 +905,11 @@ describe('orchestration store', () => {
 
       const ws = await connectAndOpen('sess-new')
 
-      expect(mockFetch).toHaveBeenCalledWith('/api/sessions', expect.objectContaining({
-        method: 'POST',
-      }))
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        '/api/sessions',
+        expect.objectContaining({ project_id: 'p1' }),
+        { skipRetry: true }
+      )
 
       const state = useOrchestrationStore.getState()
       expect(state.connected).toBe(true)
@@ -926,10 +926,7 @@ describe('orchestration store', () => {
     it('handles session creation failure (non-ok response)', async () => {
       useOrchestrationStore.setState({ selectedProjectId: 'p1' })
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        json: () => Promise.resolve({ detail: 'Unauthorized' }),
-      })
+      mockApiClient.post.mockRejectedValueOnce(new Error('Unauthorized'))
 
       await useOrchestrationStore.getState().connect()
 
@@ -940,7 +937,7 @@ describe('orchestration store', () => {
     it('handles session creation network error', async () => {
       useOrchestrationStore.setState({ selectedProjectId: 'p1' })
 
-      mockFetch.mockRejectedValueOnce(new Error('Network'))
+      mockApiClient.post.mockRejectedValueOnce(new Error('Network'))
 
       await useOrchestrationStore.getState().connect()
 
@@ -1066,7 +1063,7 @@ describe('orchestration store', () => {
       await useOrchestrationStore.getState().reconnect()
 
       // Should not have called fetch
-      expect(mockFetch).not.toHaveBeenCalled()
+      expect(mockApiClient.get).not.toHaveBeenCalledWith(expect.stringContaining('/sync'))
     })
 
     it('does nothing when already connecting', async () => {
@@ -1077,7 +1074,7 @@ describe('orchestration store', () => {
 
       await useOrchestrationStore.getState().reconnect()
 
-      expect(mockFetch).not.toHaveBeenCalled()
+      expect(mockApiClient.get).not.toHaveBeenCalledWith(expect.stringContaining('/sync'))
     })
 
     it('clears state when no session to reconnect', async () => {
@@ -1095,7 +1092,9 @@ describe('orchestration store', () => {
         tasks: { t1: { id: 't1' } as any },
       })
 
-      mockFetch.mockResolvedValueOnce({ ok: false })
+      mockApiClient.get.mockRejectedValueOnce(
+        new ApiError({ message: 'Not Found', status: 404, code: 'NOT_FOUND' })
+      )
 
       await useOrchestrationStore.getState().reconnect()
 
@@ -1112,7 +1111,7 @@ describe('orchestration store', () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       useOrchestrationStore.setState({ sessionId: 'sess-neterr' })
 
-      mockFetch.mockRejectedValueOnce(new Error('Network'))
+      mockApiClient.get.mockRejectedValueOnce(new Error('Network'))
 
       await useOrchestrationStore.getState().reconnect()
 
@@ -1148,10 +1147,7 @@ describe('orchestration store', () => {
         total_cost: 0.01,
       }
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(syncData),
-      })
+      mockApiClient.get.mockResolvedValueOnce(syncData)
 
       const reconnectPromise = useOrchestrationStore.getState().reconnect()
       await reconnectPromise
@@ -1180,18 +1176,15 @@ describe('orchestration store', () => {
     it('handles WebSocket close during reconnect (auto-reconnect)', async () => {
       useOrchestrationStore.setState({ sessionId: 'sess-reclose' })
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          session_info: null,
-          tasks: {},
-          root_task_id: null,
-          agents: {},
-          pending_approvals: {},
-          waiting_for_approval: false,
-          token_usage: {},
-          total_cost: 0,
-        }),
+      mockApiClient.get.mockResolvedValueOnce({
+        session_info: null,
+        tasks: {},
+        root_task_id: null,
+        agents: {},
+        pending_approvals: {},
+        waiting_for_approval: false,
+        token_usage: {},
+        total_cost: 0,
       })
 
       await useOrchestrationStore.getState().reconnect()
@@ -1209,18 +1202,15 @@ describe('orchestration store', () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       useOrchestrationStore.setState({ sessionId: 'sess-reconerr' })
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          session_info: null,
-          tasks: {},
-          root_task_id: null,
-          agents: {},
-          pending_approvals: {},
-          waiting_for_approval: false,
-          token_usage: {},
-          total_cost: 0,
-        }),
+      mockApiClient.get.mockResolvedValueOnce({
+        session_info: null,
+        tasks: {},
+        root_task_id: null,
+        agents: {},
+        pending_approvals: {},
+        waiting_for_approval: false,
+        token_usage: {},
+        total_cost: 0,
       })
 
       await useOrchestrationStore.getState().reconnect()
@@ -1236,18 +1226,15 @@ describe('orchestration store', () => {
     it('handles incoming messages during reconnect', async () => {
       useOrchestrationStore.setState({ sessionId: 'sess-reconmsg' })
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          session_info: null,
-          tasks: {},
-          root_task_id: null,
-          agents: {},
-          pending_approvals: {},
-          waiting_for_approval: false,
-          token_usage: {},
-          total_cost: 0,
-        }),
+      mockApiClient.get.mockResolvedValueOnce({
+        session_info: null,
+        tasks: {},
+        root_task_id: null,
+        agents: {},
+        pending_approvals: {},
+        waiting_for_approval: false,
+        token_usage: {},
+        total_cost: 0,
       })
 
       await useOrchestrationStore.getState().reconnect()
@@ -1267,18 +1254,15 @@ describe('orchestration store', () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       useOrchestrationStore.setState({ sessionId: 'sess-reconbad' })
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          session_info: null,
-          tasks: {},
-          root_task_id: null,
-          agents: {},
-          pending_approvals: {},
-          waiting_for_approval: false,
-          token_usage: {},
-          total_cost: 0,
-        }),
+      mockApiClient.get.mockResolvedValueOnce({
+        session_info: null,
+        tasks: {},
+        root_task_id: null,
+        agents: {},
+        pending_approvals: {},
+        waiting_for_approval: false,
+        token_usage: {},
+        total_cost: 0,
       })
 
       await useOrchestrationStore.getState().reconnect()
@@ -1303,10 +1287,7 @@ describe('orchestration store', () => {
     async function connectAndGetWs() {
       useOrchestrationStore.setState({ selectedProjectId: 'p1' })
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ session_id: 'sess-hm' }),
-      })
+      mockApiClient.post.mockResolvedValueOnce({ session_id: 'sess-hm' })
 
       await useOrchestrationStore.getState().connect()
 

--- a/src/dashboard/src/stores/agents.ts
+++ b/src/dashboard/src/stores/agents.ts
@@ -6,8 +6,6 @@
 
 import { create } from 'zustand'
 import { apiClient } from '../services/apiClient'
-import { getApiUrl } from '../config/api'
-import { useAuthStore } from './auth'
 import { useSettingsStore, TERMINAL_DISPLAY_NAMES } from './settings'
 
 const TASK_ANALYZER_TIMEOUT_MS = 180_000
@@ -173,8 +171,6 @@ interface AgentsState {
   deleteAnalysis: (id: string) => Promise<boolean>
   selectHistoryItem: (item: TaskAnalysisHistory | null) => void
 }
-
-const API_BASE = getApiUrl('/api')
 
 /**
  * 태스크 입력에서 git 브랜치명을 자동 생성.
@@ -401,7 +397,6 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
 
       if (attachedImages.length > 0) {
         // Use multipart/form-data endpoint when images are attached
-        // (raw fetch needed for FormData uploads)
         const formData = new FormData()
         formData.append('task', task)
         if (context) {
@@ -411,34 +406,11 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
           formData.append('images', img)
         }
 
-        const headers: Record<string, string> = {}
-        const { accessToken } = useAuthStore.getState()
-        if (accessToken) {
-          headers['Authorization'] = `Bearer ${accessToken}`
-        }
-
-        const controller = new AbortController()
-        const timeoutId = window.setTimeout(() => controller.abort(), TASK_ANALYZER_TIMEOUT_MS)
-        let response: Response
-        try {
-          response = await fetch(`${API_BASE}/agents/orchestrate/analyze-with-images`, {
-            method: 'POST',
-            headers,
-            body: formData,
-            signal: controller.signal,
-          })
-        } catch (error) {
-          if (error instanceof DOMException && error.name === 'AbortError') {
-            throw new Error('Request timed out', { cause: error })
-          }
-          throw error
-        } finally {
-          window.clearTimeout(timeoutId)
-        }
-        if (!response.ok) {
-          throw new Error(`Failed to analyze task: ${response.statusText}`)
-        }
-        result = await response.json()
+        result = await apiClient.post<TaskAnalysisResult>(
+          '/api/agents/orchestrate/analyze-with-images',
+          formData,
+          { timeout: TASK_ANALYZER_TIMEOUT_MS, skipRetry: true }
+        )
       } else {
         // Use JSON endpoint when no images
         result = await apiClient.post<TaskAnalysisResult>(
@@ -542,23 +514,11 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
       const formData = new FormData()
       formData.append('image', file)
 
-      const ocrHeaders: Record<string, string> = {}
-      const { accessToken: ocrToken } = useAuthStore.getState()
-      if (ocrToken) {
-        ocrHeaders['Authorization'] = `Bearer ${ocrToken}`
-      }
-
-      const response = await fetch(`${API_BASE}/agents/ocr`, {
-        method: 'POST',
-        headers: ocrHeaders,
-        body: formData,
-      })
-
-      if (!response.ok) {
-        throw new Error(`OCR failed: ${response.statusText}`)
-      }
-
-      const result = await response.json()
+      const result = await apiClient.post<{ success: boolean; text?: string; error?: string }>(
+        '/api/agents/ocr',
+        formData,
+        { skipRetry: true }
+      )
 
       if (!result.success) {
         console.error('OCR error:', result.error)

--- a/src/dashboard/src/stores/feedback.ts
+++ b/src/dashboard/src/stores/feedback.ts
@@ -7,7 +7,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { apiClient } from '../services/apiClient'
-import { getApiUrl } from '../config/api'
 
 // ============================================================================
 // Types
@@ -421,14 +420,10 @@ export const useFeedbackStore = create<FeedbackState>()(
           if (options?.start_date) queryParams.append('start_date', options.start_date)
           if (options?.end_date) queryParams.append('end_date', options.end_date)
 
-          const url = getApiUrl(`/api/feedback/dataset/export?${queryParams}`)
-          const response = await fetch(url)
-
-          if (!response.ok) {
-            throw new Error(`Failed to export dataset: ${response.statusText}`)
-          }
-
-          const content = await response.text()
+          const content = await apiClient.get<string>(
+            `/api/feedback/dataset/export?${queryParams}`,
+            { responseType: 'text' }
+          )
           set({ isLoading: false })
 
           return content

--- a/src/dashboard/src/stores/orchestration/wsConnection.ts
+++ b/src/dashboard/src/stores/orchestration/wsConnection.ts
@@ -1,6 +1,8 @@
 // WebSocket connection management: connect, reconnect, disconnect, heartbeat
 
 import { notificationService } from '../../services/notificationService'
+import { apiClient } from '../../services/apiClient'
+import { ApiError } from '../../services/errors'
 import type { OrchestrationState, LLMProvider, ProviderUsage } from './types'
 import { RECONNECT_CONFIG, calculateBackoff } from './types'
 import { handleMessage, transformTask } from './wsHandler'
@@ -8,6 +10,18 @@ import type { Task } from './types'
 
 type SetFn = (state: Partial<OrchestrationState> | ((state: OrchestrationState) => Partial<OrchestrationState>)) => void
 type GetFn = () => OrchestrationState
+
+/** Server payload returned by GET /api/sessions/{id}/sync */
+interface SessionSyncResponse {
+  session_info: OrchestrationState['sessionInfo']
+  tasks?: Record<string, unknown>
+  root_task_id: OrchestrationState['rootTaskId']
+  agents?: OrchestrationState['agents']
+  pending_approvals?: OrchestrationState['pendingApprovals']
+  waiting_for_approval?: boolean
+  token_usage?: OrchestrationState['tokenUsage']
+  total_cost?: number
+}
 
 // Setup WebSocket event handlers (shared between connect and reconnect)
 function setupWebSocketHandlers(
@@ -108,21 +122,14 @@ export async function connectWebSocket(set: SetFn, get: GetFn) {
   // Create session via REST API first (with project context)
   let sessionId: string
   try {
-    const res = await fetch('/api/sessions', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    const data = await apiClient.post<{ session_id: string }>(
+      '/api/sessions',
+      {
         project_id: selectedProjectId,
         organization_id: organizationId,
-      }),
-    })
-    if (!res.ok) {
-      const error = await res.json()
-      console.error('Failed to create session:', error.detail || error)
-      set({ isInitialLoading: false })
-      return
-    }
-    const data = await res.json()
+      },
+      { skipRetry: true }
+    )
     sessionId = data.session_id
   } catch (e) {
     console.error('Failed to create session:', e)
@@ -157,9 +164,29 @@ export async function reconnectWebSocket(set: SetFn, get: GetFn) {
 
   // Sync session state from server (validates session and gets latest tasks)
   try {
-    const syncRes = await fetch(`/api/sessions/${sessionId}/sync`)
+    // Sync server state to local
+    const syncData = await apiClient.get<SessionSyncResponse>(`/api/sessions/${sessionId}/sync`)
 
-    if (!syncRes.ok) {
+    // Transform and merge tasks from server
+    const serverTasks: Record<string, Task> = {}
+    for (const [id, raw] of Object.entries(syncData.tasks || {})) {
+      serverTasks[id] = transformTask(raw as Record<string, unknown>)
+    }
+
+    set({
+      sessionInfo: syncData.session_info,
+      tasks: serverTasks,
+      rootTaskId: syncData.root_task_id,
+      agents: syncData.agents || {},
+      pendingApprovals: syncData.pending_approvals || {},
+      waitingForApproval: syncData.waiting_for_approval || false,
+      tokenUsage: syncData.token_usage || {},
+      totalCost: syncData.total_cost || 0,
+    })
+  } catch (e) {
+    // An HTTP error response means the session expired or was not found.
+    // (status 0 = network/parse failure, handled by the narrower reset below.)
+    if (e instanceof ApiError && e.status > 0) {
       // Session expired or not found - clear local state
       set({
         sessionId: null,
@@ -182,26 +209,6 @@ export async function reconnectWebSocket(set: SetFn, get: GetFn) {
       return
     }
 
-    // Sync server state to local
-    const syncData = await syncRes.json()
-
-    // Transform and merge tasks from server
-    const serverTasks: Record<string, Task> = {}
-    for (const [id, raw] of Object.entries(syncData.tasks || {})) {
-      serverTasks[id] = transformTask(raw as Record<string, unknown>)
-    }
-
-    set({
-      sessionInfo: syncData.session_info,
-      tasks: serverTasks,
-      rootTaskId: syncData.root_task_id,
-      agents: syncData.agents || {},
-      pendingApprovals: syncData.pending_approvals || {},
-      waitingForApproval: syncData.waiting_for_approval || false,
-      tokenUsage: syncData.token_usage || {},
-      totalCost: syncData.total_cost || 0,
-    })
-  } catch (e) {
     console.error('[Session] Failed to sync session:', e)
     set({
       sessionId: null,


### PR DESCRIPTION
## Summary
- 대시보드의 raw `fetch()` 호출 25개 파일을 `apiClient`로 수렴 — 모든 API 호출에 Authorization 자동 첨부 + 401 시 토큰 refresh 후 재시도 적용 (토큰 만료 시 회복 불가 401 경로 제거)
- apiClient 확장: FormData body 지원(Content-Type 자동 제거), `responseType: 'text'` 옵션
- Codex 리뷰 P2 반영: 전환된 비멱등 POST 15곳에 `skipRetry: true` — 네트워크 에러 재시도로 인한 리소스 중복 생성 방지 (원 raw fetch의 무재시도 동작 보존)

## Changes
- `services/apiClient.ts`: `serializeBody`(FormData 통과), `omitContentType`, `responseType` 옵션 추가
- stores: `agents.ts`(FormData 업로드 2곳 포함), `feedback.ts`(text export), `orchestration/wsConnection.ts`
- components/pages: CostMonitor, ProcessMonitorWidget, ProcessCleanupPanel, VersionHistory, RAGQueryPanel, LLMRouterSettings, NotificationRuleEditor, ArtifactBrowser, TemplateGallery, ContextWindowMeter, AgentEvalPanel, AuditLogTable, AnalyticsPage, LoginPage, App 등
- 의도적 제외(raw fetch 유지): `stores/auth.ts`(인증 부트스트랩), 사용자 설정 `backendUrl` 연결 테스트 호출(settings/SettingsPage/llm-router 패널), `services/health.ts`(503 body 파싱 + fast-fail 프로브 시맨틱)

## Test Plan
- [x] `tsc --noEmit` 에러 0 (CWD src/dashboard)
- [x] `eslint src` 에러 0
- [x] `vitest run` 4,352/4,352 통과
- [x] Codex 리뷰 1회 통과 (P2 1건 → 반영 완료)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iNG3addLz9XJYwXyU3Hnc