### PR TITLE
docs: 구현 상태와 문서 동기화 (API/모델/대시보드/아키텍처/사용자 가이드)

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -50,18 +50,16 @@ LLM_API_FALLBACK_ENABLED=false
 
 ### 3. 인프라 실행 (PostgreSQL, Redis, Qdrant)
 
-```bash
-# 프로젝트 루트에서 실행
-docker compose up -d postgres redis qdrant
-```
-
-또는 dev.sh 스크립트 사용:
+개발 환경에서는 `~/Work/shared-infra`의 공용 DB 스택을 사용합니다 (ppt-maker, image-maker 등 다른 프로젝트와 공유). AOS는 자체 DB 스택을 띄우지 않습니다.
 
 ```bash
-./infra/scripts/dev.sh
+cd infra/scripts && ./dev.sh
 ```
 
-> **참고**: Qdrant는 컨테이너 내부에 curl/wget이 없어 Docker healthcheck을 지원하지 않습니다. `service_started` 조건으로 시작되며, 보통 수 초 내에 준비됩니다. PostgreSQL과 Redis는 healthcheck이 설정되어 있습니다.
+`dev.sh`는 `~/Work/shared-infra/docker-compose.yml`을 대상으로 PostgreSQL·Redis·Qdrant를 기동합니다. shared-infra가 없으면 스크립트가 먼저 클론/생성하라고 안내합니다.
+
+> **참고**: 프로젝트 루트의 `docker-compose.yml`은 **self-host 전체 스택 배포**(앱 + DB)용이며, 개발용 인프라 소스가 아닙니다. 이 파일은 `POSTGRES_PASSWORD:?` 같은 시크릿 가드가 걸려 있어 `docker compose up -d postgres`를 직접 실행하면 시크릿 없이 실패합니다 — self-host는 `./setup.sh`를 사용하세요 ([self-host 퀵스타트](./self-host-quickstart.md)).
+> Qdrant는 컨테이너 내부에 curl/wget이 없어 Docker healthcheck을 지원하지 않습니다. `service_started` 조건으로 시작되며, 보통 수 초 내에 준비됩니다. PostgreSQL과 Redis는 healthcheck이 설정되어 있습니다.
 
 ### 4. Backend 실행
 
@@ -159,7 +157,7 @@ http://localhost:5173
 2. **LLM 실행 에러**: `codex` CLI 로그인 상태와 `LLM_PROVIDER=codex_cli` 확인. API fallback을 의도한 경우에만 `LLM_API_FALLBACK_ENABLED=true`와 해당 key 확인
 3. **CORS 에러**: `CORS_ORIGINS` 형식 확인 (쉼표 구분: `a.com,b.com` 또는 JSON 배열)
 4. **UI 에러**: `npm install` 후 재시작
-5. **DB 에러**: `USE_DATABASE=false`로 설정하거나 `docker compose up -d postgres redis qdrant` 실행
+5. **DB 에러**: `USE_DATABASE=false`로 설정하거나 `cd infra/scripts && ./dev.sh`로 shared-infra DB 스택을 기동
 6. **Qdrant 연결 안됨**: 컨테이너 시작 후 수 초 대기 필요 (healthcheck 없이 `service_started`로 시작됨)
 
 자세한 내용은 [USER_GUIDE.md](./USER_GUIDE.md) 참조

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -86,11 +86,12 @@ cd infra/scripts && ./start-all.sh
 #### 1단계: 환경 설정
 
 ```bash
-# 프로젝트 디렉토리로 이동
-cd "/Users/younghwankang/Work/Agent-System"
+# 프로젝트 루트로 이동 (클론한 경로)
+cd Agent-System
 
-# .env 파일 생성
-cat > src/backend/.env << EOF
+# .env 파일은 프로젝트 루트에 생성합니다.
+# src/backend/.env 는 루트 .env 로의 심링크이며, dev.sh/start-all.sh 도 루트 .env 를 읽습니다.
+cat > .env << EOF
 # LLM runtime policy
 LLM_PROVIDER=codex_cli
 LLM_DEFAULT_MODE=cli
@@ -177,10 +178,8 @@ npm run dev
 | **Dashboard** | `/` | 메인 대시보드 (세션 상태, 태스크 요약) |
 | **Projects** | `/projects` | 프로젝트 목록 및 관리, RAG 검색 |
 | **Project Configs** | `/project-configs` | Skills, Agents, MCP, Hooks, Commands 관리 |
-| **Tasks** | `/tasks` | 태스크 트리 뷰, 상세 정보 |
 | **Sessions** | `/sessions` | 세션 활동 뷰 |
 | **Agents** | `/agents` | 에이전트 레지스트리, MCP, RLHF |
-| **Activity** | `/activity` | 실시간 활동 로그 |
 | **Monitor** | `/monitor` | 프로젝트 헬스 체크 (test, lint, build, typecheck) |
 | **Claude Sessions** | `/claude-sessions` | Claude Code 세션 모니터링 |
 | **Git** | `/git` | 브랜치/머지/PR 관리 |
@@ -194,6 +193,8 @@ npm run dev
 | **External Usage** | `/external-usage` | 내부 LLM ledger 기반 사용량과 provider billing reconciliation |
 | **Admin** | `/admin` | 관리자 (사용자 관리, 메뉴 설정, 시스템 정보) |
 | **Settings** | `/settings` | 시스템 설정 |
+
+> `TasksPage`·`ActivityPage` 컴포넌트는 코드에 남아 있으나 현재 `routes.tsx`에 라우트가 등록되지 않아 사이드바에서 접근할 수 없습니다 (태스크는 Dashboard/Sessions에, 활동 로그는 Monitor/Claude Sessions에 통합).
 
 ### Task Tree 상태
 
@@ -874,16 +875,19 @@ cd src/dashboard && npm run dev
 
 ### Claude Code 슬래시 명령어
 
+프로젝트 커맨드는 `.claude/commands/`에 있습니다 (전체 목록은 [claude-code-integration.md](./architecture/claude-code-integration.md) 참조).
+
 | 명령어 | 설명 |
 |--------|------|
 | `/check-health` | 타입체크, 린트, 테스트, 빌드 종합 검증 |
-| `/verify-app` | Boris Cherny 스타일 검증 루프 |
+| `/verify-loop` | 자동 재검증 루프 (최대 3회 재시도) |
 | `/test-coverage` | 테스트 커버리지 분석 |
-| `/commit-push-pr` | Git 워크플로우 자동화 |
 | `/start-all` | 전체 서비스 시작 |
 | `/stop-all` | 전체 서비스 중지 |
-| `/save-and-compact` | 컨텍스트 저장 후 /compact |
-| `/resume` | 이전 세션 컨텍스트 복원 |
+| `/session-wrap` | 세션 종료 시 문서·패턴·후속작업 정리 |
+| `/wip-save` | 작업 상태 저장/복원 (WIP 커밋) |
+
+> `commit-push-pr`·`draft-commits` 등 Git 워크플로우 커맨드는 이 리포가 아니라 사용자 전역 설정(`~/.claude/commands/`)에서 제공됩니다.
 
 ### 참고 링크
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,12 +11,16 @@ AOS Backend API 엔드포인트 문서입니다.
 
 | 도메인 | 파일 | 주요 내용 |
 |--------|------|-----------|
-| Core | [api/core.md](api/core.md) | Sessions, Auth, WebSocket, HITL |
+| Core | [api/core.md](api/core.md) | Sessions, Tasks, Auth, HITL, Permission Toggles, WebSocket |
 | Agents | [api/agents.md](api/agents.md) | Agents, Orchestration, Tmux, MCP, Claude Sessions |
-| Projects | [api/projects.md](api/projects.md) | Registry, Configs, Versions, Access, Invitations, Monitoring |
+| Projects | [api/projects.md](api/projects.md) | Registry, Configs, Versions, Access, Invitations, Monitoring, Diagnostics |
 | Git | [api/git.md](api/git.md) | Status, Branches, Merge, MR, Branch Protection, GitHub |
-| LLM | [api/llm.md](api/llm.md) | Models, Router, Credentials, Proxy, Playground |
-| Monitoring | [api/monitoring.md](api/monitoring.md) | Usage, Analytics, Audit, Health, Notifications, Orgs, Admin, Rate Limits, Cost, Feedback |
-| Automation | [api/automation.md](api/automation.md) | Workflows, Secrets, Webhooks, Pipelines, RAG, Warp |
+| LLM | [api/llm.md](api/llm.md) | Models, Router, Credentials, Access, Proxy, Usage Ledger, Playground |
+| Monitoring | [api/monitoring.md](api/monitoring.md) | Usage, Analytics, External Usage, Audit, Health, Notifications, Orgs, Admin, Rate Limits, Cost, Feedback |
+| Automation | [api/automation.md](api/automation.md) | Workflows, Secrets, Webhooks, Artifacts, Templates, Automation Loops, Pipelines, Terminal, Warp, MCP Protocol, RAG |
 
 > 새 API 엔드포인트 추가 시 해당 도메인 파일에 추가하세요.
+
+> ⚠️ **미마운트 라우터**: `automation.py`(Automation Loops)와 `pipelines.py`(Pipelines)는 구현은 있으나
+> `app.py`/`routes.py` 어디에도 등록되지 않아 런타임에 접근 불가합니다. 해당 절은 참조용으로만 유지됩니다
+> ([api/automation.md](api/automation.md) 참조).

--- a/docs/api/automation.md
+++ b/docs/api/automation.md
@@ -1,6 +1,6 @@
 # API Reference - Automation
 
-워크플로우(CI/CD), 시크릿, 웹훅, 아티팩트, 템플릿, 자동화 루프, 파이프라인, Warp 터미널, MCP Protocol, RAG API입니다.
+워크플로우(CI/CD), 시크릿, 웹훅, 아티팩트, 템플릿, 자동화 루프, 파이프라인, 터미널 연동, Warp 터미널, MCP Protocol, RAG API입니다.
 
 ## Base URL
 - Development: `http://localhost:8000`
@@ -54,6 +54,7 @@
 |--------|------|------|
 | GET | `/api/workflows/runs/{run_id}/artifacts` | 실행별 아티팩트 목록 |
 | POST | `/api/workflows/runs/{run_id}/artifacts` | 아티팩트 업로드 (multipart) |
+| GET | `/api/workflows/artifacts/{id}` | 아티팩트 메타데이터 조회 |
 | GET | `/api/workflows/artifacts/{id}/download` | 아티팩트 다운로드 |
 | DELETE | `/api/workflows/artifacts/{id}` | 아티팩트 삭제 |
 
@@ -66,11 +67,14 @@
 | GET | `/api/workflows/templates` | 템플릿 목록 (`?category=`, `?search=`) |
 | POST | `/api/workflows/templates` | 템플릿 생성 |
 | GET | `/api/workflows/templates/{id}` | 템플릿 상세 |
+| DELETE | `/api/workflows/templates/{id}` | 템플릿 삭제 |
 | POST | `/api/workflows/from-template/{id}` | 템플릿으로 워크플로우 생성 |
 
 ---
 
 ## Automation (자동화 루프)
+
+> ⚠️ **현재 미마운트**: 라우터 구현(`src/backend/api/automation.py`)은 존재하나 `app.py`/`routes.py` 어디에도 등록되지 않아 런타임에 접근 불가합니다. 아래 스펙은 구현 예정/보류 상태의 참조용입니다.
 
 | Method | Path | 설명 |
 |--------|------|------|
@@ -116,6 +120,8 @@
 
 ## Pipelines (데이터 파이프라인)
 
+> ⚠️ **현재 미마운트**: 라우터 구현(`src/backend/api/pipelines.py`)은 존재하나 `app.py`/`routes.py` 어디에도 등록되지 않아 런타임에 접근 불가합니다. 아래 스펙은 구현 예정/보류 상태의 참조용입니다.
+
 | Method | Path | 설명 |
 |--------|------|------|
 | POST | `/api/pipelines` | 파이프라인 정의 생성 |
@@ -143,6 +149,36 @@
 **내장 스테이지 타입**: `collect`, `transform`, `analyze`, `output`
 
 **에러 전략**: `fail_fast`, `continue`, `retry`
+
+---
+
+## Terminal Integration (공용)
+
+`api.warp`의 Warp 전용 경로를 보완하는 범용 터미널 실행 API입니다.
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/terminal/available` | 터미널 타입별 설치/사용 가능 여부 조회 |
+| POST | `/api/terminal/execute` | 선택한 터미널에서 명령/프롬프트 실행 |
+
+**터미널 타입**: `warp`, `tmux`, `terminal_app`, `iterm2`, `kitty`, `alacritty`, `ghostty`, `wezterm`, `cmux`, `orca`
+
+**실행 요청 본문** (`POST /api/terminal/execute`):
+```json
+{
+  "terminal": "warp",
+  "project_id": "project-uuid",
+  "command": "npm test",
+  "title": "Tab Title",
+  "branch_name": "feature/my-branch",
+  "image_paths": ["/path/to/screenshot.png"],
+  "use_claude_cli": true
+}
+```
+
+- `branch_name` 지정 시 실행 전 `git checkout -b` 수행
+
+> ⚠️ `use_claude_cli`(기본 `true`)는 요청 스키마에 존재하지만 현재 핸들러가 어댑터로 전달하지 않아 **무시된다**(`api/terminal.py:110-115`). 값과 무관하게 명령은 항상 `claude --dangerously-skip-permissions`로 감싸 실행된다.
 
 ---
 

--- a/docs/api/git.md
+++ b/docs/api/git.md
@@ -89,6 +89,7 @@ Git 상태, 브랜치, 커밋, 머지, MR, 브랜치 보호, GitHub 통합 API�
 | DELETE | `/api/git/projects/{id}/branches/{name}` | 브랜치 삭제 |
 | POST | `/api/git/projects/{id}/branches/{name}/checkout` | 브랜치 체크아웃 |
 | GET | `/api/git/projects/{id}/branches/{name}/diff` | 브랜치 diff (base 대비) |
+| POST | `/api/git/projects/{id}/branches/prune-merged` | GitHub PR이 머지된 로컬 브랜치 정리 |
 | GET | `/api/git/projects/{id}/commits` | 커밋 히스토리 |
 | GET | `/api/git/projects/{id}/commits/{sha}` | 커밋 상세 조회 |
 | GET | `/api/git/projects/{id}/commits/{sha}/files` | 커밋 파일 목록 |

--- a/docs/api/llm.md
+++ b/docs/api/llm.md
@@ -19,6 +19,9 @@ LLM 모델 레지스트리, 라우터, 자격증명, 프록시, Playground API�
 | PATCH | `/api/llm/models/{model_id}` | 모델 설정 수정 |
 | DELETE | `/api/llm/models/{model_id}` | 모델 하드 삭제 (config 행 삭제 + suppression 기록, admin 전용) |
 | DELETE | `/api/llm/models/suppressions/{model_id}` | suppression 해제 (admin 전용) |
+| POST | `/api/llm/models/check-updates` | 모델 업데이트 체크 수동 실행 |
+| GET | `/api/llm/models/update-status` | 모델 업데이트 체크 현재 상태 |
+| GET | `/api/llm/models/update-history` | 모델 업데이트 체크 이력 |
 | GET | `/api/llm/providers` | 지원 프로바이더 목록 |
 
 **응답 형식** (GET /api/llm/models):
@@ -81,6 +84,7 @@ LLM 모델 레지스트리, 라우터, 자격증명, 프록시, Playground API�
 | PATCH | `/api/llm-router/config` | 라우터 설정 업데이트 |
 | GET | `/api/llm-router/state` | 라우터 상태 |
 | GET | `/api/llm-router/stats` | 라우팅 통계 |
+| POST | `/api/llm-router/stats/reset` | 라우팅 통계 초기화 |
 | POST | `/api/llm-router/initialize` | 환경변수에서 초기화 |
 
 **라우팅 전략**: `priority`, `round_robin`, `least_cost`, `least_latency`, `fallback_chain`
@@ -113,6 +117,7 @@ CLI-first LLM profile과 user/org entitlement를 조회하고 관리합니다.
 | POST | `/api/llm-access/profiles` | CLI profile 생성 (admin/manager) |
 | PATCH | `/api/llm-access/profiles/{profile_id}` | CLI profile 수정 (admin/manager) |
 | DELETE | `/api/llm-access/profiles/{profile_id}` | CLI profile 삭제 및 연결된 entitlement profile 매핑 해제 (admin/manager) |
+| POST | `/api/llm-access/profiles/{profile_id}/health-check` | CLI 인증/명령 헬스체크 실행 |
 | GET | `/api/llm-access/entitlements` | LLM entitlement 목록 조회 (admin/manager) |
 | POST | `/api/llm-access/entitlements` | LLM entitlement 생성 (admin/manager) |
 | PATCH | `/api/llm-access/entitlements/{entitlement_id}` | LLM entitlement 수정 (admin/manager) |
@@ -168,8 +173,11 @@ CLI 구독권 중심 사용량의 내부 원장 조회 API입니다. External Us
 |--------|------|------|
 | PATCH | `/api/playground/sessions/{id}/settings` | 세션 설정 변경 |
 | POST | `/api/playground/sessions/{id}/clear` | 대화 이력 초기화 |
+| POST | `/api/playground/sessions/{id}/execute` | 프롬프트 실행 |
 | POST | `/api/playground/sessions/{id}/execute/stream` | 스트리밍 실행 |
 | GET | `/api/playground/sessions/{id}/history` | 대화 이력 조회 |
+| DELETE | `/api/playground/sessions/{id}/messages/{message_id}` | 세션 내 특정 메시지 삭제 |
+| GET | `/api/playground/sessions/{id}/effective-system-prompt` | 최종 전송될 시스템 프롬프트 미리보기 |
 | GET | `/api/playground/tools` | 사용 가능 도구 목록 |
 | POST | `/api/playground/tools/test` | 도구 테스트 실행 |
 | POST | `/api/playground/compare` | 에이전트 비교 실행 |

--- a/docs/api/monitoring.md
+++ b/docs/api/monitoring.md
@@ -162,6 +162,8 @@ org-level usage API용 admin 키(예: OpenAI `sk-admin-`)를 배포 단위로 DB
 | GET | `/api/health/services` | 서비스 상태 조회 |
 | GET | `/api/health/services/conflicts` | 포트 충돌 조회 |
 
+> **Note**: health 라우터는 `app.py`에서 prefix 없이 한 번 더 마운트됩니다. 따라서 위 경로들은 인프라 프로브용으로 `/health`, `/health/live` 처럼 `/api` 없이도 동일하게 서빙됩니다.
+
 ---
 
 ## Notifications

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -1,6 +1,6 @@
 # API Reference - Projects
 
-프로젝트 레지스트리, 오케스트레이션, 설정(Skills/Agents/MCP/Hooks/Commands), 버전 관리, 접근제어, 초대, 모니터링 API입니다.
+프로젝트 레지스트리, 오케스트레이션, 설정(Skills/Agents/MCP/Hooks/Commands), 버전 관리, 접근제어, 초대, 모니터링, 진단 API입니다.
 
 ## Base URL
 - Development: `http://localhost:8000`
@@ -17,6 +17,7 @@
 | GET | `/api/project-registry/{id}` | 프로젝트 상세 |
 | PUT | `/api/project-registry/{id}` | 프로젝트 수정 |
 | DELETE | `/api/project-registry/{id}` | 프로젝트 비활성화 (soft-delete) |
+| DELETE | `/api/project-registry/{id}/permanent` | 프로젝트 영구 삭제 (hard-delete, admin 전용) |
 | POST | `/api/project-registry/{id}/restore` | 프로젝트 복원 |
 
 ### Project Members
@@ -83,7 +84,7 @@
 | POST | `/api/project-configs/{project_id}/skills` | 스킬 생성 |
 | PUT | `/api/project-configs/{project_id}/skills/{skill_id}` | 스킬 수정 |
 | DELETE | `/api/project-configs/{project_id}/skills/{skill_id}` | 스킬 삭제 |
-| POST | `/api/project-configs/{project_id}/skills/copy` | 스킬 복사 (다른 프로젝트에서) |
+| POST | `/api/project-configs/{project_id}/skills/{skill_id}/copy` | 스킬 복사 (다른 프로젝트로) |
 
 ### Agents
 
@@ -93,7 +94,7 @@
 | POST | `/api/project-configs/{project_id}/agents` | 에이전트 생성 |
 | PUT | `/api/project-configs/{project_id}/agents/{agent_id}` | 에이전트 수정 |
 | DELETE | `/api/project-configs/{project_id}/agents/{agent_id}` | 에이전트 삭제 |
-| POST | `/api/project-configs/{project_id}/agents/copy` | 에이전트 복사 |
+| POST | `/api/project-configs/{project_id}/agents/{agent_id}/copy` | 에이전트 복사 (다른 프로젝트로) |
 
 ### MCP Servers
 
@@ -103,17 +104,20 @@
 | POST | `/api/project-configs/{project_id}/mcp` | MCP 서버 추가 |
 | PUT | `/api/project-configs/{project_id}/mcp/{server_id}` | MCP 서버 수정 |
 | DELETE | `/api/project-configs/{project_id}/mcp/{server_id}` | MCP 서버 삭제 |
-| POST | `/api/project-configs/{project_id}/mcp/copy` | MCP 서버 복사 |
+| POST | `/api/project-configs/{project_id}/mcp/{server_id}/enable` | MCP 서버 활성화 |
+| POST | `/api/project-configs/{project_id}/mcp/{server_id}/disable` | MCP 서버 비활성화 |
+| POST | `/api/project-configs/{project_id}/mcp/{server_id}/toggle` | MCP 서버 활성/비활성 토글 |
+| POST | `/api/project-configs/{project_id}/mcp/{server_id}/copy` | MCP 서버 복사 (다른 프로젝트로) |
 
 ### Hooks
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/project-configs/{project_id}/hooks` | Hook 목록 |
-| POST | `/api/project-configs/{project_id}/hooks` | Hook 생성 |
-| PUT | `/api/project-configs/{project_id}/hooks/{hook_id}` | Hook 수정 |
-| DELETE | `/api/project-configs/{project_id}/hooks/{hook_id}` | Hook 삭제 |
-| POST | `/api/project-configs/{project_id}/hooks/copy` | Hook 복사 |
+| GET | `/api/project-configs/{project_id}/hooks` | Hook 설정 조회 |
+| PUT | `/api/project-configs/{project_id}/hooks` | hooks.json 전체 내용 수정 |
+| POST | `/api/project-configs/{project_id}/hooks/events/{event}` | 이벤트에 Hook 엔트리 추가 |
+| DELETE | `/api/project-configs/{project_id}/hooks/{event}/{index}` | 이벤트/인덱스로 Hook 엔트리 삭제 |
+| POST | `/api/project-configs/{project_id}/hooks/{event}/{index}/copy` | Hook 복사 (다른 프로젝트로) |
 
 **Hook 이벤트 타입**: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Notification`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStart`, `SubagentStop`, `PreCompact`, `PermissionRequest`, `Setup`
 
@@ -266,3 +270,19 @@
 | GET | `/api/projects/{id}/checks/{check_type}` | 특정 체크 실행 (SSE) |
 
 **체크 타입**: `test`, `lint`, `build`, `type_check`
+
+---
+
+## Project Diagnostics
+
+프로젝트 환경 진단 및 self-healing API입니다.
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/projects/{project_id}/diagnostics` | 전체 환경 진단 실행 |
+| GET | `/api/projects/{project_id}/diagnostics/{category}` | 단일 카테고리 진단 실행 |
+| POST | `/api/projects/{project_id}/diagnostics/fix` | self-healing 수정 액션 실행 |
+
+**진단 카테고리**: `workspace`, `mcp`, `git`, `quota`
+
+**수정 액션** (`POST .../diagnostics/fix`): `create_aos_config`, `create_claude_md`, `enable_mcp_servers`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,12 +69,10 @@ src/backend/
 ├── orchestrator/
 │   ├── engine.py            # 메인 실행 엔진
 │   ├── graph.py             # LangGraph 그래프 구성
-│   ├── nodes.py             # 6가지 노드 구현
-│   ├── parallel_executor.py # 병렬 실행
+│   ├── nodes.py             # BaseNode + 5개 노드 (Orchestrator/Planner/Executor/Reviewer/SelfCorrection)
+│   ├── parallel_executor.py # ParallelExecutorNode (병렬 실행)
 │   └── tools.py             # MCP 도구 실행자
-├── services/                    # 72개 서비스/매니저 모듈
-│   ├── adapters/               # 어댑터 패턴 구현 (비어있음)
-│   ├── cache/                  # 캐싱 레이어 (비어있음)
+├── services/                    # 74개 서비스/매니저 모듈 (services/*.py 75개 중 __init__.py 제외, pipeline/ 패키지는 별도)
 │   ├── agent_manager.py           # 에이전트 인스턴스 관리
 │   ├── agent_registry.py          # 에이전트 등록소
 │   ├── alerting_service.py        # 알림/경고 서비스
@@ -153,8 +151,8 @@ src/backend/
 │           ├── transform_stage.py # 데이터 변환 단계
 │           ├── analyze_stage.py   # 데이터 분석 단계
 │           └── output_stage.py    # 결과 출력 단계
-├── api/                     # FastAPI 라우터 (45개 모듈)
-│   └── v1/                  # v1 API (agent_monitor, agent_registry, auth_middleware 등)
+├── api/                     # FastAPI 라우터 (48개 모듈, api/*.py 기준 __init__.py 제외)
+│   └── v1/                  # v1 API (6개 모듈: agent_monitor, agent_registry, agents, auth_middleware, rate_limiter, stations)
 │       ├── agents.py        # 에이전트 CRUD API
 │       ├── rate_limiter.py  # API 속도 제한
 │       └── stations.py      # 스테이션 관리 API
@@ -186,12 +184,15 @@ src/backend/
 │       ├── activity.py      # SessionActivityModel
 │       ├── config_version.py # ConfigVersionModel (설정 버전 스냅샷/롤백)
 │       ├── playground.py    # PlaygroundSessionModel (에이전트 테스트 세션)
+│       ├── audit.py         # AuditLogModel (감사 로그)
+│       ├── model_update.py  # ModelUpdateLogModel (모델 자동 발견/갱신 이력)
 │       └── base.py          # Base, TimestampMixin
-├── models/                  # Pydantic 데이터 모델 (32개)
+├── models/                  # Pydantic 데이터 모델 (35개, models/*.py 기준 __init__.py 제외)
 ├── middleware/
 │   └── rate_limit.py        # RateLimitMiddleware (per-user/IP, tier-based)
 ├── utils/
 │   └── time.py              # utcnow() - timezone-aware UTC (datetime.utcnow() 대체)
+├── phase_runner/            # tasks.md 웨이브 실행기 (runner, migrate, checkbox_sync, schema)
 ├── data/                    # 데이터 파일 (시드, 설정 등)
 ├── scripts/                 # 유틸리티 스크립트
 ├── config.py                # 앱 설정 (환경변수 로드)

--- a/docs/architecture/claude-code-integration.md
+++ b/docs/architecture/claude-code-integration.md
@@ -103,17 +103,17 @@ sequenceDiagram
 
 | 카테고리 | 스킬 | 설명 |
 |---------|------|------|
-| **개발** | `react-web-development` | React/TS/Tailwind/Zustand |
-| **개발** | `test-automation` | Vitest 테스트 생성 |
-| **품질** | `verification-loop` | Boris Cherny 검증 루프 |
-| **메타** | `skill-creator` | 스킬 생성 |
-| **메타** | `hook-creator` | 훅 생성 |
-| **메타** | `subagent-creator` | 에이전트 생성 |
-| **메타** | `slash-command-creator` | 커맨드 생성 |
-| **운영** | `parallel-coordinator` | 병렬 실행 조율 |
-| **운영** | `cli-orchestration` | CLI 오케스트레이션 |
-| **관측** | `agent-observability` | 에이전트 추적 |
-| **관측** | `agent-improvement` | 에이전트 개선 |
+| **개발** | `react-web-development` | React/TS/Tailwind/Zustand 개발 가이드 |
+| **개발** | `test-automation` | Vitest/RTL 테스트 생성 및 커버리지 개선 |
+| **품질** | `verification-loop` | 풀스택 검증 피드백 루프 (게이트 명령 SSOT) |
+| **품질** | `verify-backend` | FastAPI/LangGraph/SQLAlchemy 패턴 검증 |
+| **품질** | `verify-frontend` | React/TS/Tailwind 패턴 검증 (memo/displayName 등) |
+| **운영** | `aos-feature-harness` | 풀스택 기능 개발 오케스트레이터 (계획→빌드→검증→리뷰→문서) |
+| **운영** | `merge-worktree` | worktree 브랜치 squash-merge |
+| **운영** | `update-llm-models` | LLM 모델 레지스트리 갱신 절차 |
+| **관측** | `agent-observability` | 에이전트 트레이싱/메트릭 수집 |
+| **관측** | `agent-improvement` | 에이전트 실패 진단 및 개선 |
+| **평가** | `run-eval` | 에이전트 성능 벤치마크 실행 (pass@k 지표) |
 
 **스킬 구조**:
 ```
@@ -129,18 +129,28 @@ sequenceDiagram
 
 | 카테고리 | 커맨드 | 설명 |
 |---------|--------|------|
-| **개발** | `/commit-push-pr` | Git 워크플로우 자동화 |
-| **개발** | `/deploy-with-tests` | 테스트 후 배포 |
-| **개발** | `/draft-commits` | 커밋 초안 생성 |
-| **품질** | `/verify-app` | 종합 검증 (tsc+ruff+pytest+build) |
-| **품질** | `/check-health` | 프로젝트 건강 검진 |
-| **품질** | `/test-coverage` | 테스트 커버리지 분석 |
-| **품질** | `/review` | 코드 리뷰 |
-| **운영** | `/dev-docs` | Dev Docs 3-파일 시스템 |
-| **운영** | `/save-and-compact` | 컨텍스트 저장 + 압축 |
-| **운영** | `/resume` | 이전 세션 복원 |
-| **운영** | `/sync-registry` | 레지스트리 동기화 |
-| **평가** | `/run-eval` | 에이전트 평가 실행 |
+| **개발** | `/plan` | planner 에이전트로 구현 계획 수립 |
+| **개발** | `/tdd` | tdd-guide 에이전트로 TDD 워크플로우 진행 |
+| **개발** | `/explore` | 코드베이스 탐색으로 구조 파악 (`--deps` 의존성 추적) |
+| **개발** | `/execute-tasks-file` | `dev/active/<phase>/*-tasks.md` 웨이브 순차 + 태스크 병렬 실행 |
+| **개발** | `/quick-commit` | 검증 스킵 빠른 커밋 (문서·설정·단순 수정 전용) |
+| **품질** | `/check-health` | 프로젝트 건강 검진 (게이트 + 의존성 audit + 헬스 스코어) |
+| **품질** | `/verify-loop` | 자동 재검증 루프 (최대 3회 재시도, 실패 시 자동 수정) |
+| **품질** | `/build-fix` | 빌드·타입 에러를 최소 변경으로 점진 수정 |
+| **품질** | `/code-review` | 미커밋 변경을 네이티브 코드 리뷰 + 보안 리뷰로 검사 |
+| **품질** | `/test-coverage` | 커버리지 리포트 실행 및 보강 필요 영역 식별 |
+| **운영** | `/start-all` | 전체 서비스 시작 (인프라 + Backend + Dashboard) |
+| **운영** | `/stop-all` | 전체 서비스 중지 |
+| **운영** | `/start-dashboard` | React 대시보드 개발 서버 실행 |
+| **운영** | `/backup` | 전체 서비스 백업 (Postgres + Redis + Qdrant) |
+| **운영** | `/restore` | 백업 디렉토리에서 전체 서비스 복원 |
+| **운영** | `/session-wrap` | 세션 종료 시 4개 병렬 에이전트로 문서·패턴·후속작업 정리 |
+| **운영** | `/wip-save` | 작업 상태 저장/복원 (WIP 커밋, 구 `/checkpoint`) |
+| **운영** | `/update-llm-models` | LLM 모델 레지스트리 갱신 (`update-llm-models` 스킬 실행) |
+
+> 참고: 에이전트 평가는 커맨드가 아니라 `.claude/skills/run-eval` **스킬**로 제공된다.
+> `commit-push-pr`·`draft-commits`·`review`도 이 리포의 `.claude/commands/` 에는 없고,
+> 전역 스킬(`~/.claude/skills/`) 또는 플러그인 커맨드(예: `/codex:review`)로 제공된다.
 
 ### Sub-agents (서브에이전트)
 
@@ -148,14 +158,19 @@ sequenceDiagram
 
 | 에이전트 | 모델 | 역할 |
 |---------|------|------|
-| `aos-orchestrator` | opus | 멀티에이전트 조율 |
-| `web-ui-specialist` | inherit | React/Tailwind UI |
-| `backend-integration-specialist` | inherit | FastAPI/LangGraph |
-| `test-automation-specialist` | haiku | 테스트 자동화 |
-| `performance-optimizer` | haiku | 성능 최적화 |
-| `quality-validator` | haiku | 품질 검증 |
-| `eval-task-runner` | inherit | 평가 태스크 실행 |
-| `eval-grader` | inherit | 평가 채점 |
+| `architect` | opus | 시스템 설계·기술 결정 |
+| `backend-integration-specialist` | inherit | FastAPI/SQLAlchemy/LangGraph 통합 |
+| `build-error-resolver` | sonnet | 빌드·타입 에러 최소 수정 |
+| `code-reviewer` | opus | 품질·보안·유지보수성 리뷰 |
+| `docs-sync` | opus | 변경 코드↔`docs/` 동기화 |
+| `eval-grader` | inherit | 루브릭 기반 평가 채점 |
+| `eval-task-runner` | inherit | 평가 실행·pass@k 산출 |
+| `integration-qa` | opus | FastAPI↔React 계약 교차검증 |
+| `planner` | opus | 기능·리팩터링 계획 수립 |
+| `security-reviewer` | opus | 보안 취약점 탐지·조치 |
+| `tdd-guide` | opus | 테스트 우선(TDD) 방법론 강제 |
+| `test-automation-specialist` | opus | Vitest/RTL 테스트·커버리지 |
+| `web-ui-specialist` | inherit | React/Tailwind UI·UX |
 
 **에이전트 파일 위치**: `.claude/agents/`
 **공유 프로토콜**: `.claude/agents/shared/quality-reference.md`
@@ -164,11 +179,11 @@ sequenceDiagram
 
 Model Context Protocol을 통한 외부 도구 연동.
 
-| 서버 | 용도 |
-|------|------|
-| `filesystem` | 파일 시스템 접근 |
-| `github` | GitHub API (PR, Issue) |
-| `playwright` | 브라우저 자동화, E2E 테스트 |
+**이 리포의 `.claude/mcp.json` 은 `{"mcpServers": {}}` 로 비어 있다.** 공통 MCP 서버는 커밋 `f77bbeb`
+("공통 MCP 서버 11개를 글로벌 마이그레이션")에서 사용자 전역 설정(`~/.claude.json`)으로 옮겨졌기 때문이다.
+따라서 MCP 서버 목록은 프로젝트가 아니라 **개발자 환경별로 결정**되며, 이 문서에 고정 목록을 두지 않는다.
+
+프로젝트 전용 MCP 서버가 필요해지면 `.claude/mcp.json` 의 `mcpServers` 에 추가한다 (전역 설정과 병합됨).
 
 ---
 
@@ -228,11 +243,11 @@ AOS Backend ──┬── Codex CLI (기본, ChatGPT 구독 세션)
 
 | 구성요소 | 수량 | 위치 |
 |---------|------|------|
-| **Hook Events** | 13 | `settings.json` |
-| **Skills** | 16+ | `.claude/skills/` |
-| **Commands** | 22+ | `.claude/commands/` |
-| **Sub-agents** | 8+ | `.claude/agents/` |
-| **MCP Servers** | 3 | `.claude/settings.json` |
+| **Hook Events** | 13 종 지원 / **1 종 등록** | 플랫폼이 지원하는 이벤트 타입은 13종이나, `.claude/settings.json` 에 실제 등록된 것은 `PostToolUse` 하나뿐 |
+| **Skills** | 11 | `.claude/skills/` |
+| **Commands** | 18 | `.claude/commands/` |
+| **Sub-agents** | 13 | `.claude/agents/` |
+| **MCP Servers** | 0 | `.claude/mcp.json` (프로젝트 등록 서버 없음) |
 | **Shared Protocols** | 1 | `.claude/agents/shared/` |
 
 ---
@@ -241,7 +256,10 @@ AOS Backend ──┬── Codex CLI (기본, ChatGPT 구독 세션)
 
 - `CLAUDE.md` - 프로젝트 메인 가이드
 - `docs/architecture.md` - AOS 시스템 아키텍처
-- `.claude/skills/hook-creator/` - 훅 생성 스킬
-- `.claude/skills/subagent-creator/` - 에이전트 생성 스킬
-- `.claude/skills/slash-command-creator/` - 커맨드 생성 스킬
+- `.claude/skills/aos-feature-harness/SKILL.md` - 풀스택 기능 개발 오케스트레이터
+- `.claude/skills/verification-loop/SKILL.md` - 게이트 명령 SSOT
 - `docs/guides/boris-cherny-workflow-guide.md` - Boris Cherny 워크플로우
+
+> 참고: `hook-creator`, `subagent-creator`, `slash-command-creator`, `skill-creator` 등 메타 스킬은
+> 이 리포의 활성 `.claude/skills/` 에 설치되어 있지 않다. 원본은 `claude-workspace-template/core/.claude/skills/`
+> 템플릿에만 존재하므로, 필요하면 템플릿에서 복사해 사용한다.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -75,7 +75,7 @@ import { cn } from '@/lib/utils';
 | `SettingsPage` | `/settings` | 시스템 설정 (LLM Access, CLI profile, fallback API 키, Claude Code OAuth, 터미널 감지) |
 | `LoginPage` | `/login` | OAuth/Email 로그인 |
 | `RegisterPage` | `/register` | 이메일/비밀번호 회원가입 |
-| `AuthCallbackPage` | `/auth/callback` | OAuth 콜백 처리 (App.tsx에서 eager 로딩) |
+| `AuthCallbackPage` | `/auth/callback/google`, `/auth/callback/github` | OAuth 콜백 처리 (routes.tsx 미등록, App.tsx에서 provider별 eager 로딩) |
 | `InvitationAcceptPage` | `/invitations/accept` | 조직 초대 수락 페이지 |
 
 ---
@@ -299,7 +299,8 @@ import { cn } from '@/lib/utils';
 | 컴포넌트 | 설명 |
 |----------|------|
 | `ContextWindowMeter` | Context 창 사용량 게이지 |
-| `CostMonitor` | 비용 모니터링 패널 (provider별 소스 표기, Claude 주간 토큰 합산) |
+| `CostMonitor` | 비용 모니터링 패널 (provider별 소스 표기, Claude 주간 토큰 합산) — 파일은 `components/CostMonitor.tsx` (usage/ 하위 아님), DashboardPage에서 사용 |
+| `CostBadge` | 헤더 비용 요약 배지 — `components/CostMonitor.tsx`의 동일 파일 내 별도 export, App.tsx에서 사용 |
 | `UsageProgressBar` | 사용량 진행바 |
 | `ClaudeUsageDashboard` | Claude 사용량 대시보드 (Codex 5시간/주간 한도 카드 + combined weekly tokens 통합) |
 | `DailyCostTrend` | 일간 비용 추이 차트 |
@@ -397,6 +398,8 @@ import { cn } from '@/lib/utils';
 | `useLLMUsageStore` | `llmUsage.ts` | 내부 `llm_usage_ledger` summary 조회 |
 | `useLLMCredentialStore` | `llmCredentials.ts` | fallback/compatibility API 키 관리 |
 | `useInfraStatusStore` | `infraStatus.ts` | 인프라 서비스 상태 관리 (Docker, 포트 체크) |
+| `useDeploymentUsageKeyStore` | `deploymentUsageKeys.ts` | 배포 단위 usage admin 키 CRUD (`/external-usage/admin-keys`, provider별 db/env 소스 표기, 마스킹된 키) |
+| `useDiagnosticsStore` | `diagnostics.ts` | 프로젝트별 진단 결과 조회 및 fix 액션 실행 (`diagnosticsMap`, `fetchDiagnostics`, `executeFix`) |
 
 ### Store Pattern
 
@@ -578,8 +581,7 @@ src/dashboard/
 │   │   │   └── types.ts
 │   │   └── analytics/          # Analytics
 │   │       └── ProjectMultiSelect.tsx
-│   ├── services/               # API 서비스 레이어
-│   ├── stores/                 # Zustand 스토어 (27개 + index.ts)
+│   ├── stores/                 # Zustand 스토어 (31개 + index.ts)
 │   │   ├── orchestration/      # 리팩토링: index.ts, types.ts, wsConnection.ts, wsHandler.ts
 │   │   ├── orchestration.ts    # 재export
 │   │   ├── projects.ts
@@ -605,7 +607,11 @@ src/dashboard/
 │   │   ├── menuVisibility.ts
 │   │   ├── projectAccess.ts
 │   │   ├── externalUsage.ts
+│   │   ├── llmAccess.ts
+│   │   ├── llmUsage.ts
 │   │   ├── llmCredentials.ts
+│   │   ├── deploymentUsageKeys.ts
+│   │   ├── diagnostics.ts
 │   │   ├── infraStatus.ts
 │   │   └── workflows.ts
 │   ├── config/                 # 설정 (API 엔드포인트 등)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -383,13 +383,57 @@ BACKUP_S3_BUCKET=<bucket-name>
 
 ### 워크플로우
 
-| 워크플로우 | 트리거 | 설명 |
-|------------|--------|------|
-| `ci.yml` | PR, push to main | 린트, 타입체크, 테스트 |
-| `build.yml` | push to main, tag | Docker 이미지 빌드 & GHCR 푸시 |
-| `deploy-staging.yml` | build 성공 후 | 스테이징 자동 배포 |
-| `deploy-production.yml` | 릴리스 또는 수동 | 프로덕션 수동 배포 |
-| `backup.yml` | 매일 2AM UTC | DB 백업 |
+| 워크플로우 | 트리거 | 설명 | 현재 상태 |
+|------------|--------|------|-----------|
+| `ci.yml` | PR, push to main | 린트, 타입체크, 테스트 | **active** |
+| `build.yml` | push to main, tag | Docker 이미지 빌드 & GHCR 푸시 | **active** |
+| `deploy-staging.yml` | build 성공 후 | 스테이징 자동 배포 | **비활성 (disabled_manually)** |
+| `deploy-production.yml` | 릴리스 또는 수동 | 프로덕션 수동 배포 | **비활성 (disabled_manually)** |
+| `backup.yml` | 매일 2AM UTC | DB 백업 | **비활성 (disabled_manually)** |
+
+> ⚠️ **배포·백업 워크플로우는 현재 실행되지 않습니다.** `deploy-staging.yml`, `deploy-production.yml`,
+> `backup.yml` 3종은 GitHub Actions 시크릿이 등록되지 않은 상태여서 의도적으로
+> 비활성화(`disabled_manually`)되어 있습니다. 따라서 위 표의 "스테이징 자동 배포",
+> "매일 2AM UTC DB 백업"은 **시크릿 등록 + 워크플로우 재활성화 이후**에만 동작합니다.
+>
+> **필수 시크릿**: 배포는 `RAILWAY_TOKEN`(+`RAILWAY_PROJECT_ID`)에 더해 **환경 URL 시크릿**이
+> 필요합니다 — 스테이징은 `STAGING_BACKEND_URL`, `STAGING_DASHBOARD_URL`, 프로덕션은
+> `PRODUCTION_BACKEND_URL`, `PRODUCTION_DASHBOARD_URL`입니다. 두 배포 워크플로우 모두 배포 직후
+> `curl "$BACKEND_URL/health/ready"`로 헬스체크를 수행하므로, `*_BACKEND_URL`이 비어 있으면
+> **헬스체크 단계에서 실패**합니다(`*_DASHBOARD_URL`은 environment URL·배포 요약에 쓰입니다).
+> 백업은 DB 접속 계열
+> (`DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_NAME`, `DATABASE_PASSWORD`)입니다.
+>
+> **선택 시크릿(백업 스토리지)**: `backup.yml`은 업로드 대상을 시크릿 존재 여부로 분기하는데,
+> S3와 GCS 조건은 **서로 독립적**입니다 — `AWS_ACCESS_KEY_ID`가 있으면 S3(`BACKUP_S3_BUCKET`),
+> `GCS_SERVICE_ACCOUNT_KEY`가 있으면 GCS(`BACKUP_GCS_BUCKET`)에 업로드하며, **둘 다 설정하면
+> 양쪽에 모두 업로드되어 두 벌이 보관**됩니다(중복 보관·스토리지 비용 발생에 유의).
+> **둘 다 없으면 GitHub 아티팩트로 폴백**해 보관합니다.
+> 따라서 AWS·GCS 자격증명은 **필수가 아니며**, 없어도 백업 자체는 정상 동작합니다.
+>
+> **재활성화 방법**:
+> ```bash
+> # 1) 필요한 시크릿 등록 (위 "GitHub Secrets 설정" 절 참조)
+> gh secret set RAILWAY_TOKEN        # 배포용 (RAILWAY_PROJECT_ID 도 함께)
+> # 환경 URL — 배포 후 헬스체크가 "$BACKEND_URL/health/ready" 를 호출하므로 필수
+> gh secret set STAGING_BACKEND_URL
+> gh secret set STAGING_DASHBOARD_URL
+> gh secret set PRODUCTION_BACKEND_URL
+> gh secret set PRODUCTION_DASHBOARD_URL
+> gh secret set DATABASE_PASSWORD    # 백업용 (DATABASE_HOST/PORT/USER/NAME 도 함께)
+> # 스토리지는 선택 — S3에 보관하려는 경우에만
+> # gh secret set AWS_ACCESS_KEY_ID && gh secret set AWS_SECRET_ACCESS_KEY
+>
+> # 2) 워크플로우 활성화
+> gh workflow enable "Deploy Staging"
+> gh workflow enable "Deploy Production"
+> gh workflow enable "Database Backup"
+>
+> # 3) 상태 확인 (active/disabled_manually)
+> gh workflow list --all
+> ```
+>
+> `ci.yml`(CI)과 `build.yml`(Build)은 시크릿 없이 동작하므로 계속 active 상태입니다.
 
 ---
 

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1,6 +1,6 @@
 # AOS Database ERD
 
-> 38개 테이블 · `src/backend/db/models/` 기준 · 2026-03-08
+> 46개 테이블 · `src/backend/db/models/` 기준 · 2026-07-23
 
 ```mermaid
 erDiagram
@@ -148,7 +148,7 @@ erDiagram
     token_blacklist {
         string id PK
         string jti UK
-        string user_id FK
+        string user_id
         string token_type
         datetime expires_at
         datetime revoked_at
@@ -221,8 +221,10 @@ erDiagram
         string role
         string invited_by
         string token UK
+        text message
         datetime expires_at
         boolean accepted
+        datetime accepted_at
         datetime created_at
     }
 
@@ -489,6 +491,7 @@ erDiagram
         string merged_by
         string closed_by
         datetime created_at
+        datetime updated_at
         datetime merged_at
         datetime closed_at
     }
@@ -528,6 +531,13 @@ erDiagram
         datetime updated_at
     }
 
+    llm_model_suppressions {
+        string model_id PK
+        string provider
+        string reason
+        datetime suppressed_at
+    }
+
     user_llm_credentials {
         string id PK
         string user_id
@@ -538,6 +548,146 @@ erDiagram
         datetime last_verified_at
         datetime created_at
         datetime updated_at
+    }
+
+    deployment_usage_credentials {
+        string id PK
+        string provider UK
+        string api_key "encrypted"
+        string label
+        boolean is_active
+        datetime last_verified_at
+        datetime created_at
+        datetime updated_at
+    }
+
+    user_llm_entitlements {
+        string id PK
+        string user_id
+        string organization_id
+        string provider
+        string mode
+        string source_scope
+        boolean enabled
+        string cli_profile_id
+        boolean allow_api_fallback
+        string quota_policy_id
+        datetime created_at
+        datetime updated_at
+    }
+
+    llm_cli_profiles {
+        string id PK
+        string owner_user_id
+        string organization_id
+        string provider
+        string profile_name
+        string command
+        jsonb args_json
+        string working_directory
+        string auth_status
+        jsonb metadata_json
+        datetime created_at
+        datetime updated_at
+    }
+
+    llm_usage_ledger {
+        string id PK
+        string user_id
+        string organization_id
+        string provider
+        string mode
+        string source
+        string model
+        int input_tokens
+        int output_tokens
+        int total_tokens
+        string measurement_method
+        float estimated_cost_usd
+        string status
+        string session_id
+        string task_id
+        string analysis_id
+        string project_id
+        int latency_ms
+        text error_message
+        jsonb metadata_json
+        datetime started_at
+        datetime completed_at
+        datetime created_at
+    }
+
+    llm_model_update_logs {
+        string id PK
+        string provider
+        string status
+        int models_discovered
+        int new_models_found
+        int updates_found
+        int updates_applied
+        boolean is_manual
+        jsonb changes
+        text error_message
+        string triggered_by
+        datetime checked_at
+    }
+
+    %% ═══════════════════════════════════════════
+    %% Playground Domain
+    %% ═══════════════════════════════════════════
+
+    playground_sessions {
+        string id PK
+        string name
+        text description
+        string user_id
+        string project_id
+        string working_directory
+        string agent_id
+        string model
+        float temperature
+        int max_tokens
+        text system_prompt
+        boolean rag_enabled
+        int rag_k
+        boolean rag_hybrid_override
+        boolean rag_rerank_override
+        boolean rag_include_shared
+        string rules_mode
+        string memory_mode
+        jsonb selected_rule_ids
+        jsonb selected_memory_ids
+        int context_budget_tokens
+        jsonb available_tools
+        jsonb enabled_tools
+        jsonb messages
+        jsonb executions
+        int total_executions
+        int total_tokens
+        float total_cost
+        datetime created_at
+        datetime updated_at
+    }
+
+    %% ═══════════════════════════════════════════
+    %% Config Domain
+    %% ═══════════════════════════════════════════
+
+    config_versions {
+        string id PK
+        string config_type
+        string config_id
+        int version
+        string label
+        jsonb data
+        jsonb diff_from_previous
+        string status
+        text changes_summary
+        string created_by
+        text description
+        string rolled_back_from
+        datetime rolled_back_at
+        datetime created_at
     }
 
     %% ═══════════════════════════════════════════
@@ -556,6 +706,9 @@ erDiagram
         int version
         string created_by
         datetime created_at
+        datetime updated_at
+        datetime last_run_at
+        string last_run_status
     }
 
     workflow_runs {
@@ -615,6 +768,7 @@ erDiagram
         string scope_id
         string created_by FK
         datetime created_at
+        datetime updated_at
     }
 
     workflow_webhooks {
@@ -651,6 +805,7 @@ erDiagram
         string icon
         int popularity
         datetime created_at
+        datetime updated_at
     }
 
     %% ═══════════════════════════════════════════
@@ -723,10 +878,12 @@ erDiagram
 | Activity | 2 | task_analyses, session_activities |
 | Audit | 1 | audit_logs |
 | RBAC | 1 | menu_visibility |
-| LLM | 2 | llm_model_configs, user_llm_credentials |
+| LLM | 8 | llm_model_configs, llm_model_suppressions, user_llm_credentials, deployment_usage_credentials, user_llm_entitlements, llm_cli_profiles, llm_usage_ledger, llm_model_update_logs |
 | Git | 2 | merge_requests, branch_protection_rules |
+| Playground | 1 | playground_sessions |
+| Config | 1 | config_versions |
 | Workflow | 8 | workflow_definitions, workflow_runs, workflow_jobs, workflow_steps, workflow_secrets, workflow_webhooks, workflow_artifacts, workflow_templates |
-| **합계** | **38** | |
+| **합계** | **46** | |
 
 ## 관계 범례
 
@@ -738,4 +895,4 @@ erDiagram
 | PK | Primary Key |
 | UK | Unique Key |
 
-> **참고**: `feedbacks`, `task_evaluations`, `task_analyses` 등 일부 테이블은 `session_id`/`task_id`를 단순 문자열로 저장하며 DB-level FK를 사용하지 않습니다. 이 논리적 관계는 ERD에 표시하지 않았습니다.
+> **참고**: `feedbacks`, `task_evaluations`, `task_analyses`, `llm_usage_ledger` 등 일부 테이블은 `session_id`/`task_id`를 단순 문자열로 저장하며 DB-level FK를 사용하지 않습니다. 이 논리적 관계는 ERD에 표시하지 않았습니다. LLM 도메인(`llm_*`, `*_credentials`, `user_llm_entitlements`)과 `playground_sessions`, `config_versions`도 DB-level FK가 없어 관계선을 그리지 않았습니다.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1589,3 +1589,19 @@ Claude 구독(CLI 로그인) 세션으로 LLM 호출을 실행하는 opt-in 런�
 **환경 변수**: `CLAUDE_CLI_COMMAND`(기본 `claude`), `CLAUDE_CLI_ARGS`(기본 `-p --output-format text --permission-mode plan` — codex `--sandbox read-only`에 대응하는 읽기전용 장벽), `CLAUDE_CLI_TIMEOUT_SECONDS`(기본 300). profile의 command/args_json이 아닌 env가 런타임 SSOT (codex 동일)
 
 **Dashboard UI**: `ProfileCreateForm` provider 셀렉트(Codex CLI 기본, 전환 시 command/args 프리필 리셋), `PROVIDER_CONFIG`/`PROVIDER_LABELS`/`PROVIDER_COLORS` 등 provider 맵에 `claude_cli`("Claude CLI", orange) 추가 (`CostMonitor`, `MemberDetailPanel`, `AnalyticsPage`, `ModelManagementPanel`)
+
+---
+
+## 59. CI/CD 및 백업 자동화
+
+GitHub Actions 기반 검증·빌드·배포·백업 파이프라인. 검증(CI)과 빌드(Build)는 상시 동작하지만, **배포·백업 3종은 현재 비활성 상태**다.
+
+**기능**:
+- `ci.yml` (**active**): PR·main push 시 백엔드(ruff + mypy + pytest)와 대시보드(tsc + lint + vitest + build) 게이트 실행. `concurrency` 그룹으로 동일 ref 중복 실행 취소
+- `build.yml` (**active**): main push 및 `v*.*.*` 태그 시 백엔드/대시보드 Docker 이미지 빌드 후 GHCR 푸시. `workflow_dispatch`의 `push` 입력으로 푸시 없이 빌드만 검증 가능
+- `deploy-staging.yml` (**비활성**): Build 워크플로우 성공 후 Railway 스테이징 자동 배포. `secrets.RAILWAY_TOKEN` 필요
+- `deploy-production.yml` (**비활성**): 릴리스 published 또는 수동 실행(버전 태그 입력)으로 프로덕션 배포
+- `backup.yml` (**비활성**): 매일 2AM UTC(11AM KST) cron으로 `pg_dump` + gzip 덤프 생성. 보존 기간 기본 30일. 필수 시크릿은 DB 접속 계열(`DATABASE_HOST`/`PORT`/`USER`/`NAME`/`PASSWORD`)뿐이며, 업로드 대상은 시크릿 존재 여부로 분기하되 **S3·GCS 조건은 서로 독립적**이다 — AWS 자격증명이 있으면 S3(`aws s3 cp` + 만료분 정리), GCS 서비스 계정 키가 있으면 GCS(`gcloud storage cp`)에 업로드하며, **둘 다 설정하면 양쪽 모두 실행되어 두 벌이 저장**된다(중복 보관·스토리지 비용 발생에 유의). **둘 다 없으면 `actions/upload-artifact` 폴백**으로 GitHub 아티팩트에 보관. 즉 클라우드 스토리지 자격증명은 선택 사항
+- 이 외에 GitHub 관리형 워크플로우로 Dependabot Updates(의존성 자동 PR), Dependency Graph가 active 상태로 동작
+
+**현재 상태**: 배포·백업 3종은 Actions 시크릿이 등록되지 않아 의도적으로 `disabled_manually` 처리되어 있다. 실배포·자동 백업은 **동작하지 않으며**, 재활성화하려면 시크릿 등록 후 `gh workflow enable "<워크플로우 이름>"`을 실행해야 한다 (상세: `docs/deployment.md` → CI/CD 파이프라인).

--- a/docs/llm-key-systems.md
+++ b/docs/llm-key-systems.md
@@ -36,7 +36,7 @@ AOS에는 **CLI 구독권 기반 런타임 관리**와 목적이 다른 LLM key 
 AOS의 에이전트/오케스트레이터가 **기본 provider와 예외 fallback**을 결정할 때 사용.
 
 - **설정** (`config.py`): `LLM_PROVIDER`(기본 `codex_cli`, 로컬 우선), `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`, 모델 변수.
-- **소비**: `services/llm_service.py` `create_llm()` → provider별 LangChain 모델(`ChatOpenAI`/`ChatAnthropic`/`ChatGoogleGenerativeAI`/`ChatOllama`/`CodexCliChatModel`/`ClaudeCliChatModel`) 생성, settings 키 주입. 라우팅/페일오버 `services/llm_router_service.py`.
+- **소비**: `services/llm_service.py` `LLMService._get_llm()` → provider별 LangChain 모델(`ChatOpenAI`/`ChatAnthropic`/`ChatGoogleGenerativeAI`/`ChatOllama`/`CodexCliChatModel`/`ClaudeCliChatModel`) 생성, settings 키 주입. 라우팅/페일오버 `services/llm_router_service.py`.
 - **범위**: env는 배포 기본값과 fallback 정책을 제공한다. 사용자/조직별 CLI 실행 권한은 `llm_cli_profiles`와 `user_llm_entitlements`가 담당한다.
 
 ## [2] 유저 채팅 프록시 키

--- a/docs/ontology.md
+++ b/docs/ontology.md
@@ -55,6 +55,36 @@ Resource
 └── DataResource               # 데이터
 ```
 
+### Tenancy Hierarchy
+
+멀티테넌시는 Organization → Project → Session 의 2단계 소속 구조다.
+
+```
+Organization                   # 최상위 테넌트 (조직)
+├── OrganizationMember         # 조직 구성원 (role/permissions 보유)
+├── OrganizationInvitation     # 조직 초대
+└── Project                    # 조직에 속한 프로젝트 (organization_id)
+    ├── ProjectAccess          # 프로젝트 RBAC 부여
+    ├── ProjectInvitation      # 프로젝트 초대
+    └── Session                # 프로젝트 컨텍스트의 세션
+```
+
+### LLM Access Hierarchy
+
+LLM 실행 권한·자격증명·사용량은 별도 계층으로 분리되어 있다.
+
+```
+LLMAccess
+├── LLMModelConfig             # 모델 레지스트리 (가격/컨텍스트/능력)
+│   └── LLMModelSuppression    # DB 재등록 금지 목록 (hard delete)
+├── Credential                 # 자격증명 (암호화 저장)
+│   ├── UserLLMCredential      # 사용자 개인 API 키
+│   └── DeploymentUsageCredential  # 배포 단위 usage 조회 전용 키
+├── UserLLMEntitlement         # 사용자/조직의 실행 모드·범위 권한
+│   └── LLMCLIProfile          # 구독형 CLI 실행 프로파일
+└── LLMUsageLedger             # AOS 발생 LLM 사용량의 내부 정본 원장
+```
+
 ---
 
 ## 속성 (Property) - 관계와 값
@@ -86,7 +116,7 @@ Resource
 | Property | Domain | Range | Description |
 |----------|--------|-------|-------------|
 | `sessionId` | Session | string | 고유 식별자 |
-| `sessionStatus` | Session | SessionStatus | 현재 상태 |
+| `sessionStatus` | Session | SessionStatus | 현재 상태 (핵심 `sessions` 테이블은 Enum이 아닌 자유 문자열 — 아래 Status Enumerations 주석 참조) |
 | `totalCost` | Session | float | 누적 비용 |
 | `tokenUsage` | Session | TokenUsage | 토큰 사용량 |
 
@@ -156,7 +186,16 @@ assigned-to (할당)
 belongs-to (소속)
 ├── Agent belongs-to Session
 ├── Task belongs-to Session
-└── User belongs-to Organization
+├── User belongs-to Organization
+├── Project belongs-to Organization
+└── Session belongs-to Project
+
+entitled-to (권한)
+├── User entitled-to LLMRuntimeMode
+└── UserLLMEntitlement references LLMCLIProfile
+
+records (기록)
+└── LLMUsageLedger records LLMInvocation
 
 monitors (모니터링)
 ├── OrchestratorAgent monitors SpecialistAgent
@@ -190,28 +229,58 @@ monitors (모니터링)
 ### Status Enumerations
 
 ```python
+# SSOT: src/backend/models/agent_state.py
 TaskStatus = {
     PENDING,      # 대기 중
     IN_PROGRESS,  # 진행 중
+    WAITING,      # 대기(의존성/외부 응답 대기)
     PAUSED,       # 일시정지
     COMPLETED,    # 완료
     FAILED,       # 실패
     CANCELLED     # 취소
 }
 
+# SSOT: src/backend/models/hitl.py
+ApprovalStatus = {
+    PENDING,      # 승인 대기
+    APPROVED,     # 승인됨
+    DENIED,       # 거부됨
+    EXPIRED       # 만료
+}
+
+# 주의: AgentStatus는 코드에 단일 SSOT가 없다. 두 정의가 공존한다.
+# (1) 레지스트리 계열 — src/backend/services/agent_registry.py,
+#     api/v1/agents.py, api/v1/agent_registry.py
 AgentStatus = {
-    IDLE,         # 유휴
+    AVAILABLE,    # 가용
     BUSY,         # 작업 중
-    BLOCKED,      # 차단됨
+    UNAVAILABLE,  # 비가용
     ERROR         # 오류
 }
 
+# (2) 모니터 계열 — src/backend/api/v1/agent_monitor.py
+AgentMonitorStatus = {
+    IDLE,         # 유휴
+    RUNNING,      # 실행 중
+    ERROR,        # 오류
+    OFFLINE       # 오프라인
+}
+# BLOCKED는 어느 정의에도 존재하지 않는다 (문서상 값, 코드 미사용).
+
+# 주의: 핵심 Session(`sessions` 테이블)의 status는 Enum이 아닌
+# String(50) 자유 문자열이며 default="active"로 생성된다. 코드가 이 컬럼에
+# 다른 값을 기록하는 곳은 없고, 읽는 쪽도 == "active" 비교뿐이다
+# (db/repository.py, services/analytics_service.py).
+# "completed" 계열 상태는 별개 개념 — Task는 TaskStatus,
+# Claude 세션 스냅샷은 아래 SessionStatus를 쓴다. 혼동 주의.
+# 아래 Enum은 Claude 세션 스냅샷 전용 — src/backend/models/claude_session.py
 SessionStatus = {
     ACTIVE,       # 활성
     IDLE,         # 유휴
     COMPLETED,    # 완료
-    EXPIRED       # 만료
+    UNKNOWN       # 판별 불가
 }
+# EXPIRED는 두 경로(핵심 세션 / 스냅샷) 어디에서도 확인되지 않았다 — 확인 필요.
 ```
 
 ---


### PR DESCRIPTION
## Summary
- 코드베이스 실측 기준 양방향 대조로 `docs/` 16개 파일의 유령 서술·낡은 명령·누락을 정정
- 자동 인수 테스트(API 경로 코드↔문서, ERD 테이블 46=46) + Codex 리뷰 2회로 검증
- `self-host-quickstart.md`는 코드 대조 결과 정확 → 무변경 (검증 완료)

## Changes
**API / 데이터 모델**
- `api/automation.md`: `automation.py`·`pipelines.py` 라우터가 미마운트(런타임 접근 불가)임을 경고 표기 (삭제 아닌 상태 표기)
- `erd.md`: 누락 8개 테이블 추가(`llm_usage_ledger`·`user_llm_entitlements`·`llm_cli_profiles` 등), 코드 46개 테이블 양방향 일치
- `ontology.md`: `AgentStatus` 다중정의(SSOT 부재)·`sessions.status` 자유문자열(default="active")·`TaskStatus.WAITING` 반영
- `api-reference.md`·`api/{git,llm,monitoring,projects}.md`: 실측 경로 기준 정정, health 이중 마운트 노트

**아키텍처 / 배포**
- `architecture.md`: 유령 디렉토리(`services/adapters`·`cache`) 제거, 서비스 74·라우터 48·노드 구성 실측 정정
- `architecture/claude-code-integration.md`: 스킬 11·커맨드 18·에이전트 13·MCP 표를 실측과 양방향 일치, Hook 등록 실태(1종) 명시
- `deployment.md`·`features.md`: 배포·백업 워크플로우 `disabled_manually` 상태 명시, 백업 업로드 S3/GCS/아티팩트 독립 조건(동시 업로드 가능) 정정, 재활성화 시크릿 요건(URL 포함)

**대시보드 / 사용자 가이드**
- `dashboard.md`: 누락 store 2종·CostBadge 구분·라우트 정정
- `QUICK_START.md`: 개발 인프라는 shared-infra(`dev.sh`)임을 정정, 루트 `docker-compose.yml`은 self-host용(`POSTGRES_PASSWORD:?` 가드로 직접 실행 실패)
- `USER_GUIDE.md`: 유령 라우트(`/tasks`·`/activity`)·낡은 슬래시명령(`verify-app`→`verify-loop` 등)·`.env` 위치(루트) 정정
- `llm-key-systems.md`: `LLMService._get_llm()` 실측 정정

## Test Plan
- [x] API 문서 양방향 인수 테스트 (코드 411 라우트 ↔ 문서 412, 잔여는 의도적 미마운트 경고 표기분)
- [x] `erd.md` 테이블 코드↔문서 46=46, Mermaid 관계선 무결성(참조 엔티티 ⊆ 선언 엔티티)
- [x] `claude-code-integration.md` 스킬/커맨드/에이전트 표 `ls` 실측과 양방향 일치
- [x] QUICK_START/USER_GUIDE 변경 라인 타겟 재검증 (슬래시명령 실재, docker 명령 잔존 0)
- [x] Codex 리뷰 2회 — P2 2건·P3 2건 반영 (use_claude_cli 무시·백업 스토리지 조건·배포 URL 시크릿·세션 상태값)
- [x] 변경 범위 `docs/` 한정, 소스 코드 무변경

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)