### PR TITLE
feat(bundle): 컨텍스트 예산 트리거 배선 + researcher 에이전트 신설

### DIFF
--- a/docs/codex-advisor-worker-bundle/HANDOFF.md
+++ b/docs/codex-advisor-worker-bundle/HANDOFF.md
@@ -1,0 +1,61 @@
+# HANDOFF · 컨텍스트 예산 트리거 + 리서치 격리 구현
+
+작성: 2026-07-27 · 작성 사유: 컨텍스트 예산 경고(WARNING) 발동 — 본 기능이 실전에서 스스로 트리거
+
+> `.planning/STATE.md` 가 존재하나 그것은 GSD 워크플로우 상태이고 **이 작업을 추적하지 않는다.**
+> 따라서 `/gsd:pause-work` 대신 이 문서를 쓴다 (규칙의 의도 = 이미 추적되는 것을 중복 저장하지 않기).
+
+## 상태: 구현 완료 · Codex 3라운드 검증 대기
+
+## 산출물 (미커밋)
+
+```
+M  docs/codex-advisor-worker-bundle/install.sh                      (+245줄 규모)
+M  docs/codex-advisor-worker-bundle/README_조언자-작업자-전략.md
+?? docs/codex-advisor-worker-bundle/REVIEW_컨텍스트예산-리서치격리.md   ← 설계 근거 정본
+?? docs/codex-advisor-worker-bundle/HANDOFF.md                       ← 이 문서
+```
+
+실환경(`~/.claude/`)에는 이미 설치 반영됨: `agents/researcher.md` 신설,
+`agents/architect.md` tools 축소, `awesome-statusline.sh` 에 마커 블록 삽입,
+`CLAUDE.md` 번들 블록에 3개 절 추가. **`settings.json` 은 무변경**(mtime `Jul 26 23:19` 유지).
+
+## 설계 요약 (상세는 REVIEW 문서)
+
+- 임계치 = **베이스라인 델타 59k** (퍼센트 아님 — 실측 baseline 50,905 = 200k 창의 25.5%라 퍼센트는 양쪽 끝에서 깨짐). 59k 는 사용자 지정 "200k 창 사용률 50~55%" 에서 역산한 값 = `200,000 × 0.55 − 50,905`
+- 배선 = `awesome-statusline.sh` 마커 블록 → `$TMPDIR/claude-ctx-{sid}.json` → **이미 등록된** `gsd-context-monitor.js`
+- 합성 매핑: `remaining_percentage = 100 - delta*100/78666` → WARNING(35)=delta 51,133, CRITICAL(25)=delta 59,000 (`78666 = floor(59000/0.75)` — 셸 정수 나눗셈이라 반올림한 78667 은 경계에서 1 어긋난다)
+- 저장 포맷 **신설 안 함** — GSD/HANDOFF/`wip-save` 중 상황에 맞는 것에 위임
+- 역할: `researcher`(sonnet, 외부 조사) 신설 / `analyzer`(haiku) 로컬 전담 / `architect` 웹도구 제거
+
+## 검증 완료 (전부 조언자가 직접 재현)
+
+| 항목 | 결과 |
+|---|---|
+| 브리지 경계값 | delta 51,133→35, delta 59,000→25, 재래치→100 + `-warned.json` 삭제 |
+| **Red-Green 종단 주입** | GREEN: `CONTEXT CRITICAL` 실제 주입 / RED: 삭제 시 소멸 |
+| `set -e` 회귀 | GREEN `OK` 생존 / RED(`\|\| true` 제거) 출력 `[]` 사망 |
+| statusLine 5형태 | `~/…`, `bash ~/…`, `env FOO=1 ~/…`, `bash $HOME/…`, `${HOME}/…` 전부 마커 1개 |
+| 원자성 | 퍼미션 755 보존, tmp 잔여 0, **rename 실패 시 원본 md5 동일 + exit 1** |
+| 멱등성 | 미설치→삽입→재실행 `diff -r` 0, 마커 수 1 |
+| 실전 발동 | 2026-07-27 세션에서 WARNING 자연 발동 확인 |
+
+## Codex 검증 이력
+
+- 1라운드 P2×2: 래퍼 커맨드 파싱 / `set -e` 사망 → 반영·재현 확인
+- 2라운드 P2×2: 비원자적 덮어쓰기 / `$HOME` 미확장 → 반영·재현 확인
+- **3라운드: 실행 중** (`scratchpad/codex-review3.log`)
+
+## 다음 단계
+
+1. 3라운드 결과 확인 — 새로 만진 코드의 실질 결함이면 반영, 무관한 사소 지적이면 승인(무한 루프 방지)
+2. 승인 시 `TaskStop ctx-budget-worker`
+3. 커밋 (사용자 지시 대기 중). 제안 메시지:
+   `feat(bundle): 컨텍스트 예산 트리거 배선 + researcher 에이전트 신설`
+
+## 알려진 잔여 사항
+
+- **R1(High)**: `gsd-context-monitor.js` 는 GSD 플러그인 소유(`gsd-hook-version: 1.26.0` 핀). 업데이트로 임계치·스키마·메시지가 바뀌면 조용히 깨진다. install.sh 가 버전 불일치를 경고한다
+- `isGsdActive` 판정은 신뢰 불가 — `.planning/STATE.md` 가 실재해도 비-GSD 분기가 떴다(`data.cwd` 가 프로젝트 루트가 아님). REVIEW §1.3 정정 블록 참조
+- 서브에이전트 `tools:` 필드의 MCP 와일드카드 지원 여부 **미검증** — `researcher` 는 `WebSearch, WebFetch, Read, Grep, Glob` 만 부여
+- `~/.claude/hooks/universal/contextMonitor.js` 폐기 검토 = 별도 후속 과제(범위 밖)

--- a/docs/codex-advisor-worker-bundle/README_조언자-작업자-전략.md
+++ b/docs/codex-advisor-worker-bundle/README_조언자-작업자-전략.md
@@ -7,10 +7,12 @@
 ```
 ~/.claude/
 ├── CLAUDE.md              # 전략·원칙 (규칙 파일, 모든 프로젝트 공통)
+├── awesome-statusline.sh  # (기존 파일) 컨텍스트 예산 브리지 마커 블록이 삽입됨
 └── agents/
-    ├── architect.md       # 조언자 — 설계·위임 브리프 작성   (fable 별칭 · 소진 시 Opus)
+    ├── architect.md       # 조언자 — 설계·위임 브리프 작성   (opus 별칭)
     ├── worker.md          # 작업자 — 구현·테스트            (Opus, 비용 우선 시 Sonnet)
-    └── analyzer.md        # 조사·요약 (토큰 절약)           (Haiku)
+    ├── analyzer.md        # 로컬 조사·요약 (토큰 절약)       (Haiku)
+    └── researcher.md      # 외부 조사 — 웹·문서 (컨텍스트 격리) (Sonnet)
                            # 검증(reviewer) = Codex 플러그인이 담당 (별도 서브에이전트 없음)
 ```
 
@@ -18,19 +20,24 @@
 
 ## 1. 전략 개요 (Advisor–Worker–Codex)
 
-비싸고 판단력 좋은 모델은 **조언자(Advisor)** 로만 쓰고, 실제 코딩은 저렴한 **작업자(Worker)** 에게,
-그리고 **검증은 Codex** 에 맡긴다. 저렴한 모델은 "언제 멈출지"를 모르므로 조언자의 통제와
-독립적인 검증이 필수다. 이 역할 분리 구조는 특정 모델이 사라져도 유효한 방법론이다.
+설계·판단은 **조언자(Advisor)** 가, 실제 코딩은 **작업자(Worker)** 가, **검증은 Codex** 가 맡는다.
+조언자와 작업자가 같은 모델이어도 분리는 유지한다 — 목적은 모델 등급 차이가 아니라 역할·컨텍스트
+분리이며, 자기 결과를 자기가 승인하지 않게 만드는 것이 핵심이다. 작업자를 더 저렴한 모델로 내릴
+때는 "언제 멈출지"를 모르므로 조언자의 통제가 특히 중요해진다.
+이 역할 분리 구조는 특정 모델이 사라져도 유효한 방법론이다.
 
 | 역할 | 담당 | 모델/도구 |
 |---|---|---|
-| 조언자 — 설계·판단·위임·최종 결정 | 메인 세션 또는 `architect` | `fable` (소진 시 Opus) |
+| 조언자 — 설계·판단·위임·최종 결정 | 메인 세션 또는 `architect` | `opus` |
 | 작업자 — 구현·테스트 | `worker` | Opus (비용 우선 시 Sonnet) |
 | **검증 — 코드 리뷰·적대적 검토** | **Codex 플러그인** | `/codex:review`, `/codex:adversarial-review` |
-| 조사·요약 (토큰 절약) | `analyzer` | Haiku |
+| 로컬 조사·요약 — 코드베이스·로그·파일 (토큰 절약) | `analyzer` | Haiku |
+| **외부 조사 — 웹·라이브러리 문서·릴리스 노트** | **`researcher`** | **Sonnet** |
+| 컨텍스트 예산 감시 | statusline 브리지 → GSD 모니터 훅 | — |
 
-> 참고 실험(출처 문서, 교차검증 대상): Fable 5 조언자 + Opus 작업자 ≈ $7.5·9분(최고 효율),
-> Sonnet 단독 ≈ $20·59분(최악). 저렴한 모델일수록 통제가 필요하다.
+> 참고 실험(출처 문서, 교차검증 대상 · **과거 Fable 5 조언자 구성 기준이며 현재 구성의 수치가 아니다**):
+> Fable 5 조언자 + Opus 작업자 ≈ $7.5·9분(최고 효율), Sonnet 단독 ≈ $20·59분(최악).
+> 시사점만 취한다 — 통제 없는 단독 실행이 가장 비싸다.
 
 **가장 중요한 원칙 — 검증은 무조건:** 작업자의 "완료" 보고를 그대로 믿지 않는다.
 **Codex 리뷰로 diff를 실제 검토**한 뒤, 조언자가 지적 반영을 지시하고 통과 시 승인한다.
@@ -74,14 +81,14 @@ Claude Code 안에서 Codex로 코드 리뷰·작업 위임을 하는 공식 플
 ## 4. 두 가지 운용 모드
 
 ### 모드 A — 메인이 조언자 (간단)
-1. `/model` 로 메인 세션을 상위 모델(Fable 5)로 설정.
+1. `/model` 로 메인 세션을 조언자 모델(Opus)로 설정.
 2. 설계는 메인이 직접, 구현만 위임:
    `> worker에게 이 작업 구현 맡겨. 완료 기준은 X, 검증은 /codex:review 무결점, 시도 3회 상한.`
 3. 작업자가 diff 보고 → **`/codex:review` 실행 → 지적 반영 지시 → 통과 시 승인.**
 
 ### 모드 B — 메인은 저렴, 조언자는 버스트 (비용 최소)
 1. 메인은 `sonnet`.
-2. 설계가 필요할 때만 `> architect에게 설계 맡겨` (Fable 5 버스트).
+2. 설계가 필요할 때만 `> architect에게 설계 맡겨` (Opus 버스트).
 3. 구현은 `worker`(Opus, 비용 우선 시 Sonnet).
 4. 검증은 `/codex:review` (설계 도전은 `/codex:adversarial-review`).
 
@@ -90,12 +97,25 @@ Claude Code 안에서 Codex로 코드 리뷰·작업 위임을 하는 공식 플
 ## 5. 반드시 지킬 것
 - 위임 시 **완료 기준 + 검증 방법(Codex 리뷰 통과) + 시도 상한**을 함께 준다(= 브리프).
 - 작업자의 "완료" 보고를 믿지 말고 **`/codex:review` 로 검증**한다.
-- 저렴한 모델은 스스로 멈추지 못한다 → 조언자가 완료 기준으로 중단시킨다.
-- 토큰 무거운 작업(코드베이스 분석·긴 로그·대량 요약)은 `analyzer`가 먼저 압축한다.
+- 작업자는 스스로 "완료"를 확정하지 않는다 → 조언자가 완료 기준으로 중단시키고 Codex가 검증한다.
+  (작업자를 저렴한 모델로 내릴수록 이 통제가 더 중요해진다.)
+- 토큰 무거운 **로컬** 작업(코드베이스 분석·긴 로그·대량 요약)은 `analyzer`가 먼저 압축한다.
+- **리서치·외부 도구는 메인에서 직접 호출하지 않는다:** 메인 세션(모드 A의 조언자)은
+  WebSearch·WebFetch·tavily·context7 을 직접 부르지 않고 `researcher` 에게 위임해 **결론+출처 요약만** 받는다.
+  서브에이전트가 이 도구들을 갖는 것은 모순이 아니다 — 컨텍스트가 분리되기 때문이다.
+  (하드 차단은 불가능하다. `permissions.deny` 는 서브에이전트의 도구까지 함께 죽인다 → 규칙 기반 소프트 강제)
+- **컨텍스트 예산 (조언자 세션):** 세션 시작 시점 대비 **+59k 토큰**을 쓰면 새 작업을 시작하지 않는다
+  (베이스라인 50,905 기준 200k 창 사용률로는 약 55% 시점).
+  `CONTEXT WARNING`/`CONTEXT CRITICAL` 이 주입되면 ① 진행 중 작업 마무리 → ② 상태 저장
+  (`.planning/STATE.md` 있으면 `/gsd:pause-work` 제안, 없으면 HANDOFF.md 작성. 코드가 더러우면 `/wip-save` 병행)
+  → ③ **새 세션 권고**(compact 보다 우선 — 무엇을 남길지 조언자가 직접 고를 수 있다).
+  저장 포맷을 새로 만들지 않는다. 주입 문구의 숫자는 창 사용률이 아니라 **예산 소진율**이다.
 - 큰 변경 리뷰는 `/codex:review --background` 후 `/codex:status`·`/codex:result` 로 확인.
 - **worker 보고 수신:** 가능하면 동기 실행으로 결과를 직접 받는다. 백그라운드 실행 시 완료 보고
   텍스트가 조언자에게 전달되지 않을 수 있으므로, 보고를 기다리지 말고 산출물(staged diff·테스트 실행)을 직접 검증한다.
-- **조언자 직접 코딩 금지:** 구현은 worker 위임이 기본값. 예외는 단일 파일·30줄 이내 문서/설정 수정뿐이며, 예외여도 Codex 검증은 동일 적용.
+- **조언자 직접 코딩 금지:** 구현은 worker 위임이 기본값. 예외는 ① 단일 파일·30줄 이내 문서/설정 수정,
+  ② **컨텍스트 핸드오프 문서(HANDOFF / pause-work) 작성 — 줄 수 제한 없음**(저장 대상이 메인 세션
+  컨텍스트에만 존재해 위임이 원리적으로 불가능). 예외여도 Codex 검증은 동일 적용.
 - **승인 후 정리:** 서브에이전트는 과제 완료 후에도 idle로 상주한다. 승인이 끝나면 TaskStop(또는
   `ctrl+x ctrl+k`)으로 종료해 상주 에이전트를 남기지 않는다.
 
@@ -115,14 +135,30 @@ bash install.sh                                        # 번들 폴더 안에서
 #    /codex:setup           ← Codex 준비 상태 확인 / 필요 시 !codex login
 #
 # 3) 확인
-#    /agents  → architect, worker, analyzer, codex:codex-rescue
-#    /model   → Fable 5 별칭/ID 확인 후 architect의 model 값과 일치시키기
+#    /agents  → architect, worker, analyzer, researcher, codex:codex-rescue
+#    /model   → opus 별칭/ID 확인 후 architect의 model 값과 일치시키기
 ```
 
-`install.sh` 가 하는 일: `~/.claude/CLAUDE.md` 의 **번들 마커 블록만 갱신**(블록 밖 개인 내용 보존, 마커 없는 구버전은 백업 후 전체 생성), `agents/{architect,worker,analyzer}.md` 생성(내용 동일 시 백업 없이 건너뜀), 구버전 `reviewer.md` 백업 후 제거, Node/Codex 확인 및 `@openai/codex` 설치 시도, `~/.codex/config.toml` 검증 기본값(effort=high) 템플릿 생성.
+`install.sh` 가 하는 일: `~/.claude/CLAUDE.md` 의 **번들 마커 블록만 갱신**(블록 밖 개인 내용 보존, 마커 없는 구버전은 백업 후 전체 생성), `agents/{architect,worker,analyzer,researcher}.md` 생성(내용 동일 시 백업 없이 건너뜀), 구버전 `reviewer.md` 백업 후 제거, **활성 statusline 스크립트에 컨텍스트 예산 브리지 블록 삽입**(마커 관리·백업, 아래 설명), **GSD 컨텍스트 모니터 훅 버전 대조**(불일치 시 경고만), Node/Codex 확인 및 `@openai/codex` 설치 시도, `~/.codex/config.toml` 검증 기본값(effort=high) 템플릿 생성.
+
+**컨텍스트 예산 브리지 (새 훅 0개, `settings.json` 무수정):** 설치기는 `settings.json` 의
+`.statusLine.command` 를 **읽기 전용**으로 파싱해 활성 statusline 스크립트를 찾고, `CURRENT_USAGE=` 줄
+바로 뒤에 마커 블록을 삽입한다(기존 퍼미션·실행 비트 보존). 이 블록은 세션 첫 관측치를 baseline 으로
+래치하고 그 **델타**를 예산 잔량(%)으로 합성해 `$TMPDIR/claude-ctx-{session_id}.json` 에 기록한다.
+이미 `PostToolUse` 에 등록돼 있던 `~/.claude/hooks/gsd-context-monitor.js` 가 그 값을 읽어
+잔량 ≤35% 에서 `CONTEXT WARNING`, ≤25% 에서 `CONTEXT CRITICAL` 을 컨텍스트에 주입한다.
+
+- **왜 퍼센트가 아니라 델타인가:** 베이스라인(시스템 프롬프트+CLAUDE.md+스킬+도구 스키마)만으로
+  이미 200k 창의 ~25% 를 쓴다. "창의 25%" 임계치는 첫 턴부터 참이 되어 무한 발동한다.
+  델타 기준은 **창 크기와 무관**하게(200k든 1M이든) 같은 시점에 걸린다.
+- **전제가 어긋나면 조용히 skip:** jq 없음 / `settings.json` 없음 / `.statusLine` 없음 /
+  스크립트 부재 / 앵커(`CURRENT_USAGE=`) 없음 / 마커 구조 비정상 → 경고만 하고 설치는 계속된다.
+- **statusline 은 메인 세션에만 렌더된다** → 서브에이전트는 감시 대상이 아니다. 이는 의도된 설계다.
+  리서치 격리가 1차 방어(메인 델타가 애초에 천천히 참)이고, 이 트리거는 그것이 실패했을 때의 그물이다.
 
 > **개인 커스터마이징은 CLAUDE.md 의 마커 블록 밖에 작성**할 것 — 재설치해도 보존된다.
 > 마커: `<!-- codex-advisor-worker-bundle:start … -->` / `<!-- codex-advisor-worker-bundle:end -->`
+> statusline 쪽 마커: `# <<< codex-advisor-worker-bundle:ctx-budget:start … -->>>` / `…:end -->>>`
 
 ---
 
@@ -131,20 +167,20 @@ bash install.sh                                        # 번들 폴더 안에서
 ### 7.1 `~/.claude/CLAUDE.md`
 ```markdown
 # 글로벌 작업 원칙 (모든 프로젝트 공통)
-# (핵심) 조언자(Fable 5) → 작업자 worker(Opus) → 검증 Codex(/codex:review) → 조언자 승인
+# (핵심) 조언자(Opus) → 작업자 worker(Opus) → 검증 Codex(/codex:review) → 조언자 승인
 # 검증은 무조건: worker "완료" 보고를 믿지 말고 /codex:review 로 diff 검토 후 승인.
-# 운용 A: 메인=조언자(Fable 5), 구현=worker, 검증=/codex:review
+# 운용 A: 메인=조언자(Opus), 구현=worker, 검증=/codex:review
 # 운용 B: 메인=sonnet, 설계=architect 버스트, 구현=worker(Opus), 검증=Codex
 # 토큰 무거운 작업은 analyzer(Haiku)로 분리, 큰 작업은 /codex:rescue 위임
 ```
 > (전체 원문은 `install.sh` 가 생성하는 `~/.claude/CLAUDE.md` 참고)
 
-### 7.2 `~/.claude/agents/architect.md` — 조언자 (fable 별칭)
+### 7.2 `~/.claude/agents/architect.md` — 조언자 (opus 별칭)
 ```markdown
 ---
 name: architect
-model: fable   # Fable 소진 시 env ANTHROPIC_DEFAULT_FABLE_MODEL=claude-opus-4-8 로 Opus 리맵
-tools: Read, Grep, Glob, WebSearch, WebFetch
+model: opus    # 메인 세션과 같은 계열로 고정. 별칭 고정으로 동적 모델 오배정 차단
+tools: Read, Grep, Glob    # 조사(WebSearch/WebFetch)는 researcher 담당 — 판단 컨텍스트를 원문으로 희석하지 않는다
 ---
 설계·판단·위임만. 코드는 스켈레톤만, 구현은 worker에게.
 브리프에 완료 기준 + 검증 방법(/codex:review 통과) + 시도 상한 포함.
@@ -161,7 +197,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 완료 기준까지만, 막히면 멈추고 보고. 보고 = 변경파일 + diff + 테스트 결과.
 ```
 
-### 7.4 `~/.claude/agents/analyzer.md` — 조사·요약 (Haiku)
+### 7.4 `~/.claude/agents/analyzer.md` — 로컬 조사·요약 (Haiku)
 ```markdown
 ---
 name: analyzer
@@ -171,14 +207,38 @@ tools: Read, Grep, Glob, Bash
 대량 입력을 압축해 결론만 반환(원문 덤프 금지). 판단·설계 안 함, 관찰만.
 ```
 
+### 7.5 `~/.claude/agents/researcher.md` — 외부 조사 (Sonnet)
+```markdown
+---
+name: researcher
+model: sonnet
+tools: WebSearch, WebFetch, Read, Grep, Glob,
+       mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs,
+       mcp__tavily__tavily_search, mcp__tavily__tavily_extract, mcp__tavily__tavily_research
+---
+웹·라이브러리 문서 등 외부 조사 전담. 원문은 이 에이전트 컨텍스트에서 끝난다.
+반환은 결론 → 근거(출처 URL) → 불확실한 부분. 인용은 항목당 3줄 이내.
+라이브러리 문서는 context7 우선(resolve-library-id → query-docs).
+판단·설계 안 함. 출처 상충 시 상충한다고 보고. 못 찾으면 "못 찾았다"고 보고(추측 금지).
+```
+> **MCP 도구는 실명으로 나열해야 한다.** 서브에이전트 `tools:` 는 **화이트리스트**라, 여기에 없는
+> MCP 도구는 위임받은 `researcher` 도 쓸 수 없다 → "메인은 직접 호출 금지" 규칙과 겹치면
+> **아무도 못 쓰는 상태**가 된다. 와일드카드(`mcp__…__*`) 지원 여부는 **미검증**이라 쓰지 않는다.
+> **MCP 서버명은 환경마다 다르다**(플러그인 설치 방식에 따라 `mcp__context7__*` 형태일 수 있음).
+> `/agents` 에서 실제 노출되는 도구명을 확인하고 맞춰 조정할 것.
+
+> `analyzer`(로컬·Haiku)와 나누는 이유: "대량 원문 압축"과 "외부 조사·출처 판단"은 요구 모델 등급이
+> 다르다. 한 에이전트에 섞으면 어느 쪽이든 손해다.
+
 > 위 블록은 요약본이다. 실제 설치되는 전문은 `install.sh` 안의 heredoc과 동일하다.
 
 ---
 
 ## 8. 주의 · 교정 사항
-- **모델 별칭:** 어드바이저는 `fable` 별칭(= Fable 5). `/model` 로 사용 가능한 별칭 확인. `opus`·`sonnet`·`haiku`·`fable` 은 표준 별칭.
-- **모델 폴백 (Fable 소진 → Opus):** 자동이 아니다. `/model opus`(모드 A) 또는 셸에 `export ANTHROPIC_DEFAULT_FABLE_MODEL=claude-opus-4-8`(모드 무관, 파일 수정 불필요)로 전환. `--fallback-model`은 과부하(503)에만 발동하고 **한도 소진(429)에는 발동하지 않는다.**
-- **구형 모델 ID 금지:** `claude-3-opus-20240229` 같은 옛 ID 대신 `opus`(=Opus 4.8) 사용.
+- **모델 별칭:** 어드바이저는 `opus` 별칭. `/model` 로 사용 가능한 별칭 확인. `opus`·`sonnet`·`haiku`·`fable` 은 표준 별칭.
+- **모델 고정:** 조언자·작업자 모두 `opus` 별칭. 자동 폴백은 두지 않는다. `--fallback-model`은 과부하(503)에만 발동하고 **한도 소진(429)에는 발동하지 않으므로** 폴백 수단으로 신뢰하지 않는다.
+- **소진 대비 vs 소진 후:** 모드 B는 메인 세션만 `sonnet`으로 내리는 **절약책**이며, 그 안에서도 `architect`·`worker`는 그대로 `opus`를 호출한다 → 소진 후 대책이 아니다. Opus 소진 후 경로는 둘 — (a) 두 에이전트의 `model:` 을 `sonnet` 으로 임시 하향, (b) `/codex:rescue` 로 Codex(별도 한도)에 위임.
+- **구형 모델 ID 금지:** `claude-3-opus-20240229` 같은 옛 ID 대신 `opus`(= 현재 Opus 계열) 사용.
 - **파일명은 대문자 `CLAUDE.md`.** `claude.md`/`agent.md` 아님.
 - **CLAUDE.md는 강제가 아니라 지침.** 모델 고정은 서브에이전트 `model:` 이, 검증은 Codex가 담당.
 - **Codex 사용량은 ChatGPT/Codex 한도에 별도 계상.** 리뷰 게이트는 사용량 소모가 크니 상시 켜지 말 것.

--- a/docs/codex-advisor-worker-bundle/REVIEW_컨텍스트예산-리서치격리.md
+++ b/docs/codex-advisor-worker-bundle/REVIEW_컨텍스트예산-리서치격리.md
@@ -1,0 +1,457 @@
+# 검토 · 컨텍스트 예산 트리거 + 리서치 격리 + 역할 재분배
+
+> 대상 번들: `docs/codex-advisor-worker-bundle/` (조언자–작업자–Codex 검증)
+> 작성일: 2026-07-27 · 상태: **검토(설계 제안)**, 미구현
+> 요청 원문: "컨텍스트 사용량이 20~25%에 도달하면 현재 작업 상태를 문서로 저장하고 Compact하거나
+> 새 세션에서 요약만 다시 로드해 이어서 진행 / 리서치·외부 도구 호출은 서브에이전트로 분리하고
+> 메인 대화에는 최종 요약만"
+
+---
+
+## 0. 결론 (요약)
+
+| 항목 | 판정 | 근거 |
+|---|---|---|
+| 퍼센트 임계치 | **창 대비 퍼센트로는 구현 불가** → 베이스라인 델타 **59k** 로 대체 (사용자 지정 50~55% 에서 역산) | 실측 baseline 50,905 토큰 (200k 창의 25.5%) |
+| 기능의 신규성 | **신규 아님. 이미 절반 설치돼 있고 배선이 끊겨 있음** | 브리지 파일 0건, 모니터 2종 모두 사문화 |
+| 저장 포맷 | **새로 만들지 않는다.** 기존 경로에 위임 | GSD 주입 문구가 handoff 파일 작성을 금지 |
+| 번들이 새로 소유할 것 | **트리거 한 가지뿐** (언제 멈출지) | 나머지는 전부 중복 |
+| 리서치 격리 | **소프트 강제만 가능** (하드 차단 불가) | permissions.deny는 서브에이전트도 함께 죽임 |
+| 역할 분배 | `researcher` 신설 + `architect` 도구 축소 + 조언자에 HANDOFF 책임 명문화 | 아래 §8 |
+| install.sh 비용 | 함수 1개 추가(~40줄), **settings.json 미수정** | 마커 블록 삽입 기법 재사용 |
+
+핵심 문장 하나로: **번들에 추가할 것은 "저장 기능"이 아니라 "정지 신호"다.**
+
+---
+
+## 1. 실측 근거
+
+### 1.1 베이스라인이 이미 25.5% — 퍼센트 임계치는 양쪽 끝에서 깨진다 (L1 · 확실성 High)
+
+이 검토 세션의 트랜스크립트에서 직접 계산:
+
+```
+transcript: ~/.claude/projects/-Users-younghwankang-Work-Agent-System/312e9b12-….jsonl
+계산식: input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+
+첫 assistant 턴 (= 베이스라인)   50,905
+24턴 후 (도구 무거운 조사)        99,929      delta 49,024
+```
+
+| 창 크기 | 베이스라인 | 24턴 후 | "25% 도달" 판정 |
+|---|---|---|---|
+| 200,000 | **25.5%** | 50.0% | **턴 0에서 이미 참** → compact 무한 루프 |
+| 1,000,000 | 5.1% | 10.0% | 250k 필요 → **사실상 미발동** |
+
+베이스라인 51k의 정체는 시스템 프롬프트 + CLAUDE.md 6종(글로벌 1 + rules 5 + 프로젝트 1 + rules 4)
++ MEMORY.md 인덱스 + 스킬 목록 + 도구 스키마다. 사용자가 첫 글자를 치기 전에 이미 소비된 고정 비용이며,
+MCP 서버나 스킬을 추가하면 더 커진다.
+
+→ **임계치는 창 대비 퍼센트가 아니라 "세션 베이스라인 위의 델타"여야 한다.**
+
+### 1.2 컨텍스트 모니터 2종이 모두 사문화 상태 (L1 · High)
+
+```
+~/.claude/hooks/gsd-context-monitor.js      PostToolUse 등록됨. 그러나
+  └ /tmp|$TMPDIR/claude-ctx-{session}.json 부재 → existsSync 가드에서 매번 즉시 종료
+     (실측: /tmp 0건, $TMPDIR 0건)
+     원인: 브리지를 쓰는 쪽이 gsd-statusline.js 인데,
+           활성 statusLine 은 awesome-statusline.sh 로 교체돼 있음 (settings.json)
+
+~/.claude/hooks/universal/contextMonitor.js  Stop 등록됨. 그러나
+  └ 토큰이 아니라 "상호작용 횟수"(15/25회) 기반이고,
+     존재하지 않는 /save-and-compact 명령을 권고 (~/.claude/commands 에 없음)
+
+~/.claude/skills/external-memory/SKILL.md   "Automatic Trigger: Token Threshold (150K)" 라고
+  └ 선언만 하고 감지 수단이 없음 (user-invocable: false 라 사용자가 부를 수도 없음)
+```
+
+세 건 모두 같은 실패 양식이다 — **감지 수단 없는 규칙은 사문화된다.**
+따라서 이번 추가의 성패는 "규칙을 잘 쓰는 것"이 아니라 "감지가 실제로 살아있게 하는 것"에 달려 있다.
+**세 번째 모니터를 추가해선 안 된다.** 하나(GSD)를 되살리고, 나머지 둘은
+사문화 사실을 문서로 남기되 이번 변경 범위 밖으로 분리한다(§4·§11).
+
+### 1.3 GSD 모니터의 주입 문구가 요청 동작을 금지한다 (L1 · High)
+
+`gsd-context-monitor.js:120-141` — 되살렸을 때 실제로 모델에게 주입되는 텍스트:
+
+| 분기 | CRITICAL 메시지 요지 |
+|---|---|
+| `.planning/STATE.md` 있음 | "Do NOT start new complex work **or write handoff files** — GSD state is already tracked in STATE.md. … run `/gsd:pause-work`" |
+| 없음 | "Do NOT autonomously save state or write handoff files **unless the user asks**" |
+
+즉 "브리지만 살리면 끝"이 아니다. 그대로 두면 트리거가 살아나는 순간
+**요청하신 동작(상태 문서 저장)을 금지하는 문장**이 컨텍스트에 주입된다.
+
+> **실측 정정 (구현 후 Red-Green으로 확인, 2026-07-27):**
+> AOS에 `/Users/…/Agent-System/.planning/STATE.md`가 **실재하는데도 실제로 주입된 것은
+> 비-GSD 분기**였다 — `"…Do NOT autonomously save state or write handoff files **unless the user asks**."`
+> 이후 같은 세션에서 **GSD 분기가 뜬 경우도 관찰**됐다. 즉 분기는 저장소 상태가 아니라
+> **도구 호출 시점의 `data.cwd`에 따라 매번 달라진다**(`isGsdActive`는
+> `path.join(data.cwd, '.planning','STATE.md')`를 본다 — 셸 cwd가 리셋된 호출에서는 비-GSD로 떨어진다).
+> **설계에는 영향 없다** — §5의 규칙이 두 분기를 모두 처리하고, 실제로 뜬 쪽은
+> "unless the user asks" 예외를 가진 관대한 분기다. 다만 `isGsdActive` 판정을
+> **신뢰할 수 있는 분기 조건으로 가정하지 말 것**. 번들 규칙은 주입 문구가 어느 쪽이든
+> `.planning/STATE.md` **존재 여부를 조언자가 직접 확인**해 저장 경로를 고르도록 쓰여 있다.
+
+해소는 §5에서 다룬다. 결론만 미리: **번들이 저장 포맷을 소유하지 않으면 모순이 사라진다.**
+
+### 1.4 활성 statusline은 필요한 입력을 이미 받고 있다 (L1 · High)
+
+```bash
+# ~/.claude/awesome-statusline.sh
+CONTEXT_SIZE=$(… '.context_window.context_window_size // 200000')
+CURRENT_USAGE=$(… '.context_window.current_usage // null')
+#   → input_tokens + cache_creation_input_tokens + cache_read_input_tokens 로 합산 중
+# 없는 것: .session_id  (브리지 파일명에 필요 — 1줄 추가로 해결)
+```
+
+statusline 훅은 Claude Code가 **매 렌더마다** 호출하고 `context_window`를 통째로 넘겨준다.
+델타 계산에 필요한 모든 재료가 이미 이 프로세스 안에 있다. 추가 계측 불필요.
+
+### 1.5 리서치 격리는 하드 차단이 불가능하다 (L3 · Medium)
+
+- `permissions.deny`에 `WebSearch`/`WebFetch`/`mcp__tavily__*`를 넣으면 **서브에이전트도 같이 죽는다.**
+  격리의 목적지인 `researcher` 자신이 도구를 잃는다.
+- `PreToolUse` 훅이 "메인 세션 vs 서브에이전트"를 판별할 신뢰 가능한 입력 필드는 확인되지 않았다.
+  (`SubagentStart`/`Stop` 이벤트는 있으나 PreToolUse 페이로드의 서브에이전트 표식은 미검증)
+
+→ 리서치 격리는 **규칙 + 전용 에이전트**로 가는 소프트 강제가 현실적 상한이다.
+   이 항목만 확신도가 낮으므로, 하드 차단을 원하시면 별도 실험이 필요하다.
+
+---
+
+## 2. 중복 인벤토리 — 무엇을 만들지 *않을* 것인가
+
+이 하네스에는 "상태를 저장한다"는 도구가 이미 과잉이다.
+
+| 기존 자산 | 무엇을 저장하나 | 이번 요청과의 관계 |
+|---|---|---|
+| `/wip-save` (AOS) | **코드 상태** (`checkpoint:` WIP 커밋) | 겹치지 않음. 상보적 — HANDOFF와 함께 쓰면 좋음 |
+| `/gsd:pause-work` | GSD 워크플로우 상태 (`.planning/STATE.md`) | **직접 겹침.** AOS에서는 이쪽이 정본 |
+| `_workspace/RUN_STATE.md` (AOS 하네스) | 하네스 Phase별 실행 상태 | 하네스 실행 중에 한정. 조언자 세션 일반에는 미적용 |
+| `/session-wrap` (AOS) | 세션 종료 시 문서·패턴·후속작업 정리 | 세션당 1회·수동. 임계 발동용으로는 무거움 |
+| `external-memory` 스킬 | 리서치 플랜·findings·체크포인트 | 트리거가 죽어 있음. 다중 에이전트 전용 |
+| `gstack-context-save/restore` | git 상태 + 결정 + 잔여 작업 | 범용 대안. 플러그인 의존 |
+
+**판정: 새 저장 포맷을 만들면 7번째 중복이 된다.** 번들은 트리거만 소유하고, 저장은 위임한다.
+
+```
+GSD 활성 (.planning/STATE.md 존재)  →  /gsd:pause-work        ← AOS가 여기
+GSD 비활성                          →  HANDOFF.md 1장 작성
+어느 쪽이든 코드가 더러우면          →  /wip-save 병행
+```
+
+이 분기는 GSD 주입 문구와 **정확히 일치**한다 (§1.3의 표를 다시 보면, GSD 분기는 `/gsd:pause-work`를
+지시하고 비-GSD 분기는 "unless the user asks" 예외를 열어둔다 — 번들 CLAUDE.md 규칙이 곧 그 "user asks").
+모순이 소멸한다.
+
+---
+
+## 3. 트리거 설계 — 베이스라인 델타
+
+### 3.1 계산
+
+```
+baseline  := 세션에서 처음 관측한 current_tokens (세션별 상태파일에 래치)
+delta     := current_tokens - baseline
+BUDGET    := 59_000        # 조언자 세션의 실작업 예산
+```
+
+- **창 크기와 무관하다.** 200k 창이든 1M 창이든 같은 시점에 발동한다.
+  요청의 진짜 의도가 "컨텍스트 고갈 방지"가 아니라 **"조언자의 판단력을 깨끗하게 유지"**이므로 이게 맞다.
+  (1M 창에서는 고갈이 영원히 안 오지만, 판단력 저하는 똑같이 온다.)
+- **59k의 근거:** 사용자 요청("문서 저장이 200k 창 사용률 50~55% 시점에 걸릴 것")에서 역산한 값이다.
+  베이스라인 50,905 기준 `200,000 × 0.55 − 50,905 ≈ 59,000`.
+  실측 환산 — 이 세션에서 도구 무거운 오리엔테이션 24턴에 delta 49k였으므로
+  59k ≈ **조사 위주 약 29턴** 분량. 창 사용률은 어디까지나 역산의 입력이고,
+  실제 판정 기준은 창 크기와 무관한 델타다(아래 참조).
+- **compact 후 재래치:** `current < baseline` 이면 `baseline := current`.
+  compact/새 세션 후 델타가 음수로 새는 것을 1줄로 막는다.
+- **재래치 시 디바운스 상태도 함께 지운다** (필수 — 안 하면 compact 후 첫 5회 경고가 삼켜진다):
+
+  ```bash
+  rm -f "$TMPDIR/claude-ctx-$SESSION_ID-warned.json"
+  ```
+
+  근거: `gsd-context-monitor.js:86`이 읽는 `-warned.json`은 **별도 파일**이고,
+  **session_id는 compact를 건너서도 바뀌지 않는다.** 추적하면 —
+  compact 직전 `{callsSinceWarn:0, lastLevel:'critical'}` 기록 → 재래치로 delta≈0,
+  합성 remaining=100 → 모니터가 `remaining > WARNING_THRESHOLD` 가드에서 종료(파일 미갱신) →
+  다음 임계 도달 시 `firstWarn=false`, `currentLevel='warning'` vs `lastLevel='critical'` 이라
+  `severityEscalated=false` → **디바운스 5회가 그대로 적용돼 초기 경고가 유실**된다.
+
+### 3.2 기존 모니터에 값을 태우는 방식
+
+`gsd-context-monitor.js`는 `remaining_percentage`(≤35 WARNING, ≤25 CRITICAL)를 읽는다.
+훅을 고치지 않으려면 브리지에 **예산 잔량**을 그 필드로 실어 보낸다.
+
+```
+remaining_percentage := 100 - (delta * 100 / BUDGET_RAW),  clamp [0,100]   # 셸 정수 나눗셈
+BUDGET_RAW = 78_666   # CRITICAL(25%)이 delta 59k에서 떨어지도록 역산 = floor(59_000 / 0.75)
+
+  → WARNING  (≤35%) : delta ≈ 51.1k   "새 복잡 작업 시작하지 말 것"
+  → CRITICAL (≤25%) : delta ≈ 59.0k   "정지하고 사용자에게 알릴 것"
+```
+
+**`floor` 를 쓰는 이유(고치지 말 것):** 브리지는 POSIX 셸 `$(( ))` 로 계산하므로 나눗셈이 내림이다.
+`59_000 / 0.75 = 78_666.67` 을 반올림해 `78_667` 로 쓰면 `delta = 59_000` 에서 몫이 74가 되어
+잔량 26 — CRITICAL 임계(≤25)에 1 모자라 그 지점에서 발동하지 않는다. 두 경계를 모두 만족하는
+가장 큰 값이 `78_666` 이다 (`≤ 5_113_300/65` 이고 `≤ 5_900_000/75`).
+
+**트레이드오프 (정직하게):** 주입 메시지의 `Usage at X%. Remaining: Y%.` 숫자가
+"창 사용률"이 아니라 "예산 소진율"을 뜻하게 된다. 사람이 읽으면 혼동 가능하다.
+대가로 얻는 것 — 훅 파일 무수정, settings.json 무수정, 창 크기 무관 동작.
+혼동이 싫다면 대안은 번들 전용 훅 신설이고, 그건 install.sh를 JSON 병합기로 승격시킨다(§7).
+
+---
+
+## 4. 배선 설계 (새 훅 0개, settings.json 무수정)
+
+```
+Claude Code
+   │ statusline JSON (context_window, session_id)  ── 매 렌더
+   ▼
+awesome-statusline.sh   ← 번들이 마커 블록 6~10줄 삽입 (백업 후)
+   │   baseline 래치 → delta 계산 → remaining_percentage 합성
+   │   $TMPDIR/claude-ctx-{session_id}.json 기록
+   ▼
+gsd-context-monitor.js  ← 이미 PostToolUse 에 등록돼 있음. 무수정
+   │   ≤35 / ≤25 판정 → additionalContext 주입 (5툴 디바운스)
+   ▼
+모델 컨텍스트에 경고 등장
+   │
+   ▼
+~/.claude/CLAUDE.md 번들 블록의 규칙이 대응을 규정 (§6)
+```
+
+**남의 파일 수정 문제:** `awesome-statusline.sh`는 번들 소유가 아니다.
+번들이 CLAUDE.md에 쓰는 것과 동일한 **마커 블록 + 백업** 기법을 그대로 적용한다
+(`install.sh`의 `backup_file`/`install_file` 헬퍼 재사용). 마커 밖 사용자 커스터마이징은 보존된다.
+
+**이번 범위에 넣지 않는 것:** `~/.claude/hooks/universal/contextMonitor.js` (Stop 훅).
+사문화 상태이긴 하나(§1.2) 이 트리거와 **충돌하지는 않는다** — Stop 시점에 횟수를 출력할 뿐이다.
+번들 소유 파일도 아니어서 손대려면 statusline과 같은 마커/백업 규율이 필요하다.
+`golden-principles.md`의 surgical-changes 원칙에 따라 **별도 후속 과제로 분리**한다.
+
+---
+
+## 5. GSD 주입 문구와의 정합 (§1.3 해소)
+
+```
+주입: "…Do NOT write handoff files — GSD state is already tracked in STATE.md.
+       Inform the user so they can run /gsd:pause-work…"
+
+번들 규칙(대응): GSD 활성이면 handoff를 쓰지 않는다. /gsd:pause-work 를 제안한다.
+                 GSD 비활성이면 HANDOFF.md 를 쓴다 (= 주입문의 "unless the user asks" 충족).
+```
+
+두 지시가 **같은 방향을 가리키므로** 모델이 어느 쪽을 따를지 고민할 여지가 없다.
+번들이 자체 저장 포맷을 고집했다면 여기서 상충이 발생했을 것이다 — 이것이 §2 "저장은 위임" 판단의 실질 근거다.
+
+---
+
+## 6. Compact vs 새 세션 — 실측에 근거한 판정
+
+요청에는 둘 다 언급돼 있으나, 실측을 넣으면 우열이 갈린다.
+
+```
+compact 후 잔존:  베이스라인 51k (시스템·CLAUDE.md·스킬·도구스키마) + 자동 생성 요약
+새 세션 시작:     베이스라인 51k (동일) + 조언자가 고른 HANDOFF
+```
+
+**절감 토큰은 사실상 같다** — 양쪽 다 51k에서 다시 시작한다. 실제로 다른 변수는 하나뿐:
+**delta 자리를 무엇이 채우느냐.** 자동 요약(통제 약함) vs 조언자가 직접 고른 결정 로그(통제 강함).
+
+조언자–작업자 구조에서는 남길 것이 명확하다 — 설계 결정, 완료 기준, 검증 상태, 시도 횟수.
+자동 요약은 이걸 보존한다는 보장이 없다.
+
+→ **권고: 새 세션 + HANDOFF 를 기본, `/compact`는 예외.**
+   단, 번들은 이를 *권고*로만 쓴다. compact를 강제할 수단이 없고 사용자 선택이기 때문.
+
+---
+
+## 7. install.sh 변경 비용
+
+| 안 | settings.json | 새 훅 | install.sh 증분 | 위험 |
+|---|---|---|---|---|
+| **채택안 (§4)** | 무수정 | 0개 | 마커 삽입 함수 1개 ≈ 40줄 | 낮음. 기존 백업 헬퍼 재사용 |
+| 전용 훅 신설 | **필요** — 기존 14개 이벤트·Orca 항목 보존하는 멱등 JSON 병합 | 1개 | ≈ 150줄 + 롤백 | **높음.** 설치기가 텍스트 치환기 → JSON 병합기로 승격 |
+
+채택안이 싼 이유는 "이미 등록된 훅에 데이터를 흘려보내기만" 하기 때문이다.
+대신 **GSD 플러그인 내부 구현에 의존**한다 — 아래 리스크 참조.
+
+---
+
+## 8. 역할 재분배
+
+### 8.1 변경 후 역할표
+
+| 역할 | 담당 | 모델 | 변경 |
+|---|---|---|---|
+| 조언자 — 설계·판단·위임·승인 | 메인 세션 / `architect` | opus | **+ HANDOFF 작성 책임 (위임 불가)** |
+| 작업자 — 구현·테스트 | `worker` | opus | 변경 없음 |
+| 로컬 압축 — 코드베이스·로그·파일 | `analyzer` | haiku | **경계 축소: 로컬 전용 명시** |
+| **외부 조사 — 웹·MCP·라이브러리 문서** | **`researcher` (신설)** | **sonnet** | **신규** |
+| 검증 — 리뷰·적대적 검토 | Codex | — | 변경 없음 |
+| 컨텍스트 예산 감시 | statusline 브리지 → GSD 모니터 | — | **신규 배선** |
+
+### 8.2 `researcher` 신설이 필요한 이유
+
+`analyzer`(haiku)에 웹 도구를 얹는 대안은 두 성격을 한 파일에 섞는다 —
+"대량 원문 압축"(haiku로 충분)과 "외부 조사·출처 판단"(haiku로는 부족).
+모델 등급이 서로 다른 두 일을 한 에이전트에 두면 어느 쪽이든 손해다.
+
+```markdown
+---
+name: researcher
+description: 웹·MCP 외부 조사 전담. 라이브러리 문서, 릴리스 노트, 외부 사례 조사에 사용.
+  원문을 삼키고 결론+출처만 반환해 메인 세션 컨텍스트를 보호한다.
+tools: WebSearch, WebFetch, Read, Grep, Glob,
+       mcp__plugin_context7_context7__*, mcp__tavily__*
+model: sonnet
+---
+너는 외부 조사 담당이다. 조사 원문은 네 컨텍스트에서 끝난다.
+- 반환은 결론 → 근거(출처 URL/문서 위치) → 불확실한 부분. 원문 인용은 3줄 이내.
+- 판단·설계는 하지 않는다. 상충하는 출처는 상충한다고 보고한다.
+- 라이브러리/프레임워크는 context7 우선 (학습 데이터보다 최신).
+```
+
+### 8.3 `architect` 도구 축소 (부수 개선)
+
+현재 `architect`는 `WebSearch, WebFetch`를 갖는다. 서브에이전트라 **메인 컨텍스트 오염은 없지만**,
+판단 전용 에이전트의 컨텍스트를 조사 원문으로 채우는 건 그 자체가 손해다 —
+`architect`가 존재하는 이유는 "깨끗한 컨텍스트에서 내리는 설계 판단"이고, 원문 덤프는 그걸 희석한다.
+(조언자·작업자가 모두 opus로 고정된 뒤로는 "비싼 모델 아끼기"가 아니라 **판단 품질**이 주된 근거다.)
+조사는 `researcher`(sonnet)로 넘기고 `architect`는 요약만 받는 것이 일관적이다.
+
+```diff
+- tools: Read, Grep, Glob, WebSearch, WebFetch
++ tools: Read, Grep, Glob
+```
+
+### 8.4 규칙이 구속하는 범위 (명확화)
+
+리서치 격리 규칙은 **모드 A의 메인 세션**을 구속한다.
+서브에이전트가 웹 도구를 갖는 것은 모순이 아니다 — 컨텍스트가 분리돼 있기 때문이다.
+번들 문서에 이 문장을 넣지 않으면 규칙이 자기모순으로 읽힌다.
+
+### 8.5 HANDOFF는 왜 위임 불가인가 (구조적 제약)
+
+저장해야 할 내용(설계 결정, 왜 그 대안을 버렸는지, 검증 상태)은 **메인 세션의 대화 안에만** 존재한다.
+서브에이전트는 원리적으로 그것을 볼 수 없다. 따라서 조언자 본인이 쓴다.
+
+→ 번들의 **"조언자 직접 코딩 금지(예외: 단일 파일·30줄 이내 문서/설정)"** 조항에 카브아웃이 필요하다.
+   HANDOFF는 30줄을 넘기 쉽다.
+
+```diff
+  예외(조언자 직접 처리 허용): 단일 파일이며 30줄 이내의 문서·설정 수정.
++ 예외 2: 컨텍스트 핸드오프 문서(HANDOFF/pause-work) 작성 — 줄 수 제한 없음.
++   근거: 저장 대상이 메인 세션 컨텍스트에만 존재해 위임이 원리적으로 불가능.
+```
+
+### 8.6 관측: 리서치 격리가 1차 방어, 트리거는 2차 안전망
+
+statusline은 **메인 세션에만** 렌더링된다 → 서브에이전트 컨텍스트는 감시 대상이 아니다.
+이건 결함이 아니라 설계 의도와 맞는다: 무거운 조사를 서브에이전트로 밀어내면
+메인의 델타가 애초에 천천히 찬다. 트리거는 그게 실패했을 때 걸리는 그물이다.
+
+---
+
+## 9. 번들 CLAUDE.md 블록에 추가할 문안 (초안)
+
+```markdown
+## 컨텍스트 예산 (조언자 세션)
+세션 시작 시점 대비 +59k 토큰을 쓰면 새 작업을 시작하지 않는다.
+컨텍스트 경고가 주입되면(WARNING/CRITICAL) 즉시 다음을 한다:
+1. 진행 중 작업을 자연스러운 지점에서 마무리
+2. 상태 저장 — `.planning/STATE.md` 있으면 `/gsd:pause-work` 제안,
+   없으면 HANDOFF.md 작성(결정·완료기준·검증상태·다음 단계). 코드가 더러우면 `/wip-save` 병행
+3. 새 세션 권고 (compact보다 우선 — 남길 것을 조언자가 직접 고를 수 있다)
+저장 포맷을 새로 만들지 않는다. 위 경로 중 하나를 쓴다.
+
+## 리서치·외부 도구는 메인에서 직접 호출하지 않는다
+메인 세션(모드 A의 조언자)은 WebSearch/WebFetch/tavily/context7을 직접 부르지 않는다.
+`researcher`에게 위임하고 결론+출처 요약만 받는다. 로컬 대량 입력은 `analyzer`.
+서브에이전트가 이 도구들을 갖는 것은 모순이 아니다 — 컨텍스트가 분리되기 때문.
+```
+
+---
+
+## 10. 리스크 · 가정
+
+| # | 항목 | 수준 | 비고 |
+|---|---|---|---|
+| R1 | **GSD 플러그인 내부 의존** | High | `gsd-context-monitor.js`는 `gsd-hook-version: 1.26.0`이고 `gsd-check-update.js`가 SessionStart로 갱신을 확인한다. 임계치·브리지 스키마·메시지가 업데이트로 바뀌면 조용히 깨진다. → install.sh가 버전을 기록하고 불일치 시 경고할 것 |
+| R2 | GSD가 컨텍스트 경고를 끌 수 있음 | Medium | `.planning/config.json`의 `hooks.context_warnings=false`면 무력화 |
+| R3 | 합성 `remaining_percentage`의 의미 왜곡 | Medium | 주입문 숫자가 "예산 소진율"로 읽힘 (§3.2 트레이드오프) |
+| R4 | 리서치 격리는 소프트 강제 | Medium | 하드 차단 수단 미확인 (§1.5, L3) |
+| R5 | BUDGET 59k는 사용자 지정값 | Medium | 사용자 요청(200k 창 사용률 50~55%)에서 역산. 턴 수 환산(≈29턴)만 1개 세션 표본(조사 편중) 실측이므로, 위임 위주 세션에서 재측정 권장 |
+| R6 | statusline 미호출 환경 | Low | headless/cron 실행 시 statusline이 안 돌면 브리지도 없음 → 훅은 조용히 종료(무해) |
+
+**가정**
+- A1. 최초 요청의 "20~25%"는 목표 수치가 아니라 **"조언자를 일찍 정지시킨다"는 의도**의 표현이었다.
+  이후 사용자가 발동 시점을 **200k 창 사용률 50~55%** 로 명시했고, 델타 59k가 그 지점(≈55%)을 재현한다.
+- A2. 저장 포맷 중복 제거가 새 포맷 신설보다 가치가 크다 (사문화 3건이 근거).
+- A3. 이 검토는 **미구현**이다. 채택 시 §11로 진행.
+
+---
+
+## 11. 채택 시 다음 단계 (worker 브리프 초안)
+
+> 조언자–작업자 원칙상 구현은 worker에게 위임하고, Codex 검증을 통과해야 승인한다.
+
+**범위 (2개 파일)**
+1. `install.sh` — statusline 마커 삽입 함수 추가(baseline 래치 + 재래치 시 `-warned.json` 삭제 포함)
+   + `researcher.md` heredoc 추가 + `architect.md` tools에서 WebSearch/WebFetch 제거
+   + CLAUDE.md 블록에 §9 문안 추가 + GSD 훅 버전 기록/불일치 경고
+2. `README_조언자-작업자-전략.md` — 역할표(§8.1), 예외 카브아웃(§8.5), 배선도(§4) 반영
+   > Fable→Opus 이관은 **이미 완료**돼 있다(워킹트리 실측: `install.sh` fable 0건,
+   > README 잔존 3건은 과거 실험 각주·별칭 목록으로 의도적). 건드리지 말 것.
+(`researcher.md`는 별도 파일이 아니라 `install.sh` 안의 heredoc으로 들어간다 — 기존 3종과 동일 방식)
+
+**완료 기준**
+- `bash install.sh` 재실행이 **멱등** (2회 실행 후 diff 0, 백업 파일 1세트만)
+- 마커 밖 statusline 커스터마이징 보존 확인
+- 새 세션에서 `$TMPDIR/claude-ctx-*.json` 생성 확인 — **단, 이건 writer만 증명한다**
+- **Red-Green 종단 검증 (이것이 유일한 결정적 증거)**:
+
+  | 단계 | 조작 | 기대 |
+  |---|---|---|
+  | GREEN | 브리지 파일에 `remaining_percentage: 20` 강제 기록 | 다음 도구 호출 후 컨텍스트에 `CONTEXT CRITICAL` **문자열이 실제로 등장** |
+  | RED | 브리지 파일 삭제 | 경고가 사라짐 |
+
+  근거: §1.2의 실패는 "훅은 등록됐는데 파일이 없었다"였다. 거울상 실패(파일은 있는데
+  GSD 업데이트로 리더가 사라짐 / R2의 `context_warnings:false` / matcher 불일치)는
+  **파일 존재 확인만으로는 통과하고 죽은 채로 출하된다.** RED 단계 없이는 주입과 우연을 구분할 수 없다.
+- `/agents`에 `researcher` 노출 확인
+- settings.json **무변경** 확인 (md5 비교)
+
+**후속 과제(이번 범위 밖)**: `~/.claude/hooks/universal/contextMonitor.js` 폐기 검토 (§4)
+
+**검증 방법**: `/codex:review` 무결점. 설치기 변경이므로 `--scope working-tree`.
+**시도 상한**: 3회. 멱등성이 2회 안에 안 잡히면 멈추고 보고.
+
+---
+
+## 부록 · 재현 명령
+
+```bash
+# 베이스라인/델타 실측
+TR=~/.claude/projects/-Users-younghwankang-Work-Agent-System/<session>.jsonl
+python3 -c "
+import json,sys
+rows=[]
+for l in open(sys.argv[1]):
+    try: d=json.loads(l)
+    except: continue
+    u=(d.get('message') or {}).get('usage')
+    if u: rows.append(u.get('input_tokens',0)+u.get('cache_creation_input_tokens',0)+u.get('cache_read_input_tokens',0))
+print('baseline',rows[0],'now',rows[-1],'delta',rows[-1]-rows[0])" "$TR"
+
+# 브리지 사문화 확인
+ls $TMPDIR/claude-ctx-*.json /tmp/claude-ctx-*.json 2>/dev/null || echo "브리지 없음 = 모니터 미동작"
+
+# GSD 분기 판정
+ls .planning/STATE.md 2>/dev/null && echo "GSD 분기" || echo "비-GSD 분기"
+```

--- a/docs/codex-advisor-worker-bundle/install.sh
+++ b/docs/codex-advisor-worker-bundle/install.sh
@@ -2,8 +2,10 @@
 #
 # 조언자–작업자–Codex 검증 번들 · 원샷 설치기
 # ─ ~/.claude/CLAUDE.md 의 번들 마커 블록 갱신 (블록 밖 개인 내용은 보존)
-# ─ ~/.claude/agents/{architect,worker,analyzer}.md 생성 (내용 동일 시 건너뜀)
+# ─ ~/.claude/agents/{architect,worker,analyzer,researcher}.md 생성 (내용 동일 시 건너뜀)
 # ─ 구버전 reviewer.md 백업 후 제거(검증은 Codex로 대체)
+# ─ 활성 statusline 스크립트에 컨텍스트 예산 브리지 블록 삽입 (마커 관리·백업, settings.json 무수정)
+# ─ GSD 컨텍스트 모니터 훅 버전 대조 (불일치 시 경고만)
 # ─ Node/Codex CLI 확인 및 설치 시도
 # ─ ~/.codex/config.toml 검증 기본값 템플릿(없을 때만)
 # ─ 마지막에 Claude Code 안에서 실행할 플러그인 명령 안내
@@ -20,6 +22,14 @@ CODEX_DIR="${HOME}/.codex"
 # 개인 추가 내용은 반드시 블록 밖에 작성할 것 (재설치 시 보존됨).
 MARK_START='<!-- codex-advisor-worker-bundle:start — 이 블록은 install.sh가 관리. 개인 내용은 블록 밖에 -->'
 MARK_END='<!-- codex-advisor-worker-bundle:end -->'
+
+# statusline 컨텍스트 브리지 마커 — 남의 파일(statusline 스크립트)에 삽입하므로
+# 이 블록 안만 설치기가 관리하고, 마커 밖 사용자 커스터마이징은 보존한다.
+CTX_MARK_START='# <<< codex-advisor-worker-bundle:ctx-budget:start — install.sh가 관리 -->>>'
+CTX_MARK_END='# <<< codex-advisor-worker-bundle:ctx-budget:end -->>>'
+
+# 브리지 값을 읽는 GSD 훅의 핀 버전. 불일치 시 경고만 하고 설치는 계속한다.
+GSD_HOOK_PIN='1.26.0'
 
 mkdir -p "${AGENTS_DIR}"
 
@@ -54,6 +64,206 @@ install_file() {
   fi
 }
 
+# install_file 과 같지만 mv 대신 리다이렉트로 덮어써 기존 퍼미션·inode 를 보존한다.
+# statusline 스크립트는 실행 비트(+x)가 필요하고 mktemp 파일은 0600 이므로 mv 를 쓰면 안 된다.
+install_file_preserve_mode() {
+  target="$1"
+  tmpfile="$2"
+  if [ -f "${target}" ] && cmp -s "${tmpfile}" "${target}"; then
+    echo "  변경 없음 → 건너뜀: ${target}"
+    rm -f "${tmpfile}"
+  else
+    backup_if_exists "${target}"
+    # 원자적 교체: 'cat > target' 은 리다이렉션이 열리는 순간 truncate 하므로
+    # 중간에 실패하면 사용자의 활성 statusline 이 빈 파일로 남는다(백업은 자동 복원되지 않음).
+    # 대상과 '같은 디렉토리'에 임시본을 만들어 rename 한다 — 같은 파일시스템이라 mv 가 원자적.
+    # ($TMPDIR 은 다른 파일시스템일 수 있어 원자성이 보장되지 않는다)
+    atomic_tmp="${target}.tmp.$$"
+    # cp -p 로 퍼미션·소유를 승계한다 (chmod --reference 는 BSD/macOS 에 없다)
+    if ! cp -p "${target}" "${atomic_tmp}" 2>/dev/null; then
+      rm -f "${atomic_tmp}" "${tmpfile}"
+      echo "  ⚠ 임시본 생성 실패 → ${target} 를 변경하지 않았습니다(원본 보존)."
+      return 0
+    fi
+    if ! cat "${tmpfile}" > "${atomic_tmp}" 2>/dev/null; then
+      rm -f "${atomic_tmp}" "${tmpfile}"
+      echo "  ⚠ 임시본 쓰기 실패 → ${target} 를 변경하지 않았습니다(원본 보존)."
+      return 0
+    fi
+    if ! mv -f "${atomic_tmp}" "${target}" 2>/dev/null; then
+      rm -f "${atomic_tmp}" "${tmpfile}"
+      echo "  ⚠ 교체(rename) 실패 → ${target} 원본을 그대로 유지합니다."
+      return 0
+    fi
+    rm -f "${tmpfile}"
+    echo "  설치 완료: ${target}"
+  fi
+}
+
+# 브리지 값을 소비하는 GSD 훅의 버전을 핀 값과 대조 (경고만, 설치는 계속).
+check_gsd_hook_version() {
+  echo "▶ GSD 컨텍스트 모니터 훅 버전 대조 (핀: ${GSD_HOOK_PIN})"
+  gsd_hook="${CLAUDE_DIR}/hooks/gsd-context-monitor.js"
+  if [ ! -f "${gsd_hook}" ]; then
+    echo "  ⚠ 주의: ${gsd_hook} 가 없습니다. 브리지를 써도 컨텍스트 경고가 주입되지 않습니다."
+    echo "     REVIEW 문서 §10 R1 을 확인하세요."
+    return 0
+  fi
+  gsd_ver="$(grep -m1 '^// gsd-hook-version:' "${gsd_hook}" 2>/dev/null | sed 's|^// gsd-hook-version:[[:space:]]*||' || true)"
+  if [ -z "${gsd_ver}" ]; then
+    gsd_ver="unknown"
+  fi
+  if [ "${gsd_ver}" = "${GSD_HOOK_PIN}" ]; then
+    echo "  버전 일치: ${gsd_ver}"
+  else
+    echo "  ⚠ 주의: gsd-context-monitor.js 버전이 ${GSD_HOOK_PIN} 이 아닙니다(현재: ${gsd_ver})."
+    echo "     임계치·브리지 스키마가 바뀌었을 수 있으니 REVIEW 문서 §10 R1 을 확인하세요."
+  fi
+}
+
+# 활성 statusline 스크립트에 컨텍스트 예산 브리지 블록을 삽입한다.
+# settings.json 은 읽기만 하고 절대 쓰지 않는다. 전제가 하나라도 어긋나면 경고 후 skip.
+install_ctx_bridge() {
+  echo "▶ statusline 컨텍스트 예산 브리지 삽입"
+  ctx_settings="${CLAUDE_DIR}/settings.json"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  ⚠ jq 가 없어 statusline 경로를 확인할 수 없습니다 → 브리지 건너뜀"
+    return 0
+  fi
+  if [ ! -f "${ctx_settings}" ]; then
+    echo "  ⚠ ${ctx_settings} 없음 → 브리지 건너뜀"
+    return 0
+  fi
+
+  # settings.json 은 읽기 전용으로만 접근한다.
+  ctx_cmd="$(jq -r '.statusLine.command // ""' "${ctx_settings}" 2>/dev/null || true)"
+  if [ -z "${ctx_cmd}" ] || [ "${ctx_cmd}" = "null" ]; then
+    echo "  ⚠ settings.json 에 .statusLine.command 가 없습니다 → 브리지 건너뜀"
+    return 0
+  fi
+
+  # 래퍼 커맨드 대응: 첫 토큰이 아니라 토큰을 순회하며 대상을 고른다.
+  #   "bash ~/statusline.sh" / "env FOO=1 ~/statusline.sh" / "/bin/zsh ~/statusline.sh"
+  # 첫 토큰만 보면 인터프리터(bash/env)를 대상으로 잡아 앵커를 못 찾고 조용히 skip 된다.
+  # 후보 조건: 선행 '~' 를 $HOME 으로 확장한 뒤 실제 파일(-f)이고 앵커를 포함한 첫 파일.
+  #   - 'bash'·'env' 같은 PATH 실행파일은 상대경로라 -f 에서 탈락
+  #   - '/bin/bash' 처럼 절대경로로 와도 앵커 검사에서 탈락
+  #   - 'FOO=1' 같은 env 대입도 -f 에서 탈락
+  ctx_script=""
+  for ctx_tok in ${ctx_cmd}; do
+    # Claude Code 는 이 커맨드를 셸로 실행하므로 '$HOME/...' 형태도 정상 설정이다.
+    # 공백 포함·따옴표 감싼 경로는 단어 분리로 이미 깨지므로 다루지 않는다.
+    case "${ctx_tok}" in
+      '~/'*)       ctx_tok="${HOME}/${ctx_tok#\~/}" ;;
+      '~')         ctx_tok="${HOME}" ;;
+      '$HOME/'*)   ctx_tok="${HOME}/${ctx_tok#\$HOME/}" ;;
+      '${HOME}/'*) ctx_tok="${HOME}/${ctx_tok#\$\{HOME\}/}" ;;
+    esac
+    [ -f "${ctx_tok}" ] || continue
+    if grep -q '^CURRENT_USAGE=' "${ctx_tok}" 2>/dev/null; then
+      ctx_script="${ctx_tok}"
+      break
+    fi
+  done
+  if [ -z "${ctx_script}" ]; then
+    echo "  ⚠ statusLine 커맨드에서 앵커(^CURRENT_USAGE=)를 가진 스크립트를 찾지 못했습니다."
+    echo "    커맨드: ${ctx_cmd}"
+    echo "    컨텍스트 예산 경고가 동작하지 않습니다. statusline 스크립트 경로를 공백 없는"
+    echo "    '~/' 또는 '\$HOME/' 형태로 두거나, 블록을 수동 삽입하세요(REVIEW 문서 §4 참조)."
+    return 0
+  fi
+  echo "  대상 statusline: ${ctx_script}"
+
+  # 마커 구조 검증: 없음(0쌍) 또는 정확히 1쌍(start가 end보다 앞)만 허용.
+  ctx_n_start="$(grep -cF "${CTX_MARK_START}" "${ctx_script}" || true)"
+  ctx_n_end="$(grep -cF "${CTX_MARK_END}" "${ctx_script}" || true)"
+  if [ "${ctx_n_start}" -ne "${ctx_n_end}" ] || [ "${ctx_n_start}" -gt 1 ]; then
+    echo "  ⚠ 브리지 마커 구조 비정상(start=${ctx_n_start}, end=${ctx_n_end}) → 건너뜀"
+    echo "    ${ctx_script} 에서 마커를 수동 정리 후 재실행하세요."
+    return 0
+  fi
+  if [ "${ctx_n_start}" -eq 1 ]; then
+    ctx_l_start="$(grep -nF "${CTX_MARK_START}" "${ctx_script}" | head -1 | cut -d: -f1)"
+    ctx_l_end="$(grep -nF "${CTX_MARK_END}" "${ctx_script}" | head -1 | cut -d: -f1)"
+    if [ "${ctx_l_start}" -ge "${ctx_l_end}" ]; then
+      echo "  ⚠ 브리지 마커 순서 역전(start=${ctx_l_start}, end=${ctx_l_end}) → 건너뜀"
+      return 0
+    fi
+  fi
+
+  # 브리지 본문. POSIX sh 호환이고 표준출력에 아무것도 쓰지 않는다(statusline 표시가 깨진다).
+  ctx_body="$(mktemp)"
+  cat > "${ctx_body}" <<'CTXBRIDGE'
+# 조언자 컨텍스트 예산 브리지: baseline 대비 델타를 예산 잔량(%)으로 합성해
+# gsd-context-monitor.js(PostToolUse)에 전달한다. 표준출력에 아무것도 쓰지 않는다.
+# 비0 종료 가능한 명령에는 전부 '|| true' 를 붙인다 — 대상 스크립트가 set -e 면
+# baseline 파일이 없는 첫 렌더에서 cat 이 비0으로 끝나 statusline 전체가 죽는다.
+__ctx_sid=$(printf '%s' "$input" | jq -r '.session_id // ""' 2>/dev/null || true)
+if [ -n "$__ctx_sid" ] && [ "$CURRENT_USAGE" != "null" ]; then
+  __ctx_now=$(printf '%s' "$CURRENT_USAGE" | jq -r '(.input_tokens // 0) + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0)' 2>/dev/null || true)
+  case "$__ctx_now" in ''|*[!0-9]*) __ctx_now=0 ;; esac
+  if [ "$__ctx_now" -gt 0 ]; then
+    __ctx_dir="${TMPDIR:-/tmp}"; __ctx_dir="${__ctx_dir%/}"
+    __ctx_base_f="${__ctx_dir}/claude-ctx-${__ctx_sid}-base"
+    __ctx_base=$(cat "$__ctx_base_f" 2>/dev/null || true)
+    case "$__ctx_base" in ''|*[!0-9]*) __ctx_base=0 ;; esac
+    # 최초 관측이거나 compact 후(현재<기존)면 재래치 + 디바운스 상태 제거
+    if [ "$__ctx_base" -eq 0 ] || [ "$__ctx_now" -lt "$__ctx_base" ]; then
+      __ctx_base="$__ctx_now"
+      printf '%s' "$__ctx_base" > "$__ctx_base_f" 2>/dev/null || true
+      rm -f "${__ctx_dir}/claude-ctx-${__ctx_sid}-warned.json" 2>/dev/null || true
+    fi
+    __ctx_delta=$(( __ctx_now - __ctx_base ))
+    # BUDGET_RAW=78666 → CRITICAL(잔량 25%)이 delta 59,000 에서 발동, WARNING(35%)은 51,133
+    # 78666 = floor(59000/0.75). 반올림한 78667 을 쓰면 $(( )) 의 정수 truncation 때문에
+    # delta 59,000 에서 26 이 나와(잔량<=25 미달) CRITICAL 이 그 지점에서 안 뜬다.
+    __ctx_rem=$(( 100 - (__ctx_delta * 100 / 78666) ))
+    if [ "$__ctx_rem" -lt 0 ]; then __ctx_rem=0; fi
+    if [ "$__ctx_rem" -gt 100 ]; then __ctx_rem=100; fi
+    __ctx_used=$(( 100 - __ctx_rem ))
+    printf '{"session_id":"%s","remaining_percentage":%s,"used_pct":%s,"timestamp":%s}' \
+      "$__ctx_sid" "$__ctx_rem" "$__ctx_used" "$(date +%s)" \
+      > "${__ctx_dir}/claude-ctx-${__ctx_sid}.json" 2>/dev/null || true
+  fi
+fi
+CTXBRIDGE
+
+  # 멱등성: 매 실행마다 (1) 기존 마커 블록 제거 → (2) 앵커 뒤에 새 블록 삽입.
+  # 최초 삽입과 재삽입이 같은 코드 경로를 타므로 2회 실행 결과가 바이트 동일해진다.
+  ctx_stripped="$(mktemp)"
+  awk -v s="${CTX_MARK_START}" -v e="${CTX_MARK_END}" '
+    $0 == s { inblock=1; next }
+    $0 == e { inblock=0; next }
+    inblock { next }
+    { print }
+  ' "${ctx_script}" > "${ctx_stripped}"
+
+  ctx_new="$(mktemp)"
+  awk -v s="${CTX_MARK_START}" -v e="${CTX_MARK_END}" -v bf="${ctx_body}" '
+    { print }
+    !ins && /^CURRENT_USAGE=/ {
+      print s
+      while ((getline line < bf) > 0) print line
+      close(bf)
+      print e
+      ins = 1
+    }
+  ' "${ctx_stripped}" > "${ctx_new}"
+
+  # 사후 확인: 삽입 결과에 마커가 정확히 1쌍 있어야 한다.
+  ctx_v_start="$(grep -cF "${CTX_MARK_START}" "${ctx_new}" || true)"
+  ctx_v_end="$(grep -cF "${CTX_MARK_END}" "${ctx_new}" || true)"
+  if [ "${ctx_v_start}" -ne 1 ] || [ "${ctx_v_end}" -ne 1 ]; then
+    echo "  ⚠ 삽입 결과 검증 실패(start=${ctx_v_start}, end=${ctx_v_end}) → statusline 을 변경하지 않았습니다."
+    rm -f "${ctx_body}" "${ctx_stripped}" "${ctx_new}"
+    return 0
+  fi
+
+  install_file_preserve_mode "${ctx_script}" "${ctx_new}"
+  rm -f "${ctx_body}" "${ctx_stripped}"
+}
+
 echo "▶ ~/.claude/CLAUDE.md 번들 블록 갱신"
 TMP_BLOCK="$(mktemp)"
 cat > "${TMP_BLOCK}" <<'CLAUDEMD'
@@ -63,12 +273,12 @@ cat > "${TMP_BLOCK}" <<'CLAUDEMD'
 > `~/.claude/agents/` 서브에이전트의 `model:` 필드로 강제한다. 검증은 Codex 플러그인이 담당한다.
 
 ## 핵심: 조언자–작업자–검증 (Advisor–Worker–Codex)
-- 조언자(Advisor · 상위 모델 Fable 5): 설계·판단·위임·최종 결정. 직접 코딩하지 않는다.
+- 조언자(Advisor · Opus): 설계·판단·위임·최종 결정. 직접 코딩하지 않는다.
 - 작업자(Worker · Opus): 조언자의 브리프대로 구현·테스트만. 범위 확장·무한 리팩터링 금지.
 - 검증(Codex): 작업자 결과는 조언자가 직접 보지 않고 Codex 리뷰로 검증한다.
   - 표준 검증: /codex:review
   - 설계·트레이드오프 도전(적대적 검증): /codex:adversarial-review
-- 저렴한 모델은 스스로 멈추지 못하므로, 조언자가 완료 기준·시도 상한을 주고 Codex 검증으로 관문을 만든다.
+- 조언자와 작업자가 같은 모델이어도 분리는 유지한다. 목적은 모델 등급 차이가 아니라 역할(설계 vs 구현)·컨텍스트 분리다. 조언자가 완료 기준·시도 상한을 주고 Codex 검증으로 관문을 만든다 — 자기 결과를 자기가 승인하지 않는 것이 핵심이다.
 
 ## 검증은 무조건 (가장 중요)
 작업자의 "완료" 보고를 그대로 믿지 않는다. /codex:review(또는 /codex:adversarial-review)를 실행해
@@ -77,6 +287,7 @@ diff를 실제로 검토한 뒤, 조언자가 지적사항 반영을 지시하�
 ## 조언자 직접 코딩 금지의 범위
 - 구현은 worker 위임이 기본값. "브리프 작성 비용이 구현과 비슷하다"는 위임 회피 사유가 아니다.
 - 예외(조언자 직접 처리 허용): 단일 파일이며 30줄 이내의 문서·설정 수정. 예외여도 Codex 검증은 동일하게 적용한다.
+- 예외 2: 컨텍스트 핸드오프 문서(HANDOFF / pause-work) 작성 — 줄 수 제한 없음. 저장 대상이 메인 세션 컨텍스트에만 존재해 위임이 원리적으로 불가능하다.
 
 ## 작업 순서 기본형
 1. architect(조언자) — 설계 + 브리프(완료 기준·검증 방법·시도 상한)
@@ -90,13 +301,15 @@ worker 보고 수신: 가능하면 동기 실행으로 결과를 직접 받는�
 실행)을 직접 검증한다.
 
 ## 운용 모드
-- 모드 A(기본): 메인 세션 = 조언자(Fable 5). 구현은 worker(Opus), 검증은 /codex:review.
-- 모드 B(비용 최소): 메인은 Sonnet. 설계는 architect 버스트(Fable 5), 구현은 worker(Opus), 검증은 Codex.
+- 모드 A(기본): 메인 세션 = 조언자(Opus). 구현은 worker(Opus), 검증은 /codex:review.
+- 모드 B(비용 최소): 메인은 Sonnet. 설계는 architect 버스트(Opus), 구현은 worker(Opus), 검증은 Codex.
 - (옵션) 자동 검증: /codex:setup --enable-review-gate — 종료 전 Codex 자동 리뷰. 사용량 소모 큼, 감시하며 사용.
 
-## 모델 폴백 (Fable 한도 소진 → Opus)
-어드바이저는 fable 별칭 사용. 소진 시: /model opus (모드 A) 또는 셸에 export ANTHROPIC_DEFAULT_FABLE_MODEL=claude-opus-4-8 (모드 무관).
---fallback-model 은 과부하(503)에만 발동, 한도 소진(429)에는 안 됨.
+## 모델 고정
+조언자·작업자 모두 opus 별칭으로 고정한다 (~/.claude/agents/architect.md, worker.md). 자동 폴백은 두지 않는다.
+--fallback-model 은 과부하(503)에만 발동하고 한도 소진(429)에는 발동하지 않으므로 폴백 수단으로 신뢰하지 않는다.
+모드 B는 소진 "대비" 절약책이지 소진 "후" 대책이 아니다 — 모드 B에서도 architect·worker는 그대로 opus를 호출한다.
+Opus 소진 후 경로는 둘: (a) 두 에이전트의 model: 을 sonnet 으로 임시 하향, (b) /codex:rescue 로 Codex(별도 한도)에 위임.
 
 ## Reasoning effort
 - Claude 기본 high. Codex 검증 effort는 ~/.codex/config.toml 의 model_reasoning_effort 로 조절(high 권장).
@@ -104,6 +317,21 @@ worker 보고 수신: 가능하면 동기 실행으로 결과를 직접 받는�
 ## 토큰 무거운 작업은 분리
 코드베이스 분석·긴 로그·대량 요약은 analyzer(Haiku)에 먼저 위임하고 압축 결론만 넘긴다.
 규모가 큰 구현·버그 조사는 /codex:rescue 로 Codex에 위임할 수 있다.
+
+## 컨텍스트 예산 (조언자 세션)
+세션 시작 시점 대비 +59k 토큰을 쓰면 새 작업을 시작하지 않는다.
+컨텍스트 경고(CONTEXT WARNING / CONTEXT CRITICAL)가 주입되면 즉시:
+1. 진행 중 작업을 자연스러운 지점에서 마무리
+2. 상태 저장 — `.planning/STATE.md` 가 있으면 `/gsd:pause-work` 를 제안하고, 없으면 HANDOFF.md 작성(설계 결정·완료 기준·검증 상태·다음 단계). 코드가 더러우면 `/wip-save` 병행
+3. 새 세션을 권고한다 (compact 보다 우선 — 무엇을 남길지 조언자가 직접 고를 수 있다)
+저장 포맷을 새로 만들지 않는다. 위 경로 중 하나를 쓴다.
+주입 문구의 숫자는 창 사용률이 아니라 예산 소진율이다.
+기준은 델타(토큰)다. 베이스라인 50,905 기준 200k 창 사용률로는 약 55% 시점이며, 1M 창에서는 같은 작업량 시점에 울린다(창 사용률로는 약 11%).
+
+## 리서치·외부 도구는 메인에서 직접 호출하지 않는다
+메인 세션(모드 A의 조언자)은 WebSearch·WebFetch·tavily·context7 을 직접 부르지 않는다.
+researcher 에게 위임하고 결론+출처 요약만 받는다. 로컬 대량 입력은 analyzer.
+서브에이전트가 이 도구들을 갖는 것은 모순이 아니다 — 컨텍스트가 분리되기 때문이다.
 
 ## 출력 규약
 요약 → 근거 → 주의/가정 → 다음 단계. 근거 수준 L1/L2/L3, 불확실성 High/Medium/Low 표시.
@@ -159,9 +387,9 @@ cat > "${TMP_AGENT}" <<'ARCHMD'
 ---
 name: architect
 description: 설계, 아키텍처 결정, 기술 선택, 트레이드오프 분석, 작업 위임 설계에 사용(조언자의 설계 역할). 코드를 직접 작성하지 않고 계획·판단·위임 지시만 산출한다. 새 기능·모듈 시작, 리팩터링 방향 결정, ADR 작성 시 선제적으로 사용한다.
-tools: Read, Grep, Glob, WebSearch, WebFetch
-# 어드바이저 모델. 'fable' 별칭 = Fable 5. 한도 소진 시 env ANTHROPIC_DEFAULT_FABLE_MODEL=claude-opus-4-8 로 Opus 리맵, 또는 /model opus
-model: fable
+tools: Read, Grep, Glob
+# 어드바이저 모델. 'opus' 별칭으로 고정 — 메인 세션(settings.json "model": "opus[1m]")과 같은 계열. 별칭 고정으로 동적 모델 오배정을 차단한다.
+model: opus
 ---
 
 너는 조언자(Advisor)의 설계 역할이다. 구현이 아니라 판단·설계, 그리고 작업 위임 설계를 한다.
@@ -232,12 +460,36 @@ model: haiku
 ANALYZERMD
 install_file "${AGENTS_DIR}/analyzer.md" "${TMP_AGENT}"
 
+echo "▶ ~/.claude/agents/researcher.md 작성"
+TMP_AGENT="$(mktemp)"
+cat > "${TMP_AGENT}" <<'RESEARCHERMD'
+---
+name: researcher
+description: 웹·MCP 외부 조사 전담. 라이브러리 문서, 릴리스 노트, 외부 사례·스펙 조사에 사용. 원문을 삼키고 결론+출처만 반환해 메인 세션 컨텍스트를 보호한다. 로컬 코드베이스 조사는 analyzer 담당.
+tools: WebSearch, WebFetch, Read, Grep, Glob, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs, mcp__tavily__tavily_search, mcp__tavily__tavily_extract, mcp__tavily__tavily_research
+model: sonnet
+---
+
+너는 외부 조사 담당이다. 조사 원문은 네 컨텍스트에서 끝난다.
+
+원칙:
+- 반환은 결론 → 근거(출처 URL 또는 문서 위치) → 불확실한 부분 순. 원문 인용은 항목당 3줄 이내.
+- 판단·설계는 하지 않는다. 출처가 상충하면 상충한다고 보고한다.
+- 라이브러리·프레임워크는 최신 문서를 우선한다(학습 데이터보다 문서가 정본).
+- 라이브러리·프레임워크 문서는 context7 로 먼저 조회한다(resolve-library-id → query-docs).
+- 찾지 못했으면 "찾지 못했다"고 보고한다. 추측으로 채우지 않는다.
+RESEARCHERMD
+install_file "${AGENTS_DIR}/researcher.md" "${TMP_AGENT}"
+
 # 구버전 reviewer.md 백업 후 제거 (검증은 Codex로 대체)
 if [ -f "${AGENTS_DIR}/reviewer.md" ]; then
   backup_if_exists "${AGENTS_DIR}/reviewer.md"
   rm -f "${AGENTS_DIR}/reviewer.md"
   echo "▶ 구버전 reviewer.md 백업 후 제거 (검증은 Codex로 대체)"
 fi
+
+install_ctx_bridge
+check_gsd_hook_version
 
 echo "▶ Node.js 확인"
 if command -v node >/dev/null 2>&1; then
@@ -284,12 +536,12 @@ cat <<'DONE'
   !codex login          # 로그인 안 돼 있으면
 
 확인:
-  /agents   → architect, worker, analyzer, codex:codex-rescue 표시
-  /model    → 사용 가능한 별칭 확인 (architect는 fable 별칭 사용)
+  /agents   → architect, worker, analyzer, researcher, codex:codex-rescue 표시
+  /model    → 사용 가능한 별칭 확인 (architect는 opus 별칭 사용)
 
-폴백 (Fable 한도 소진 시 Opus):
-  /model opus                                            # 모드 A: 즉석 전환
-  export ANTHROPIC_DEFAULT_FABLE_MODEL=claude-opus-4-8   # 모드 무관: 셸 프로필에 추가
+모델 고정 (조언자·작업자 모두 opus):
+  /model opus     # 메인 세션을 조언자 등급으로
+  # 모드 B(메인 sonnet)는 소진 "대비" 절약책 — 소진 후엔 architect·worker의 model: 하향 또는 /codex:rescue
 
 검증 실행:
   /codex:review                 # 표준 검증
@@ -298,6 +550,7 @@ cat <<'DONE'
 
 참고: ~/.claude/CLAUDE.md 의 개인 추가 내용은 번들 마커 블록 밖에 작성하세요.
       재설치 시 마커 블록 안만 교체되고 밖은 보존됩니다.
+      statusline 스크립트에도 컨텍스트 예산 브리지 마커 블록이 삽입됩니다(마커 밖은 보존).
 ────────────────────────────────────────────────────────────
 DONE
 


### PR DESCRIPTION
## Summary
- 조언자 세션이 베이스라인 대비 +59k 토큰을 쓰면 새 작업을 시작하지 않도록 컨텍스트 예산 트리거를 배선 (`install.sh`가 활성 statusline 스크립트에 마커 블록을 삽입해 기존 `gsd-context-monitor.js` PostToolUse 훅으로 값을 흘려보냄, 새 훅/설정 파일 수정 없음)
- 외부 조사(웹/MCP) 전담 `researcher` 서브에이전트(Sonnet) 신설, 리서치는 메인 세션이 아닌 서브에이전트로 격리
- `architect`의 도구에서 WebSearch/WebFetch 제거 (조사는 researcher로 위임)
- 조언자·작업자 모델을 fable 별칭에서 opus 별칭으로 고정 전환
- `HANDOFF.md`/`REVIEW_...md` 문서로 설계 근거와 실측 검증 결과, Codex 검토 이력 기록

## Testing
- 브리지 경계값 계산 및 Red-Green 종단 주입 테스트로 `CONTEXT WARNING`/`CONTEXT CRITICAL` 실제 주입 확인 (HANDOFF.md 기록)
- `set -e` 회귀, statusLine 5가지 커맨드 형태(래퍼 포함), 원자적 교체(rename 실패 시 원본 보존), 멱등성(재실행 시 diff 0) 확인
- 실전 세션에서 컨텍스트 예산 경고 자연 발동 확인
- Codex 3라운드 검증 진행 (1~2라운드 지적사항 반영·재현 확인, 3라운드 결과는 HANDOFF.md에 최신 상태 없음 — 확인 필요)