### PR TITLE
chore: SkillSpector 정적 오탐 baseline 7종 추가

### DIFF
--- a/.claude/skills/agent-improvement/.skillspector-baseline.yaml
+++ b/.claude/skills/agent-improvement/.skillspector-baseline.yaml
@@ -1,0 +1,11 @@
+# SkillSpector baseline — findings listed here are suppressed on future scans.
+# Edit 'reason' fields and add glob 'rules' as needed. See docs/SUPPRESSION.md.
+version: 2
+scanner_version: 2.5.1
+rules: []
+fingerprints:
+- hash: sha256:379777a5b6addab91a796ce3a70d8545dc9999fc700b85026cbaf4aa14367174
+  rule_id: AS3
+  file: SKILL.md
+  reason: 'False positive: References section names one specific sibling skill path;
+    no wildcard enumeration of the skills directory. Verified 2026-08-03.'

--- a/.claude/skills/agent-observability/.skillspector-baseline.yaml
+++ b/.claude/skills/agent-observability/.skillspector-baseline.yaml
@@ -1,0 +1,11 @@
+# SkillSpector baseline — findings listed here are suppressed on future scans.
+# Edit 'reason' fields and add glob 'rules' as needed. See docs/SUPPRESSION.md.
+version: 2
+scanner_version: 2.5.1
+rules: []
+fingerprints:
+- hash: sha256:c51b33bd10071d7122be12c627cec8de404520b99e1417de2a1a427341bb1950
+  rule_id: AS3
+  file: SKILL.md
+  reason: 'False positive: References section names one specific sibling skill path;
+    no wildcard enumeration of the skills directory. Verified 2026-08-03.'

--- a/.claude/skills/aos-feature-harness/.skillspector-baseline.yaml
+++ b/.claude/skills/aos-feature-harness/.skillspector-baseline.yaml
@@ -1,0 +1,11 @@
+# SkillSpector baseline — findings listed here are suppressed on future scans.
+# Edit 'reason' fields and add glob 'rules' as needed. See docs/SUPPRESSION.md.
+version: 2
+scanner_version: 2.5.1
+rules: []
+fingerprints:
+- hash: sha256:0ada464fdea9c9b19ad04292cbe080af8e3d4815e4ff578dbf6d97db61fd8a43
+  rule_id: RA2
+  file: SKILL.md
+  reason: 'False positive: nohup is command detach to survive this environment''s
+    ~150s process kill, not cross-session persistence. Verified 2026-08-03.'

--- a/.claude/skills/run-eval/.skillspector-baseline.yaml
+++ b/.claude/skills/run-eval/.skillspector-baseline.yaml
@@ -1,0 +1,12 @@
+# SkillSpector baseline — findings listed here are suppressed on future scans.
+# Edit 'reason' fields and add glob 'rules' as needed. See docs/SUPPRESSION.md.
+version: 2
+scanner_version: 2.5.1
+rules: []
+fingerprints:
+- hash: sha256:b41cf0346de1563e52a3705e5d19119521bd7b6fefc345f8e7f38f01e82167c8
+  rule_id: AS1
+  file: SKILL.md
+  reason: 'False positive: all .claude/ access is scoped to .claude/evals/ (task definitions,
+    this skill''s core function); no settings.json or credential access. Verified
+    2026-08-03.'

--- a/.claude/skills/update-llm-models/.skillspector-baseline.yaml
+++ b/.claude/skills/update-llm-models/.skillspector-baseline.yaml
@@ -1,0 +1,16 @@
+# SkillSpector baseline — findings listed here are suppressed on future scans.
+# Edit 'reason' fields and add glob 'rules' as needed. See docs/SUPPRESSION.md.
+version: 2
+scanner_version: 2.5.1
+rules: []
+fingerprints:
+- hash: sha256:b73246c21080967b1a13e2c5904a1ee4ad7923fdd1d39e21261a6bc34064561f
+  rule_id: RP1
+  file: SKILL.md
+  reason: 'False positive: npx tsc / npx vitest resolve to local node_modules binaries,
+    not an MCP server invocation (npx -y @vendor/mcp-server). Verified 2026-08-03.'
+- hash: sha256:70dac811f365c592e41b287801f1e45b3c2924f84016c7c0b8638b1bb2d38a37
+  rule_id: RP1
+  file: SKILL.md
+  reason: 'False positive: npx tsc / npx vitest resolve to local node_modules binaries,
+    not an MCP server invocation (npx -y @vendor/mcp-server). Verified 2026-08-03.'

--- a/.claude/skills/verification-loop/.skillspector-baseline.yaml
+++ b/.claude/skills/verification-loop/.skillspector-baseline.yaml
@@ -1,0 +1,16 @@
+# SkillSpector baseline — findings listed here are suppressed on future scans.
+# Edit 'reason' fields and add glob 'rules' as needed. See docs/SUPPRESSION.md.
+version: 2
+scanner_version: 2.5.1
+rules: []
+fingerprints:
+- hash: sha256:b1f31126f6904d98b80a7c28b2bc6bfd975e22dd41a076d9bcd9c30b4e12ffe3
+  rule_id: RP1
+  file: references/verification-patterns.md
+  reason: 'False positive: npx resolves to a local node_modules binary; nohup is command
+    detach for this environment''s ~150s process kill. Verified 2026-08-03.'
+- hash: sha256:24d6cd3ec8f6dad79a23eb7046b329839909b701f6191c28d77506ec534c0ecf
+  rule_id: RA2
+  file: SKILL.md
+  reason: 'False positive: npx resolves to a local node_modules binary; nohup is command
+    detach for this environment''s ~150s process kill. Verified 2026-08-03.'

--- a/.claude/skills/verify-backend/.skillspector-baseline.yaml
+++ b/.claude/skills/verify-backend/.skillspector-baseline.yaml
@@ -1,0 +1,18 @@
+# SkillSpector baseline — findings listed here are suppressed on future scans.
+# Edit 'reason' fields and add glob 'rules' as needed. See docs/SUPPRESSION.md.
+version: 2
+scanner_version: 2.5.1
+rules: []
+fingerprints:
+- hash: sha256:dded5d374f64582f8deeff7eb3afa1dc69fc2d7dc9a7974b855ace5427a5a62d
+  rule_id: LP1
+  file: scripts/verify.sh
+  reason: 'False positive: .env at verify.sh:41 sits behind grep -v as an EXCLUSION
+    filter, not credential access; script contains zero network calls (requests.get
+    is a search pattern being checked for). Verified 2026-08-03.'
+- hash: sha256:40f6632caa27605e4f4c439aac021a48864d45a2814c37c0860d64b4639180c1
+  rule_id: PE3
+  file: scripts/verify.sh
+  reason: 'False positive: .env at verify.sh:41 sits behind grep -v as an EXCLUSION
+    filter, not credential access; script contains zero network calls (requests.get
+    is a search pattern being checked for). Verified 2026-08-03.'


### PR DESCRIPTION
## 요약

`.claude/skills/` 11개 스킬을 SkillSpector v2.5.1로 스캔하고, 정적 findings 10건을 **소스 대조로 오탐 판정**해 스킬별 baseline에 수용했다. 스킬 파일 자체는 수정하지 않았다 — 추가된 것은 baseline 7개뿐이다.

## 오탐 판정 근거 (소스 직접 확인)

| 탐지 | 건수 | 근거 |
|---|---|---|
| Privilege Escalation — 자격증명 접근 | 1 | `verify.sh:41`의 `.env`는 `grep -v` 뒤의 **제외 대상**. 하드코딩 시크릿 검사에서 `.env` 참조를 빼는 필터로, 의미가 정반대 |
| MCP Least Privilege — 미선언 network | 1 | 같은 스크립트에 curl/wget/urllib 호출 0건. sync I/O 검사용 **패턴 문자열** `requests.get`을 실제 호출로 오인 |
| Agent Snooping — 설정 디렉터리 접근 | 1 | 접근 경로 9건 전부 `.claude/evals/` 하위. settings.json·자격증명 미접근 |
| Agent Snooping — 스킬 열거 | 2 | References 절에서 형제 스킬 **1개를 이름으로 지목**. 와일드카드 열거 없음 |
| MCP Rug Pull — 미고정 npx | 3 | `npx tsc` / `npx vitest`는 로컬 `node_modules` 바이너리. 러그풀 형태(`npx -y @vendor/mcp-server`)가 아님 |
| Rogue Agent — 세션 지속성 | 2 | `nohup`은 이 환경의 ~150초 프로세스 강제종료를 우회하는 단일 명령 detach |

판정 근거는 각 baseline 파일의 `reason` 필드에도 기록했다.

## 검증 (Red-Green)

| 스킬 | baseline 미적용 → 적용 |
|---|---|
| agent-improvement / agent-observability / aos-feature-harness / run-eval | 1 → **0** |
| update-llm-models / verification-loop / verify-backend | 2 → **0** |

YAML 파싱 7/7 유효, `hash`/`file`/`reason` 필드 전부 채워짐, 절대경로·홈경로 노출 없음(상대경로만).

## 운용 주의 — 3가지

**1. 기존 스캔 명령은 baseline을 무시한다.** `--baseline`이 재귀 스캔에서 거부되므로(`not supported for recursive multi-skill scans`) 순회 형태를 써야 한다:

```bash
for d in .claude/skills/*/; do
  b="$d.skillspector-baseline.yaml"
  [ -f "$b" ] && skillspector scan "$d" --no-llm --baseline "$b" \
              || skillspector scan "$d" --no-llm
done
```

**2. 스킬을 수정하면 억제가 풀린다 (fail-closed).** fingerprint가 스킬 전체 콘텐츠 해시 기반임을 실측 확인했다 — 무관한 파일(`SKILL.md`)을 고쳐도 `verify.sh`의 억제 2건이 되살아난다. 이는 "예전에 승인된 스킬"이 변경 후에도 무검증 통과하는 경로를 막는 의도된 설계다. 스킬 수정 후에는 baseline 재생성이 필요하다.

**3. LLM 의미 계층은 억제 대상이 아니다.** `--no-llm`으로 생성했으므로 의미 분석 findings는 baseline을 통과한다.

## 미결 사안 (이 PR 범위 밖)

LLM 의미 분석에서 `aos-feature-harness/SKILL.md:103`의 **Phase A 자기승인**이 지적됐다 — "~5분 무응답 시 저위험 계획 자동 승인"에서 승인을 구하는 주체와 저위험을 판정하는 주체가 동일하다. 2026-07-19에 의도적으로 도입된 정책이므로 이 PR에서 변경하지 않았고, baseline도 이 지적을 억제하지 않도록 구성해 다음 스캔에서 계속 표면에 남는다.

## 부수 관찰

`.claude/commands/`의 슬래시 커맨드 18개는 `SKILL.md`가 없어 스캐너가 구조적으로 인식하지 못한다. 별도로 래핑해 스캔한 결과 새로운 위험 신호는 0건이었으나(findings 5건은 전부 `npx`·캐시 삭제 오탐), 정기 스캔에서는 계속 빠지는 사각지대로 남는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaELqafcWdqMzscZoC96Sx