### PR TITLE
fix(ctx-budget): 컨텍스트 예산 임계를 창 크기 비례로 전환 (15%/20%)

### DIFF
--- a/docs/codex-advisor-worker-bundle/HANDOFF.md
+++ b/docs/codex-advisor-worker-bundle/HANDOFF.md
@@ -74,10 +74,15 @@ docs/codex-advisor-worker-bundle/HANDOFF.md                       ← 이 문서
 
 ## 설계 요약 (상세는 REVIEW 문서)
 
-- 임계치 = **베이스라인 델타 59k** (퍼센트 아님 — 실측 baseline 50,905 = 200k 창의 25.5%라 퍼센트는 양쪽 끝에서 깨짐). 59k 는 사용자 지정 "200k 창 사용률 50~55%" 에서 역산한 값 = `200,000 × 0.55 − 50,905`
+- 임계치 = **베이스라인 델타를 창 크기에 비례 판정** (WARNING `window×15%` / CRITICAL `window×20%`, 2026-08-03 전환).
+  판정 **대상**은 여전히 delta 다 — 창 *사용률* 퍼센트가 아니다(실측 baseline 50,905 = 200k 창의 25.5%라
+  사용률 임계치는 양쪽 끝에서 깨진다). 구 고정값 59k 는 사용자 지정 "200k 창 사용률 50~55%" 역산값
+  (`200,000 × 0.55 − 50,905`)이었으나, 1M 창에서 창의 6% 지점에 울려 정상 작업 하나가 경고를 2회
+  띄우는 사문화 직전 상태였다 → 창 비례로 전환
 - **[현행]** 배선 = `awesome-statusline.sh` 마커 블록 → `$TMPDIR/claude-ctx-advisor-{sid}.json`(사실만 기록:
   `baseline/current/delta/window/window_pct`) → **번들 소유 훅** `~/.claude/hooks/advisor-context-budget.js`
-  (settings.json `hooks.PostToolUse` 에 등록). 임계는 훅이 직접 판정: `delta>=51133` WARNING / `delta>=59000` CRITICAL.
+  (settings.json `hooks.PostToolUse` 에 등록). 임계는 훅이 직접 판정:
+  `delta >= window×0.15` WARNING / `delta >= window×0.20` CRITICAL (window 필드 부재·이상 시 200k 폴백).
   디바운스 5회 + 승격 시 즉시 발화는 훅이 자체 구현(구 GSD 훅에서 공짜로 받던 것)
 - **[폐기됨 — 이력]** 구 배선은 `claude-ctx-{sid}.json` 에 `remaining_percentage = 100 - delta*100/78666` 를
   **합성**해 GSD 플러그인 훅에 태웠다. 그 기교(`78666 = floor(59000/0.75)`, 정수 나눗셈 경계 보정)는
@@ -911,3 +916,40 @@ W-① RED 는 정의상 실 `/tmp` 로 쓴다 → 세션 고유 SID + 쓰였음�
 **설치기를 실행하지 않았다.** settings.json·statusline·훅 md5 전부 무변경, 새 `.bak` 0,
 `.settings.presnap.*` 0, advisor 엔트리 1. 적용은 Codex 승인 후 별도 단계
 (지금 적용하면 statusline·훅이 갱신되어 "무변경" 기준을 스스로 깬다).
+
+## 2026-08-03 임계치 창 비례 전환 — 반영 완료
+
+**바뀐 것: 임계 수치만.** 소유권·배선·디바운스는 그대로다 (2026-07-29 섹션의 원칙 준수 —
+두 가지를 동시에 바꾸면 회귀 원인을 가린다).
+
+| 항목 | 이전 | 이후 |
+|------|------|------|
+| WARNING | `51133` 고정 | `floor(window × 0.15)` |
+| CRITICAL | `59000` 고정 | `floor(window × 0.20)` |
+| 1M 창 | 51k / 59k | **150k / 200k** |
+| 200k 창 | 51k / 59k | **30k / 40k** |
+| window 부재·이상 | — | `FALLBACK_WINDOW = 200000` |
+
+**계기(실측).** 1M 창에서 고정 59k 는 창의 **6% 지점**에 울렸다. 영상 2편 전사·요약이라는
+정상 작업 **하나**를 끝내는 동안 WARNING 2회 + CRITICAL 1회가 발화 — 이 하네스의 반복 실패
+양식인 **"경고 사문화"** 직전이었다. 판정 대상은 여전히 delta(0에서 시작)이므로 창 사용률
+임계치의 "턴 0 발동" 함정은 전환 후에도 없다.
+
+**폴백이 필수인 이유.** `window` 를 못 읽고 0 으로 계산하면 임계가 0 이 되어 **매 턴 발화**한다.
+경고가 꺼지는 것보다 나쁘다(무시 학습). 그래서 `Number.isFinite && > 0` 검사 후 200k 폴백.
+
+**동기화 지점 5곳** — 하나라도 빠지면 재설치 시 조용히 롤백된다(번들의 정본은 `install.sh` heredoc):
+
+| 대상 | 정본 | 실파일 |
+|------|------|--------|
+| 훅 로직 | `install.sh` 훅 heredoc | `~/.claude/hooks/advisor-context-budget.js` |
+| 운영 규칙 | `install.sh` CLAUDE.md heredoc | `~/.claude/CLAUDE.md` |
+| statusline 주석 | `install.sh` statusline heredoc | `~/.claude/awesome-statusline.sh` |
+
+**검증.** 경계 10건 PASS — 1M(149,999 clear / 150,000 WARNING / 199,999 WARNING / 200,000 CRITICAL),
+200k(29,999 clear / 30,000 WARNING / 40,000 CRITICAL), 폴백(window 없음·0 → 30,000 WARNING).
+Red-Green: `delta 51,529` 는 구 임계로 **실제 발화했고** 신 임계로 clear — 인과 확정.
+`node --check` · `bash -n` · Codex 리뷰(지적 0건) 통과.
+
+**정본↔실파일 대조법.** 눈으로 훑지 말고 불변식 문자열 카운트로 본다. 실제로 이 방법이
+`install.sh` CLAUDE.md heredoc 미수정(실파일 1 / 정본 0)을 잡아냈다.

--- a/docs/codex-advisor-worker-bundle/install.sh
+++ b/docs/codex-advisor-worker-bundle/install.sh
@@ -249,17 +249,22 @@ install_ctx_hook() {
 //
 // 판정은 창 사용률이 아니라 '세션 베이스라인 대비 델타'다. 베이스라인(시스템 프롬프트 +
 // CLAUDE.md + 도구 스키마)이 이미 창의 25% 를 차지하므로 창 퍼센트 임계는 양쪽 끝에서 깨진다.
-// 창 크기와 무관하게 같은 작업량 시점에 발동한다(200k 든 1M 이든 동일).
+// 판정은 창 사용률이 아니라 baseline 델타로 한다(베이스라인이 창의 25%를 먹으므로
+// 창 퍼센트 임계치는 200k 에서 턴 0 에 발동한다).
 //
-// 임계: delta >= 51,133 WARNING / delta >= 59,000 CRITICAL (사용자 지정값)
+// 임계: 창 크기 비례 — delta >= window*15% WARNING / >= window*20% CRITICAL.
+//   고정 상수(51133/59000)는 200k 창 시절 값이라 1M 창에서 창의 6% 지점에 울렸다.
+//   정상 작업 하나가 경고를 여러 번 띄우면 규칙이 사문화된다 → 창에 비례시킨다.
+//   delta 기준이므로(0에서 시작) 창 사용률 임계치의 "턴 0 발동" 함정은 없다.
 // 디바운스: 경고 사이 도구 호출 5회. 단 WARNING → CRITICAL 승격은 즉시 발화.
 // 어떤 예외에서도 도구 실행을 막지 않는다.
 
 const fs = require('fs');
 const path = require('path');
 
-const WARNING_DELTA = 51133;
-const CRITICAL_DELTA = 59000;
+const WARNING_RATIO = 0.15;
+const CRITICAL_RATIO = 0.20;
+const FALLBACK_WINDOW = 200000;   // window 필드 부재/이상 시 (구 statusline 호환)
 const STALE_SECONDS = 60;   // 60초 지난 지표는 무시 (statusline 이 안 돌고 있는 상태)
 const DEBOUNCE_CALLS = 5;
 
@@ -340,6 +345,13 @@ process.stdin.on('end', () => {
 
     const delta = Number(metrics.delta);
     if (!Number.isFinite(delta)) process.exit(0);
+
+    // 임계는 창 크기에 비례한다. 브리지의 window 를 쓰되 이상값이면 폴백 —
+    // 창을 모른 채 0 으로 나눠 임계가 0 이 되면 매 턴 경고가 터진다.
+    const winRaw = Number(metrics.window);
+    const windowSize = Number.isFinite(winRaw) && winRaw > 0 ? winRaw : FALLBACK_WINDOW;
+    const WARNING_DELTA = Math.floor(windowSize * WARNING_RATIO);
+    const CRITICAL_DELTA = Math.floor(windowSize * CRITICAL_RATIO);
 
     // 임계 미만이면 디바운스 파일을 건드리지 않고 종료한다 —
     // 여기서 카운터를 올리면 경고 이력이 없는 세션에서도 디바운스가 소진된다.
@@ -1221,7 +1233,7 @@ if [ -n "$__ctx_sid" ] && [ "$CURRENT_USAGE" != "null" ]; then
     __ctx_write "$__ctx_prev_f" "$__ctx_now" || true
     __ctx_delta=$(( __ctx_now - __ctx_base ))
     __ctx_wpct=$(( __ctx_now * 100 / __ctx_win ))
-    # 사실만 기록한다. 임계 판정(51133 / 59000)은 훅이 delta 로 직접 수행한다.
+    # 사실만 기록한다. 임계 판정(창 비례 15% / 20%)은 훅이 delta 와 window 로 직접 수행한다.
     __ctx_json=$(printf '{"session_id":"%s","baseline":%s,"current":%s,"delta":%s,"window":%s,"window_pct":%s,"timestamp":%s}' \
       "$__ctx_sid" "$__ctx_base" "$__ctx_now" "$__ctx_delta" "$__ctx_win" "$__ctx_wpct" "$(date +%s)" 2>/dev/null || true)
     __ctx_write "${__ctx_dir}/claude-ctx-advisor-${__ctx_sid}.json" "$__ctx_json" || true
@@ -1330,7 +1342,7 @@ Opus 소진 후 경로는 둘: (a) 두 에이전트의 model: 을 sonnet 으로 
 규모가 큰 구현·버그 조사는 /codex:rescue 로 Codex에 위임할 수 있다.
 
 ## 컨텍스트 예산 (조언자 세션)
-세션 시작 시점 대비 +59k 토큰을 쓰면 새 작업을 시작하지 않는다.
+세션 시작 시점 대비 컨텍스트 창의 20%를 쓰면 새 작업을 시작하지 않는다(1M 창 = +200k, 200k 창 = +40k).
 컨텍스트 경고(CONTEXT BUDGET WARNING / CONTEXT BUDGET CRITICAL)가 주입되면 즉시:
 1. 진행 중 작업을 자연스러운 지점에서 마무리
 2. 상태 저장 — `.planning/STATE.md` 가 있으면 `/gsd:pause-work` 를 제안하고, 없으면 HANDOFF.md 작성(설계 결정·완료 기준·검증 상태·다음 단계). 코드가 더러우면 `/wip-save` 병행
@@ -1338,7 +1350,10 @@ Opus 소진 후 경로는 둘: (a) 두 에이전트의 model: 을 sonnet 으로 
 저장 포맷을 새로 만들지 않는다. 위 경로 중 하나를 쓴다.
 경고는 예산 소진(세션 시작 대비 델타)과 컨텍스트 창 사용률을 함께 표시한다.
 둘은 다른 지표다 — 창에 여유가 있어도 예산을 넘으면 정지 대상이다.
-기준은 델타(토큰)다. 베이스라인 50,905 기준 200k 창 사용률로는 약 55% 시점이며, 1M 창에서는 같은 작업량 시점에 울린다(창 사용률로는 약 11%).
+기준은 델타(토큰)이되 임계치는 창 크기에 비례한다 — WARNING 15% / CRITICAL 20% (2026-08-03 변경).
+이전의 고정 상수(51,133 / 59,000)는 200k 창 시절 값이라 1M 창에서 창의 6% 지점에 울렸고,
+정상 작업 하나가 경고를 여러 번 띄워 규칙이 사문화될 위험이 있었다. 델타 기준이므로(0에서 시작)
+창 사용률 임계치의 "턴 0 발동" 함정은 여전히 없다.
 
 ## 리서치·외부 도구는 메인에서 직접 호출하지 않는다
 메인 세션(모드 A의 조언자)은 WebSearch·WebFetch·tavily·context7 을 직접 부르지 않는다.


### PR DESCRIPTION
## Summary

- 조언자 세션 컨텍스트 예산 임계를 **고정 상수 → 창 크기 비례**로 전환 (WARNING `window×15%` / CRITICAL `window×20%`)
- `window` 필드 부재·이상 시 `FALLBACK_WINDOW = 200000` 폴백 추가
- 번들 정본(`install.sh` heredoc)과 실파일 3쌍을 동시 반영 — 한쪽만 고치면 재설치 시 롤백된다

## 계기 (실측)

고정 상수 `51,133 / 59,000`은 200k 창 시절 사용자 지정값("창 사용률 50~55%")을 역산한 것이라, **1M 창에서는 창의 6% 지점**에 울렸다. 영상 2편 전사·요약이라는 정상 작업 **하나**를 끝내는 동안 WARNING 2회 + CRITICAL 1회가 발화 — 이 하네스의 반복 실패 양식인 **"경고 사문화"** 직전이었다.

| 창 | 이전 (WARN/CRIT) | 이후 |
|---|---|---|
| 1M | 51k / 59k | **150k / 200k** |
| 200k | 51k / 59k | **30k / 40k** |

## 유지된 설계 (바꾸지 않은 것)

- **판정 대상은 여전히 baseline 델타**다 — 창 *사용률* 퍼센트가 아니다. 실측 baseline 50,905가 200k 창의 25.5%를 차지하므로 사용률 임계치는 양쪽 끝에서 깨진다. 델타는 0에서 시작하므로 **"턴 0 발동" 함정은 전환 후에도 없다**
- 소유권·배선·디바운스(5회 + 승격 시 즉시 발화)는 무변경 — 두 가지를 동시에 바꾸면 회귀 원인을 가린다

## 폴백이 필수인 이유

`window`를 못 읽고 0으로 계산하면 임계가 0이 되어 **매 턴 발화**한다. 경고가 꺼지는 것보다 나쁘다(무시 학습). `Number.isFinite && > 0` 검사 후 200k 폴백.

## Test Plan

- [x] **정본↔실파일 불변식 5/5 일치** — `WARNING_RATIO`·`CRITICAL_RATIO`·`FALLBACK_WINDOW`·CLAUDE.md 규칙·statusline 주석 각각 정본 1 / 실파일 1
- [x] **구 고정 상수 잔존 로직 0건** — `51133|59000` 출현은 전환 사유를 적은 설명 주석 1줄뿐(정본·실파일 동일), 임계 계산부는 `Math.floor(windowSize * RATIO)`만 사용
- [x] `bash -n install.sh` OK / `node --check advisor-context-budget.js` OK (fresh 실행)
- [x] 시크릿 스캔 0건
- [x] 경계 10건 PASS (이전 세션 기록) — 1M(149,999 clear / 150,000 WARN / 199,999 WARN / 200,000 CRIT), 200k(29,999 clear / 30,000 WARN / 40,000 CRIT), 폴백(window 없음·0 → 30,000 WARN)
- [x] Red-Green (이전 세션 기록) — `delta 51,529`가 구 임계로 **실제 발화**했고 신 임계로 clear, 인과 확정

## 주의

`HANDOFF.md`의 "동기화 지점 **5곳**" 표현과 바로 아래 표(3쌍 = 6파일)가 어긋난다. 원문 그대로 두었으니 의도한 셈법을 확인해 주세요.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7sBVQKkUKGCeqFMf7HzLP