### PR TITLE
chore: paseo.json 을 gitignore 에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,9 @@ dev/harness-legacy-scan/
 # AGENTS.md is intentionally NOT ignored (portable public doc, mirror of CLAUDE.md)
 .agents/
 .codex/
+# 외부 도구가 작업 디렉토리에 떨구는 빈 설정 파일. 레포 내 소비자 0건(실측 2026-08-09)인데
+# pre-commit 훅이 무관한 커밋에 쓸어 담은 사례가 있어(B4) 아예 시야에서 제외한다.
+paseo.json
 
 # Harness intermediate artifacts (aos-feature-harness) — audit trail, not committed
 _workspace/


### PR DESCRIPTION
## Summary

외부 도구가 작업 디렉토리에 떨구는 빈 설정 파일(`{}`, 3바이트)을 gitignore 에 넣는다. 레포 내 소비자 **0건**(실측)이다.

## 왜 지금

유일한 레포 내 참조는 B4·B5 계획서의 **"이 파일을 조심하라"** 는 경고 문구다. 근거가 있다 — pre-commit 훅이 이 미추적 파일을 무관한 커밋에 쓸어 담은 실측 사례가 B4 에 있었다.

B5(#247)는 `git add .` 대신 파일을 명시하고 매 커밋마다 `git show --stat` 으로 확인해 28개 커밋 전부 깨끗했다. 하지만 **매번 사람이 확인해야 하는 안전장치는 언젠가 빠진다.** 아예 시야에서 제외하는 편이 낫다.

배치 위치는 기존 "Local AI-tooling config" 섹션 (`.agents/` · `.codex/` 옆) — 성격이 같다.

## Test Plan

- [x] `git check-ignore -v paseo.json` → `.gitignore:114:paseo.json`
- [x] `git status` 에서 사라짐 (워킹트리 클린)
- [x] main 대비 diff 가 `.gitignore` 3줄뿐 — 코드·의존성 변경 0

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4K9oDEUioqDWX1sW9Lz3i