### PR TITLE
fix(deps): high 등급 취약점 2건 해소 (nanoid, brace-expansion)

### DIFF
--- a/src/dashboard/package-lock.json
+++ b/src/dashboard/package-lock.json
@@ -993,9 +993,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1013,9 +1010,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1033,9 +1027,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1053,9 +1044,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1073,9 +1061,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1093,9 +1078,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1113,9 +1095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1133,9 +1112,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1650,9 +1626,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1668,9 +1641,6 @@
       "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1688,9 +1658,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1706,9 +1673,6 @@
       "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1726,9 +1690,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1744,9 +1705,6 @@
       "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3034,16 +2992,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4707,9 +4665,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -5842,9 +5800,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5864,9 +5819,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5888,9 +5840,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5910,9 +5859,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,


### PR DESCRIPTION
## 요약

`npm audit fix`로 high 등급 취약점 2건을 해소합니다. **`package-lock.json`만 변경**되고
`package.json`은 그대로입니다 — 두 건 모두 기존 semver 범위 안에서 해결됩니다.

| 패키지 | 변화 | Advisory |
|--------|------|----------|
| `nanoid` | 3.3.16 → 3.3.18 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generator가 size=0일 때 무한 루프 |
| `brace-expansion` | 패치 | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 — unbounded expansion으로 인한 OOM DoS |

둘 다 transitive 의존성입니다 (`vite → postcss → nanoid`). 직접 의존성이 아니라서
Dependabot 주간 스케줄로는 PR이 올라오지 않았습니다.

## 부수 효과: vite 8.1.5 → 8.2.0

업그레이드가 아니라 **lock이 manifest에 뒤처져 있던 상태를 바로잡은 것**입니다.
`package.json`은 원래 `^8.2.0`을 요구하는데 lock은 8.1.5에 묶여 있었고,
`npm ls`가 이를 `invalid: "^8.2.0" from the root project`로 표기하고 있었습니다.

이 레포에는 Vite 8(oxc) 전환 시 로컬 vitest가 전멸했던 이력(#135)이 있어
테스트 게이트를 중점 확인했습니다.

## 검증

| 게이트 | 결과 |
|--------|------|
| `npm audit --audit-level=high` | **found 0 vulnerabilities** |
| `tsc --noEmit` | exit 0 |
| `eslint` | exit 0 |
| `vitest run` | **205 파일 / 4365 테스트 통과** (변동 없음) |
| `vite build` | 성공 (1.17s) |

## 로컬 환경 메모 (이 PR과 무관)

로컬에서 `npm run knip`이 `Error: File 'expo/tsconfig.base' not found`로 실패합니다.
원인은 개발 머신 홈의 `~/tsconfig.json`(다른 Expo 프로젝트 잔재)이며, knip 내부 jiti가
CWD부터 상향 탐색하다 이를 만나기 때문입니다. CI 러너에는 해당 파일이 없어 재현되지
않습니다 (#249에서 `Frontend Knip` pass 확인). repo 변경으로 대응할 사안이 아니라
기록만 남깁니다.

## 테스트 계획

- [x] `npm audit` 0건
- [x] tsc / eslint / vitest / build
- [ ] CI 8개 job 통과 확인 (특히 `Frontend Knip` — 로컬 실패가 환경 탓임을 확증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UEJENahpFQRnU6aYKkH7V