### PR TITLE
fix: merge-tree 파싱의 도달 불가 no-op 분기 제거

### DIFF
--- a/src/backend/services/merge_service.py
+++ b/src/backend/services/merge_service.py
@@ -187,9 +187,6 @@ class MergeService:
                     parts = line.split()
                     if len(parts) > 3:
                         conflict_files.append(parts[-1])
-                elif "+<<<<<<<" in line or "+=======":
-                    # Git merge-tree shows conflicts with + prefix
-                    pass
 
             # Alternative: look for files with merge conflict status
             if not conflict_files and "<<<<<<" in output:


### PR DESCRIPTION
## 요약

`services/merge_service.py`의 merge-tree 출력 파싱 루프에서 **세 겹으로 죽어 있던 분기**를 제거합니다.
도달 불가 + no-op이므로 동작 변화는 없습니다.

```diff
                 if line.startswith("changed in both"):
                     parts = line.split()
                     if len(parts) > 3:
                         conflict_files.append(parts[-1])
-                elif "+<<<<<<<" in line or "+=======":
-                    # Git merge-tree shows conflicts with + prefix
-                    pass
```

## 왜 세 겹인가

| # | 문제 |
|---|------|
| 1 | `or "+======="`에 **`in line`이 누락**되어 비어 있지 않은 문자열 리터럴 → 조건이 **항상 참** |
| 2 | 그런데 **애초에 도달 불가** — 루프 첫 `if`가 `"<<<<<<" in line or "======" in line`이면 `continue`하므로, `"+<<<<<<<"`·`"+======="`를 포함하는 줄은 전부 그 지점에서 걸러짐 |
| 3 | 본체가 `pass` (no-op) |

조건 오타만 고치면 죽은 코드를 살려두는 셈이라 분기 자체를 제거했습니다.

## 발견 경위

백엔드 미사용 코드 조사(`vulture 2.16`) 중 발견했습니다. vulture가 검출한 1094건 중
**유일하게 실질 신호였던 항목**입니다 — 나머지는 인터페이스 계약 인자(SQLAlchemy
`TypeDecorator.dialect`, `__exit__(exc_tb)`, `Protocol` 정의)이거나 `try/except ImportError`
의존성 가용성 검사였습니다.

## 검증

| 게이트 | 결과 |
|--------|------|
| `uv run ruff check .` | exit 0 |
| `uv run ruff format --check .` | exit 0 (316 files already formatted) |
| `uv run mypy . --ignore-missing-imports` | exit 0 (317 source files) |
| `uv run pytest ../../tests/backend` | **1362 passed**, 2 skipped |
| `uvx vulture` | `redundant if-condition` 경고 해소 |
| Codex 리뷰 | 지적 0건 — *"removes an unreachable no-op branch and does not introduce behavioral regressions"* |

로컬 pytest에서 `test_embedding_model_consistency` 1건이 실패하지만, 개발 머신 `.env`의
`RAG_EMBEDDING_MODEL=intfloat/multilingual-e5-base` 오버라이드 탓이며 이 변경과 무관합니다
(CI는 `BAAI/bge-m3`로 통과).

## 테스트 계획

- [x] 백엔드 트랙 4종 (ruff / format / mypy / pytest)
- [x] Codex 외부 리뷰
- [ ] CI 8개 job 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UEJENahpFQRnU6aYKkH7V