### PR TITLE
refactor: 프론트 잔여 미사용 export 7건 제거 + 감사 로그 타입 중복 통합

### DIFF
--- a/src/dashboard/src/components/audit/AuditLogTable.tsx
+++ b/src/dashboard/src/components/audit/AuditLogTable.tsx
@@ -14,43 +14,17 @@ import {
 } from 'lucide-react'
 import { apiClient } from '@/services/apiClient'
 
-// Types
-export interface AuditLogEntry {
-  id: string
-  session_id: string | null
-  user_id: string | null
-  project_id: string | null
-  action: string
-  resource_type: string
-  resource_id: string | null
-  old_value: Record<string, unknown> | null
-  new_value: Record<string, unknown> | null
-  changes: Record<string, unknown> | null
-  agent_id: string | null
-  ip_address: string | null
-  user_agent: string | null
-  metadata: Record<string, unknown>
-  status: string
-  error_message: string | null
-  created_at: string
-}
+// 감사 로그 타입의 단일 출처는 스토어다. 컴포넌트가 같은 API 응답을 다시
+// 타이핑하면 필드가 소리 없이 어긋난다 — 실제로 AuditLogFilter 가 스토어에만
+// include_global 이 있는 상태로 갈려 있었다.
+import type { AuditLogEntry, AuditLogFilter } from '@/stores/audit'
 
+// Types
 export interface AuditLogResponse {
   logs: AuditLogEntry[]
   total: number
   limit: number
   offset: number
-}
-
-export interface AuditLogFilter {
-  session_id?: string
-  user_id?: string
-  project_id?: string
-  action?: string
-  resource_type?: string
-  status?: string
-  start_date?: string
-  end_date?: string
 }
 
 interface AuditLogTableProps {

--- a/src/dashboard/src/components/audit/__tests__/AuditLogTable.test.tsx
+++ b/src/dashboard/src/components/audit/__tests__/AuditLogTable.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
-import type { AuditLogEntry } from '../AuditLogTable'
+import type { AuditLogEntry } from '@/stores/audit'
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({

--- a/src/dashboard/src/components/git/index.ts
+++ b/src/dashboard/src/components/git/index.ts
@@ -1,5 +1,5 @@
 export { BranchList } from './BranchList'
-export { MergeRequestCard, MergeRequestList } from './MergeRequestCard'
+export { MergeRequestList } from './MergeRequestCard'
 export { MergePreviewPanel } from './MergePreviewPanel'
 export { PullRequestList, PRReviewPanel } from './PullRequestList'
 export { CommitHistory } from './CommitHistory'

--- a/src/dashboard/src/stores/__tests__/feedback.test.ts
+++ b/src/dashboard/src/stores/__tests__/feedback.test.ts
@@ -667,67 +667,13 @@ describe('processFeedback - processed=0 branch', () => {
 // directly to the store state, which exercises lines 598-603.
 
 describe('selectors', () => {
-  // selector functions mirroring feedback.ts lines 598-603
-  const feedbackCountSelector = (state: ReturnType<typeof useFeedbackStore.getState>) =>
-    state.feedbacks.length
-  const pendingCountSelector = (state: ReturnType<typeof useFeedbackStore.getState>) =>
-    state.feedbacks.filter((f) => f.status === 'pending').length
-  const positiveRateSelector = (state: ReturnType<typeof useFeedbackStore.getState>) =>
-    state.stats?.positive_rate ?? 0
+  // selector function mirroring usePendingFeedbackCount in feedback.ts
   const pendingFeedbackCountSelector = (state: ReturnType<typeof useFeedbackStore.getState>) =>
     state.pendingFeedbacks.length + state.pendingEvaluations.length
 
   beforeEach(() => {
     resetStore()
     vi.clearAllMocks()
-  })
-
-  it('useFeedbackCount selector returns total number of feedbacks', () => {
-    useFeedbackStore.setState({
-      feedbacks: [{ id: 'f1' } as any, { id: 'f2' } as any, { id: 'f3' } as any],
-    })
-    expect(feedbackCountSelector(useFeedbackStore.getState())).toBe(3)
-  })
-
-  it('useFeedbackCount selector returns 0 when feedbacks empty', () => {
-    useFeedbackStore.setState({ feedbacks: [] })
-    expect(feedbackCountSelector(useFeedbackStore.getState())).toBe(0)
-  })
-
-  it('usePendingCount selector returns count of feedbacks with status=pending', () => {
-    useFeedbackStore.setState({
-      feedbacks: [
-        { id: 'f1', status: 'pending' } as any,
-        { id: 'f2', status: 'processed' } as any,
-        { id: 'f3', status: 'pending' } as any,
-      ],
-    })
-    expect(pendingCountSelector(useFeedbackStore.getState())).toBe(2)
-  })
-
-  it('usePendingCount selector returns 0 when no feedbacks have pending status', () => {
-    useFeedbackStore.setState({
-      feedbacks: [
-        { id: 'f1', status: 'processed' } as any,
-        { id: 'f2', status: 'skipped' } as any,
-      ],
-    })
-    expect(pendingCountSelector(useFeedbackStore.getState())).toBe(0)
-  })
-
-  it('usePositiveRate selector returns stats.positive_rate when stats is set', () => {
-    useFeedbackStore.setState({ stats: { positive_rate: 0.85 } as any })
-    expect(positiveRateSelector(useFeedbackStore.getState())).toBe(0.85)
-  })
-
-  it('usePositiveRate selector returns 0 when stats is null', () => {
-    useFeedbackStore.setState({ stats: null })
-    expect(positiveRateSelector(useFeedbackStore.getState())).toBe(0)
-  })
-
-  it('usePositiveRate selector returns 0 when positive_rate is 0', () => {
-    useFeedbackStore.setState({ stats: { positive_rate: 0 } as any })
-    expect(positiveRateSelector(useFeedbackStore.getState())).toBe(0)
   })
 
   it('usePendingFeedbackCount selector returns sum of pendingFeedbacks and pendingEvaluations', () => {

--- a/src/dashboard/src/stores/feedback.ts
+++ b/src/dashboard/src/stores/feedback.ts
@@ -590,10 +590,6 @@ if (typeof window !== 'undefined') {
 // Selectors
 // ============================================================================
 
-export const useFeedbackCount = () => useFeedbackStore((state) => state.feedbacks.length)
-export const usePendingCount = () =>
-  useFeedbackStore((state) => state.feedbacks.filter((f) => f.status === 'pending').length)
-export const usePositiveRate = () => useFeedbackStore((state) => state.stats?.positive_rate ?? 0)
 export const usePendingFeedbackCount = () =>
   useFeedbackStore((state) => state.pendingFeedbacks.length + state.pendingEvaluations.length)
 

--- a/src/dashboard/src/stores/orchestration/index.ts
+++ b/src/dashboard/src/stores/orchestration/index.ts
@@ -24,13 +24,9 @@ export type {
 } from './types'
 
 export {
-  RECONNECT_CONFIG,
-  calculateBackoff,
   PROVIDER_CONFIG,
   identifyProvider,
 } from './types'
-
-export { transformTask, handleMessage } from './wsHandler'
 
 export const useOrchestrationStore = create<OrchestrationState>()(
   persist(


### PR DESCRIPTION
## 요약

#249에서 남겨둔 잔여 8건 중 7건을 정리하고, 별건으로 보고했던 감사 로그 타입 중복
정의를 통합합니다. 두 커밋으로 분리했습니다.

knip `Unused exports` **8 → 1**.

## 커밋 1 — 잔여 미사용 export 7건 (`e1e3db7`)

앞선 5배치와 달리 기계적 처리가 불가능해 세 갈래로 나눠 개별 확인했습니다.

| 갈래 | 대상 | 처리 |
|------|------|------|
| 이름 단위 편집 | `components/git/index.ts` | `MergeRequestCard` 재노출만 제거. 같은 줄의 `MergeRequestList`는 `GitPage.tsx:22,429`에서 사용 중이라 유지 |
| 멀티라인 재노출 | `stores/orchestration/index.ts` | `RECONNECT_CONFIG`·`calculateBackoff`·`transformTask`·`handleMessage` 제거. `PROVIDER_CONFIG`·`identifyProvider`는 유지 |
| 셀렉터 + 테스트 | `stores/feedback.ts` | `useFeedbackCount`·`usePendingCount`·`usePositiveRate` 제거. `usePendingFeedbackCount`는 사용 중이라 유지 |

**`orchestration/index.ts`는 barrel이 아니라 500줄짜리 Zustand 스토어 구현체**라,
제거 전 파일 내부 사용 여부를 먼저 확인했습니다(각 1회 = 재노출 줄에만 등장).

**삭제한 테스트 7개에 대해**: 이 테스트들은 프로덕션 export를 호출하지 않았습니다.
주석에 명시된 대로 같은 로직을 복제한 함수(`feedbackCountSelector` 등)를 검증하던
것이라, 원본을 제거하면 미러링 대상이 사라집니다. 복제본을 테스트하고 있었으므로
`feedback.ts`의 셀렉터 라인은 애초에 커버되지 않았습니다.

## 커밋 2 — 감사 로그 타입 중복 통합 (`5b6a51e`)

`AuditLogTable.tsx`와 `stores/audit.ts`가 같은 API 응답을 각각 타이핑하고 있었습니다.

| 타입 | 상태 |
|------|------|
| `AuditLogEntry` | 18줄 **완전 동일** |
| `AuditLogFilter` | 스토어에만 `include_global` — 컴포넌트 쪽이 **부분집합** |

부분집합이라는 게 문제입니다. 한쪽에만 필드를 추가해도 컴파일이 통과하므로
소리 없이 어긋납니다. 단일 출처를 `stores/audit`로 정하고 컴포넌트와 테스트가
그곳에서 import하도록 바꿨습니다. 재노출은 두지 않았습니다 — 두면 중복 구조가
그대로 남습니다.

## 검증

| 게이트 | 커밋 1 | 커밋 2 |
|--------|--------|--------|
| `tsc --noEmit` | exit 0 | exit 0 |
| `eslint` | exit 0 | exit 0 |
| `vitest run` | 4365 → **4358** (제거한 7개만큼) | **4358** (리팩터라 불변) |
| `vite build` | 성공 | 성공 |
| Codex 리뷰 | 지적 0건 — *"dead tests"* 판정 일치 | 지적 0건 |

로컬 `npm run knip`은 개발 머신의 `~/tsconfig.json`(Expo 잔재) 때문에 실행되지
않습니다. CI `Frontend Knip`으로 확인합니다.

## 남는 것

knip `Unused exports` 1건 — `components/git/index.ts`의 잔여 항목은 없고,
`Unused exported types` 78건은 **정리하지 않기를 권고**합니다: TS 타입은 컴파일 시
소거되어 출력 변화가 0이고, 게이트 대상도 아니며, FastAPI↔React 계약 타입이라
`integration-qa`의 대조 근거로 쓰입니다.

## 테스트 계획

- [x] tsc / eslint / vitest / build (커밋별)
- [x] Codex 외부 리뷰 2회
- [ ] CI 8개 job 통과 확인 (`Frontend Knip` 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UEJENahpFQRnU6aYKkH7V