### PR TITLE
fix(backup): PostgreSQL 자동 백업 무음 실패 수정 + recovery 런북 환경 분리

### DIFF
--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -2,6 +2,81 @@
 
 이 문서는 AOS 시스템의 장애 복구 및 데이터베이스 복원 절차를 설명합니다.
 
+---
+
+## ⚠️ 먼저: 환경을 고르고 변수를 설정하세요
+
+AOS는 **두 가지 토폴로지**로 실행되며 컨테이너 이름·DB 유저·볼륨 접두사가 서로 다릅니다. 이 문서의 명령은 아래에서 설정한 변수를 사용하므로, **다른 무엇보다 먼저** 해당 블록을 실행하세요.
+
+| 항목 | 로컬 개발 (기본) | Self-host 배포 |
+|------|------------------|----------------|
+| Compose 파일 | `~/Work/shared-infra/docker-compose.yml` | 레포 루트 `docker-compose.yml` |
+| 기동 방법 | `infra/scripts/dev.sh` | `docker compose up -d --build` |
+| PostgreSQL 컨테이너 | `shared-postgres` | `aos-postgres` |
+| Redis 컨테이너 | `shared-redis` | `aos-redis` |
+| Qdrant 컨테이너 | `shared-qdrant` | `aos-qdrant` |
+| DB 유저 / DB 이름 | `postgres` / `aos` | `aos` / `aos` |
+| 볼륨 접두사 | `shared-infra_` (디렉토리명) | `aos_` (compose `name: aos`) |
+| 데이터 공유 범위 | **AOS·elitedeck·image_maker 공용** | AOS 전용 |
+
+**둘 중 하나만** 실행하세요. 두 블록을 연달아 붙여넣으면 뒤의 값이 앞의 값을 덮어써 잘못된 환경을 겨냥합니다.
+
+**A. 로컬 개발 (shared-infra)** — `infra/scripts/dev.sh`로 기동한 경우:
+
+```bash
+COMPOSE_DIR=~/Work/shared-infra; TOPOLOGY=local
+
+# shared-infra compose 가 읽는 .env 를 먼저 반영한다 — QDRANT_REST_PORT 등이
+# 오버라이드돼 있으면 셸에 불러오지 않는 한 기본 포트로 잘못 계산된다
+[ -f "$COMPOSE_DIR/.env" ] && { set -a; . "$COMPOSE_DIR/.env"; set +a; }
+
+PG=shared-postgres; RD=shared-redis; QD=shared-qdrant
+PGUSER=postgres; PGDB=aos; VOLPREFIX=shared-infra
+export CONTAINER_NAME="$PG" REDIS_CONTAINER="$RD" DB_USER="$PGUSER" DB_NAME="$PGDB"
+export QDRANT_URL="http://localhost:${QDRANT_REST_PORT:-6333}"   # shared-infra 는 QDRANT_REST_PORT
+echo "선택된 환경: $TOPOLOGY / $PG / $QDRANT_URL"
+```
+
+**B. Self-host 배포** — 레포 루트 `docker compose up -d`로 기동한 경우 (**레포 루트에서 실행**):
+
+```bash
+# compose 가 읽는 .env 를 먼저 반영한다 — POSTGRES_USER/POSTGRES_DB/QDRANT_PORT 는
+# .env 로 오버라이드 가능하므로, 셸에 불러오지 않으면 기본값으로 잘못 계산된다
+[ -f .env ] && { set -a; . ./.env; set +a; }
+
+PG=aos-postgres; RD=aos-redis; QD=aos-qdrant
+PGUSER="${POSTGRES_USER:-aos}"; PGDB="${POSTGRES_DB:-aos}"
+VOLPREFIX=aos                            # 루트 compose 의 `name: aos` 가 볼륨 접두사
+COMPOSE_DIR="$PWD"; TOPOLOGY=selfhost    # 절대경로로 고정 — 이후 cd 해도 유효
+export CONTAINER_NAME="$PG" REDIS_CONTAINER="$RD" DB_USER="$PGUSER" DB_NAME="$PGDB"
+export QDRANT_URL="http://localhost:${QDRANT_PORT:-6333}"   # self-host 는 QDRANT_PORT
+echo "선택된 환경: $TOPOLOGY / $PG / $PGUSER@$PGDB / $QDRANT_URL / $COMPOSE_DIR"
+```
+
+> **`export` 가 필요한 이유:** `backup-all.sh`·`restore-all.sh`는 `PG`/`PGUSER`가 아니라 `CONTAINER_NAME`·`REDIS_CONTAINER`·`DB_USER`·`DB_NAME`을 읽습니다. 이 줄이 없으면 self-host 환경에서 두 스크립트가 shared-infra 기본값으로 되돌아가, 엉뚱한 인스턴스를 백업하거나 복원합니다.
+
+**이 문서의 인라인 명령**은 설정을 건너뛰면 `PG: parameter null or not set`으로 즉시 실패합니다. 존재하지 않는 컨테이너를 조용히 겨냥하는 것보다 낫기 때문에 의도한 동작입니다.
+
+> **단, 통합 스크립트는 fail-closed가 아닙니다.** `backup-all.sh`·`restore-all.sh`는 변수가 없으면 **shared-infra 기본값**(`shared-postgres`/`shared-redis`)으로 조용히 진행합니다 — launchd 자동 백업이 그 기본값으로 돌아야 하므로 의도된 설계입니다. 따라서 **self-host에서 이 두 스크립트를 쓸 때는 위 B 블록을 반드시 먼저 실행하세요.** 건너뛰면 self-host를 복구하려다 로컬 공유 인스턴스를 백업하거나 덮어씁니다. 두 스택을 한 호스트에서 함께 돌릴 때 특히 위험합니다. 실행 전 `echo "$CONTAINER_NAME"`으로 대상을 눈으로 확인하세요.
+
+**백엔드/대시보드 프로세스는 토폴로지마다 다릅니다.** self-host에서는 `backend`·`dashboard`가 compose 서비스지만, 로컬 개발의 shared-infra compose에는 `postgres`·`redis`·`qdrant` 세 서비스뿐입니다. 로컬에서 백엔드를 재시작하려면 compose가 아니라 `uvicorn` 프로세스를 직접 다시 띄웁니다:
+
+```bash
+# 백엔드 재시작 (토폴로지 자동 분기)
+if [ "${TOPOLOGY:?}" = "selfhost" ]; then
+  (cd "$COMPOSE_DIR" && docker compose restart backend)
+else
+  # 로컬: uvicorn 프로세스를 중단(Ctrl-C)한 뒤 재기동
+  echo "cd src/backend && uvicorn api.app:app --reload 를 다시 실행하세요"
+fi
+```
+
+> **`docker compose`는 실행 위치가 곧 대상입니다.** 로컬 개발에서 `docker compose restart postgres`를 레포 루트에서 실행하면 shared-infra가 아니라 레포의 self-host 스택을 건드립니다. 반드시 `cd "$COMPOSE_DIR"` 후 실행하세요.
+
+> **공유 인프라 경고.** 로컬 개발 스택은 elitedeck·image_maker와 데이터를 공유합니다. `docker compose down -v`와 `docker volume rm shared-infra_*`는 **세 프로젝트 데이터를 모두 영구 삭제**합니다. 복구 작업 중에도 절대 사용하지 마세요.
+
+---
+
 ## 목차
 
 1. [장애 대응 프로세스](#장애-대응-프로세스)
@@ -30,8 +105,12 @@ curl https://api.aos.example.com/health/detailed | jq '.'
 # 로그 확인 (Railway)
 railway logs --service backend --recent
 
-# 로그 확인 (Docker Compose)
-docker compose logs -f backend --tail=100
+# 백엔드 로그 (토폴로지 분기) — 로컬의 shared-infra compose 에는 backend 서비스가 없다
+if [ "${TOPOLOGY:?}" = "selfhost" ]; then
+  (cd "$COMPOSE_DIR" && docker compose logs -f backend --tail=100)
+else
+  echo "로컬: 백엔드는 compose 밖 uvicorn 프로세스입니다. 해당 터미널 출력을 확인하세요"
+fi
 ```
 
 ### 2. 장애 분류
@@ -73,6 +152,8 @@ cd infra/scripts
 ```
 
 설치 시 `com.aos.db-backup.plist` 템플릿의 `__PROJECT_ROOT__`, `__LOG_DIR__` 플레이스홀더가 실제 경로로 치환되어 `~/Library/LaunchAgents/`에 복사됩니다.
+
+> **템플릿을 고쳤으면 반드시 다시 설치하세요.** launchd가 실행하는 것은 레포의 템플릿이 아니라 `~/Library/LaunchAgents/`의 **복사본**입니다. 템플릿만 수정하면 이미 설치된 에이전트는 옛 설정으로 계속 돕니다. `./setup-auto-backup.sh install`을 다시 실행하면 재생성 후 재적재됩니다. `./setup-auto-backup.sh status`가 설치본과 템플릿을 대조해 `Template: stale`로 알려줍니다.
 
 ### 관리 명령어
 
@@ -129,15 +210,30 @@ macOS `StartCalendarInterval`은 컴퓨터가 꺼져 있거나 잠자기 상태�
 
 ### 환경 변수 (선택)
 
-plist 내 기본값이 설정되어 있으며, 필요 시 수정 가능합니다:
+기본값의 정본(SSOT)은 `infra/scripts/backup-all.sh` 상단이며, 로컬 개발(shared-infra) 기준입니다:
 
 | 변수 | 기본값 | 설명 |
 |------|--------|------|
-| `CONTAINER_NAME` | `aos-postgres` | PostgreSQL 컨테이너 |
-| `REDIS_CONTAINER` | `aos-redis` | Redis 컨테이너 |
-| `DB_USER` | `aos` | 데이터베이스 사용자 |
+| `CONTAINER_NAME` | `shared-postgres` | PostgreSQL 컨테이너 |
+| `REDIS_CONTAINER` | `shared-redis` | Redis 컨테이너 |
+| `DB_USER` | `postgres` | 데이터베이스 사용자 |
 | `DB_NAME` | `aos` | 데이터베이스 이름 |
 | `QDRANT_URL` | `http://localhost:6333` | Qdrant 엔드포인트 |
+
+> **plist에서 이 값들을 재정의하지 마세요.** launchd plist에 `CONTAINER_NAME` 등을 넣으면 스크립트 기본값을 가리고, 인프라 이관 후 그 값이 낡으면 백업이 조용히 실패합니다. 실제로 plist에 남아 있던 `aos-postgres` 오버라이드 때문에 PostgreSQL 백업이 보관 기간 30일 내내 건너뛰어졌습니다(Redis·Qdrant는 정상이라 작업은 "성공"으로 보였습니다). self-host 등 다른 토폴로지에서 백업하려면 plist를 고치지 말고 셸에서 변수를 지정해 `backup-all.sh`를 직접 실행하세요.
+
+### 백업이 실제로 남았는지 확인 (매번)
+
+작업 성공 여부가 아니라 **서비스별 상태**를 봐야 합니다. `backup-all.sh`는 건너뛴 서비스를 실패로 세지 않으므로(`SERVICES_FAIL`만 종료 코드에 반영), 서비스가 통째로 빠져도 작업은 **exit 0으로 끝납니다**:
+
+```bash
+jq '.services' infra/backups/latest/manifest.json
+# 세 서비스 모두 "ok" 여야 합니다.
+# postgres 는 누락 시 "missing", redis/qdrant 는 "skipped" 로 기록됩니다
+# (backup-all.sh 의 manifest 생성부 참조). "ok" 가 아니면 그 서비스는 백업되지 않았습니다.
+
+ls -la infra/backups/latest/   # postgres.dump 실존 확인
+```
 
 ---
 
@@ -146,30 +242,30 @@ plist 내 기본값이 설정되어 있으며, 필요 시 수정 가능합니다
 ### pg_dump를 이용한 백업
 
 ```bash
-# 로컬 Docker 환경에서 백업
-docker exec aos-postgres pg_dump -U aos -d aos -Fc > aos_backup_$(date +%Y%m%d_%H%M%S).dump
+# Docker 환경에서 백업 (변수는 문서 상단 "환경을 고르고" 블록에서 설정)
+docker exec "${PG:?}" pg_dump -U "${PGUSER:?}" -d "${PGDB:?}" -Fc > aos_backup_$(date +%Y%m%d_%H%M%S).dump
 
 # 또는 SQL 형식 백업 (사람이 읽기 가능)
-docker exec aos-postgres pg_dump -U aos -d aos > aos_backup_$(date +%Y%m%d_%H%M%S).sql
+docker exec "${PG:?}" pg_dump -U "${PGUSER:?}" -d "${PGDB:?}" > aos_backup_$(date +%Y%m%d_%H%M%S).sql
 
 # 원격 DB 백업
 PGPASSWORD=<password> pg_dump -h <host> -p <port> -U <user> -d aos -Fc > aos_backup.dump
 
 # 압축 백업
-docker exec aos-postgres pg_dump -U aos -d aos | gzip > aos_backup_$(date +%Y%m%d_%H%M%S).sql.gz
+docker exec "${PG:?}" pg_dump -U "${PGUSER:?}" -d "${PGDB:?}" | gzip > aos_backup_$(date +%Y%m%d_%H%M%S).sql.gz
 ```
 
 ### pg_restore를 이용한 복원
 
 ```bash
 # Custom format (.dump) 복원 - 기존 DB에 덮어쓰기
-docker exec -i aos-postgres pg_restore -U aos -d aos --clean --if-exists < aos_backup.dump
+docker exec -i "${PG:?}" pg_restore -U "${PGUSER:?}" -d "${PGDB:?}" --clean --if-exists < aos_backup.dump
 
 # SQL 형식 복원
-docker exec -i aos-postgres psql -U aos -d aos < aos_backup.sql
+docker exec -i "${PG:?}" psql -U "${PGUSER:?}" -d "${PGDB:?}" < aos_backup.sql
 
 # 압축된 SQL 복원
-gunzip -c aos_backup.sql.gz | docker exec -i aos-postgres psql -U aos -d aos
+gunzip -c aos_backup.sql.gz | docker exec -i "${PG:?}" psql -U "${PGUSER:?}" -d "${PGDB:?}"
 
 # 원격 DB로 복원
 PGPASSWORD=<password> pg_restore -h <host> -p <port> -U <user> -d aos --clean --if-exists aos_backup.dump
@@ -222,44 +318,46 @@ Redis는 AOF(Append Only File)와 RDB 스냅샷을 사용합니다. Docker Compo
 
 ```bash
 # 현재 시점 RDB 스냅샷 생성
-docker exec aos-redis redis-cli BGSAVE
+docker exec "${RD:?}" redis-cli BGSAVE
 
 # 스냅샷 완료 대기
-docker exec aos-redis redis-cli LASTSAVE
+docker exec "${RD:?}" redis-cli LASTSAVE
 
 # dump.rdb 파일 복사 (컨테이너 → 호스트)
-docker cp aos-redis:/data/dump.rdb ./redis_backup_$(date +%Y%m%d_%H%M%S).rdb
+docker cp "${RD:?}":/data/dump.rdb ./redis_backup_$(date +%Y%m%d_%H%M%S).rdb
 ```
 
 ### RDB 복원
 
+> **🚨 로컬(shared-infra)에서는 조율 없이 실행하지 마세요.** RDB 파일은 **Redis 서버 전체**를 담습니다. `shared-redis`는 elitedeck·image_maker와 논리 DB를 공유하므로, 복원하면 **다른 프로젝트의 캐시·큐가 통째로 과거 시점으로 되돌아가거나 사라집니다**. `restore-all.sh latest`도 같은 경로를 탑니다. 공유 환경에서는 (1) 관련 프로젝트와 시점을 합의한 뒤 전체 인스턴스를 함께 복원하거나, (2) AOS 키만 선별 내보내기/복원하세요. 아래 절차는 그 조율이 끝났거나 self-host 전용 인스턴스일 때만 사용합니다.
+
 ```bash
-# 1. Redis 컨테이너 중지
-docker compose stop redis
+# 1. Redis 컨테이너 중지 (compose 는 반드시 해당 환경 디렉토리에서)
+(cd "${COMPOSE_DIR:?}" && docker compose stop redis)
 
 # 2. 기존 데이터 백업
-docker cp aos-redis:/data/dump.rdb ./redis_old_backup.rdb
+docker cp "${RD:?}":/data/dump.rdb ./redis_old_backup.rdb
 
 # 3. 백업 파일을 컨테이너에 복사
-docker cp redis_backup.rdb aos-redis:/data/dump.rdb
+docker cp redis_backup.rdb "${RD:?}":/data/dump.rdb
 
 # 4. Redis 재시작
-docker compose start redis
+(cd "${COMPOSE_DIR:?}" && docker compose start redis)
 
 # 5. 데이터 확인
-docker exec aos-redis redis-cli DBSIZE
+docker exec "${RD:?}" redis-cli DBSIZE
 ```
 
 ### AOF 파일 복원
 
 ```bash
 # AOF 파일은 /data/appendonlydir/ 에 저장됨
-docker cp aos-redis:/data/appendonlydir ./redis_aof_backup/
+docker cp "${RD:?}":/data/appendonlydir ./redis_aof_backup/
 
 # 복원 시
-docker compose stop redis
-docker cp ./redis_aof_backup/. aos-redis:/data/appendonlydir/
-docker compose start redis
+(cd "${COMPOSE_DIR:?}" && docker compose stop redis)
+docker cp ./redis_aof_backup/. "${RD:?}":/data/appendonlydir/
+(cd "${COMPOSE_DIR:?}" && docker compose start redis)
 ```
 
 ---
@@ -272,7 +370,7 @@ Qdrant는 REST API를 통한 스냅샷 기능을 제공합니다.
 
 ```bash
 # 전체 스냅샷 생성 (모든 컬렉션 포함)
-curl -X POST http://localhost:6333/snapshots
+curl -X POST "${QDRANT_URL:?}"/snapshots
 
 # 응답 예시:
 # {"result": {"name": "snapshot-2026-03-24-12-00-00.snapshot", ...}}
@@ -282,26 +380,26 @@ curl -X POST http://localhost:6333/snapshots
 
 ```bash
 # 특정 컬렉션 스냅샷 생성
-curl -X POST http://localhost:6333/collections/{collection_name}/snapshots
+curl -X POST "${QDRANT_URL:?}"/collections/{collection_name}/snapshots
 
 # 스냅샷 목록 확인
-curl http://localhost:6333/collections/{collection_name}/snapshots
+curl "${QDRANT_URL:?}"/collections/{collection_name}/snapshots
 
 # 스냅샷 다운로드
 curl -o qdrant_backup.snapshot \
-  http://localhost:6333/collections/{collection_name}/snapshots/{snapshot_name}
+  "${QDRANT_URL:?}"/collections/{collection_name}/snapshots/{snapshot_name}
 ```
 
 ### 스냅샷 복원
 
 ```bash
 # 스냅샷 파일 업로드로 컬렉션 복원
-curl -X POST http://localhost:6333/collections/{collection_name}/snapshots/upload \
+curl -X POST "${QDRANT_URL:?}"/collections/{collection_name}/snapshots/upload \
   -H 'Content-Type: multipart/form-data' \
   -F 'snapshot=@qdrant_backup.snapshot'
 
 # 또는 URL에서 복원
-curl -X PUT http://localhost:6333/collections/{collection_name}/snapshots/recover \
+curl -X PUT "${QDRANT_URL:?}"/collections/{collection_name}/snapshots/recover \
   -H 'Content-Type: application/json' \
   -d '{"location": "http://backup-server/qdrant_backup.snapshot"}'
 ```
@@ -310,36 +408,44 @@ curl -X PUT http://localhost:6333/collections/{collection_name}/snapshots/recove
 
 ```bash
 # 전체 스냅샷 목록 확인
-curl http://localhost:6333/snapshots
+curl "${QDRANT_URL:?}"/snapshots
 
 # 전체 스냅샷 다운로드
-curl -o full_snapshot.snapshot http://localhost:6333/snapshots/{snapshot_name}
+curl -o full_snapshot.snapshot "${QDRANT_URL:?}"/snapshots/{snapshot_name}
 
 # 전체 복원 (Qdrant 재시작 필요)
 # 1. Qdrant 중지
-docker compose stop qdrant
+(cd "${COMPOSE_DIR:?}" && docker compose stop qdrant)
 
 # 2. 스냅샷 파일을 스토리지에 복사
-docker cp full_snapshot.snapshot aos-qdrant:/qdrant/storage/snapshots/
+docker cp full_snapshot.snapshot "${QD:?}":/qdrant/storage/snapshots/
 
 # 3. Qdrant 재시작 (자동 복원)
-docker compose start qdrant
+(cd "${COMPOSE_DIR:?}" && docker compose start qdrant)
 ```
 
 ### Docker 볼륨 직접 백업
 
 ```bash
 # Qdrant 볼륨 데이터 직접 백업 (오프라인)
-docker compose stop qdrant
-docker run --rm -v agent-system_qdrant_data:/data -v $(pwd):/backup \
+(cd "${COMPOSE_DIR:?}" && docker compose stop qdrant)
+docker run --rm -v "${VOLPREFIX:?}_qdrant_data":/data -v $(pwd):/backup \
   alpine tar czf /backup/qdrant_volume_backup.tar.gz -C /data .
-docker compose start qdrant
+(cd "${COMPOSE_DIR:?}" && docker compose start qdrant)
+```
 
-# 볼륨 복원
-docker compose stop qdrant
-docker run --rm -v agent-system_qdrant_data:/data -v $(pwd):/backup \
+#### 볼륨 복원
+
+> **🚨 로컬 개발(shared-infra)에서는 이 절차를 쓰지 마세요.** 아래 복원은 `rm -rf /data/*`로 볼륨을 통째로 비웁니다. `shared-infra_qdrant_data`는 elitedeck·image_maker와 공유하므로 **다른 프로젝트의 벡터 데이터까지 삭제**됩니다. 공유 환경에서는 컬렉션 단위 스냅샷 복원(위 "스냅샷 복원" 절)을 쓰세요. 아래는 AOS 전용 볼륨을 쓰는 **self-host 환경에서만** 유효합니다.
+
+```bash
+# self-host 전용 — VOLPREFIX 가 AOS 전용 볼륨인지 반드시 확인
+[ "${VOLPREFIX:?}" = "aos" ] || { echo "공유 볼륨에는 실행 금지"; exit 1; }
+
+(cd "${COMPOSE_DIR:?}" && docker compose stop qdrant)
+docker run --rm -v "${VOLPREFIX}_qdrant_data":/data -v $(pwd):/backup \
   alpine sh -c "rm -rf /data/* && tar xzf /backup/qdrant_volume_backup.tar.gz -C /data"
-docker compose start qdrant
+(cd "${COMPOSE_DIR:?}" && docker compose start qdrant)
 ```
 
 ---
@@ -371,6 +477,8 @@ railway rollback --service dashboard
 
 ### Docker Compose 롤백
 
+> **self-host 전용.** `backend`·`dashboard`는 레포 루트 compose에만 정의된 서비스입니다. 로컬 개발에서는 두 프로세스를 compose 밖(uvicorn / vite)에서 직접 기동하므로 이 절차가 적용되지 않습니다. 아래 명령은 레포 루트에서 실행합니다.
+
 ```bash
 # 특정 버전 이미지로 롤백
 docker compose down backend dashboard
@@ -394,15 +502,15 @@ sqlalchemy.exc.OperationalError: connection refused
 
 **대응**:
 ```bash
-# 1. DB 컨테이너 상태 확인
-docker compose ps postgres
-docker compose logs postgres --tail=20
+# 1. DB 컨테이너 상태 확인 (compose 는 반드시 해당 환경 디렉토리에서)
+(cd "${COMPOSE_DIR:?}" && docker compose ps postgres)
+(cd "${COMPOSE_DIR:?}" && docker compose logs postgres --tail=20)
 
 # 2. 연결 테스트
-docker exec aos-postgres pg_isready -U aos -d aos
+docker exec "${PG:?}" pg_isready -U "${PGUSER:?}" -d "${PGDB:?}"
 
 # 3. DB 재시작
-docker compose restart postgres
+(cd "${COMPOSE_DIR:?}" && docker compose restart postgres)
 
 # 4. Railway 환경
 railway status
@@ -420,13 +528,13 @@ redis.exceptions.ConnectionError: Connection refused
 **대응**:
 ```bash
 # 1. Redis 상태 확인
-docker exec aos-redis redis-cli ping
+docker exec "${RD:?}" redis-cli ping
 
 # 2. 메모리 확인
-docker exec aos-redis redis-cli info memory
+docker exec "${RD:?}" redis-cli info memory
 
 # 3. Redis 재시작
-docker compose restart redis
+(cd "${COMPOSE_DIR:?}" && docker compose restart redis)
 ```
 
 ### 3. LLM API 오류
@@ -444,8 +552,7 @@ RateLimitError: Rate limit exceeded
    LLM_PROVIDER=anthropic
    ANTHROPIC_API_KEY=<key>
 
-   # Backend 재시작
-   docker compose restart backend
+   # Backend 재시작 — 문서 상단 "백엔드 재시작 (토폴로지 자동 분기)" 블록 사용
    ```
 3. 요청 제한 활성화
 
@@ -475,13 +582,13 @@ ConnectionError: Qdrant connection failed
 **대응**:
 ```bash
 # 1. Qdrant 상태 확인 (호스트에서)
-curl http://localhost:6333/healthz
+curl "${QDRANT_URL:?}"/healthz
 
 # 2. 컬렉션 목록 확인
-curl http://localhost:6333/collections
+curl "${QDRANT_URL:?}"/collections
 
 # 3. Qdrant 재시작
-docker compose restart qdrant
+(cd "${COMPOSE_DIR:?}" && docker compose restart qdrant)
 
 # 참고: Qdrant는 healthcheck 없이 service_started로 시작됨
 # 재시작 후 수 초 대기 필요
@@ -499,10 +606,10 @@ AOS의 SQLAlchemy는 `create_all()`로 테이블을 자동 생성합니다. 기�
 
 ```bash
 # 1. 현재 스키마 백업
-docker exec aos-postgres pg_dump -U aos -d aos --schema-only > schema_backup.sql
+docker exec "${PG:?}" pg_dump -U "${PGUSER:?}" -d "${PGDB:?}" --schema-only > schema_backup.sql
 
 # 2. 데이터 백업 (필수!)
-docker exec aos-postgres pg_dump -U aos -d aos -Fc > data_backup.dump
+docker exec "${PG:?}" pg_dump -U "${PGUSER:?}" -d "${PGDB:?}" -Fc > data_backup.dump
 ```
 
 ### DROP SCHEMA 방법 (전체 초기화)
@@ -510,34 +617,36 @@ docker exec aos-postgres pg_dump -U aos -d aos -Fc > data_backup.dump
 > **주의**: 모든 테이블과 데이터가 삭제됩니다. 반드시 백업 후 실행하세요.
 
 ```bash
-# 1. DB 접속
-docker exec -it aos-postgres psql -U aos -d aos
+# 1. DB 접속 (공유 환경이면 $PGDB 가 aos 인지 반드시 확인 — 다른 프로젝트 DB 삭제 방지)
+docker exec -it "${PG:?}" psql -U "${PGUSER:?}" -d "${PGDB:?}"
 
 # 2. public 스키마 전체 삭제 및 재생성
 DROP SCHEMA public CASCADE;
 CREATE SCHEMA public;
-GRANT ALL ON SCHEMA public TO aos;
+-- 접속 중인 롤에 부여한다. 로컬(shared-infra)에는 postgres 롤만 존재하고
+-- self-host 에는 aos 롤이 존재하므로, 롤 이름을 literal 로 적으면 한쪽에서 실패한다.
+GRANT ALL ON SCHEMA public TO CURRENT_USER;
 GRANT ALL ON SCHEMA public TO public;
 \q
 
 # 3. Backend 재시작 (SQLAlchemy가 테이블 자동 재생성)
-docker compose restart backend
+#    문서 상단 "백엔드 재시작 (토폴로지 자동 분기)" 블록을 사용한다
 
 # 4. 필요 시 데이터 복원
-docker exec -i aos-postgres pg_restore -U aos -d aos --data-only data_backup.dump
+docker exec -i "${PG:?}" pg_restore -U "${PGUSER:?}" -d "${PGDB:?}" --data-only data_backup.dump
 ```
 
 ### 특정 테이블만 재생성
 
 ```bash
-docker exec -it aos-postgres psql -U aos -d aos
+docker exec -it "${PG:?}" psql -U "${PGUSER:?}" -d "${PGDB:?}"
 
 # 특정 테이블 삭제 (CASCADE로 의존 관계도 함께)
 DROP TABLE IF EXISTS <table_name> CASCADE;
 \q
 
 # Backend 재시작으로 자동 재생성
-docker compose restart backend
+# 문서 상단 "백엔드 재시작 (토폴로지 자동 분기)" 블록을 사용한다
 ```
 
 ---

--- a/infra/scripts/com.aos.db-backup.plist
+++ b/infra/scripts/com.aos.db-backup.plist
@@ -28,16 +28,14 @@
     <key>StandardErrorPath</key>
     <string>__LOG_DIR__/backup-stderr.log</string>
 
+    <!-- CONTAINER_NAME/DB_USER/DB_NAME are intentionally absent: backup-all.sh owns
+         those defaults (shared-infra 기준). Setting them here shadows the script and
+         silently breaks backups after an infra migration — a stale aos-postgres
+         override skipped every PostgreSQL backup for the full 30-day retention. -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
-        <key>CONTAINER_NAME</key>
-        <string>aos-postgres</string>
-        <key>DB_USER</key>
-        <string>aos</string>
-        <key>DB_NAME</key>
-        <string>aos</string>
     </dict>
 
     <!-- Do not restart on failure -->

--- a/infra/scripts/setup-auto-backup.sh
+++ b/infra/scripts/setup-auto-backup.sh
@@ -115,38 +115,77 @@ cmd_status() {
         echo -e "  Template:  ${GREEN}current${NC}"
     fi
 
-    # Per-service result of the most recent run. The job exits 0 even when a service
-    # is skipped, so "it ran" is not evidence that anything was backed up.
-    MANIFEST="$PROJECT_ROOT/infra/backups/latest/manifest.json"
-    if [[ -f "$MANIFEST" ]]; then
-        # Count entries as well as failures: a truncated manifest has zero status
-        # entries, and "no failures found" must not be reported as healthy.
-        # `|| true`: grep exits 1 on no match, which would abort us under `set -e`.
-        TOTAL=$(grep -c '"status":' "$MANIFEST" || true)
-        OK_COUNT=$(grep -c '"status": *"ok"' "$MANIFEST" || true)
-        if [[ "$TOTAL" != "$EXPECTED_SERVICES" ]]; then
-            echo -e "  Services:  ${RED}unknown${NC} — manifest has $TOTAL/$EXPECTED_SERVICES entries (truncated?): $MANIFEST"
-        elif [[ "$OK_COUNT" == "$EXPECTED_SERVICES" ]]; then
-            echo -e "  Services:  ${GREEN}all ok${NC}"
-        else
-            echo -e "  Services:  ${RED}$((EXPECTED_SERVICES - OK_COUNT)) service(s) not backed up${NC} — see $MANIFEST"
+    # Resolve the backup set once, before reporting anything: the per-service verdict
+    # and the "latest" line must describe the *same* backup. Reading the `latest`
+    # symlink while listing by mtime lets them disagree when a run aborts before
+    # updating the symlink — status would show the failed attempt while reporting the
+    # previous run's "all ok".
+    #
+    # Count both layouts: backup-all.sh writes timestamped directories, while the
+    # legacy backup-db.sh path (still reachable via the cmd_run fallback) writes
+    # aos_backup_*.dump files. Matching only the legacy pattern reported
+    # "no backups yet" on every run regardless of how many backups existed.
+    # Sort by mtime, not name — a name sort would rank every '20*' directory above
+    # every 'aos_backup_*' file regardless of age. `find` exits 0 when nothing
+    # matches, unlike ls/grep under `set -e`.
+    BACKUP_DIR="$PROJECT_ROOT/infra/backups"
+    COUNT=0
+    LATEST=""
+    if [[ -d "$BACKUP_DIR" ]]; then
+        FIND_BACKUPS=(find "$BACKUP_DIR" -maxdepth 1
+            \( -type d -name '20*' -o -type f -name 'aos_backup_*.dump' \))
+        COUNT=$("${FIND_BACKUPS[@]}" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$COUNT" -gt 0 ]]; then
+            # Guarded by COUNT: `xargs ls` with empty input would list the cwd.
+            # Take the first line in the shell instead of piping to `head`, which can
+            # close the pipe mid-write and surface as a SIGPIPE failure under pipefail.
+            LATEST=$("${FIND_BACKUPS[@]}" -print0 2>/dev/null | xargs -0 ls -td)
+            LATEST=${LATEST%%$'\n'*}
         fi
     fi
 
-    # Show recent backups
-    BACKUP_DIR="$PROJECT_ROOT/infra/backups"
-    if [[ -d "$BACKUP_DIR" ]]; then
-        LATEST=$(find "$BACKUP_DIR" -maxdepth 1 -name "aos_backup_*.dump" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
-        if [[ -n "$LATEST" ]]; then
-            SIZE=$(du -h "$LATEST" | cut -f1)
-            MOD=$(stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$LATEST")
-            echo "  Latest:    $(basename "$LATEST") ($SIZE, $MOD)"
+    # Per-service result of that backup. The job exits 0 even when a service is
+    # skipped, so "it ran" is not evidence that anything was backed up.
+    if [[ -d "$LATEST" ]]; then
+        MANIFEST="$LATEST/manifest.json"
+        # Parse the JSON rather than counting matching lines. A manifest truncated
+        # after its status lines still yields the expected count by grep while being
+        # unusable to restore-all.sh, which would report a broken backup as healthy.
+        if [[ ! -f "$MANIFEST" ]]; then
+            SERVICE_STATE="nomanifest"
         else
-            echo "  Latest:    no backups yet"
+        SERVICE_STATE=$(python3 -c '
+import json, sys
+try:
+    services = json.load(open(sys.argv[1]))["services"]
+except Exception:
+    print("unparseable"); raise SystemExit
+if len(services) != int(sys.argv[2]):
+    print("incomplete:%d" % len(services)); raise SystemExit
+bad = sorted(k for k, v in services.items() if v.get("status") != "ok")
+print("ok" if not bad else "failed:" + ",".join(bad))
+' "$MANIFEST" "$EXPECTED_SERVICES" 2>/dev/null || echo "unparseable")
         fi
-        COUNT=$(find "$BACKUP_DIR" -name "aos_backup_*.dump" -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
-        echo "  Total:     $COUNT backup(s)"
+
+        case "$SERVICE_STATE" in
+            ok)           echo -e "  Services:  ${GREEN}all ok${NC}" ;;
+            failed:*)     echo -e "  Services:  ${RED}not backed up: ${SERVICE_STATE#failed:}${NC} — see $MANIFEST" ;;
+            incomplete:*) echo -e "  Services:  ${RED}incomplete${NC} — ${SERVICE_STATE#incomplete:}/$EXPECTED_SERVICES entries: $MANIFEST" ;;
+            nomanifest)   echo -e "  Services:  ${RED}incomplete${NC} — no manifest in $(basename "$LATEST") (run aborted?)" ;;
+            *)            echo -e "  Services:  ${RED}unreadable manifest${NC} — $MANIFEST" ;;
+        esac
+    elif [[ -n "$LATEST" ]]; then
+        echo -e "  Services:  ${YELLOW}n/a${NC} — latest backup is a legacy single-file dump"
     fi
+
+    if [[ -n "$LATEST" ]]; then
+        SIZE=$(du -sh "$LATEST" | cut -f1)
+        MOD=$(stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$LATEST")
+        echo "  Latest:    $(basename "$LATEST") ($SIZE, $MOD)"
+    else
+        echo "  Latest:    no backups yet"
+    fi
+    echo "  Total:     $COUNT backup(s)"
 
     # Show recent log
     if [[ -d "$LOG_DIR" ]]; then

--- a/infra/scripts/setup-auto-backup.sh
+++ b/infra/scripts/setup-auto-backup.sh
@@ -14,6 +14,8 @@ LABEL="com.aos.db-backup"
 PLIST_SRC="$SCRIPT_DIR/com.aos.db-backup.plist"
 PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
 LOG_DIR="$PROJECT_ROOT/infra/backups/logs"
+# backup-all.sh writes one manifest entry per service (postgres, redis, qdrant).
+EXPECTED_SERVICES=3
 
 # Colors
 GREEN='\033[0;32m'
@@ -101,6 +103,35 @@ cmd_status() {
 
     # Show schedule
     echo "  Schedule:  daily at 03:00"
+
+    # Installed plist vs template — an agent installed before a template change keeps
+    # running the old copy. A stale CONTAINER_NAME override once skipped every
+    # PostgreSQL backup for the full retention window without failing the job.
+    EXPECTED=$(sed -e "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" -e "s|__LOG_DIR__|$LOG_DIR|g" "$PLIST_SRC")
+    if [[ "$EXPECTED" != "$(cat "$PLIST_DST")" ]]; then
+        echo -e "  Template:  ${RED}stale${NC} — installed plist differs from $PLIST_SRC"
+        echo -e "             ${YELLOW}Run '$0 install' to regenerate and reload.${NC}"
+    else
+        echo -e "  Template:  ${GREEN}current${NC}"
+    fi
+
+    # Per-service result of the most recent run. The job exits 0 even when a service
+    # is skipped, so "it ran" is not evidence that anything was backed up.
+    MANIFEST="$PROJECT_ROOT/infra/backups/latest/manifest.json"
+    if [[ -f "$MANIFEST" ]]; then
+        # Count entries as well as failures: a truncated manifest has zero status
+        # entries, and "no failures found" must not be reported as healthy.
+        # `|| true`: grep exits 1 on no match, which would abort us under `set -e`.
+        TOTAL=$(grep -c '"status":' "$MANIFEST" || true)
+        OK_COUNT=$(grep -c '"status": *"ok"' "$MANIFEST" || true)
+        if [[ "$TOTAL" != "$EXPECTED_SERVICES" ]]; then
+            echo -e "  Services:  ${RED}unknown${NC} — manifest has $TOTAL/$EXPECTED_SERVICES entries (truncated?): $MANIFEST"
+        elif [[ "$OK_COUNT" == "$EXPECTED_SERVICES" ]]; then
+            echo -e "  Services:  ${GREEN}all ok${NC}"
+        else
+            echo -e "  Services:  ${RED}$((EXPECTED_SERVICES - OK_COUNT)) service(s) not backed up${NC} — see $MANIFEST"
+        fi
+    fi
 
     # Show recent backups
     BACKUP_DIR="$PROJECT_ROOT/infra/backups"


### PR DESCRIPTION
## Summary

- **launchd 자동 백업이 PostgreSQL을 매일 조용히 건너뛰고 있었다.** 보관된 백업 31개 전부에 `postgres.dump`가 없었고, 보관 기간이 30일이라 복원 가능한 PostgreSQL 백업이 하나도 없는 상태였다.
- 원인은 plist가 `CONTAINER_NAME=aos-postgres`로 `backup-all.sh`의 올바른 기본값(`shared-postgres`)을 가린 것. `backup-all.sh`는 컨테이너가 없으면 경고만 남기고 **건너뛰며 종료 코드에 반영하지 않아**, Redis·Qdrant가 정상인 작업은 계속 "성공"으로 보였다.
- `docs/recovery.md`는 로컬(shared-infra)과 self-host 두 토폴로지를 구분하지 않아, 로컬 개발자가 따라 하면 존재하지 않는 컨테이너를 겨냥한다.

## Changes

**`infra/scripts/com.aos.db-backup.plist`**
- `CONTAINER_NAME`/`DB_USER`/`DB_NAME` 오버라이드 제거 → SSOT를 `backup-all.sh` 하나로 환원. 값을 고치는 대신 제거한 것은 다음 인프라 이관 때 같은 방식으로 또 어긋나는 것을 막기 위함이다.

**`infra/scripts/setup-auto-backup.sh`** — 같은 실패가 다시 조용히 지나가지 않도록 `status`를 관측 지점으로 만든다
- 설치본↔템플릿 스테일 탐지. launchd가 실행하는 것은 레포 템플릿이 아니라 `~/Library/LaunchAgents`의 사본이라, 템플릿만 고치면 기존 설치본은 옛 설정으로 계속 돈다.
- 최근 백업의 서비스별 상태 검사. manifest를 줄 세기가 아니라 JSON으로 파싱해 `ok`/`failed`/`incomplete`/`unparseable`을 구분한다.
- 백업 집계가 레거시 `aos_backup_*.dump` 패턴만 보던 것을 현재 타임스탬프 디렉토리와 함께 세도록 수정. 이전에는 백업이 33개 있어도 `Total: 0 backup(s)`을 출력했다.
- `Services:`와 `Latest:`가 같은 백업을 가리키도록 백업 선택을 먼저 수행. 이전에는 전자가 `latest` 심링크를, 후자가 mtime 최신 디렉토리를 읽어, 실행이 심링크 갱신 전에 죽으면 실패한 시도를 표시하면서 직전 실행의 `all ok`를 보고했다.

**`docs/recovery.md`**
- 문서 맨 앞에 토폴로지 선택을 전제로 배치(A: 로컬 shared-infra / B: self-host). 두 블록을 분리해 연달아 붙여넣어도 값이 덮어써지지 않게 했다.
- 명령을 `${PG:?}` 형태로 변수화 — 미설정 시 존재하지 않는 컨테이너를 조용히 겨냥하는 대신 즉시 실패한다. 단, 통합 스크립트는 shared-infra 기본값으로 진행하므로(launchd가 의존) 그 사실을 명시했다.
- 공유 인프라 파괴 경고 추가: 볼륨 복원(`rm -rf /data/*`)과 Redis 전체 RDB 복원은 elitedeck·image_maker 데이터까지 되돌린다.
- 사실 정정: self-host 볼륨 접두사는 `agent-system_`이 아니라 `aos_`(루트 compose `name: aos`), `GRANT ... TO aos`는 로컬에서 `role "aos" does not exist`로 실패하므로 `CURRENT_USER` 사용.

## Test Plan

- [x] `bash -n` — 문서 내 셸 블록 29개 및 `setup-auto-backup.sh` 문법 오류 0
- [x] `plutil -lint` — plist 유효
- [x] Red-Green: 구 설정 `docker exec aos-postgres` → `No such container` / 신 설정 → `pg_dump` 2,530,424바이트 생성
- [x] `status`의 manifest 4경로(`ok`/`failed`/`incomplete`/`unparseable`) 실행 확인
- [x] 중단된 실행 디렉토리를 만들어 `incomplete — no manifest` 보고 확인 후 정리(잔여물 0)
- [x] 혼합 레이아웃에서 mtime 정렬이 이름 정렬의 오류를 회피함을 격리 테스트로 확인
- [x] **종단 검증**: `launchctl kickstart`로 실제 스케줄 경로 실행 → `postgres`/`redis`/`qdrant` 전부 `"status": "ok"`인 백업 생성
- [x] Codex 외부 리뷰 12라운드 — 13건 지적 전부 반영, 최종 라운드 지적 0건(명령 31회 실행)

## 머지 후 필수 조치

```bash
./infra/scripts/setup-auto-backup.sh install   # 설치된 에이전트 갱신
./infra/scripts/setup-auto-backup.sh status    # Template: current / Services: all ok 확인
```

이 단계 없이는 `~/Library/LaunchAgents`의 사본이 옛 설정을 유지해 백업이 계속 깨진 채로 남는다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)