### PR TITLE
fix(orchestrator): 병렬 병합 agents 유실 + Executor 토큰 누계 덮어쓰기 (#273, #275)

### DIFF
--- a/src/backend/orchestrator/nodes/executor.py
+++ b/src/backend/orchestrator/nodes/executor.py
@@ -9,7 +9,7 @@ MCP 는 optional 의존이다(위 planner 의 RAG 와 같은 구조·같은 주�
 
 import json
 import uuid
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
@@ -282,8 +282,11 @@ After completing all necessary tool calls, provide a final summary."""
             final_result = None
             pending_approvals = dict(state.get("pending_approvals", {}))
 
-            # Track token usage across iterations
+            # Track token usage across iterations.
+            # `_extract_and_update_tokens` 는 넘겨받은 state 의 누계 위에 이번 회차를
+            # 더해 새 dict 를 돌려준다. 기준선을 회차마다 굴려야 누계가 쌓인다.
             accumulated_token_updates: dict[str, Any] = {}
+            token_baseline: AgentState = state
             llm, resolved_model, runtime_resolution = self._resolved_llm_for_state(state)
             llm_with_tools = llm.bind_tools(self.tools) if self.tools and llm else llm
             runtime_metadata = runtime_resolution.usage_metadata() if runtime_resolution else {}
@@ -300,13 +303,23 @@ After completing all necessary tool calls, provide a final summary."""
                 # Extract and accumulate token usage
                 token_update = self._extract_and_update_tokens(
                     response,
-                    state,
+                    token_baseline,
                     "Executor",
                     model=resolved_model,
                     metadata=runtime_metadata,
                 )
                 if token_update:
                     accumulated_token_updates = token_update
+                    token_baseline = cast(
+                        AgentState,
+                        {
+                            **token_baseline,
+                            "token_usage": token_update["token_usage"],
+                            "total_cost": token_update["total_cost"],
+                        },
+                    )
+                    # 원장에는 회차 델타(`_last_token_update`)만 기록되므로
+                    # 원본 state 를 그대로 넘긴다 — 누적 기준선과 무관하다.
                     await self._record_token_update_usage(
                         token_update,
                         state,

--- a/src/backend/orchestrator/parallel_executor.py
+++ b/src/backend/orchestrator/parallel_executor.py
@@ -90,6 +90,7 @@ class ParallelExecutorNode(BaseNode):
             Merged state update
         """
         merged_tasks = dict(state.get("tasks", {}))
+        merged_agents = dict(state.get("agents", {}))
         all_messages = []
         all_errors = list(state.get("errors", []))
         waiting_for_approval = False
@@ -114,6 +115,15 @@ class ParallelExecutorNode(BaseNode):
                         completed_count += 1
                     elif task.status == TaskStatus.FAILED:
                         failed_count += 1
+
+            # Merge agent updates.
+            #
+            # Conflict policy: last-write-wins per agent id. ExecutorNode derives
+            # its agent id from the task id (`executor-{task_id[:8]}`), so parallel
+            # branches produce disjoint keys and no real conflict occurs. If that
+            # id rule ever changes, this merge needs an explicit conflict strategy.
+            if "agents" in result:
+                merged_agents.update(result["agents"])
 
             # Collect messages
             if "messages" in result:
@@ -168,6 +178,7 @@ class ParallelExecutorNode(BaseNode):
 
         return {
             "tasks": merged_tasks,
+            "agents": merged_agents,
             "messages": all_messages,
             "errors": all_errors,
             "waiting_for_approval": waiting_for_approval,

--- a/tests/backend/test_executor_token_accumulation.py
+++ b/tests/backend/test_executor_token_accumulation.py
@@ -1,0 +1,148 @@
+"""ExecutorNode 멀티 iteration 토큰 누적 회귀 테스트 (issue #275).
+
+`_extract_and_update_tokens` 는 넘겨받은 state 의 누계 위에 이번 회차를 더해
+새 dict 를 돌려주는 함수형 갱신자다. 루프가 매 회차 같은 state 를 넘기면
+반환값은 항상 "원래 누계 + 이번 회차"라서, 마지막 회차만 반환 state 에 남는다.
+
+원장(ledger) 기록은 회차 델타(`_last_token_update`)를 읽으므로 영향받지 않는다 —
+이 테스트는 state 누계와 ledger 기록을 함께 검증해 그 경계를 고정한다.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.agent_state import TaskNode, create_initial_state
+from orchestrator.nodes.executor import ExecutorNode
+
+# 회차별 토큰 사용량 — 합계가 회차 값과 구분되도록 서로 다른 수를 쓴다.
+FIRST_USAGE = {"input_tokens": 10, "output_tokens": 20}
+SECOND_USAGE = {"input_tokens": 5, "output_tokens": 7}
+RESOLVED_MODEL = "claude-sonnet-5"
+
+
+def _response(content: str, usage: dict[str, int], tool_calls: list[dict[str, Any]]) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = usage
+    response.tool_calls = tool_calls
+    return response
+
+
+@pytest.fixture
+def executor_state():
+    state = create_initial_state(session_id="session-token-accumulation")
+    state["tasks"]["task-1"] = TaskNode(id="task-1", title="Task 1", description="do work")
+    state["current_task_id"] = "task-1"
+    return state
+
+
+@pytest.fixture
+def usage_recorder(monkeypatch):
+    """ledger 기록을 가로채 회차별 인자를 캡처한다."""
+    recorder = AsyncMock()
+    monkeypatch.setattr("orchestrator.nodes.base.record_usage_best_effort", recorder)
+    monkeypatch.setattr("orchestrator.nodes.executor.AuditService.log", MagicMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.audit_task_status_change", MagicMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.audit_tool_executed", MagicMock())
+    return recorder
+
+
+def _build_node(monkeypatch, responses: list[MagicMock]) -> ExecutorNode:
+    """두 회차를 돌도록 구성한 ExecutorNode 를 만든다.
+
+    `safe_tool` 은 TOOL_RISK_CONFIG 에 없어 DEFAULT_RISK(승인 불필요)로 떨어진다 —
+    승인 게이트에 막혀 루프가 1회차에서 조기 반환되지 않도록 하기 위함이다.
+    """
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = AsyncMock(side_effect=responses)
+
+    node = ExecutorNode(llm=fake_llm, tools=[])
+    monkeypatch.setattr(
+        ExecutorNode,
+        "_resolved_llm_for_state",
+        lambda self, state, **kwargs: (fake_llm, RESOLVED_MODEL, None),
+    )
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", AsyncMock(return_value="tool ok"))
+    return node
+
+
+@pytest.mark.asyncio
+async def test_executor_accumulates_token_usage_across_iterations(
+    monkeypatch, executor_state, usage_recorder
+):
+    """반환 state 의 token_usage 는 모든 iteration 의 합이어야 한다."""
+    node = _build_node(
+        monkeypatch,
+        [
+            _response("", FIRST_USAGE, [{"name": "safe_tool", "args": {}, "id": "call-1"}]),
+            _response("done", SECOND_USAGE, []),
+        ],
+    )
+
+    result = await node.run(executor_state)
+
+    usage = result["token_usage"]["Executor"]
+    assert usage["call_count"] == 2
+    assert usage["total_input_tokens"] == 15  # 10 + 5
+    assert usage["total_output_tokens"] == 27  # 20 + 7
+    assert usage["total_tokens"] == 42  # 30 + 12
+
+
+@pytest.mark.asyncio
+async def test_executor_total_cost_matches_ledger_sum(
+    monkeypatch, executor_state, usage_recorder
+):
+    """state 의 total_cost 는 원장에 기록된 회차별 비용의 합과 일치해야 한다."""
+    node = _build_node(
+        monkeypatch,
+        [
+            _response("", FIRST_USAGE, [{"name": "safe_tool", "args": {}, "id": "call-1"}]),
+            _response("done", SECOND_USAGE, []),
+        ],
+    )
+
+    result = await node.run(executor_state)
+
+    ledger_costs = [call.args[0].estimated_cost_usd for call in usage_recorder.await_args_list]
+    assert len(ledger_costs) == 2
+    assert all(cost > 0 for cost in ledger_costs)
+    assert result["total_cost"] == pytest.approx(sum(ledger_costs))
+
+
+@pytest.mark.asyncio
+async def test_executor_ledger_records_per_iteration_deltas(
+    monkeypatch, executor_state, usage_recorder
+):
+    """원장은 누계가 아니라 회차별 델타를 기록해야 한다(누적 수정의 비회귀 경계)."""
+    node = _build_node(
+        monkeypatch,
+        [
+            _response("", FIRST_USAGE, [{"name": "safe_tool", "args": {}, "id": "call-1"}]),
+            _response("done", SECOND_USAGE, []),
+        ],
+    )
+
+    await node.run(executor_state)
+
+    records = [call.args[0] for call in usage_recorder.await_args_list]
+    assert [r.input_tokens for r in records] == [10, 5]
+    assert [r.output_tokens for r in records] == [20, 7]
+    assert [r.total_tokens for r in records] == [30, 12]
+
+
+@pytest.mark.asyncio
+async def test_executor_single_iteration_usage_unchanged(
+    monkeypatch, executor_state, usage_recorder
+):
+    """단일 iteration 경로의 값은 그대로여야 한다(누적 도입으로 이중 계산 금지)."""
+    node = _build_node(monkeypatch, [_response("done", FIRST_USAGE, [])])
+
+    result = await node.run(executor_state)
+
+    usage = result["token_usage"]["Executor"]
+    assert usage["call_count"] == 1
+    assert usage["total_input_tokens"] == 10
+    assert usage["total_output_tokens"] == 20
+    assert usage["total_tokens"] == 30

--- a/tests/backend/test_parallel_executor_merge.py
+++ b/tests/backend/test_parallel_executor_merge.py
@@ -1,0 +1,82 @@
+"""ParallelExecutorNode 결과 병합 회귀 테스트 (issue #273).
+
+병렬 브랜치가 만든 `agents` 상태가 병합 결과에 남는지 검증한다.
+checkpointer 도입 시 반환되지 않은 키는 채널에 반영되지 않아 유실된다.
+"""
+
+from models.agent_state import (
+    AgentInfo,
+    AgentRole,
+    TaskNode,
+    TaskStatus,
+    create_initial_state,
+)
+from orchestrator.parallel_executor import ParallelExecutorNode
+
+
+def _executor_agent(task_id: str) -> AgentInfo:
+    """ExecutorNode(`nodes/executor.py`)와 같은 규칙으로 agent id 를 만든다."""
+    return AgentInfo(
+        id=f"executor-{task_id[:8]}",
+        role=AgentRole.EXECUTOR,
+        name=f"Executor for {task_id}",
+        status=TaskStatus.COMPLETED,
+        current_task=task_id,
+    )
+
+
+def _branch_result(task_id: str) -> dict:
+    """단일 브랜치(ExecutorNode.run)의 반환 형태를 모사한다."""
+    agent = _executor_agent(task_id)
+    return {
+        "task_id": task_id,
+        "result": {
+            "tasks": {task_id: TaskNode(id=task_id, title=task_id, status=TaskStatus.COMPLETED)},
+            "agents": {agent.id: agent},
+            "messages": [],
+        },
+    }
+
+
+def test_merge_results_preserves_agents_from_every_branch():
+    """각 병렬 브랜치의 agent 가 병합 결과에 모두 남아야 한다."""
+    node = ParallelExecutorNode(llm=None, tools=[])
+    state = create_initial_state(session_id="session-merge")
+
+    merged = node._merge_results(
+        [_branch_result("task-a1"), _branch_result("task-b2")],
+        state,
+    )
+
+    assert set(merged["agents"]) == {"executor-task-a1", "executor-task-b2"}
+    assert merged["agents"]["executor-task-a1"].current_task == "task-a1"
+    assert merged["agents"]["executor-task-b2"].current_task == "task-b2"
+
+
+def test_merge_results_keeps_agents_already_in_state():
+    """다른 노드가 등록한 기존 agent 는 병합으로 지워지지 않아야 한다."""
+    node = ParallelExecutorNode(llm=None, tools=[])
+    state = create_initial_state(session_id="session-merge")
+    planner = AgentInfo(id="planner-1", role=AgentRole.PLANNER, name="Planner")
+    state["agents"]["planner-1"] = planner
+
+    merged = node._merge_results([_branch_result("task-a1")], state)
+
+    assert merged["agents"]["planner-1"] is planner
+    assert "executor-task-a1" in merged["agents"]
+
+
+def test_merge_results_handles_branch_without_agents():
+    """agents 키가 없는 브랜치 결과(조기 반환 경로)도 병합을 깨뜨리지 않는다."""
+    node = ParallelExecutorNode(llm=None, tools=[])
+    state = create_initial_state(session_id="session-merge")
+
+    merged = node._merge_results(
+        [
+            {"task_id": "task-a1", "result": {"last_error": "No valid task to execute"}},
+            _branch_result("task-b2"),
+        ],
+        state,
+    )
+
+    assert set(merged["agents"]) == {"executor-task-b2"}


### PR DESCRIPTION
2026-06-09 하네스 감사에서 나온 P2 결함 2건을 수정합니다. 둘 다 기계적 수정이라 한 PR로 묶었습니다 (동작 변경이 있는 #274 는 별도 PR).

## #273 — `_merge_results` 가 `agents` 를 병합하지 않음

`ParallelExecutorNode._merge_results` 가 `tasks`/`messages`/`errors` 만 병합하고 `agents` 는 반환 state 에 넣지 않았습니다. 현재는 `_execute_with_semaphore` 의 `task_state = dict(state)` 가 shallow copy 라 브랜치들이 같은 dict 를 in-place 로 갱신해 증상이 가려져 있지만, checkpointer 를 도입하면 반환되지 않은 키는 채널에 반영되지 않아 병렬 브랜치의 agent 상태가 유실됩니다.

**충돌 정책**: last-write-wins per agent id. `ExecutorNode` 가 agent id 를 task id 에서 파생하므로(`executor-{task_id[:8]}`, `nodes/executor.py:242`) 병렬 브랜치의 키는 서로소이고 실질 충돌이 없습니다. id 규칙이 바뀌면 이 병합도 재검토해야 한다는 주석을 남겼습니다.

## #275 — Executor 멀티 iteration 토큰이 반환 state 에서 유실됨

`_extract_and_update_tokens`(`nodes/base.py:165`)는 넘겨받은 state 의 누계 위에 이번 회차를 더해 **새 dict** 를 돌려주는 함수형 갱신자입니다. 루프가 매 회차 같은 `state` 를 넘기고 있어 반환값이 항상 "원래 누계 + 이번 회차"였고, 이를 `=` 로 덮어써 반환 state 에는 마지막 iteration 분만 남았습니다.

수정은 대입 연산자가 아니라 **입력 기준선을 회차마다 굴리는 것**입니다.

**범위**: 원장(`_record_token_update_usage`)은 회차 델타(`_last_token_update`)를 읽으므로 기존에도 정상이었고 이번 변경으로도 바뀌지 않습니다. 이를 증명하기 위해 원본 `state` 를 계속 넘기고, ledger 델타 검증 테스트를 함께 넣었습니다.

## 테스트

회귀 테스트 7건 추가.

- `tests/backend/test_parallel_executor_merge.py` (3건) — 브랜치별 agent 보존, 기존 state agent 보존, `agents` 키 없는 조기 반환 경로
- `tests/backend/test_executor_token_accumulation.py` (4건) — 2 iteration 누계 정확값, `total_cost` == ledger 합, ledger 회차 델타(비회귀 경계), 단일 iteration 불변

Red-Green 확인:

| 단계 | 결과 |
|---|---|
| 수정 전 | #273 `KeyError: 'agents'` / #275 `call_count 1 != 2`, `total_cost 0.00012` vs ledger 합 `0.00045` |
| 수정 후 | 7 passed |

ledger 검증 2건은 수정 전에도 통과했습니다 — 실패를 잡는 테스트가 아니라 **원장이 누계로 바뀌어 이중 집계되는 사고를 막는 경계선**입니다.

## 검증

| 항목 | 결과 |
|---|---|
| `ruff check` / `ruff format --check` | 위반 0개 / 316 files formatted |
| `mypy . --ignore-missing-imports` | Success: no issues found in 317 source files |
| `pytest ../../tests/backend` | 1420 passed, 2 skipped, 1 failed |
| Codex review (`--scope branch --base main`) | 지적 0건 |

pytest 실패 1건은 `test_rag_verification.py::test_embedding_model_consistency` 로, 로컬 `.env:95` 의 `RAG_EMBEDDING_MODEL=intfloat/multilingual-e5-base` 오버라이드가 원인입니다. CI 는 `BAAI/bge-m3` 로 통과하며 이 변경과 무관합니다.

Closes #273
Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJU6daSKzCZjRGUbXxjJuF