### PR TITLE
docs(architecture): LeadOrchestrator 분석 결과의 전파 경로를 명시 (#276)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,6 +286,30 @@ class LeadOrchestratorAgent(BaseAgent):
 - `medium`: 중간 복잡도 (4-6)
 - `thorough`: 복잡한 태스크 (7-10)
 
+### LeadOrchestrator 분석 결과의 전파 경로
+
+`LeadOrchestratorAgent` 의 태스크 분석 결과는 **두 갈래로 나뉘어 흐르며, 갈래마다 도달 범위가 다르다.**
+
+| 산출물 | 경로 | 도달 지점 |
+|--------|------|-----------|
+| `execution_plan` | `POST /api/agents/orchestrate/execute-analysis` 가 `plan_metadata.pre_analyzed_execution_plan` 으로 주입(`api/agents/orchestrate.py:467`) | `PlannerNode` 가 읽어 LLM 계획 수립을 건너뛴다(`orchestrator/nodes/planner.py:229`) |
+| `safety_flags` | Claude Code CLI 프롬프트의 `## Safety Warnings` 섹션 생성 | `services/tmux_service.py:639 build_claude_prompt` 와 그 프론트엔드 포팅 `src/dashboard/src/stores/agents.ts:205 buildClaudePrompt` |
+
+즉 노드 그래프와 LeadOrchestrator 는 **직접 import 가 없을 뿐**(`grep -rn "LeadOrchestrator" src/backend/orchestrator` → 0건)
+`plan_metadata` 를 경유해 이미 결합돼 있다. 심볼 grep 은 이 데이터 경유 결합을 잡지 못하므로
+"두 서브시스템은 무관하다"고 결론내지 말 것.
+
+**전파되지 않는 것은 `safety_flags` 하나다.** 주입 코드가 `entry.analysis.get("execution_plan", {})`
+만 넘기므로 flags 는 노드 그래프에 도달하지 않는다.
+
+노드 그래프의 위험 판단은 `safety_flags` 가 아니라 HITL 승인 게이트가 담당한다 —
+`orchestrator/nodes/executor.py` 의 `_check_approval_required` 가 `models/hitl.py` 의
+`assess_operation_risk`(`TOOL_RISK_CONFIG` 기반)를 호출한다. 따라서 **노드 그래프에
+`safety_flags` 가 없다는 사실이 승인 게이트 부재를 뜻하지 않는다.**
+
+flags 를 노드에 전파하는 것 자체는 기존 주입 경로에 키를 추가하는 작은 변경이다.
+설계가 필요한 부분은 전파가 아니라 **노드가 flags 를 위험 판단에 어떻게 반영할지**다.
+
 ## MCP Service
 
 ```python


### PR DESCRIPTION
사용자 결정에 따라 **A안(문서화 후 종료)** 으로 처리합니다. 문서 없이 이슈만 닫으면 다음 감사에서 같은 항목이 재등록되므로, 계약을 `docs/architecture.md` 에 고정합니다.

## 이슈 기술의 두 단계 정정

이 항목은 등록 후 두 번 정정됐습니다.

| 시점 | 기술 | 문제 |
|---|---|---|
| 2026-06-09 등록 | "lead_orchestrator 가 산출한 safety_flags 를 노드가 읽지 않는다" | 노드가 값을 받고도 무시한다는 뉘앙스 — 사실이 아님 |
| 2026-08-18 재조사 | "두 개의 별개 서브시스템이다" | `grep LeadOrchestrator src/backend/orchestrator` → 0건을 근거로 삼음 |
| **이번 실측** | "`execution_plan` 은 전파되고 `safety_flags` 만 전파되지 않는다" | 심볼 grep 은 **직접 import 부재**만 뜻함 |

두 번째 기술도 과장이었습니다. 실제로는 API 핸들러가 state 에 값을 주입하고 노드가 그 키를 읽는 **데이터 경유 결합**이 이미 존재하며, 이런 결합은 심볼 grep 에 걸리지 않습니다.

## 실측한 전파 경로

| 산출물 | 경로 | 도달 지점 |
|---|---|---|
| `execution_plan` | `POST /api/agents/orchestrate/execute-analysis` 가 `plan_metadata.pre_analyzed_execution_plan` 으로 주입 (`api/agents/orchestrate.py:467`) | `PlannerNode` 가 읽어 LLM 계획 수립을 건너뜀 (`orchestrator/nodes/planner.py:229`) |
| `safety_flags` | Claude Code CLI 프롬프트의 `## Safety Warnings` 섹션 생성 | `services/tmux_service.py:639 build_claude_prompt`, 그 프론트엔드 포팅 `src/dashboard/src/stores/agents.ts:205 buildClaudePrompt` |

주입 코드가 `entry.analysis.get("execution_plan", {})` 만 넘기므로 `safety_flags` 는 노드 그래프에 도달하지 않습니다.

또한 노드 그래프의 위험 판단은 `safety_flags` 가 아니라 HITL 승인 게이트(`_check_approval_required` → `assess_operation_risk`)가 담당하므로, **flags 부재가 승인 게이트 부재를 뜻하지 않습니다.**

마지막으로 "노드에 반영하려면 아키텍처 변경이 필요하다"는 이슈 본문의 결론도 완화했습니다. 주입 경로가 이미 있으므로 전파 자체는 키 추가로 되는 작은 변경이고, 설계가 필요한 것은 **노드가 flags 를 위험 판단에 어떻게 쓸지** 입니다.

## 검증

Codex review (`--scope branch --base main`) 2회.

1회차에서 두 건을 지적받아 모두 실측 후 반영했습니다.

- 대시보드 소비처를 "분석 표시"로 적었으나 실제로는 `buildClaudePrompt` 의 프롬프트 생성 경로 → 정정
- "별개 서브시스템"이라는 단정이 과함, `pre_analyzed_execution_plan` 경유 결합이 존재 → 정정

2회차: "The patch only adds architecture documentation, and the documented data flow matches the current implementation." 지적 0건.

문서 변경만이므로 코드 게이트(ruff/mypy/pytest)는 해당 없음.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJU6daSKzCZjRGUbXxjJuF
