### PR TITLE
fix(session): DB에서 읽은 state의 도메인 모델 복원 (#281)

### DIFF
--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -15,6 +15,7 @@ from db.models import (
     SessionModel,
     TaskModel,
 )
+from models.agent_state import AgentInfo, TaskNode
 from utils.time import utcnow
 
 
@@ -50,6 +51,36 @@ def serialize_state(state: dict[str, Any]) -> dict[str, Any]:
         else:
             serialized[key] = serialize_value(value)
     return serialized
+
+
+def deserialize_state(state: dict[str, Any]) -> dict[str, Any]:
+    """Restore domain models from a JSON state dict (inverse of serialize_state).
+
+    `state_json` 은 JSON 이므로 읽어오면 `tasks`/`agents` 값이 raw dict 다.
+    노드들은 `task.status` 처럼 속성으로 접근하므로 여기서 모델로 되돌리지 않으면
+    캐시 미스·프로세스 재시작 시 오케스트레이션이 AttributeError 로 깨진다.
+
+    복원할 값이 없으면 입력을 그대로 돌려준다. in-memory 저장 경로는 이미 모델을
+    담고 있는데, 거기서 복사본을 만들면 반환된 state 를 직접 수정하는 호출자
+    (`api/hitl.py` 등)의 변경이 저장된 세션에 반영되지 않는다.
+    """
+    restored: dict[str, Any] | None = None
+
+    for key, model in (("tasks", TaskNode), ("agents", AgentInfo)):
+        value = state.get(key)
+        if not isinstance(value, dict):
+            continue
+        if not any(isinstance(item, dict) for item in value.values()):
+            continue  # 이미 전부 모델 — 복사할 이유가 없다
+
+        if restored is None:
+            restored = dict(state)
+        restored[key] = {
+            item_id: (model.model_validate(item) if isinstance(item, dict) else item)
+            for item_id, item in value.items()
+        }
+
+    return restored if restored is not None else state
 
 
 class SessionRepository:

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -63,6 +63,9 @@ def deserialize_state(state: dict[str, Any]) -> dict[str, Any]:
     복원할 값이 없으면 입력을 그대로 돌려준다. in-memory 저장 경로는 이미 모델을
     담고 있는데, 거기서 복사본을 만들면 반환된 state 를 직접 수정하는 호출자
     (`api/hitl.py` 등)의 변경이 저장된 세션에 반영되지 않는다.
+
+    모델이 모르는 필드는 `extra="allow"`(TaskNode·AgentInfo·StructuredError)로
+    보존된다 — 버리면 다음 저장 때 `model_dump()` 결과가 쓰여 영구 삭제된다.
     """
     restored: dict[str, Any] | None = None
 

--- a/src/backend/models/agent_state.py
+++ b/src/backend/models/agent_state.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, TypedDict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from utils.time import utcnow
 
@@ -36,6 +36,11 @@ class AgentRole(str, Enum):
 class AgentInfo(BaseModel):
     """Information about an individual agent."""
 
+    # 세션 state 는 JSON 으로 영속화되고 다시 모델로 복원된다. extra 를 버리면
+    # 구/신 버전이 남긴 필드가 복원→저장 왕복에서 영구 삭제되므로 보존한다
+    # (`db/repository.py` 의 serialize_state/deserialize_state 짝).
+    model_config = ConfigDict(extra="allow")
+
     id: str
     role: AgentRole
     name: str
@@ -47,6 +52,9 @@ class AgentInfo(BaseModel):
 
 class TaskNode(BaseModel):
     """A node in the task tree."""
+
+    # AgentInfo 와 같은 이유로 extra 를 보존한다 — 상세는 그쪽 주석 참조.
+    model_config = ConfigDict(extra="allow")
 
     id: str
     parent_id: str | None = None

--- a/src/backend/models/errors.py
+++ b/src/backend/models/errors.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from utils.time import utcnow
 
@@ -139,6 +139,10 @@ class StructuredError(BaseModel):
             elif error.category == ErrorCategory.TRANSIENT:
                 # Simple retry without LLM
     """
+
+    # TaskNode.structured_errors 로 세션 state 에 실려 영속화된다. 중첩 모델도
+    # extra 를 보존해야 왕복에서 미지 필드가 사라지지 않는다.
+    model_config = ConfigDict(extra="allow")
 
     category: ErrorCategory
     severity: ErrorSeverity

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -9,7 +9,13 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from db.database import async_session_factory
-from db.repository import ApprovalRepository, MessageRepository, SessionRepository, TaskRepository
+from db.repository import (
+    ApprovalRepository,
+    MessageRepository,
+    SessionRepository,
+    TaskRepository,
+    deserialize_state,
+)
 from models.agent_state import AgentState, create_initial_state, migrate_state
 from models.project import Project
 from utils.time import utcnow
@@ -184,6 +190,12 @@ class SessionService:
 
         # Migrate from older schema versions if needed
         state = migrate_state(state)
+
+        # DB 경로는 JSON 을 돌려주므로 tasks/agents 가 raw dict 다. 노드들은
+        # `task.status` 처럼 속성으로 접근하므로 여기서 모델로 되돌린다.
+        # 저장 백엔드를 추상화하는 유일한 관문이라 memory 경로에도 함께 적용한다
+        # (이미 모델이면 그대로 통과 — deserialize_state 는 재적용에 안전).
+        state = deserialize_state(state)
 
         # Restore or create metadata
         metadata = self._session_metadata.get(session_id)

--- a/tests/backend/test_session_service.py
+++ b/tests/backend/test_session_service.py
@@ -13,6 +13,7 @@ from models.agent_state import (
     TaskStatus,
     create_initial_state,
 )
+from models.errors import ErrorCategory, ErrorSeverity, StructuredError
 from models.project import Project
 from orchestrator.nodes.orchestrator import OrchestratorNode
 from services.session_service import (
@@ -704,3 +705,84 @@ class TestSessionStateRehydration:
         got = await service.get_session(sid)
 
         assert got is service._memory_sessions[sid]
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_fields_survive_read_modify_write(self, monkeypatch):
+        """미지 필드가 read→modify→write 왕복에서 지워지면 안 된다.
+
+        `TaskNode` 는 extra="ignore"(Pydantic 기본)라 model_validate 가 모르는 키를
+        버린다. 복원 후 다시 저장하면 `model_dump()` 결과가 쓰이므로 그 키는 영구
+        삭제된다. `engine.cancel` 처럼 노드를 돌리지 않는 read-modify-write 경로가
+        실제로 있어 가정이 아니다.
+        """
+        state = create_initial_state(session_id="s1")
+        state["tasks"]["t1"] = _full_task()
+        raw = serialize_state(state)
+        raw["tasks"]["t1"]["future_field"] = "keep me"
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+
+        restored["next_action"] = None  # 무관한 필드 수정
+        written = serialize_state(restored)
+
+        assert written["tasks"]["t1"].get("future_field") == "keep me"
+
+    @pytest.mark.asyncio
+    async def test_task_with_unknown_fields_is_still_a_model(self, monkeypatch):
+        """미지 필드가 있어도 모델로 복원된다.
+
+        `OrchestratorNode` 는 `tasks.values()` 전체를 순회하며 `t.status` 를 읽으므로
+        raw dict 를 하나라도 남기면 세션 전체 실행이 멈춘다. extra 보존은 모델
+        설정(`extra="allow"`)이 맡고, 복원 경로는 예외를 두지 않는다.
+        """
+        state = create_initial_state(session_id="s1")
+        state["tasks"]["t1"] = _full_task()
+        raw = serialize_state(state)
+        raw["tasks"]["t1"]["future_field"] = "keep me"
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+
+        assert isinstance(restored["tasks"]["t1"], TaskNode)
+
+    @pytest.mark.asyncio
+    async def test_unknown_agent_fields_survive_read_modify_write(self, monkeypatch):
+        """agents 도 같은 정책을 따른다."""
+        state = create_initial_state(session_id="s1")
+        state["agents"]["executor-t1"] = _full_agent()
+        raw = serialize_state(state)
+        raw["agents"]["executor-t1"]["future_field"] = "keep me"
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+        written = serialize_state(restored)
+
+        assert written["agents"]["executor-t1"].get("future_field") == "keep me"
+
+    @pytest.mark.asyncio
+    async def test_unknown_fields_inside_structured_errors_survive(self, monkeypatch):
+        """중첩 모델(TaskNode.structured_errors)의 미지 필드도 왕복에서 살아남는다.
+
+        최상위 키만 검사해서는 닿을 수 없는 지점이다 — `structured_errors` 는 알려진
+        필드라 통과하고, 그 안의 StructuredError 가 extra 를 버리면 조용히 사라진다.
+        """
+        state = create_initial_state(session_id="s1")
+        task = TaskNode(id="t1", title="t")
+        task.structured_errors = [
+            StructuredError(
+                category=ErrorCategory.TRANSIENT,
+                severity=ErrorSeverity.MEDIUM,
+                message="boom",
+                original_type="RuntimeError",
+            )
+        ]
+        state["tasks"]["t1"] = task
+        raw = serialize_state(state)
+        raw["tasks"]["t1"]["structured_errors"][0]["future_field"] = "keep me"
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+        written = serialize_state(restored)
+
+        assert written["tasks"]["t1"]["structured_errors"][0].get("future_field") == "keep me"

--- a/tests/backend/test_session_service.py
+++ b/tests/backend/test_session_service.py
@@ -2,10 +2,19 @@
 
 import pytest
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from utils.time import utcnow
+from db.repository import serialize_state
+from models.agent_state import (
+    AgentInfo,
+    AgentRole,
+    TaskNode,
+    TaskStatus,
+    create_initial_state,
+)
 from models.project import Project
+from orchestrator.nodes.orchestrator import OrchestratorNode
 from services.session_service import (
     SessionMetadata,
     SessionService,
@@ -533,3 +542,165 @@ class TestGlobalServiceHelpers:
         custom = SessionService(use_database=False)
         set_session_service(custom)
         assert get_session_service() is custom
+
+
+# ---------------------------------------------------------------------------
+# DB round-trip: state rehydration (issue #281)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSessionFactory:
+    """`async with async_session_factory() as db:` 를 모사한다."""
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return MagicMock()
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+def _full_task() -> TaskNode:
+    """기본값과 구분되도록 모든 필드를 채운 TaskNode."""
+    return TaskNode(
+        id="t1",
+        parent_id="root",
+        title="risky step",
+        description="do the thing",
+        status=TaskStatus.WAITING,
+        assigned_agent="executor-t1",
+        children=["t2"],
+        result={"summary": "partial"},
+        pending_approval_id="approval-1",
+        retry_count=1,
+        max_retries=5,
+        error_history=["boom"],
+        pause_reason="waiting on user",
+    )
+
+
+def _full_agent() -> AgentInfo:
+    return AgentInfo(
+        id="executor-t1",
+        role=AgentRole.EXECUTOR,
+        name="Executor #1",
+        status=TaskStatus.IN_PROGRESS,
+        current_task="t1",
+        capabilities=["read_file", "execute_bash"],
+    )
+
+
+def _db_service_returning(raw_state: dict, monkeypatch) -> SessionService:
+    """`get_state` 가 raw JSON 을 돌려주는 DB 모드 SessionService 를 만든다."""
+    repo = MagicMock()
+    repo.get_state = AsyncMock(return_value=raw_state)
+    monkeypatch.setattr("services.session_service.SessionRepository", MagicMock(return_value=repo))
+    monkeypatch.setattr("services.session_service.async_session_factory", _FakeSessionFactory())
+    return SessionService(use_database=True)
+
+
+class TestSessionStateRehydration:
+    """DB 에서 읽은 state 가 도메인 모델로 복원되는지 (issue #281).
+
+    저장은 `serialize_state` 가 모델을 JSON 으로 바꾸지만 읽기 경로에는 역변환이
+    없었다. 캐시 미스·프로세스 재시작 시 `tasks` 값이 raw dict 로 남아
+    `task.status` 를 읽는 모든 노드가 AttributeError 로 깨진다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_session_restores_task_nodes(self, monkeypatch):
+        state = create_initial_state(session_id="s1")
+        state["tasks"]["t1"] = _full_task()
+        raw = serialize_state(state)
+        assert isinstance(raw["tasks"]["t1"], dict), "저장 시점에는 dict 여야 한다(전제)"
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+
+        assert isinstance(restored["tasks"]["t1"], TaskNode)
+
+    @pytest.mark.asyncio
+    async def test_get_session_restores_agent_info(self, monkeypatch):
+        state = create_initial_state(session_id="s1")
+        state["agents"]["executor-t1"] = _full_agent()
+        raw = serialize_state(state)
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+
+        assert isinstance(restored["agents"]["executor-t1"], AgentInfo)
+
+    @pytest.mark.asyncio
+    async def test_restored_task_preserves_every_field(self, monkeypatch):
+        original = _full_task()
+        state = create_initial_state(session_id="s1")
+        state["tasks"]["t1"] = original
+        raw = serialize_state(state)
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+
+        assert restored["tasks"]["t1"].model_dump() == original.model_dump()
+
+    @pytest.mark.asyncio
+    async def test_restored_agent_preserves_every_field(self, monkeypatch):
+        original = _full_agent()
+        state = create_initial_state(session_id="s1")
+        state["agents"]["executor-t1"] = original
+        raw = serialize_state(state)
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+
+        assert restored["agents"]["executor-t1"].model_dump() == original.model_dump()
+
+    @pytest.mark.asyncio
+    async def test_restored_state_drives_orchestrator(self, monkeypatch):
+        """이슈가 말하는 실제 증상: 복원 없이는 오케스트레이션이 멈춘다.
+
+        `OrchestratorNode` 는 `t.status` 로 다음 태스크를 고른다(orchestrator.py:77).
+        raw dict 면 이 접근에서 AttributeError 가 난다.
+        """
+        state = create_initial_state(session_id="s1")
+        state["tasks"]["root"] = TaskNode(
+            id="root", title="root", status=TaskStatus.IN_PROGRESS, children=["t1"]
+        )
+        state["tasks"]["t1"] = TaskNode(id="t1", parent_id="root", title="child")
+        state["root_task_id"] = "root"
+        raw = serialize_state(state)
+
+        service = _db_service_returning(raw, monkeypatch)
+        restored = await service.get_session("s1")
+
+        out = await OrchestratorNode(llm=None).run(restored)
+
+        assert out["next_action"] == "execute"
+        assert out["current_task_id"] == "t1"
+
+    @pytest.mark.asyncio
+    async def test_rehydration_is_idempotent(self, monkeypatch):
+        """이미 모델인 state 를 통과시켜도 그대로 유지된다."""
+        state = create_initial_state(session_id="s1")
+        state["tasks"]["t1"] = _full_task()
+
+        service = _db_service_returning(state, monkeypatch)
+        restored = await service.get_session("s1")
+
+        assert isinstance(restored["tasks"]["t1"], TaskNode)
+        assert restored["tasks"]["t1"].model_dump() == state["tasks"]["t1"].model_dump()
+
+    @pytest.mark.asyncio
+    async def test_memory_path_returns_the_stored_state_object(self):
+        """in-memory 경로는 저장된 state 객체를 그대로 돌려줘야 한다.
+
+        호출자(api/hitl.py 등)가 반환된 state 를 직접 수정하는 코드가 있어,
+        복원 단계가 무조건 복사본을 만들면 그 수정이 저장된 세션에 반영되지 않는다.
+        """
+        service = SessionService(use_database=False)
+        sid = await service.create_session()
+
+        got = await service.get_session(sid)
+
+        assert got is service._memory_sessions[sid]


### PR DESCRIPTION
세션 state 를 저장할 때는 `serialize_state` 가 Pydantic 모델을 JSON 으로 바꾸지만, 읽기 경로에 역변환이 없어 캐시 미스·프로세스 재시작 시 오케스트레이션이 깨지던 문제를 고칩니다.

## 결함

```python
# src/backend/db/repository.py — 저장은 직렬화
serialized = serialize_state(state)          # TaskNode → dict

# 읽기는 raw JSON 그대로
async def get_state(self, session_id):
    return session.state_json                # dict 인 채로 반환
```

`SessionService.get_session` 도 `migrate_state`(누락 키 채우기)만 거칠 뿐 모델을 복원하지 않습니다. 노드들은 `task.status` 처럼 속성으로 접근하므로 오케스트레이션이 멈춥니다.

RED 단계에서 이슈가 기술한 증상이 그대로 재현됐고, 실제로는 이슈에 적은 `orchestrator.py:77` 보다 **앞선 지점**에서 먼저 터집니다:

```
orchestrator/nodes/orchestrator.py:67: in run
    if root_task.status == TaskStatus.COMPLETED:
E   AttributeError: 'dict' object has no attribute 'status'
```

`OrchestrationEngine._sessions` in-memory 캐시가 같은 프로세스 안에서는 모델을 유지해 증상을 가리고 있었습니다. 영향은 HITL 경로에 한정되지 않습니다 — `task.status` 를 읽는 모든 노드가 대상입니다.

## 수정

**1. `deserialize_state` 추가** (`serialize_state` 와 같은 파일, 짝으로 유지)

`tasks` → `TaskNode`, `agents` → `AgentInfo`. 중첩 `structured_errors` 는 `model_validate` 가 처리합니다.

**2. 복원 호출은 `SessionService.get_session` 에**

`db/repository.py` 에 두면 "DB 백엔드는 복원한다 + memory 백엔드는 원래 모델이다"라는 **두 개의 우연한 사실**에 계약이 의존합니다. `get_session` 은 두 저장 백엔드를 추상화하는 단일 관문이라, 여기 두면 "반환되는 state 는 모델을 담는다"가 백엔드와 무관하게 한 곳에서 보장됩니다.

배치는 취향이 아니라 import 방향으로 결정했습니다 — `models/agent_state.py` 는 `db.*` 를 참조하지 않아(0건) 순환이 없고, 따라서 `try/except ImportError` 폴백 없이 모듈 최상단 import 가 가능합니다.

**3. 복원할 raw dict 가 없으면 입력 객체를 그대로 반환**

무조건 새 dict 를 만들면 반환된 state 를 직접 수정하는 호출자(`api/hitl.py` 가 `state["pending_approvals"]` 를 갱신)의 변경이 in-memory 저장 세션에 반영되지 않습니다. `is` 비교 테스트가 없었다면 값 비교 테스트를 전부 통과한 채 지나갔을 회귀입니다.

**4. `extra="allow"` — `TaskNode` · `AgentInfo` · `StructuredError`**

복원 도입이 새 파괴 경로를 만들었습니다. 모델이 모르는 키를 `model_validate` 가 버리고, 다음 저장 때 `model_dump()` 결과가 쓰여 **영구 삭제**됩니다. 수정 전에는 raw dict 가 `serialize_value` 를 통과해 보존됐습니다. `engine.cancel`(`engine.py:527-531`)처럼 노드를 돌리지 않는 read-modify-write 경로가 실제로 있어 가정이 아닙니다.

`model_dump(mode="json")` 이 extra 를 포함해 왕복이 무손실임을 실측했고, `structured_errors` 같은 중첩 모델까지 덮습니다 — 최상위 키만 검사하는 방식으로는 구조적으로 닿을 수 없는 지점입니다.

### 폐기한 대안: "미지 키가 있는 항목은 raw 로 남기기"

먼저 구현했다가 되돌렸습니다. `OrchestratorNode` 는 `tasks.values()` **전체**를 순회하며 `t.status` 를 읽으므로(`orchestrator.py:74-78`), raw 항목이 하나만 있어도 **세션 전체 실행이 멈춥니다.** 데이터를 지키고 서비스를 잃는 거래였습니다.

### `extra="allow"` 의 잔여 비용 (의도적 수용)

| 비용 | 평가 |
|---|---|
| 직접 생성자가 오타 kwargs 를 거부하지 않음 | 호출 7곳(`planner.py` 4 · `orchestrator.py:94` · `parallel_executor.py:294` · `executor.py:243`) 전부 고정 리터럴 인자이며 거부에 의존하는 로직 없음. mypy 는 `call-arg` 가 래칫에서 비활성이라 어차피 못 잡음 |
| API 응답에 extra 노출 (`api/sessions.py:157·249·335`) | 노출되는 값은 **이 시스템이 저장한 것**이지 사용자 입력이 아니어서 주입·민감정보 경로가 없음. 롤백 배포가 잠깐 여분 키를 반환하는 쪽이, 측정된 대안(영구 데이터 유실)보다 낫다는 판단 |

두 모델은 API 입력 검증에 쓰이지 않습니다(`src/backend/api` 에서 `TaskNode` 0건).

## 테스트

`tests/backend/test_session_service.py` 에 11건 추가(기존 파일에 합류 — 같은 주제의 두 번째 집을 만들지 않음).

| 테스트 | 수정 전 |
|---|---|
| `get_session` 이 `TaskNode` 로 복원 | **FAIL** (dict) |
| `get_session` 이 `AgentInfo` 로 복원 | **FAIL** (dict) |
| 복원된 task 의 모든 필드 보존(`model_dump()` 비교) | **FAIL** (`'dict' object has no attribute 'model_dump'`) |
| 복원된 agent 의 모든 필드 보존 | **FAIL** |
| **복원된 state 로 `OrchestratorNode` 가 다음 태스크를 고름** | **FAIL** (`AttributeError` at `orchestrator.py:67`) |
| in-memory 경로가 저장된 객체를 그대로 반환(`is`) | **FAIL** (내가 도입한 회귀) |
| 미지 필드 read→modify→write 생존 (tasks) | **FAIL** |
| 미지 필드 read→modify→write 생존 (agents) | **FAIL** |
| **중첩 `structured_errors` 의 미지 필드 생존** | **FAIL** |
| 미지 필드가 있어도 모델로 복원 | 계약 고정 |
| 재적용 안전(idempotent) | 계약 고정 |

핵심 증거는 round-trip 이 아니라 **`get_session` 계약**입니다 — `serialize_state → deserialize_state` 왕복 테스트는 새 함수를 자기 자신에 대해 검사하는 것이라 애초에 RED 가 될 수 없습니다.

중첩 테스트는 Red-Green 으로 확인했습니다: `StructuredError` 의 `extra="allow"` 를 빼면 FAIL, 복원하면 PASS.

## 검증

| 항목 | 결과 |
|---|---|
| `ruff check` / `format --check` | 위반 0개 / 316 files formatted |
| `mypy . --ignore-missing-imports` | Success: no issues found in 317 source files |
| `pytest ../../tests/backend` | 1437 passed, 2 skipped, 1 failed |
| Codex adversarial-review | 3라운드 — 아래 |

pytest 실패 1건은 `test_rag_verification.py::test_embedding_model_consistency` 로, 로컬 `.env:95` 의 `RAG_EMBEDDING_MODEL` 오버라이드가 원인입니다. CI 는 `BAAI/bge-m3` 로 통과하며 이 변경과 무관합니다.

## Codex 적대적 검증 3라운드

지적을 전부 코드로 검증했습니다. 반영한 것과 반영하지 않은 것, 그리고 그 이유를 남깁니다.

**반영함**

- 미지 필드 유실 → `extra="allow"`(위 4번). 이 PR 이 만든 새 파괴 경로였고 정당한 지적입니다.
- 중첩 모델 유실 → `StructuredError` 에도 적용 + 왕복 테스트.

**반영하지 않음 (근거)**

- **캐시가 복원을 우회한다** — 캐시 진입점을 전수 확인한 결과 raw dict 가 들어갈 경로가 없습니다: `engine.py:232`(생성 직후, 모델) · `:260`(서비스 경유, 복원됨) · `:494`·`:530`(노드 출력, 모델) · `api/agents/orchestrate.py:471`(`get_session` 결과). 남는 실제 문제는 **만료 검사 우회**이며 이 변경 이전부터 존재합니다 → #284.
- **`ValidationError` 가 세션 전체 로드를 실패시킨다** — 수정 전에도 같은 payload 는 `AttributeError` 로 치명적이었으므로 회귀가 아닙니다. `ValidationError` 를 삼키면 이 수정이 없애려던 조용한 폴백이 되돌아옵니다. 기존 데이터로는 도달 불가합니다: `git log -p --follow` 로 확인한 결과 `TaskNode`/`AgentInfo` 에서 제거·개명된 필드나 삭제된 `TaskStatus`/`AgentRole` enum 값이 없습니다(유일한 `-` 2건은 `datetime.utcnow` → `utcnow` default_factory 교체). 전방 롤백 시나리오에서만 성립하는 가정으로 남깁니다.
- **`structured_errors` 에 dict 를 직접 대입한 혼합 상태** — 그런 대입 지점이 코드베이스에 0건입니다(정의와 `self_correction.py:81` 의 읽기뿐). 이론적 시나리오입니다.
- **`orchestrate.py:471` 이 `plan_metadata` 를 영속화하지 않음** — 사실이나 이 변경과 무관한 기존 결함 → #284 에 함께 기록.
- **"생성자는 `extra="forbid"`, DB 왕복은 별도 envelope"** — 새로 짓는 시스템에는 타당한 설계지만, 버그 수정 PR 에서는 모든 `TaskNode` 생성 지점과 dump 지점을 건드리는 병렬 모델 계층을 도입하는 셈입니다. 막으려는 오타 클래스는 mypy 도 못 잡습니다.

세 라운드가 각각 diff 에서 점점 멀어졌고(1: 이 변경 → 2: 방금 쓴 정책 → 3: `orchestrate.py`·API 응답 형태), Codex 는 세 라운드 모두 테스트를 실행하지 못했다고 보고했습니다(환경 문제). 이 지점에서 선을 긋습니다.

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJU6daSKzCZjRGUbXxjJuF
