### PR TITLE
fix(hitl): 승인 완료된 WAITING task 를 실행 대상에 포함 (#282)

### DIFF
--- a/src/backend/models/hitl.py
+++ b/src/backend/models/hitl.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from models.agent_state import TaskNode, TaskStatus
 from utils.time import utcnow
 
 
@@ -124,6 +125,29 @@ DEFAULT_RISK = OperationRisk(
     requires_approval=False,
     description="Unknown operation",
 )
+
+
+def is_task_resumable_after_approval(
+    task: TaskNode,
+    pending_approvals: dict[str, Any],
+) -> bool:
+    """승인이 완료돼 실행을 재개해야 하는 승인 대기 task 인가.
+
+    승인 대기 task 는 `TaskStatus.WAITING` 이라 PENDING 만 보는 스케줄러에서
+    누락된다. 승인 후 그래프를 다시 돌려도 executor 로 돌아가지 못하는 원인이다.
+
+    `APPROVED` 일 때만 True 다 — "PENDING 이 아님"이 아니라 "APPROVED 임"으로
+    판정한다. DENIED/EXPIRED/PENDING, 승인 레코드 부재, `pending_approval_id`
+    부재는 모두 False.
+    """
+    if task.status != TaskStatus.WAITING or not task.pending_approval_id:
+        return False
+
+    approval = pending_approvals.get(task.pending_approval_id)
+    if not approval:
+        return False
+
+    return bool(approval.get("status") == ApprovalStatus.APPROVED.value)
 
 
 def get_tool_risk(tool_name: str) -> OperationRisk:

--- a/src/backend/orchestrator/graph.py
+++ b/src/backend/orchestrator/graph.py
@@ -20,7 +20,11 @@ async def waiting_node(state: AgentState) -> dict[str, Any]:
     Waiting node for HITL approval.
 
     This node is a passthrough that maintains the waiting state.
-    The graph will be resumed from this point after approval/denial.
+
+    승인/거부 후 그래프는 이 지점이 아니라 진입점(orchestrator)부터 다시 돈다 —
+    checkpointer 가 없어 중단 지점이 보존되지 않는다. 재개된 실행이 승인된 task 를
+    다시 고르는 것은 `OrchestratorNode` 의 선택 조건(WAITING + 승인 APPROVED)이
+    담당한다.
     """
     return {
         "waiting_for_approval": state.get("waiting_for_approval", True),

--- a/src/backend/orchestrator/nodes/orchestrator.py
+++ b/src/backend/orchestrator/nodes/orchestrator.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from models.agent_state import AgentState, TaskNode, TaskStatus
+from models.hitl import is_task_resumable_after_approval
 
 from .base import BaseNode
 
@@ -71,10 +72,18 @@ Respond with a JSON object containing:
                 }
 
             # Find next task to execute (respecting dependencies)
+            # 승인이 끝난 WAITING task 도 실행 대상이다 — 승인 대기 중에는 status 가
+            # PENDING 이 아니라 WAITING 이라, 이 조건이 없으면 승인해도 executor 로
+            # 돌아가지 못하고 그래프가 그대로 끝난다.
+            pending_approvals = state.get("pending_approvals", {})
             pending_tasks = [
                 t
                 for t in tasks.values()
-                if t.status == TaskStatus.PENDING and t.parent_id == root_task_id
+                if t.parent_id == root_task_id
+                and (
+                    t.status == TaskStatus.PENDING
+                    or is_task_resumable_after_approval(t, pending_approvals)
+                )
             ]
 
             # Get dependency map from plan_metadata if available

--- a/src/backend/orchestrator/parallel_executor.py
+++ b/src/backend/orchestrator/parallel_executor.py
@@ -7,6 +7,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import BaseTool
 
 from models.agent_state import AgentState, TaskNode, TaskStatus
+from models.hitl import is_task_resumable_after_approval
 from orchestrator.nodes import BaseNode, ExecutorNode
 from utils.time import utcnow
 
@@ -207,11 +208,18 @@ class ParallelExecutorNode(BaseNode):
         batch_task_ids = state.get("batch_task_ids", [])
         tasks = state.get("tasks", {})
 
-        # Validate batch tasks
+        # Validate batch tasks.
+        # 순차 경로(OrchestratorNode)와 같은 조건을 써야 한다 — 승인이 끝난 WAITING
+        # task 가 배치에 들어와도 여기서 걸러지면 그 task 만 조용히 실행되지 않는다.
+        pending_approvals = state.get("pending_approvals", {})
         valid_task_ids = [
             tid
             for tid in batch_task_ids
-            if tid in tasks and tasks[tid].status == TaskStatus.PENDING
+            if tid in tasks
+            and (
+                tasks[tid].status == TaskStatus.PENDING
+                or is_task_resumable_after_approval(tasks[tid], pending_approvals)
+            )
         ]
 
         if not valid_task_ids:

--- a/tests/backend/test_hitl_approval_resume.py
+++ b/tests/backend/test_hitl_approval_resume.py
@@ -1,0 +1,253 @@
+"""승인 후 재개 라우팅 회귀 테스트 (issue #282).
+
+승인 API 는 `engine.run` 으로 그래프를 재개하지만, 그래프 진입점은 항상
+`OrchestratorNode` 이고 그 노드는 `TaskStatus.PENDING` 인 task 만 실행 대상으로
+골랐다. 승인 대기 task 는 `WAITING`(executor.py 가 유일한 writer)이므로
+승인해도 executor 로 돌아가지 못하고 그래프가 그대로 끝났다.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.agent_state import TaskNode, TaskStatus, create_initial_state
+from models.hitl import ApprovalStatus
+from orchestrator.graph import compile_graph, create_orchestrator_graph
+from orchestrator.nodes.executor import ExecutorNode
+from orchestrator.nodes.orchestrator import OrchestratorNode
+from orchestrator.parallel_executor import ParallelExecutorNode
+
+RISKY_CALL = {"name": "execute_bash", "args": {"command": "rm -rf /tmp/scratch"}, "id": "call-1"}
+
+
+def _response(content: str, tool_calls: list[dict[str, Any]]) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 1, "output_tokens": 1}
+    response.tool_calls = tool_calls
+    return response
+
+
+def _state_with_waiting_task(approval_status: str | None) -> dict[str, Any]:
+    """승인 대기 상태에서 재진입한 state 를 만든다.
+
+    `approval_status` 가 None 이면 승인 레코드 자체가 없는(dangling) 경우다.
+    """
+    state = create_initial_state(session_id="s-resume")
+    state["tasks"]["root"] = TaskNode(
+        id="root", title="root", status=TaskStatus.IN_PROGRESS, children=["t1"]
+    )
+    state["root_task_id"] = "root"
+
+    task = TaskNode(id="t1", parent_id="root", title="risky", status=TaskStatus.WAITING)
+    task.pending_approval_id = "approval-1"
+    state["tasks"]["t1"] = task
+
+    if approval_status is not None:
+        state["pending_approvals"] = {
+            "approval-1": {
+                "id": "approval-1",
+                "task_id": "t1",
+                "tool_name": "execute_bash",
+                "tool_args": RISKY_CALL["args"],
+                "status": approval_status,
+            }
+        }
+    state["waiting_for_approval"] = False  # approve_operation 이 해제한 상태
+    return state
+
+
+class TestOrchestratorResumeSelection:
+    """승인된 WAITING task 를 다시 실행 대상으로 고르는지."""
+
+    @pytest.mark.asyncio
+    async def test_approved_waiting_task_is_routed_to_executor(self):
+        state = _state_with_waiting_task(ApprovalStatus.APPROVED.value)
+
+        out = await OrchestratorNode(llm=None).run(state)
+
+        assert out["next_action"] == "execute"
+        assert out["current_task_id"] == "t1"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status",
+        [
+            ApprovalStatus.PENDING.value,
+            ApprovalStatus.DENIED.value,
+            ApprovalStatus.EXPIRED.value,
+            None,  # 승인 레코드 없음(dangling id)
+        ],
+    )
+    async def test_unapproved_waiting_task_is_not_routed(self, status):
+        """APPROVED 가 아니면 실행 대상이 아니다 — 'PENDING 이 아님' 이 아니라 'APPROVED 임'."""
+        state = _state_with_waiting_task(status)
+
+        out = await OrchestratorNode(llm=None).run(state)
+
+        assert out["next_action"] is None
+        assert out.get("current_task_id") is None
+
+    @pytest.mark.asyncio
+    async def test_waiting_task_without_approval_id_is_not_routed(self):
+        """pending_approval_id 가 없는 WAITING task 는 선택되지 않는다."""
+        state = _state_with_waiting_task(ApprovalStatus.APPROVED.value)
+        state["tasks"]["t1"].pending_approval_id = None
+
+        out = await OrchestratorNode(llm=None).run(state)
+
+        assert out["next_action"] is None
+
+
+class TestParallelExecutorResumeSelection:
+    """병렬 경로도 같은 조건을 따라야 한다."""
+
+    @pytest.mark.asyncio
+    async def test_approved_waiting_task_is_included_in_batch(self, monkeypatch):
+        state = _state_with_waiting_task(ApprovalStatus.APPROVED.value)
+        state["batch_task_ids"] = ["t1"]
+
+        node = ParallelExecutorNode(llm=None, tools=[])
+        executed = AsyncMock(return_value={"task_id": "t1", "result": {}})
+        monkeypatch.setattr(ParallelExecutorNode, "_execute_with_semaphore", executed)
+
+        await node.run(state)
+
+        executed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_denied_waiting_task_is_excluded_from_batch(self, monkeypatch):
+        state = _state_with_waiting_task(ApprovalStatus.DENIED.value)
+        state["batch_task_ids"] = ["t1"]
+
+        node = ParallelExecutorNode(llm=None, tools=[])
+        executed = AsyncMock(return_value={"task_id": "t1", "result": {}})
+        monkeypatch.setattr(ParallelExecutorNode, "_execute_with_semaphore", executed)
+
+        await node.run(state)
+
+        executed.assert_not_awaited()
+
+
+@pytest.fixture
+def graph_env(monkeypatch):
+    """그래프를 부작용 없이 돌리기 위한 공통 패치."""
+    monkeypatch.setattr("orchestrator.nodes.base.record_usage_best_effort", AsyncMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.AuditService.log", MagicMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.audit_task_status_change", MagicMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.audit_tool_executed", MagicMock())
+
+
+def _build_graph(monkeypatch, responses: list[MagicMock]):
+    """실제 orchestrator·executor 를 쓰고 planner/reviewer 는 대역으로 채운 그래프."""
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = AsyncMock(side_effect=responses)
+
+    executor = ExecutorNode(llm=fake_llm, tools=[])
+    monkeypatch.setattr(
+        ExecutorNode,
+        "_resolved_llm_for_state",
+        lambda self, state, **kwargs: (fake_llm, "claude-sonnet-5", None),
+    )
+    execute_tool = AsyncMock(return_value="tool ok")
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", execute_tool)
+
+    async def _reviewer_run(state):
+        """리뷰는 범위 밖 — root 를 완료 처리해 그래프를 끝낸다."""
+        root = state["tasks"][state["root_task_id"]]
+        root.status = TaskStatus.COMPLETED
+        return {"tasks": {root.id: root}}
+
+    planner = MagicMock()
+    planner.run = AsyncMock(return_value={})
+    reviewer = MagicMock()
+    reviewer.run = _reviewer_run
+
+    graph = create_orchestrator_graph(
+        orchestrator_node=OrchestratorNode(llm=None),
+        planner_node=planner,
+        executor_node=executor,
+        reviewer_node=reviewer,
+    )
+    return compile_graph(graph), execute_tool
+
+
+class TestApprovalResumeEndToEnd:
+    """compiled graph 를 실제로 통과하는 승인 왕복."""
+
+    @pytest.mark.asyncio
+    async def test_approved_tool_runs_exactly_once_and_task_completes(
+        self, monkeypatch, graph_env
+    ):
+        """승인 생성 → 승인 → 도구가 정확히 한 번 실행 → task COMPLETED."""
+        compiled, execute_tool = _build_graph(
+            monkeypatch,
+            [
+                _response("", [RISKY_CALL]),  # 1차: 승인 요청하고 멈춤
+                _response("", [RISKY_CALL]),  # 재개: 같은 호출 → 승인 대조 통과
+                _response("done", []),  # 도구 실행 후 마무리
+            ],
+        )
+
+        state = create_initial_state(session_id="s-e2e")
+        state["tasks"]["root"] = TaskNode(
+            id="root", title="root", status=TaskStatus.IN_PROGRESS, children=["t1"]
+        )
+        state["root_task_id"] = "root"
+        state["tasks"]["t1"] = TaskNode(id="t1", parent_id="root", title="risky")
+
+        paused = await compiled.ainvoke(state)
+
+        assert paused["waiting_for_approval"] is True
+        assert paused["tasks"]["t1"].status == TaskStatus.WAITING
+        execute_tool.assert_not_awaited()
+
+        # api/hitl.py 의 approve_operation 이 state 에 가하는 변경
+        approval_id = next(iter(paused["pending_approvals"]))
+        paused["pending_approvals"][approval_id]["status"] = ApprovalStatus.APPROVED.value
+        paused["waiting_for_approval"] = False
+
+        resumed = await compiled.ainvoke(paused)
+
+        execute_tool.assert_awaited_once()
+        assert resumed["tasks"]["t1"].status == TaskStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_second_risky_call_requires_its_own_approval(self, monkeypatch, graph_env):
+        """승인 소비 후 두 번째 위험 호출은 새 승인을 받아야 한다.
+
+        PR #279 의 1회용 소비(`task.pending_approval_id = None`)와 이 변경이
+        맞물리는 지점이다 — 재개 조건이 소비된 승인으로 다시 열리면 안 된다.
+        """
+        second_call = {
+            "name": "execute_bash",
+            "args": {"command": "chmod 777 /tmp/x"},
+            "id": "call-2",
+        }
+        compiled, execute_tool = _build_graph(
+            monkeypatch,
+            [
+                _response("", [RISKY_CALL]),  # 1차: 승인 요청
+                _response("", [RISKY_CALL]),  # 재개: 승인 대조 통과 → 실행
+                _response("", [second_call]),  # 같은 루프에서 두 번째 위험 호출
+            ],
+        )
+
+        state = create_initial_state(session_id="s-e2e-2")
+        state["tasks"]["root"] = TaskNode(
+            id="root", title="root", status=TaskStatus.IN_PROGRESS, children=["t1"]
+        )
+        state["root_task_id"] = "root"
+        state["tasks"]["t1"] = TaskNode(id="t1", parent_id="root", title="risky")
+
+        paused = await compiled.ainvoke(state)
+        approval_id = next(iter(paused["pending_approvals"]))
+        paused["pending_approvals"][approval_id]["status"] = ApprovalStatus.APPROVED.value
+        paused["waiting_for_approval"] = False
+
+        resumed = await compiled.ainvoke(paused)
+
+        assert execute_tool.await_count == 1, "승인받은 호출만 실행돼야 한다"
+        assert resumed["waiting_for_approval"] is True
+        assert resumed["tasks"]["t1"].status == TaskStatus.WAITING


### PR DESCRIPTION
승인 API 가 `resumed: true` 를 반환해도 승인된 도구가 실행되지 않던 문제를 고칩니다. HITL 승인 재개가 실제로는 동작하지 않았습니다.

## 결함: 상태 어휘의 비대칭

승인 API 는 `engine.run` 으로 그래프를 재개하지만 **진입점은 항상 `OrchestratorNode`** 이고, 그 노드는 `TaskStatus.PENDING` 인 task 만 실행 대상으로 골랐습니다.

```python
# src/backend/orchestrator/nodes/orchestrator.py (수정 전)
pending_tasks = [
    t for t in tasks.values()
    if t.status == TaskStatus.PENDING and t.parent_id == root_task_id
]
```

그런데 승인 대기 task 는 `WAITING` 입니다(`executor.py:374` 가 유일한 writer). 따라서 `pending_tasks` 가 비고, `all_children_complete and root_task.children` 도 False 라 review 로도 가지 않고 폴백 반환(`orchestrator.py:142-145`)으로 그래프가 그대로 끝났습니다.

executor 는 승인 대기를 `WAITING` 으로 표현하는데 스케줄러는 `PENDING` 만 "실행 가능"으로 읽은 것 — 어느 쪽도 단독으로는 버그처럼 보이지 않으면서 흐름이 끊겼습니다.

## 수정

**1. 공유 판정 헬퍼** — `models/hitl.py` 의 `is_task_resumable_after_approval`

`APPROVED` 일 때만 True 입니다. **"PENDING 이 아님"이 아니라 "APPROVED 임"** 으로 판정하며, `DENIED`/`EXPIRED`/`PENDING`, 승인 레코드 부재(dangling id), `pending_approval_id` 부재는 모두 False 입니다.

**2. 두 스케줄러가 같은 헬퍼를 사용**

순차(`OrchestratorNode`)와 병렬(`ParallelExecutorNode`) 양쪽에 적용했습니다. 병렬을 범위에 넣은 이유: `parallel_executor.py` 의 `valid_task_ids` 도 `PENDING` 만 필터하므로, 순차만 고치면 `execute_batch` 로 라우팅된 승인 task 가 **그쪽에서 조용히 누락**됩니다. 그리고 WAITING task 를 배치 대상에 넣는 것은 이 수정 자체입니다 — 순차만 고치면 `execute` 에서는 되고 `execute_batch` 에서는 조용히 실패하는 상태로 배포됩니다. 판정 로직을 두 파일에 복제하지 않고 헬퍼로 뽑은 것도 드리프트 방지 목적입니다.

**3. `waiting_node` docstring 정정**

"그래프가 이 지점에서 재개된다"고 적혀 있었으나 사실이 아닙니다 — checkpointer 가 없어 항상 진입점부터 다시 돕니다. 재개 주제의 PR 이므로 함께 정정했습니다.

## 테스트

`tests/backend/test_hitl_approval_resume.py` 10건.

| 테스트 | 수정 전 |
|---|---|
| 승인된 WAITING task → `next_action="execute"` | **FAIL** (`None`) |
| 미승인(PENDING·DENIED·EXPIRED·레코드 없음) → 라우팅 안 됨 | 경계선 (수정 후에도 유지) |
| `pending_approval_id` 없는 WAITING → 라우팅 안 됨 | 경계선 |
| 승인된 WAITING task 가 병렬 배치에 포함 | **FAIL** (제외됨) |
| 거부된 WAITING task 는 배치에서 제외 | 경계선 |
| **E2E: 승인 생성 → 승인 → 도구 정확히 1회 → task COMPLETED** | **FAIL** (도구 0회 실행) |
| **E2E: 두 번째 위험 호출은 새 승인을 요구** | **FAIL** |

E2E 2건은 `create_orchestrator_graph` + `compile_graph` 로 **compiled graph 를 실제로 통과**합니다(LLM·`_execute_tool`·audit 만 대역). 단위 프로브는 결함을 찾을 수는 있어도 흐름이 복원됐음을 증명하지 못하기 때문입니다.

"정확히 한 번"은 승인 **전** `assert_not_awaited()` 와 승인 **후** `assert_awaited_once()` 를 쌍으로 걸어 보장합니다. 두 번째 E2E 는 PR #279 의 1회용 승인 소비(`task.pending_approval_id = None`)와 이 변경이 맞물리는 지점을 고정합니다 — 소비된 승인으로 재개가 다시 열리면 안 됩니다.

## 검증

| 항목 | 결과 |
|---|---|
| `ruff check` / `format --check` | 위반 0개 / 316 files formatted |
| `mypy . --ignore-missing-imports` | Success: no issues found in 317 source files |
| `pytest ../../tests/backend` | 1447 passed, 2 skipped, 1 failed |
| Codex adversarial-review | needs-attention 2건 — 아래 |

pytest 실패 1건은 `test_rag_verification.py::test_embedding_model_consistency` 로, 로컬 `.env:95` 의 `RAG_EMBEDDING_MODEL` 오버라이드가 원인입니다. CI 는 `BAAI/bge-m3` 로 통과하며 이 변경과 무관합니다.

`models/hitl.py` 가 `models/agent_state.py` 를 import 하지만 순환은 없습니다(`agent_state` 의 hitl 참조 0건). Codex 도 실제 import 로 재현되지 않음을 확인했습니다.

## Codex 적대적 검증 (NO-SHIP 판정, 근거를 확인해 진행)

**1. 승인 소비가 원자적·내구적이지 않다 (high)** — 사실이나 **이미 #283 으로 등록된 기존 결함**입니다. 다만 정직하게 적자면, **이 PR 이 재개 경로를 처음 실제로 동작하게 만들므로 #283 의 창이 latent 에서 reachable 로 바뀝니다.** 이는 #283 의 우선순위를 올릴 근거이지 이 PR 을 막을 근거는 아닙니다 — 대안은 다중 워커·도구 실행 중 크래시 같은, 현재 아키텍처가 전제하지 않는 조건에서만 문제되는 동시성 창을 피하려고 HITL 승인을 계속 먹통으로 두는 것입니다.

**2. EXPIRED 승인 task 가 고착된다 (medium)** — **도달 불가**입니다. `ApprovalStatus.EXPIRED` 를 **설정하는 코드가 코드베이스에 0건**입니다(enum 정의뿐). 즉 그 상태는 만들어지지 않으므로 엄격한 `APPROVED`-only 판정은 도달 가능한 상태 전체를 덮습니다. 나중에 EXPIRED writer 를 추가한다면 그때 전이 경로도 함께 넣어야 합니다. 참고로 `DENIED` 는 `deny_operation` 이 task 를 FAILED 로 만들고 `pending_approval_id` 를 지우므로 고착되지 않고, `PENDING` 은 정상 대기 상태이며 승인 목록 API 에 노출됩니다.

Codex 는 이번에도 테스트를 실행하지 못했다고 보고했습니다(임시 디렉터리 제한). compiled graph 를 통과하는 E2E 2건이 그 공백을 메웁니다.

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJU6daSKzCZjRGUbXxjJuF
