### PR TITLE
fix(hitl): 승인 전이·소비를 원자적·내구적으로 (#283)

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -68,6 +68,11 @@ HITL 엔드포인트는 세션 컨텍스트 하에 동작합니다. 승인 요�
 
 **승인 요청 응답 필드**: `approval_id`, `task_id`, `tool_name`, `tool_args`, `risk_level`, `risk_description`, `created_at`, `status`
 
+**승인 상태**: `pending` → `approved` → `consumed`(실제 도구 호출에 사용됨) / `denied` / `expired`.
+목록 조회는 `pending` 만 돌려줍니다. 이미 해소된 승인에 approve/deny 를 다시 호출하면 400 이며,
+같은 승인에 대한 동시 요청은 한 건만 통과합니다(전이는 세션당 직렬화·즉시 영속화).
+승인은 **1회용**이라 소비된 뒤 같은 도구 호출이 다시 나오면 새 승인이 필요합니다.
+
 **승인/거부 요청 본문** (선택 사항):
 ```json
 {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,52 @@ pending → in_progress → completed
                      ↘ waiting → (unblock) → in_progress
 ```
 
+## HITL 승인 생명주기
+
+```
+pending ──(POST /approve)──> approved ──(executor 가 도구 호출과 대조)──> consumed
+   │                                                                        (실행)
+   └────(POST /deny)────> denied ──> task FAILED
+```
+
+승인은 **task 가 아니라 도구 호출에 바인딩**된다(`tool_name` + `tool_args` 대조).
+재진입한 executor 는 LLM 을 다시 호출하므로 승인받은 것과 다른 호출이 나올 수 있고,
+status 만 보고 통과시키면 이전 승인의 권한으로 그 호출이 실행된다.
+
+**at-most-once 보장** — 비가역 도구(`execute_bash` 등)가 같은 승인으로 두 번
+실행되지 않게 하는 세 가지 계약:
+
+| 계약 | 위치 | 없으면 |
+|------|------|--------|
+| 전이의 관문은 하나다 (REST·WebSocket 공용) | `api/hitl.py` 의 `resolve_approval` | WebSocket 경로에 PENDING 검사가 없어 소비된 승인이 다시 `approved` 로 열림 |
+| 전이는 세션 조회부터 저장까지 직렬화된다 | 같은 함수의 루프별 전이 락 | 캐시 미스 동시 요청 두 건이 각자 사본에서 PENDING 을 보고 둘 다 통과 |
+| 전이는 `engine.run` **전에** 영속화된다 | `resolve_approval` → `engine.save_session` | 그래프 실행 실패·프로세스 종료 시 승인이 통째로 사라짐 |
+| 소비(`consumed`)는 도구 실행 **전에** 영속화된다 | `orchestrator/nodes/executor.py` 의 `_consume_approval` | 실행 후 저장 전 종료 시 재시작 후 같은 승인으로 재실행 |
+| 소비는 락 안에서 상태를 다시 확인하는 compare-and-set 이다 | 같은 함수 (`APPROVAL_STATE_LOCK`) | 병렬 배치에서 낡은 스냅샷이 늦게 커밋돼 다른 소비를 `approved` 로 되돌림 |
+| 소비는 승인 레코드를 **제자리에서** 바꾼다 | 같은 함수 | 저장소는 `consumed`, 엔진 캐시는 `approved` 로 갈라져 낡은 캐시가 재승인 |
+| 소비 직전에 **저장소의** 승인 상태를 다시 읽는다 | `_approval_is_claimable_in_storage` | 캐시가 빈 상태에서 겹친 두 실행이 각자 `approved` 사본을 들고 둘 다 실행 |
+| 영속화가 실패하면 전이를 되돌린다 | `resolve_approval` · `_consume_approval` | 캐시 `approved` / 저장소 `pending` 으로 갈려 재시도가 400 — 승인이 영영 해소 불가 |
+| 소비 기록은 엔진이 읽는 저장소에 쓴다 | `ExecutorNode(session_service=...)` (엔진이 주입) | 커스텀 서비스 주입 시 소비가 다른 저장소로 가 재시작 후 승인이 부활 |
+
+소비 기록만 남고 결과가 남지 않은 잔재(실행 도중 종료)는 `OrchestratorNode` 가
+`is_task_orphaned_by_consumed_approval` 로 찾아 **실패로 정리**한다. 실행 여부를 알 수
+없으므로 자동 재개는 하지 않고, 그렇다고 조용히 멈추지도 않는다.
+
+`pending_approvals` 를 반환하지 않는 노드 결과는 그래프 종료 시의 전체 state 저장이
+`consumed` 를 되돌려 놓는다 — executor 의 모든 반환 경로가 이 키를 실어 보내는 이유다.
+
+승인 전이와 소비는 **같은 락**(`models/hitl.py` 의 `APPROVAL_STATE_LOCK`)을 공유한다 —
+둘 다 세션 JSON 전체를 덮어쓰므로 따로 잠그면 서로의 쓰기를 되돌린다. 락 안에서
+그래프를 돌리면 교착이므로, 승인 API 는 저장까지만 잡고 놓은 뒤 `engine.run` 을 부른다.
+
+승인 후 그래프 실행이 실패해 task 가 `WAITING` + `approved` 로 남으면, 다음 그래프 실행에서
+스케줄러가 그 task 를 집어 재개한다(`is_task_resumable_after_approval`). 승인 API 를 다시
+호출하는 방식의 재개는 없다 — 중복 승인 요청과 구분할 수 없기 때문이다.
+
+크로스 프로세스 원자성(다중 워커)은 아직 없다. 현재 배포는 단일 인스턴스이고
+(`render.yaml`, `--workers` 없음) `approvals` 테이블을 진실의 출처로 쓰는 조건부
+UPDATE 는 다중 워커 도입 시점의 과제다.
+
 ## Directory Structure (Backend)
 
 ```

--- a/src/backend/api/hitl.py
+++ b/src/backend/api/hitl.py
@@ -3,15 +3,123 @@
 Approval workflow: list pending, approve, deny operations.
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from api.deps import get_engine
-from models.agent_state import TaskStatus
-from models.hitl import ApprovalResponse, ApprovalStatus
+from models.agent_state import AgentState, TaskStatus
+from models.hitl import APPROVAL_STATE_LOCK, ApprovalResponse, ApprovalStatus
 from orchestrator import OrchestrationEngine
+from services.audit_service import AuditAction, AuditService, ResourceType
+from utils.time import utcnow
 
 router = APIRouter(tags=["orchestration"])
+
+# 승인 전이(조회 → 검사 → 변경 → 영속화)는 `APPROVAL_STATE_LOCK` 으로 직렬화한다.
+#
+# 경합 창은 검사와 변경 사이가 아니라 **그 위의 세션 조회**에 있다.
+# `engine.get_session` 은 캐시 미스 시 `await` 하고, DB 경로는 호출마다 새 dict 를
+# 돌려주므로(`repo.get_state` 가 JSONB 를 매번 디코딩), 캐시가 빈 상태(프로세스
+# 재시작 직후)에서 동시에 들어온 두 요청이 각자 사본에서 PENDING 을 보고
+# **둘 다 통과**한다 — 같은 승인으로 위험한 도구가 두 번 실행되는 경로다.
+#
+# 세션별이 아니라 전역 락 하나인 이유: 승인은 사람이 누르는 저빈도 경로이고
+# 임계구역은 조회·저장 왕복뿐이다. 세션별 락은 세션 수만큼 락 객체가 누적된다.
+
+
+async def resolve_approval(
+    engine: OrchestrationEngine,
+    session_id: str,
+    approval_id: str,
+    *,
+    approved: bool,
+    note: str | None,
+) -> tuple[AgentState, dict[str, Any]]:
+    """승인/거부 전이의 **유일한** 관문 (REST · WebSocket 공용).
+
+    두 경로가 같은 전이를 각자 구현하면 한쪽에만 검사가 걸린다 — 실제로
+    WebSocket 경로에는 PENDING 검사가 없어 이미 소비된(`consumed`) 승인을 다시
+    `approved` 로 되돌릴 수 있었고, 그러면 같은 도구가 다시 실행된다.
+
+    조회 → 검사 → 변경 → 영속화를 락 안에서 끝낸다. 그래프 실행은 호출자가 락
+    **밖에서** 한다 — 분 단위 실행을 락 안에 두면 두 번째 요청이 응답 없이 매달린다.
+
+    Raises:
+        HTTPException: 404(세션·승인 없음) / 400(이미 해소된 승인)
+    """
+    async with APPROVAL_STATE_LOCK.lock():
+        state = await engine.get_session(session_id)
+        if not state:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        pending_approvals = state.get("pending_approvals", {})
+        if approval_id not in pending_approvals:
+            raise HTTPException(status_code=404, detail="Approval request not found")
+
+        approval = pending_approvals[approval_id]
+        if approval["status"] != ApprovalStatus.PENDING.value:
+            raise HTTPException(
+                status_code=400, detail=f"Approval already resolved: {approval['status']}"
+            )
+
+        # 영속화가 실패하면 되돌리기 위해 이전 값을 잡아 둔다. 되돌리지 않으면
+        # 캐시는 `approved`, 저장소는 `pending` 으로 갈라져 재시도가 400 을 받고
+        # 그 승인은 영영 해소할 수 없게 된다.
+        before_approval = dict(approval)
+        before_waiting = state.get("waiting_for_approval")
+        before_task: tuple[TaskStatus, str | None, str | None] | None = None
+
+        approval["status"] = (
+            ApprovalStatus.APPROVED.value if approved else ApprovalStatus.DENIED.value
+        )
+        approval["resolver_note"] = note if approved else (note or "Denied by user")
+        approval["resolved_at"] = utcnow().isoformat()
+        state["pending_approvals"] = pending_approvals
+        state["waiting_for_approval"] = False
+
+        task_id = approval["task_id"]
+        if not approved:
+            tasks = state.get("tasks", {})
+            if task_id in tasks:
+                task = tasks[task_id]
+                before_task = (task.status, task.error, task.pending_approval_id)
+                task.status = TaskStatus.FAILED
+                task.error = f"Operation denied: {approval['resolver_note']}"
+                task.pending_approval_id = None
+
+        # 그래프 실행 **전에** 저장한다. `engine.run` 의 일괄 저장에만 기대면
+        # 실행이 실패했을 때 승인이 통째로 사라지고, 도구가 부수효과를 낸 뒤
+        # 저장 전에 죽으면 재시작 후 같은 승인이 다시 PENDING 으로 보인다.
+        # 거부는 그래프를 돌리지도 않으므로 여기서 저장하지 않으면 아무 데도 남지 않는다.
+        try:
+            await engine.save_session(session_id, state)
+        except Exception:
+            approval.clear()
+            approval.update(before_approval)
+            state["waiting_for_approval"] = before_waiting
+            if before_task is not None:
+                task = state["tasks"][task_id]
+                task.status, task.error, task.pending_approval_id = before_task
+            raise
+
+        # 감사 로그는 **저장에 성공한 뒤**에 남긴다. 먼저 남기면 롤백된 전이가
+        # "승인됨"으로 기록돼 감사 기록만 홀로 어긋난다.
+        AuditService.log(
+            action=AuditAction.APPROVAL_GRANTED if approved else AuditAction.APPROVAL_DENIED,
+            resource_type=ResourceType.APPROVAL,
+            resource_id=approval_id,
+            session_id=session_id,
+            project_id=state.get("project", {}).get("id"),
+            metadata={
+                "task_id": task_id,
+                "tool_name": approval.get("tool_name"),
+                "note": approval["resolver_note"],
+            },
+        )
+
+    return state, approval
 
 
 class ApprovalRequestResponse(BaseModel):
@@ -66,25 +174,13 @@ async def approve_operation(
 
     This will update the approval status and resume execution.
     """
-    state = await engine.get_session(session_id)
-    if not state:
-        raise HTTPException(status_code=404, detail="Session not found")
-
-    pending_approvals = state.get("pending_approvals", {})
-    if approval_id not in pending_approvals:
-        raise HTTPException(status_code=404, detail="Approval request not found")
-
-    approval = pending_approvals[approval_id]
-    if approval["status"] != ApprovalStatus.PENDING.value:
-        raise HTTPException(
-            status_code=400, detail=f"Approval already resolved: {approval['status']}"
-        )
-
-    # Update approval status
-    approval["status"] = ApprovalStatus.APPROVED.value
-    approval["resolver_note"] = response.note if response else None
-    state["pending_approvals"] = pending_approvals
-    state["waiting_for_approval"] = False
+    _, approval = await resolve_approval(
+        engine,
+        session_id,
+        approval_id,
+        approved=True,
+        note=response.note if response else None,
+    )
 
     # Resume execution
     try:
@@ -115,37 +211,16 @@ async def deny_operation(
 
     This will mark the task as failed and stop execution.
     """
-    state = await engine.get_session(session_id)
-    if not state:
-        raise HTTPException(status_code=404, detail="Session not found")
-
-    pending_approvals = state.get("pending_approvals", {})
-    if approval_id not in pending_approvals:
-        raise HTTPException(status_code=404, detail="Approval request not found")
-
-    approval = pending_approvals[approval_id]
-    if approval["status"] != ApprovalStatus.PENDING.value:
-        raise HTTPException(
-            status_code=400, detail=f"Approval already resolved: {approval['status']}"
-        )
-
-    # Update approval status
-    approval["status"] = ApprovalStatus.DENIED.value
-    approval["resolver_note"] = response.note if response else "Denied by user"
-    state["pending_approvals"] = pending_approvals
-    state["waiting_for_approval"] = False
-
-    # Update the task status
-    task_id = approval["task_id"]
-    tasks = state.get("tasks", {})
-    if task_id in tasks:
-        task = tasks[task_id]
-        task.status = TaskStatus.FAILED
-        task.error = f"Operation denied: {approval['resolver_note']}"
-        task.pending_approval_id = None
+    _, approval = await resolve_approval(
+        engine,
+        session_id,
+        approval_id,
+        approved=False,
+        note=response.note if response else None,
+    )
 
     return {
         "message": "Operation denied",
         "approval_id": approval_id,
-        "task_id": task_id,
+        "task_id": approval["task_id"],
     }

--- a/src/backend/api/websocket.py
+++ b/src/backend/api/websocket.py
@@ -3,11 +3,11 @@
 import asyncio
 import os
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
 
 from api.deps import get_engine
-from models.hitl import ApprovalStatus
+from api.hitl import resolve_approval
 from models.message import (
     ApprovalDeniedPayload,
     ApprovalGrantedPayload,
@@ -16,7 +16,6 @@ from models.message import (
     MessageType,
     TaskCreatePayload,
 )
-from services.audit_service import AuditAction, AuditService, ResourceType
 
 # Heartbeat configuration
 WS_HEARTBEAT_INTERVAL = int(os.getenv("WS_HEARTBEAT_INTERVAL", "20"))
@@ -170,107 +169,65 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     await manager.send_message(session_id, event)
 
             elif message.type == MessageType.APPROVAL_RESPONSE:
-                # Handle HITL approval/denial from client
+                # Handle HITL approval/denial from client.
+                #
+                # 전이 자체는 `api.hitl.resolve_approval` 한 곳에서만 한다. 이 경로가
+                # 승인 레코드를 직접 쓰면 PENDING 검사·직렬화·영속화가 REST 에만 걸려,
+                # 중복 응답 한 번으로 이미 소비된(`consumed`) 승인이 다시 `approved` 로
+                # 되돌아간다 — 같은 위험 도구가 다시 실행되는 경로다.
                 try:
                     payload = ApprovalResponsePayload(**message.payload)
-                    state = await engine.get_session(session_id)
-
-                    if state:
-                        pending_approvals = state.get("pending_approvals", {})
-                        project_id = state.get("project", {}).get("id")
-                        if payload.approval_id in pending_approvals:
-                            approval = pending_approvals[payload.approval_id]
-
-                            if payload.approved:
-                                # Approve and resume
-                                approval["status"] = ApprovalStatus.APPROVED.value
-                                approval["resolver_note"] = payload.note
-                                state["waiting_for_approval"] = False
-
-                                # Audit: Log approval granted
-                                AuditService.log(
-                                    action=AuditAction.APPROVAL_GRANTED,
-                                    resource_type=ResourceType.APPROVAL,
-                                    resource_id=payload.approval_id,
-                                    session_id=session_id,
-                                    project_id=project_id,
-                                    metadata={
-                                        "task_id": approval["task_id"],
-                                        "tool_name": approval.get("tool_name"),
-                                        "note": payload.note,
-                                    },
-                                )
-
-                                # Send confirmation
-                                await manager.send_message(
-                                    session_id,
-                                    Message(
-                                        type=MessageType.APPROVAL_GRANTED,
-                                        payload=ApprovalGrantedPayload(
-                                            approval_id=payload.approval_id,
-                                            task_id=approval["task_id"],
-                                        ).model_dump(),
-                                        session_id=session_id,
+                    try:
+                        _, approval = await resolve_approval(
+                            engine,
+                            session_id,
+                            payload.approval_id,
+                            approved=payload.approved,
+                            note=payload.note,
+                        )
+                    except HTTPException as exc:
+                        await manager.send_message(
+                            session_id,
+                            Message(
+                                type=MessageType.ERROR,
+                                payload={
+                                    "code": (
+                                        "APPROVAL_NOT_FOUND"
+                                        if exc.status_code == 404
+                                        else "APPROVAL_CONFLICT"
                                     ),
-                                )
-
-                                # Resume execution
-                                async for event in engine.stream(session_id, ""):
-                                    await manager.send_message(session_id, event)
-
-                            else:
-                                # Deny
-                                approval["status"] = ApprovalStatus.DENIED.value
-                                approval["resolver_note"] = payload.note or "Denied by user"
-                                state["waiting_for_approval"] = False
-
-                                # Audit: Log approval denied
-                                AuditService.log(
-                                    action=AuditAction.APPROVAL_DENIED,
-                                    resource_type=ResourceType.APPROVAL,
-                                    resource_id=payload.approval_id,
+                                    "message": str(exc.detail),
+                                },
+                                session_id=session_id,
+                            ),
+                        )
+                    else:
+                        if payload.approved:
+                            await manager.send_message(
+                                session_id,
+                                Message(
+                                    type=MessageType.APPROVAL_GRANTED,
+                                    payload=ApprovalGrantedPayload(
+                                        approval_id=payload.approval_id,
+                                        task_id=approval["task_id"],
+                                    ).model_dump(),
                                     session_id=session_id,
-                                    project_id=project_id,
-                                    metadata={
-                                        "task_id": approval["task_id"],
-                                        "tool_name": approval.get("tool_name"),
-                                        "note": approval["resolver_note"],
-                                    },
-                                )
+                                ),
+                            )
 
-                                # Update task status
-                                task_id = approval["task_id"]
-                                tasks = state.get("tasks", {})
-                                if task_id in tasks:
-                                    from models.agent_state import TaskStatus
-
-                                    task = tasks[task_id]
-                                    task.status = TaskStatus.FAILED
-                                    task.error = f"Denied: {approval['resolver_note']}"
-                                    task.pending_approval_id = None
-
-                                # Send denial confirmation
-                                await manager.send_message(
-                                    session_id,
-                                    Message(
-                                        type=MessageType.APPROVAL_DENIED,
-                                        payload=ApprovalDeniedPayload(
-                                            approval_id=payload.approval_id,
-                                            task_id=approval["task_id"],
-                                            note=approval["resolver_note"],
-                                        ).model_dump(),
-                                        session_id=session_id,
-                                    ),
-                                )
+                            # Resume execution
+                            async for event in engine.stream(session_id, ""):
+                                await manager.send_message(session_id, event)
                         else:
                             await manager.send_message(
                                 session_id,
                                 Message(
-                                    type=MessageType.ERROR,
-                                    payload={
-                                        "code": "APPROVAL_NOT_FOUND",
-                                        "message": f"Approval {payload.approval_id} not found",
-                                    },
+                                    type=MessageType.APPROVAL_DENIED,
+                                    payload=ApprovalDeniedPayload(
+                                        approval_id=payload.approval_id,
+                                        task_id=approval["task_id"],
+                                        note=approval["resolver_note"],
+                                    ).model_dump(),
                                     session_id=session_id,
                                 ),
                             )

--- a/src/backend/models/hitl.py
+++ b/src/backend/models/hitl.py
@@ -8,7 +8,19 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from models.agent_state import TaskNode, TaskStatus
+from utils.locks import LoopBoundLockPool
 from utils.time import utcnow
+
+# 승인 상태를 바꾸는 **모든** 경로가 공유하는 락:
+# REST·WebSocket 전이(`api/hitl.py`)와 executor 의 소비(`nodes/executor.py`).
+#
+# 두 경로 모두 세션 JSON 전체를 덮어쓰며 저장한다. 직렬화하지 않으면 늦게 도착한
+# 낡은 스냅샷이 다른 전이를 되돌린다 — 병렬 배치(`execute_batch`)에서 승인된
+# 위험 task 가 둘 이상이면 실제로 겹친다.
+#
+# 락 안에서 그래프를 돌리지 말 것(교착) — 승인 API 는 저장까지만 잡고 놓은 뒤
+# `engine.run` 을 호출하며, 그 안에서 executor 가 같은 락을 다시 잡는다.
+APPROVAL_STATE_LOCK = LoopBoundLockPool()
 
 
 class RiskLevel(str, Enum):
@@ -27,6 +39,9 @@ class ApprovalStatus(str, Enum):
     APPROVED = "approved"
     DENIED = "denied"
     EXPIRED = "expired"
+    # 승인이 실제 도구 호출에 쓰였음. executor 가 도구 실행 **전에** 전이·영속화하며,
+    # 이 상태가 되면 같은 승인으로는 다시 실행할 수 없다(1회용 보장의 정본).
+    CONSUMED = "consumed"
 
 
 class OperationRisk(BaseModel):
@@ -148,6 +163,34 @@ def is_task_resumable_after_approval(
         return False
 
     return bool(approval.get("status") == ApprovalStatus.APPROVED.value)
+
+
+ORPHANED_APPROVAL_ERROR = "승인이 이미 소비됐다 — 실행 결과를 알 수 없어 재승인이 필요하다"
+
+
+def is_task_orphaned_by_consumed_approval(
+    task: TaskNode,
+    pending_approvals: dict[str, Any],
+) -> bool:
+    """소비된 승인에 매달린 채 남은 task 인가.
+
+    승인 소비는 도구 실행 **전에** 영속화되므로, 실행 도중 프로세스가 죽으면
+    `consumed` 승인 + 실행 중(IN_PROGRESS)이거나 대기 중(WAITING)인 task 가
+    남는다. 도구가 실제로 부수효과를 냈는지는 알 수 없다 — 자동 재개는
+    금지이고(비가역 작업 중복 실행), 그렇다고 조용히 멈추면 세션이 영영
+    끝나지 않는다. 스케줄러는 이 판정으로 잔재를 실패로 드러낸다.
+    """
+    if task.status not in (TaskStatus.IN_PROGRESS, TaskStatus.WAITING):
+        return False
+
+    if not task.pending_approval_id:
+        return False
+
+    approval = pending_approvals.get(task.pending_approval_id)
+    if not approval:
+        return False
+
+    return bool(approval.get("status") == ApprovalStatus.CONSUMED.value)
 
 
 def get_tool_risk(tool_name: str) -> OperationRisk:

--- a/src/backend/orchestrator/engine.py
+++ b/src/backend/orchestrator/engine.py
@@ -144,16 +144,24 @@ class OrchestrationEngine:
         self.tools = tools if tools is not None else ALL_TOOLS
         print(f"🔧 Loaded {len(self.tools)} tools: {[t.name for t in self.tools]}")
 
+        # Session service for persistence.
+        # 노드 생성보다 먼저 확정한다 — executor 가 승인 소비를 기록할 저장소가
+        # 엔진이 읽는 저장소와 같아야 한다.
+        self.session_service = session_service or get_session_service()
+
         # Initialize nodes
         self.orchestrator_node = OrchestratorNode(self.llm)
         self.planner_node = PlannerNode(self.llm, tools=self.tools)
-        self.executor_node = ExecutorNode(self.llm, tools=self.tools)
+        self.executor_node = ExecutorNode(
+            self.llm, tools=self.tools, session_service=self.session_service
+        )
         self.reviewer_node = ReviewerNode(self.llm)
         self.self_correction_node = SelfCorrectionNode(self.llm)
         self.parallel_executor_node = ParallelExecutorNode(
             llm=self.llm,
             tools=self.tools,
             max_concurrent=3,
+            session_service=self.session_service,
         )
 
         # Create and compile graph with self-correction and parallel execution support
@@ -168,9 +176,6 @@ class OrchestrationEngine:
         self.compiled_graph = compile_graph(self.graph)
         print("✅ Self-correction enabled")
         print("✅ Parallel execution enabled (max 3 concurrent tasks)")
-
-        # Session service for persistence
-        self.session_service = session_service or get_session_service()
 
         # Context compressor — closes the token economy gap
         self._compressor = ContextCompressor()
@@ -259,6 +264,17 @@ class OrchestrationEngine:
         if state:
             self._sessions[session_id] = state
         return state
+
+    async def save_session(self, session_id: str, state: AgentState) -> None:
+        """세션 상태를 캐시와 영속 저장소에 함께 반영한다.
+
+        캐시만 갱신하면 프로세스 재시작이나 다른 인스턴스의 캐시 미스 이후에
+        변경이 사라진다. HITL 승인처럼 **그래프 실행 밖에서** 일어나는 전이는
+        `run` 의 일괄 저장을 기다리지 말고 이 경로로 즉시 저장해야 한다 —
+        `run` 이 실패하면 그 저장은 아예 일어나지 않는다.
+        """
+        self._sessions[session_id] = state
+        await self.session_service.update_session(session_id, state)
 
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session."""

--- a/src/backend/orchestrator/nodes/executor.py
+++ b/src/backend/orchestrator/nodes/executor.py
@@ -8,6 +8,7 @@ MCP 는 optional 의존이다(위 planner 의 RAG 와 같은 구조·같은 주�
 """
 
 import json
+import logging
 import uuid
 from typing import Any, cast
 
@@ -16,7 +17,7 @@ from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool
 
 from models.agent_state import AgentInfo, AgentRole, AgentState, TaskStatus
-from models.hitl import ApprovalStatus, assess_operation_risk
+from models.hitl import APPROVAL_STATE_LOCK, ApprovalStatus, assess_operation_risk
 from models.llm_usage import LLMUsageSource
 from services.audit_service import (
     AuditAction,
@@ -25,9 +26,12 @@ from services.audit_service import (
     audit_task_status_change,
     audit_tool_executed,
 )
+from services.session_service import SessionService, get_session_service
 from utils.time import utcnow
 
 from .base import BaseNode
+
+logger = logging.getLogger(__name__)
 
 try:
     from orchestrator.tools import MCPToolExecutor
@@ -71,9 +75,20 @@ When you need to perform an action, use the appropriate tool.
 Think step by step and use tools as needed to complete the task.
 After completing all necessary tool calls, provide a final summary."""
 
-    def __init__(self, llm: BaseChatModel | None = None, tools: list[BaseTool] | None = None):
-        """Initialize ExecutorNode with LLM and tools."""
+    def __init__(
+        self,
+        llm: BaseChatModel | None = None,
+        tools: list[BaseTool] | None = None,
+        session_service: SessionService | None = None,
+    ):
+        """Initialize ExecutorNode with LLM and tools.
+
+        `session_service` 는 승인 소비를 기록할 저장소다. 엔진이 커스텀 서비스를
+        주입받았는데 노드가 전역 인스턴스에 쓰면, 소비 기록이 엔진이 읽는 곳과
+        **다른 저장소**로 가서 재시작 후 승인이 다시 살아난다.
+        """
         super().__init__(llm)
+        self.session_service = session_service
         self.tools = tools or []
         self._tools_by_name = {tool.name: tool for tool in self.tools}
 
@@ -156,6 +171,118 @@ After completing all necessary tool calls, provide a final summary."""
             return str(result)
         except Exception as e:
             return f"Error executing {tool_name}: {str(e)}"
+
+    async def _consume_approval(
+        self,
+        state: AgentState,
+        pending_approvals: dict[str, Any],
+        approval: dict[str, Any],
+    ) -> bool:
+        """승인을 1회용으로 소비한다. 소비에 성공했을 때만 True.
+
+        승인은 1회용이다 — 바인딩을 끊지 않으면 이후 iteration 이나 다른 실행이
+        같은 승인으로 다시 도구를 돌릴 수 있다. 바인딩은 `task.pending_approval_id`
+        를 지우는 대신 승인 레코드를 `CONSUMED` 로 전이해 끊는다. 대조가
+        `status == APPROVED` 를 요구하므로 효과는 같고, 포인터를 남기면 실행 도중
+        죽었을 때 "어느 승인으로 무엇을 하다 멈췄는지"가 남아 스케줄러가 잔재를
+        실패로 정리할 수 있다(`is_task_orphaned_by_consumed_approval`).
+
+        락 안에서 상태를 **다시 확인**하는 compare-and-set 이다. 병렬 배치
+        (`execute_batch`)는 여러 executor 가 같은 세션에 동시에 쓰는데
+        `update_session` 은 세션 JSON 전체를 덮으므로, 직렬화하지 않으면 늦게
+        도착한 낡은 스냅샷이 다른 소비를 `approved` 로 되돌린다.
+
+        사본이 아니라 **레코드 자체를** 바꾼다. 이 dict 는 `state["pending_approvals"]`
+        를 거쳐 엔진 캐시가 들고 있는 바로 그 객체다 — 사본에만 쓰면 저장소는
+        `consumed`, 캐시는 `approved` 로 갈라지고, 그래프가 최종 state 를 저장하기
+        전에 실패하면 다음 시도가 낡은 캐시를 읽어 다시 승인한다.
+
+        메모리 사본만 보지 않고 **저장소의 승인 상태를 다시 읽는다**. 캐시가 빈
+        상태에서 같은 세션에 그래프 실행 둘이 겹치면 각자 독립된 `approved` 사본을
+        들고 오므로, 로컬 사본만 보는 검사는 둘 다 통과시킨다.
+
+        영속화가 실패하면 전이를 되돌리고 예외를 올린다 — 소비는 도구 실행 **전**에
+        기록하므로 저장이 실패한 시점에는 도구가 아직 실행되지 않았다. 되돌려야
+        나중에 정당하게 재시도할 수 있다. 저장이 실제로는 반영됐는데 예외만 올라온
+        경우(타임아웃 등)는 위 재검증이 걸러낸다.
+        """
+        async with APPROVAL_STATE_LOCK.lock():
+            if approval.get("status") != ApprovalStatus.APPROVED.value:
+                return False  # 다른 실행이 먼저 소비했다
+
+            if not await self._approval_is_claimable_in_storage(state, approval):
+                return False  # 다른 실행이 저장소에서 먼저 가져갔다
+
+            before = dict(approval)
+            approval["status"] = ApprovalStatus.CONSUMED.value
+            approval["consumed_at"] = utcnow().isoformat()
+            try:
+                await self._persist_approval_consumption(state, pending_approvals)
+            except Exception:
+                approval.clear()
+                approval.update(before)
+                raise
+
+        return True
+
+    async def _approval_is_claimable_in_storage(
+        self,
+        state: AgentState,
+        approval: dict[str, Any],
+    ) -> bool:
+        """저장소에 남은 승인이 아직 `approved` 인가.
+
+        저장소에서 **세션 자체**를 찾을 수 없으면(서비스를 거치지 않고 만든 state·
+        이미 삭제된 세션) 판정 근거가 없으므로 막지 않는다 — 그런 세션은 재시작 시
+        통째로 사라져 재실행 창도 함께 사라진다.
+
+        반대로 세션은 있는데 그 승인만 없으면 **막는다**. 그건 "영속 저장소가 없다"가
+        아니라 "이 승인은 더 이상 유효하지 않다"는 뜻이고, 그대로 진행하면 뒤이은
+        전체 state 저장이 없어진 승인을 되살린 뒤 도구까지 실행한다.
+        """
+        session_id = state.get("session_id", "")
+        if not session_id:
+            return True
+
+        service = self.session_service or get_session_service()
+        stored = await service.get_session(session_id)
+        if not stored:
+            return True
+
+        stored_approval = stored.get("pending_approvals", {}).get(approval.get("id"))
+        if not stored_approval:
+            return False
+
+        return bool(stored_approval.get("status") == ApprovalStatus.APPROVED.value)
+
+    async def _persist_approval_consumption(
+        self,
+        state: AgentState,
+        pending_approvals: dict[str, Any],
+    ) -> None:
+        """승인 소비를 즉시 저장한다 — 반드시 도구 실행 **전에** 호출한다.
+
+        그래프 전체가 끝난 뒤의 일괄 저장(`engine.run`)에만 기대면, 도구가
+        비가역 부수효과를 낸 뒤 저장 전에 프로세스가 죽었을 때 재시작 후 승인이
+        다시 살아나 같은 작업이 재실행된다.
+
+        저장 실패(예외)는 삼키지 않는다 — 소비를 기록할 수 없으면 실행해서도
+        안 된다. 호출자의 try/except 가 task 실패로 처리한다.
+        """
+        session_id = state.get("session_id", "")
+        service = self.session_service or get_session_service()
+        persisted = await service.update_session(
+            session_id,
+            cast(AgentState, {**state, "pending_approvals": pending_approvals}),
+        )
+        if not persisted:
+            # 저장소에 없는 세션이다(이미 삭제됐거나 서비스를 거치지 않고 만든 state).
+            # 재시작하면 세션 자체가 사라지므로 재실행 창도 함께 사라진다 —
+            # 실행을 막을 이유는 없으나 조용히 넘기지는 않는다.
+            logger.warning(
+                "Approval consumption was not persisted (session=%s)",
+                session_id,
+            )
 
     def _check_approval_required(
         self,
@@ -260,6 +387,10 @@ After completing all necessary tool calls, provide a final summary."""
             metadata={"task_id": current_task_id, "role": AgentRole.EXECUTOR.value},
         )
 
+        # try 밖에서 바인딩한다 — except 절이 이 값을 결과에 실어 보내므로,
+        # 루프 진입 전에 예외가 나면 unbound 가 된다.
+        pending_approvals = dict(state.get("pending_approvals", {}))
+
         try:
             # Build message history for this execution
             messages = [
@@ -280,7 +411,6 @@ After completing all necessary tool calls, provide a final summary."""
             max_iterations = 10
             tool_results = []
             final_result = None
-            pending_approvals = dict(state.get("pending_approvals", {}))
 
             # Track token usage across iterations.
             # `_extract_and_update_tokens` 는 넘겨받은 state 의 누계 위에 이번 회차를
@@ -364,12 +494,14 @@ After completing all necessary tool calls, provide a final summary."""
                             and existing_approval.get("tool_args") == tool_args
                         )
 
-                        if approval_matches_call:
-                            # 승인 대상과 동일한 호출 — 실행을 허용하고 승인을 소비한다.
-                            # 승인은 1회용이다: 바인딩을 끊지 않으면 이후 iteration 에서
-                            # 같은 승인으로 다시 실행할 수 있다.
-                            task.pending_approval_id = None
-                        else:
+                        # 승인 대상과 동일한 호출이면 소비하고 실행을 허용한다.
+                        consumed = approval_matches_call and await self._consume_approval(
+                            state,
+                            pending_approvals,
+                            cast(dict[str, Any], existing_approval),
+                        )
+
+                        if not consumed:
                             # Need approval - pause execution
                             task.status = TaskStatus.WAITING
                             task.pending_approval_id = approval_id
@@ -495,6 +627,9 @@ After completing all necessary tool calls, provide a final summary."""
                 "agents": agents,
                 "messages": [self._create_message("assistant", f"Completed task: {task.title}")],
                 "tool_results": tool_results,
+                # 소비된 승인을 채널에 돌려보낸다. 빠뜨리면 그래프 종료 시의 전체
+                # state 저장이 `consumed` 를 `approved` 로 되돌려 놓는다.
+                "pending_approvals": pending_approvals,
             }
 
             # Include token usage updates
@@ -528,6 +663,8 @@ After completing all necessary tool calls, provide a final summary."""
                 "agents": agents,
                 "last_error": str(e),
                 "errors": state.get("errors", []) + [str(e)],
+                # 실패 경로에서도 소비 기록은 유지해야 한다 — 위와 같은 이유다.
+                "pending_approvals": pending_approvals,
             }
 
             # Include token usage even on failure

--- a/src/backend/orchestrator/nodes/orchestrator.py
+++ b/src/backend/orchestrator/nodes/orchestrator.py
@@ -3,7 +3,12 @@
 from typing import Any
 
 from models.agent_state import AgentState, TaskNode, TaskStatus
-from models.hitl import is_task_resumable_after_approval
+from models.hitl import (
+    ORPHANED_APPROVAL_ERROR,
+    is_task_orphaned_by_consumed_approval,
+    is_task_resumable_after_approval,
+)
+from utils.time import utcnow
 
 from .base import BaseNode
 
@@ -61,6 +66,30 @@ Respond with a JSON object containing:
         # Check task statuses
         tasks = state.get("tasks", {})
         root_task_id = state.get("root_task_id")
+        pending_approvals = state.get("pending_approvals", {})
+
+        # 소비된 승인에 매달린 잔재 정리.
+        # executor 는 승인을 도구 실행 **전에** `consumed` 로 전이·영속화하므로,
+        # 실행 도중 프로세스가 죽으면 소비 기록만 남고 결과는 남지 않는다.
+        # 도구가 실제로 부수효과를 냈는지 알 수 없으니 재개는 금지다 — 다만
+        # 조용히 멈추면 세션이 영영 끝나지 않으므로 실패로 드러낸다.
+        orphaned = {
+            task_id: task
+            for task_id, task in tasks.items()
+            if is_task_orphaned_by_consumed_approval(task, pending_approvals)
+        }
+        if orphaned:
+            for task in orphaned.values():
+                task.status = TaskStatus.FAILED
+                task.error = ORPHANED_APPROVAL_ERROR
+                task.updated_at = utcnow()
+
+            return {
+                "tasks": orphaned,
+                "next_action": None,
+                "iteration_count": iteration_count,
+                "errors": state.get("errors", []) + [ORPHANED_APPROVAL_ERROR],
+            }
 
         if root_task_id and root_task_id in tasks:
             root_task = tasks[root_task_id]
@@ -75,7 +104,6 @@ Respond with a JSON object containing:
             # 승인이 끝난 WAITING task 도 실행 대상이다 — 승인 대기 중에는 status 가
             # PENDING 이 아니라 WAITING 이라, 이 조건이 없으면 승인해도 executor 로
             # 돌아가지 못하고 그래프가 그대로 끝난다.
-            pending_approvals = state.get("pending_approvals", {})
             pending_tasks = [
                 t
                 for t in tasks.values()

--- a/src/backend/orchestrator/parallel_executor.py
+++ b/src/backend/orchestrator/parallel_executor.py
@@ -9,6 +9,7 @@ from langchain_core.tools import BaseTool
 from models.agent_state import AgentState, TaskNode, TaskStatus
 from models.hitl import is_task_resumable_after_approval
 from orchestrator.nodes import BaseNode, ExecutorNode
+from services.session_service import SessionService
 from utils.time import utcnow
 
 # Maximum concurrent tasks (configurable)
@@ -29,6 +30,7 @@ class ParallelExecutorNode(BaseNode):
         llm: BaseChatModel | None = None,
         tools: list[BaseTool] | None = None,
         max_concurrent: int = DEFAULT_MAX_CONCURRENT_TASKS,
+        session_service: SessionService | None = None,
     ):
         """
         Initialize the parallel executor.
@@ -37,13 +39,14 @@ class ParallelExecutorNode(BaseNode):
             llm: Language model for task execution
             tools: Available tools for execution
             max_concurrent: Maximum number of concurrent task executions
+            session_service: 승인 소비를 기록할 저장소(내부 executor 로 전달)
         """
         super().__init__(llm)
         self.tools = tools or []
         self.max_concurrent = max_concurrent
 
         # Create a single-task executor for reuse
-        self.executor = ExecutorNode(llm=llm, tools=tools)
+        self.executor = ExecutorNode(llm=llm, tools=tools, session_service=session_service)
 
     async def _execute_with_semaphore(
         self,

--- a/src/backend/utils/locks.py
+++ b/src/backend/utils/locks.py
@@ -1,0 +1,31 @@
+"""이벤트 루프에 안전한 asyncio 락 도구."""
+
+import asyncio
+import weakref
+
+
+class LoopBoundLockPool:
+    """실행 중인 이벤트 루프마다 락을 하나씩 내주는 풀.
+
+    모듈 수준에 `asyncio.Lock()` 하나를 두면 **처음 경합한 루프에 바인딩**되고,
+    다른 루프에서 쓰면 `RuntimeError: is bound to a different event loop` 가 난다.
+    프로덕션은 루프가 하나뿐이라 무해하지만, 루프를 새로 만드는 테스트에서 그
+    RuntimeError 가 "두 번째 요청이 거부됐다"로 오인되면 검증이 조용히 무력해진다
+    (`return_exceptions=True` 로 모으면 예외 종류가 가려진다).
+
+    루프는 약한 참조로 들고 있어 끝난 루프의 락은 자동으로 사라진다.
+    """
+
+    def __init__(self) -> None:
+        self._locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+            weakref.WeakKeyDictionary()
+        )
+
+    def lock(self) -> asyncio.Lock:
+        """현재 실행 중인 루프의 락 (`async with pool.lock():` 형태로 쓴다)."""
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock

--- a/tests/backend/test_hitl_approval_atomicity.py
+++ b/tests/backend/test_hitl_approval_atomicity.py
@@ -1,0 +1,662 @@
+"""승인 전이·소비의 원자성·내구성 회귀 테스트 (issue #283).
+
+세 가지를 고정한다.
+
+1. **원자성** — 승인 전이(`pending → approved`)는 세션당 직렬화된다.
+   경합 창은 검사↔변경 사이가 아니라 그 위의 `engine.get_session` 에 있다:
+   캐시 미스 경로가 `await` 를 포함하고(engine.py:253-261) DB 경로는 호출마다
+   **새 dict** 를 돌려주므로(`repo.get_state` 가 JSONB 를 매번 디코딩),
+   재시작 직후 동시 요청 두 건이 각자 사본에서 PENDING 을 보고 둘 다 통과한다.
+2. **내구성** — 전이는 `engine.run` 이 그래프를 끝내기 전에 영속화된다.
+   기존 코드는 `engine.run` 이 실패하면 승인이 통째로 사라졌고, deny 는
+   아예 아무것도 저장하지 않았다.
+3. **1회 소비(at-most-once)** — executor 는 승인을 `consumed` 로 전이해
+   **도구 실행 전에** 영속화한다. 실행 도중 프로세스가 죽어도 같은 승인으로
+   다시 실행되지 않는다.
+"""
+
+import asyncio
+import copy
+import pathlib
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import api.websocket
+from api.hitl import approve_operation, deny_operation
+from models.agent_state import TaskNode, TaskStatus, create_initial_state
+from models.hitl import ApprovalStatus
+from orchestrator.nodes.executor import ExecutorNode
+from orchestrator.nodes.orchestrator import OrchestratorNode
+
+RISKY_ARGS = {"command": "rm -rf /tmp/scratch"}
+RISKY_CALL = {"name": "execute_bash", "args": RISKY_ARGS, "id": "call-1"}
+
+
+# ─────────────────────────────────────────────────────────────
+# Fixtures / doubles
+# ─────────────────────────────────────────────────────────────
+
+
+class StubEngine:
+    """`OrchestrationEngine` 의 캐시·영속화 계약만 모사한다.
+
+    핵심은 `get_session` 의 **캐시 미스 경로가 await 를 포함**하고 저장소가
+    호출마다 새 사본을 돌려준다는 점이다 — 실제 엔진(engine.py:253-261)이
+    DB 모드에서 갖는 성질이며, 여기가 승인 경합의 창이다.
+    """
+
+    def __init__(self, stored: dict[str, Any]):
+        self._stored = stored
+        self._sessions: dict[str, Any] = {}
+        self.events: list[str] = []
+        self.run_calls = 0
+        self.run_error: Exception | None = None
+        self.save_error: Exception | None = None
+
+    async def get_session(self, session_id: str):
+        if session_id in self._sessions:
+            return self._sessions[session_id]
+        await asyncio.sleep(0)  # DB 왕복 — 이벤트 루프가 여기서 양보한다
+        state = copy.deepcopy(self._stored)
+        self._sessions[session_id] = state
+        return state
+
+    async def save_session(self, session_id: str, state) -> bool:
+        self.events.append("persist")
+        self._sessions[session_id] = state
+        if self.save_error:
+            raise self.save_error
+        self._stored = copy.deepcopy(state)
+        return True
+
+    async def run(self, session_id: str, user_message: str):
+        self.events.append("run")
+        self.run_calls += 1
+        if self.run_error:
+            raise self.run_error
+        return self._sessions[session_id]
+
+    # 검증 헬퍼 — 영속화된(=재시작 후에 보이는) 값만 본다
+    def stored_approval(self, approval_id: str) -> dict[str, Any]:
+        return self._stored["pending_approvals"][approval_id]
+
+    def stored_task(self, task_id: str) -> TaskNode:
+        return self._stored["tasks"][task_id]
+
+    def cached_approval(self, session_id: str, approval_id: str) -> dict[str, Any]:
+        return self._sessions[session_id]["pending_approvals"][approval_id]
+
+
+def _waiting_state() -> dict[str, Any]:
+    """승인 대기 중인 세션 state."""
+    state = create_initial_state(session_id="s-283")
+    task = TaskNode(id="t1", parent_id="root", title="risky", status=TaskStatus.WAITING)
+    task.pending_approval_id = "a1"
+    state["tasks"]["root"] = TaskNode(
+        id="root", title="root", status=TaskStatus.IN_PROGRESS, children=["t1"]
+    )
+    state["tasks"]["t1"] = task
+    state["root_task_id"] = "root"
+    state["pending_approvals"] = {
+        "a1": {
+            "id": "a1",
+            "session_id": "s-283",
+            "task_id": "t1",
+            "tool_name": "execute_bash",
+            "tool_args": RISKY_ARGS,
+            "risk_level": "high",
+            "risk_description": "shell",
+            "status": ApprovalStatus.PENDING.value,
+            "created_at": "2026-08-19T00:00:00+00:00",
+        }
+    }
+    state["waiting_for_approval"] = True
+    return state
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. 원자성 — 동시 승인은 한 번만 통과한다
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_approve_resolves_once():
+    """캐시가 빈 상태(재시작 직후)에서 동시 승인 두 건 → 1건만 성공한다.
+
+    락이 없으면 둘 다 자기 사본에서 PENDING 을 보고 통과해 `engine.run` 이
+    두 번 돌아간다 — 같은 승인으로 위험한 도구가 두 번 실행되는 경로다.
+    """
+    engine = StubEngine(_waiting_state())
+
+    results = await asyncio.gather(
+        approve_operation("s-283", "a1", None, engine),
+        approve_operation("s-283", "a1", None, engine),
+        return_exceptions=True,
+    )
+
+    successes = [r for r in results if not isinstance(r, Exception)]
+    rejections = [r for r in results if isinstance(r, HTTPException)]
+
+    assert len(successes) == 1, f"승인이 두 번 통과했다: {results}"
+    assert len(rejections) == 1
+    assert rejections[0].status_code == 400
+    assert engine.run_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_approve_and_deny_resolves_once():
+    """approve 와 deny 가 동시에 들어와도 한쪽만 이긴다."""
+    engine = StubEngine(_waiting_state())
+
+    results = await asyncio.gather(
+        approve_operation("s-283", "a1", None, engine),
+        deny_operation("s-283", "a1", None, engine),
+        return_exceptions=True,
+    )
+
+    successes = [r for r in results if not isinstance(r, Exception)]
+    rejections = [r for r in results if isinstance(r, HTTPException)]
+
+    assert len(successes) == 1, f"두 전이가 모두 통과했다: {results}"
+    # 진 쪽이 **400 으로** 거부됐는지까지 본다. 여기서 종류를 안 보면 락이
+    # 다른 루프에 묶여 터진 RuntimeError 도 "거부됨"으로 통과한다.
+    assert len(rejections) == 1, f"거부가 HTTPException 이 아니다: {results}"
+    assert rejections[0].status_code == 400
+    assert engine.stored_approval("a1")["status"] in (
+        ApprovalStatus.APPROVED.value,
+        ApprovalStatus.DENIED.value,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. 내구성 — 전이는 그래프 실행 전에 저장된다
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_approval_persisted_before_graph_run():
+    """승인은 `engine.run` **이전에** 영속화된다.
+
+    그래프가 끝난 뒤에 저장하면, 도구가 부수효과를 낸 뒤 프로세스가 죽었을 때
+    재시작 후 승인이 다시 PENDING 으로 보인다.
+    """
+    engine = StubEngine(_waiting_state())
+
+    await approve_operation("s-283", "a1", None, engine)
+
+    assert engine.events[:2] == ["persist", "run"], engine.events
+    assert engine.stored_approval("a1")["status"] == ApprovalStatus.APPROVED.value
+    assert engine.stored_approval("a1")["resolved_at"]
+
+
+@pytest.mark.asyncio
+async def test_approval_survives_failed_graph_run():
+    """`engine.run` 이 실패해도 승인 전이는 남는다."""
+    engine = StubEngine(_waiting_state())
+    engine.run_error = RuntimeError("graph exploded")
+
+    result = await approve_operation("s-283", "a1", None, engine)
+
+    assert result["error"] == "graph exploded"
+    assert engine.stored_approval("a1")["status"] == ApprovalStatus.APPROVED.value
+
+
+@pytest.mark.asyncio
+async def test_denial_is_persisted():
+    """거부는 상태 전이와 task 실패를 함께 영속화한다.
+
+    기존 구현은 deny 경로에서 아무것도 저장하지 않아, 재시작하면 거부한 작업이
+    다시 승인 대기로 나타났다.
+    """
+    engine = StubEngine(_waiting_state())
+
+    await deny_operation("s-283", "a1", None, engine)
+
+    assert engine.events == ["persist"]
+    assert engine.stored_approval("a1")["status"] == ApprovalStatus.DENIED.value
+    assert engine.stored_task("t1").status == TaskStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_consumed_approval_cannot_be_reopened():
+    """소비된 승인은 다시 `approved` 로 되돌릴 수 없다.
+
+    중복 응답(더블클릭·WebSocket 재전송)이 `consumed` 를 `approved` 로 덮으면
+    executor 의 대조(`status == APPROVED`)가 다시 통과해 같은 도구가 재실행된다.
+    """
+    state = _waiting_state()
+    state["pending_approvals"]["a1"]["status"] = ApprovalStatus.CONSUMED.value
+    engine = StubEngine(state)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await approve_operation("s-283", "a1", None, engine)
+
+    assert excinfo.value.status_code == 400
+    assert engine.run_calls == 0
+
+
+def test_websocket_does_not_bypass_the_transition_gateway():
+    """WebSocket 경로가 승인 레코드를 직접 쓰지 않는다.
+
+    REST 와 WebSocket 이 전이를 각자 구현하면 검사·직렬화·영속화가 한쪽에만
+    걸린다. 실제로 WebSocket 핸들러에는 PENDING 검사가 없어 소비된 승인을 다시
+    열 수 있었다 — 재발하면 여기서 잡는다.
+    """
+    source = (pathlib.Path(api.websocket.__file__)).read_text()
+
+    assert "resolve_approval" in source, "WebSocket 이 전이 관문을 거치지 않는다"
+    assert 'approval["status"]' not in source, "WebSocket 이 승인 상태를 직접 쓴다"
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. 1회 소비 — 도구 실행 전에 consumed 를 영속화한다
+# ─────────────────────────────────────────────────────────────
+
+
+class RecordingSessionService:
+    """`update_session` 호출 시점의 승인 상태를 기록한다."""
+
+    def __init__(self, events: list[tuple[str, Any]]):
+        self.events = events
+
+    async def get_session(self, session_id: str, update_activity: bool = True):
+        return None  # 저장소에 없는 세션 — 재검증은 건너뛴다
+
+    async def update_session(self, session_id: str, state) -> bool:
+        approvals = {aid: a.get("status") for aid, a in state.get("pending_approvals", {}).items()}
+        self.events.append(("persist", approvals))
+        return True
+
+
+@pytest.fixture
+def executor_env(monkeypatch):
+    monkeypatch.setattr("orchestrator.nodes.base.record_usage_best_effort", AsyncMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.AuditService.log", MagicMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.audit_task_status_change", MagicMock())
+    monkeypatch.setattr("orchestrator.nodes.executor.audit_tool_executed", MagicMock())
+
+
+def _executor_state() -> dict[str, Any]:
+    state = create_initial_state(session_id="s-283-exec")
+    task = TaskNode(id="t1", title="risky", description="do risky work")
+    task.pending_approval_id = "a1"
+    state["tasks"]["t1"] = task
+    state["current_task_id"] = "t1"
+    state["pending_approvals"] = {
+        "a1": {
+            "id": "a1",
+            "session_id": "s-283-exec",
+            "task_id": "t1",
+            "tool_name": "execute_bash",
+            "tool_args": RISKY_ARGS,
+            "risk_level": "high",
+            "risk_description": "shell",
+            "status": ApprovalStatus.APPROVED.value,
+            "created_at": "2026-08-19T00:00:00+00:00",
+        }
+    }
+    state["waiting_for_approval"] = False
+    return state
+
+
+def _llm_response(content: str, tool_calls: list[dict[str, Any]]) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 1, "output_tokens": 1}
+    response.tool_calls = tool_calls
+    return response
+
+
+@pytest.mark.asyncio
+async def test_consumption_persisted_before_tool_execution(monkeypatch, executor_env):
+    """`consumed` 전이가 도구 실행보다 먼저 저장된다.
+
+    순서가 뒤집히면 "도구는 실행됐는데 소비 기록은 없는" 창이 생기고,
+    그 사이에 죽으면 재시작 후 같은 승인으로 다시 실행된다.
+    """
+    events: list[tuple[str, Any]] = []
+    monkeypatch.setattr(
+        "orchestrator.nodes.executor.get_session_service",
+        lambda: RecordingSessionService(events),
+    )
+
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = AsyncMock(
+        side_effect=[_llm_response("", [RISKY_CALL]), _llm_response("done", [])]
+    )
+    node = ExecutorNode(llm=fake_llm, tools=[])
+    monkeypatch.setattr(
+        ExecutorNode,
+        "_resolved_llm_for_state",
+        lambda self, state, **kwargs: (fake_llm, "claude-sonnet-5", None),
+    )
+
+    async def _record_tool(self, tool_name, tool_args, usage_context=None):
+        events.append(("tool", tool_name))
+        return "ok"
+
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", _record_tool)
+
+    result = await node.run(_executor_state())
+
+    assert ("tool", "execute_bash") in events, f"도구가 실행되지 않았다: {events}"
+    persist_index = next(i for i, (kind, _) in enumerate(events) if kind == "persist")
+    tool_index = next(i for i, (kind, _) in enumerate(events) if kind == "tool")
+    assert persist_index < tool_index, f"소비 기록이 실행보다 늦다: {events}"
+    assert events[persist_index][1] == {"a1": ApprovalStatus.CONSUMED.value}
+    assert result["pending_approvals"]["a1"]["status"] == ApprovalStatus.CONSUMED.value
+
+
+@pytest.mark.asyncio
+async def test_tool_not_executed_when_consumption_persist_fails(monkeypatch, executor_env):
+    """소비를 기록하지 못하면 도구를 실행하지 않는다 (at-most-once)."""
+    class FailingService:
+        async def get_session(self, session_id: str, update_activity: bool = True):
+            return None
+
+        async def update_session(self, session_id: str, state) -> bool:
+            raise RuntimeError("db down")
+
+    monkeypatch.setattr("orchestrator.nodes.executor.get_session_service", FailingService)
+
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = AsyncMock(side_effect=[_llm_response("", [RISKY_CALL])])
+    node = ExecutorNode(llm=fake_llm, tools=[])
+    monkeypatch.setattr(
+        ExecutorNode,
+        "_resolved_llm_for_state",
+        lambda self, state, **kwargs: (fake_llm, "claude-sonnet-5", None),
+    )
+    execute_tool = AsyncMock(return_value="ok")
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", execute_tool)
+
+    result = await node.run(_executor_state())
+
+    execute_tool.assert_not_awaited()
+    assert result["tasks"]["t1"].status == TaskStatus.FAILED
+    # 소비는 실행 **전에** 기록하므로, 저장이 실패한 시점에는 도구가 아직 안 돌았다.
+    # 전이를 되돌려야 나중에 정당하게 재시도할 수 있다.
+    assert result["pending_approvals"]["a1"]["status"] == ApprovalStatus.APPROVED.value
+    assert "consumed_at" not in result["pending_approvals"]["a1"]
+
+
+@pytest.mark.asyncio
+async def test_consumed_approval_does_not_re_authorize(monkeypatch, executor_env):
+    """소비된 승인은 같은 호출을 다시 통과시키지 않는다."""
+    monkeypatch.setattr(
+        "orchestrator.nodes.executor.get_session_service",
+        lambda: RecordingSessionService([]),
+    )
+    state = _executor_state()
+    state["pending_approvals"]["a1"]["status"] = ApprovalStatus.CONSUMED.value
+
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = AsyncMock(side_effect=[_llm_response("", [RISKY_CALL])])
+    node = ExecutorNode(llm=fake_llm, tools=[])
+    monkeypatch.setattr(
+        ExecutorNode,
+        "_resolved_llm_for_state",
+        lambda self, state, **kwargs: (fake_llm, "claude-sonnet-5", None),
+    )
+    execute_tool = AsyncMock(return_value="ok")
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", execute_tool)
+
+    result = await node.run(state)
+
+    execute_tool.assert_not_awaited()
+    assert result["waiting_for_approval"] is True
+
+
+class JitteryRecordingService:
+    """쓰기 지연이 들쭉날쭉한 저장소 double.
+
+    실제 저장은 state 를 직렬화해 세션 JSON **전체**를 덮어쓴다. 직렬화 시점과
+    커밋 시점 사이에는 실제 지연이 있고 그 지연은 호출마다 다르다 — 먼저 시작한
+    쓰기가 **나중에** 커밋될 수 있다. 첫 호출만 느리게 만들어 그 순서를 고정한다.
+    직렬화가 없으면 늦게 커밋된 낡은 스냅샷이 다른 소비를 되돌린다.
+    """
+
+    FIRST_WRITE_DELAY = 0.02
+
+    def __init__(self) -> None:
+        self.writes: list[dict[str, str]] = []
+        self._calls = 0
+
+    async def get_session(self, session_id: str, update_activity: bool = True):
+        return None  # 저장소 재검증은 이 테스트의 관심사가 아니다
+
+    async def update_session(self, session_id: str, state) -> bool:
+        snapshot = {aid: a.get("status") for aid, a in state.get("pending_approvals", {}).items()}
+        delay = self.FIRST_WRITE_DELAY if self._calls == 0 else 0.0
+        self._calls += 1
+        await asyncio.sleep(delay)
+        self.writes.append(snapshot)
+        return True
+
+
+def _two_approved_tasks_state() -> dict[str, Any]:
+    state = create_initial_state(session_id="s-283-parallel")
+    for idx, (task_id, approval_id, command) in enumerate(
+        (("t1", "a1", "rm -rf /tmp/one"), ("t2", "a2", "rm -rf /tmp/two")), start=1
+    ):
+        task = TaskNode(id=task_id, title=f"risky {idx}", description="do risky work")
+        task.pending_approval_id = approval_id
+        state["tasks"][task_id] = task
+        state["pending_approvals"][approval_id] = {
+            "id": approval_id,
+            "session_id": "s-283-parallel",
+            "task_id": task_id,
+            "tool_name": "execute_bash",
+            "tool_args": {"command": command},
+            "risk_level": "high",
+            "risk_description": "shell",
+            "status": ApprovalStatus.APPROVED.value,
+            "created_at": "2026-08-19T00:00:00+00:00",
+        }
+    state["waiting_for_approval"] = False
+    return state
+
+
+@pytest.mark.asyncio
+async def test_parallel_consumption_writes_are_serialized(monkeypatch, executor_env):
+    """병렬 배치에서 소비 기록이 서로를 되돌리지 않는다.
+
+    `execute_batch` 는 executor 여럿을 같은 세션 state 위에서 동시에 돌린다.
+    `update_session` 이 세션 JSON 전체를 덮으므로, 직렬화하지 않으면 늦게 도착한
+    낡은 스냅샷이 다른 소비를 `approved` 로 되돌린다 — 그 직후 프로세스가 죽으면
+    되살아난 승인으로 도구가 다시 실행된다.
+    """
+    service = JitteryRecordingService()
+    monkeypatch.setattr("orchestrator.nodes.executor.get_session_service", lambda: service)
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", AsyncMock(return_value="ok"))
+
+    shared = _two_approved_tasks_state()
+
+    def _node_for(command: str) -> ExecutorNode:
+        call = {"name": "execute_bash", "args": {"command": command}, "id": f"call-{command}"}
+        fake_llm = MagicMock()
+        fake_llm.ainvoke = AsyncMock(
+            side_effect=[_llm_response("", [call]), _llm_response("done", [])]
+        )
+        node = ExecutorNode(llm=fake_llm, tools=[])
+        # 인스턴스에 직접 건다 — 클래스에 걸면 두 노드가 같은 LLM 을 공유해
+        # 응답 순서가 섞이고, 테스트가 검증하려는 병렬성이 사라진다.
+        node._resolved_llm_for_state = (  # type: ignore[method-assign]
+            lambda state, **kwargs: (fake_llm, "claude-sonnet-5", None)
+        )
+        return node
+
+    # `ParallelExecutorNode._execute_with_semaphore` 와 같은 형태: state 는 얕은 복사라
+    # `pending_approvals` 와 그 레코드들이 두 실행 사이에 공유된다.
+    await asyncio.gather(
+        _node_for("rm -rf /tmp/one").run({**shared, "current_task_id": "t1"}),
+        _node_for("rm -rf /tmp/two").run({**shared, "current_task_id": "t2"}),
+    )
+
+    assert service.writes, "소비가 저장되지 않았다"
+    assert service.writes[-1] == {
+        "a1": ApprovalStatus.CONSUMED.value,
+        "a2": ApprovalStatus.CONSUMED.value,
+    }, f"낡은 스냅샷이 다른 소비를 되돌렸다: {service.writes}"
+
+
+class StoreBackedService:
+    """저장소를 흉내내는 double — 읽을 때마다 **새 사본**을 준다.
+
+    DB 모드의 `SessionService` 가 그렇다(`repo.get_state` 가 JSONB 를 매번 디코딩).
+    따라서 캐시가 비어 있으면 동시에 시작한 두 실행이 서로 독립된 state 를 든다.
+    """
+
+    def __init__(self, state: dict[str, Any]):
+        self.stored = state
+
+    async def get_session(self, session_id: str, update_activity: bool = True):
+        await asyncio.sleep(0)
+        return copy.deepcopy(self.stored)
+
+    async def update_session(self, session_id: str, state) -> bool:
+        await asyncio.sleep(0)
+        self.stored = copy.deepcopy(state)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_execute_approved_tool_once(monkeypatch, executor_env):
+    """독립된 state 사본을 든 두 실행이 겹쳐도 도구는 한 번만 돈다.
+
+    캐시가 빈 상태(재시작 직후)에서 같은 세션에 그래프 실행이 둘 겹치면 각자
+    `approved` 사본을 들고 온다. 로컬 사본만 보는 검사는 둘 다 통과시키므로,
+    소비 직전에 **저장소**의 승인 상태를 다시 확인해야 한다.
+    """
+    base = _executor_state()
+    service = StoreBackedService(copy.deepcopy(base))
+    monkeypatch.setattr("orchestrator.nodes.executor.get_session_service", lambda: service)
+    execute_tool = AsyncMock(return_value="ok")
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", execute_tool)
+
+    def _node() -> ExecutorNode:
+        fake_llm = MagicMock()
+        fake_llm.ainvoke = AsyncMock(
+            side_effect=[_llm_response("", [RISKY_CALL]), _llm_response("done", [])]
+        )
+        node = ExecutorNode(llm=fake_llm, tools=[])
+        node._resolved_llm_for_state = (  # type: ignore[method-assign]
+            lambda state, **kwargs: (fake_llm, "claude-sonnet-5", None)
+        )
+        return node
+
+    await asyncio.gather(
+        _node().run(copy.deepcopy(base)),
+        _node().run(copy.deepcopy(base)),
+    )
+
+    assert execute_tool.await_count == 1, "같은 승인으로 도구가 두 번 실행됐다"
+
+
+@pytest.mark.asyncio
+async def test_consumption_fails_closed_when_storage_lost_the_approval(monkeypatch, executor_env):
+    """저장소에 세션은 있는데 그 승인이 없으면 실행하지 않는다.
+
+    "영속 저장소가 없다"가 아니라 "이 승인은 더 이상 유효하지 않다"는 뜻이다.
+    그대로 진행하면 뒤이은 전체 state 저장이 없어진 승인을 되살린 뒤 도구까지 돌린다.
+    """
+    stored = _executor_state()
+    stored["pending_approvals"] = {}  # 저장소에는 이 승인이 없다
+    monkeypatch.setattr(
+        "orchestrator.nodes.executor.get_session_service",
+        lambda: StoreBackedService(stored),
+    )
+    execute_tool = AsyncMock(return_value="ok")
+    monkeypatch.setattr(ExecutorNode, "_execute_tool", execute_tool)
+
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = AsyncMock(side_effect=[_llm_response("", [RISKY_CALL])])
+    node = ExecutorNode(llm=fake_llm, tools=[])
+    node._resolved_llm_for_state = (  # type: ignore[method-assign]
+        lambda state, **kwargs: (fake_llm, "claude-sonnet-5", None)
+    )
+
+    result = await node.run(_executor_state())
+
+    execute_tool.assert_not_awaited()
+    assert result["waiting_for_approval"] is True
+
+
+@pytest.mark.asyncio
+async def test_transition_rolled_back_when_persistence_fails():
+    """영속화가 실패하면 전이를 되돌린다.
+
+    되돌리지 않으면 캐시는 `approved`, 저장소는 `pending` 으로 갈라져 이후
+    재시도가 400 을 받는다 — 그 승인은 영영 해소할 수 없게 된다.
+    """
+    engine = StubEngine(_waiting_state())
+    engine.save_error = RuntimeError("db down")
+
+    with pytest.raises(RuntimeError):
+        await approve_operation("s-283", "a1", None, engine)
+
+    cached = engine.cached_approval("s-283", "a1")
+    assert cached["status"] == ApprovalStatus.PENDING.value
+    assert engine.run_calls == 0
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. 크래시 잔재 — 소비된 승인에 매달린 task 는 실패로 정리한다
+# ─────────────────────────────────────────────────────────────
+
+
+def _orphan_state(task_status: TaskStatus) -> dict[str, Any]:
+    """도구 실행 도중 죽은 뒤 재시작한 state.
+
+    소비는 영속화됐고(consumed) task 는 실행 중 상태로 남아 있다.
+    """
+    state = create_initial_state(session_id="s-283-orphan")
+    state["tasks"]["root"] = TaskNode(
+        id="root", title="root", status=TaskStatus.IN_PROGRESS, children=["t1"]
+    )
+    state["root_task_id"] = "root"
+    task = TaskNode(id="t1", parent_id="root", title="risky", status=task_status)
+    task.pending_approval_id = "a1"
+    state["tasks"]["t1"] = task
+    state["pending_approvals"] = {
+        "a1": {
+            "id": "a1",
+            "task_id": "t1",
+            "tool_name": "execute_bash",
+            "tool_args": RISKY_ARGS,
+            "status": ApprovalStatus.CONSUMED.value,
+        }
+    }
+    return state
+
+
+@pytest.mark.parametrize("task_status", [TaskStatus.IN_PROGRESS, TaskStatus.WAITING])
+@pytest.mark.asyncio
+async def test_orphaned_task_after_consumed_approval_fails_explicitly(task_status):
+    """소비된 승인에 매달린 task 는 조용히 멈추지 않고 실패로 드러난다.
+
+    실행 여부를 알 수 없으므로 자동 재실행은 금지다 — 대신 재승인이
+    필요하다는 사실을 오류로 남긴다.
+    """
+    node = OrchestratorNode()
+
+    result = await node.run(_orphan_state(task_status))
+
+    assert result["tasks"]["t1"].status == TaskStatus.FAILED
+    assert "재승인" in (result["tasks"]["t1"].error or "")
+    assert result["next_action"] is None
+
+
+@pytest.mark.asyncio
+async def test_approved_waiting_task_still_resumes():
+    """승인만 된(미소비) WAITING task 의 재개는 그대로다 (#282 회귀 방지)."""
+    state = _orphan_state(TaskStatus.WAITING)
+    state["pending_approvals"]["a1"]["status"] = ApprovalStatus.APPROVED.value
+
+    result = await OrchestratorNode().run(state)
+
+    assert result["next_action"] == "execute"
+    assert result["current_task_id"] == "t1"


### PR DESCRIPTION
같은 승인으로 비가역 도구(`execute_bash` 등)가 두 번 실행될 수 있는 경로들을 닫습니다. Closes #283.

## 먼저: 대시보드는 승인을 **WebSocket 으로만** 보낸다

`src/dashboard/src/stores/orchestration/index.ts:194,224` — `approveOperation`/`denyOperation` 둘 다 `ws.send({type:'approval_response'})` 입니다. REST `/approve`·`/deny` 는 UI 가 쓰지 않습니다.

그런데 `api/websocket.py` 의 승인 처리는 REST 와 **같은 전이를 각자 구현**하고 있었고, 그쪽에는 PENDING 검사가 없었습니다. 중복 응답 한 번이면 이미 소비된(`consumed`) 승인이 다시 `approved` 로 돌아가고, 그 상태에서 재개하면 같은 도구가 다시 실행됩니다(거부된 승인도 되살릴 수 있었습니다).

**REST 만 고쳤다면 UI 가 지나지 않는 경로만 안전해졌을 것**이라 `websocket.py` 를 함께 바꿨습니다.

## 결함 3층

### 1. 전이가 원자적이지 않다

경합 창은 검사↔변경 사이가 아니라 **그 위의 세션 조회**입니다. `engine.get_session` 은 캐시 미스 시 `await` 하고, DB 경로는 호출마다 새 dict 를 돌려줍니다(`repo.get_state` 가 JSONB 를 매번 디코딩). 캐시가 빈 상태(프로세스 재시작 직후)의 동시 요청 두 건이 각자 사본에서 PENDING 을 보고 **둘 다 통과**합니다.

추정이 아니라 실측입니다 — 회귀 테스트가 락 없이 RED 입니다(`승인이 두 번 통과했다`, `engine.run` 2회).

### 2. 전이가 영속화되지 않는다

- 승인은 `engine.run` 이 **그래프를 다 마친 뒤에야** 저장됐습니다. 실행이 실패하면(200 + `error` 응답) 승인은 아무 데도 남지 않습니다.
- **거부는 그래프를 돌리지도 않으므로 아예 저장되지 않았습니다** — 재시작하면 거부한 작업이 다시 승인 대기로 나타납니다.

### 3. 소비가 프로세스 로컬이다

PR #279 의 1회용 소비(`task.pending_approval_id = None`)는 메모리 변경일 뿐이라, 도구가 부수효과를 낸 뒤 저장 전에 죽으면 재시작 후 승인이 다시 살아납니다.

## 수정

| 계약 | 위치 |
|---|---|
| 전이의 관문은 하나 (REST·WebSocket 공용) | `api/hitl.py` 의 `resolve_approval` |
| 조회→검사→변경→영속화를 직렬화 | `APPROVAL_STATE_LOCK` (`models/hitl.py`) |
| 전이는 `engine.run` **전에** 영속화 | `resolve_approval` → `engine.save_session` |
| 소비는 `CONSUMED` 전이로 표현하고 도구 실행 **전에** 영속화 | `ExecutorNode._consume_approval` |
| 소비는 락 안에서 상태를 다시 확인하는 compare-and-set | 같은 함수 |
| 소비 직전 **저장소의** 승인 상태를 재확인(없으면 fail closed) | `_approval_is_claimable_in_storage` |
| 소비는 승인 레코드를 **제자리에서** 변경 | 같은 함수 |
| 영속화 실패 시 전이를 롤백 | `resolve_approval` · `_consume_approval` |
| 소비 기록은 **엔진이 읽는** 저장소에 | `ExecutorNode(session_service=...)` 주입 |
| 소비된 승인에 매달린 잔재는 실패로 정리 | `OrchestratorNode` + `is_task_orphaned_by_consumed_approval` |

설계상 요점 몇 가지:

- **`task.pending_approval_id` 를 지우지 않고 승인 레코드를 `CONSUMED` 로 전이합니다.** 대조가 `status == APPROVED` 를 요구하므로 1회용 바인딩(#274)은 그대로이고, 포인터를 남기면 실행 도중 죽은 잔재를 스케줄러가 식별해 **실패로 정리**할 수 있습니다(조용히 멈추지 않습니다). 자동 재개는 하지 않습니다 — 도구가 실제로 돌았는지 알 수 없기 때문입니다.
- **executor 의 모든 반환 경로가 `pending_approvals` 를 실어 보냅니다.** 빠뜨리면 그래프 종료 시의 전체 state 저장이 `consumed` 를 `approved` 로 되돌립니다.
- **전이와 소비가 같은 락을 공유합니다.** 둘 다 세션 JSON 전체를 덮어쓰므로 따로 잠그면 서로의 쓰기를 되돌립니다. 락은 저장까지만 잡고 그래프 실행은 밖에서 합니다(분 단위 실행을 락 안에 두면 두 번째 요청이 매달리고, 교착도 됩니다).
- **락은 이벤트 루프별**입니다(`utils/locks.py`). 모듈 수준 `asyncio.Lock` 은 처음 경합한 루프에 바인딩되고, 그 `RuntimeError` 가 테스트에서 "거부됨"으로 오인되면 검증이 조용히 무력해집니다 — 실측으로 재현했습니다.

`resolve_approval` 로 합치면서 REST 경로에도 승인 감사 로그가 생깁니다(기존엔 WebSocket 에만 있었습니다). 감사 로그는 **저장에 성공한 뒤**에만 남깁니다. WebSocket 의 task 오류 문구는 REST 쪽(`Operation denied: ...`)으로 통일했습니다 — 프론트·테스트에서 옛 문구(`Denied:`)를 읽는 곳은 0건입니다.

## 테스트

`tests/backend/test_hitl_approval_atomicity.py` 17건. **전부 수정 전 RED 확인**했고, 나중에 추가한 3건은 해당 수정만 되돌려 개별 RED 를 확인했습니다.

| 보장 | 되돌렸을 때의 실패 |
|---|---|
| 동시 승인 1건만 통과 | 승인 2건 통과, `engine.run` 2회 |
| 동시 approve/deny 중 한쪽만 | (락 루프 바인딩 시) `RuntimeError` 가 "거부됨"으로 위장 |
| 소비된 승인 재개봉 차단 | — |
| WebSocket 이 관문을 우회하지 않음(소스 불변식) | — |
| 승인/거부가 `engine.run` 전에 영속화 | `persist` 없이 `run` 만 |
| 소비 기록이 도구 실행보다 먼저 | 순서 역전 |
| 병렬 배치 소비가 서로를 되돌리지 않음 | 마지막 쓰기가 `{a1: consumed, a2: approved}` |
| 독립 사본을 든 동시 실행에서 도구 1회 | 도구 2회 실행 |
| 저장소가 승인을 잃었으면 실행 금지 | 실행됨 |
| 영속화 실패 시 롤백 | 캐시 `approved` / 저장소 `pending` |
| 소비된 승인 잔재는 실패로 정리 | 조용히 멈춤 |

## 검증

| 항목 | 결과 |
|---|---|
| `ruff check` / `format --check` | 위반 0 / 317 files formatted |
| `mypy . --ignore-missing-imports` | Success: no issues found in 318 source files |
| `pytest ../../tests/backend` | **1465 passed, 2 skipped, 0 failed** |
| Codex adversarial-review | 4라운드 (5건 → 2 → 2 → 2), 아래 |

기존 HITL 테스트(#274 바인딩 · #282 재개 · e2e) 전부 무회귀입니다. 이 브랜치는 main 기준이며 게이트는 격리 워크트리에서 돌렸습니다.

## Codex 검증 — 반영/이월

**반영(8건):** WebSocket 우회 · 소비의 compare-and-set · 캐시↔저장소 분기 · 전역 서비스 대신 주입된 서비스 · 락 루프 바인딩 · 병렬 배치 쓰기 직렬화 · 저장소 기준 재검증 · 영속화 실패 롤백. 하나하나 회귀 테스트로 고정했습니다.

**이월(1건) — 동일 세션에 대한 동시 그래프 실행.** `engine.run`/`stream` 의 최종 전체 state 저장은 락 밖이므로, 오래된 스냅샷에서 시작한 실행이 나중에 끝나면 `consumed` 를 되돌릴 수 있습니다. 다만 이는 **한 세션에서 그래프 실행이 둘 이상 겹칠 때만** 성립하며, 그 조건에서는 승인뿐 아니라 task·토큰 등 state 전반이 깨집니다 — 승인 문제가 아니라 세션 실행 직렬화(또는 낙관적 CAS)라는 별도 과제입니다. 라운드 2·3에서 같은 뿌리의 **도달 가능한** 형태(병렬 배치 내부, 독립 사본 간 소비)는 이 PR 에서 닫았습니다.

**범위 밖 — 크로스 프로세스 원자성.** 현재 배포는 단일 인스턴스입니다(`render.yaml`, `--workers` 없음). `approvals` 테이블과 `ApprovalRepository` 는 존재하지만 **호출자가 0건**이라, 그 테이블을 진실의 출처로 삼는 조건부 UPDATE 는 다중 워커 도입 시점의 작업입니다. 이번 PR 은 죽은 코드를 건드리지 않았습니다.

## 알려진 후속 (프론트)

대시보드는 승인 전송 후 로컬 상태를 낙관적으로 `approved` 로 바꾸고 되돌리지 않습니다. 이제 서버가 `APPROVAL_CONFLICT` 로 거절할 수 있으므로 오류 메시지는 뜨지만 카드는 승인됨으로 남습니다. 백엔드 전용 변경이라 프론트 테스트에 영향은 없고, 별도 이슈로 다루는 편이 낫습니다.

## 마이그레이션

없습니다. 새 상태값 `consumed` 는 세션 JSONB 안에서만 쓰이고, `approvals.status` 는 `String(20)` 에 CHECK 제약이 없습니다. `GET /approvals` 는 `pending` 만 돌려주므로 응답도 그대로입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011phVz5Vrvtq7CaFShYG39H