### PR TITLE
fix(engine): 세션 캐시를 서비스 계층 경계 안으로 (#284)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,24 @@ pending → in_progress → completed
                      ↘ waiting → (unblock) → in_progress
 ```
 
+## 세션 캐시 경계
+
+`OrchestrationEngine._sessions` 는 `SessionService` 앞의 프로세스 로컬 캐시다.
+TTL·삭제·영속화는 전부 서비스가 소유하므로, 캐시가 서비스를 우회하면 그 판정이
+통째로 건너뛰어진다.
+
+| 계약 | 위치 | 없으면 |
+|------|------|--------|
+| 캐시 히트도 만료를 확인한다 | `engine.get_session` → `SessionService.is_session_expired` | 만료된 세션이 캐시에서 무기한 서빙됨 |
+| 메타데이터 부재는 **만료**로 본다 | `SessionService.is_session_expired` | `delete_session` 이 메타데이터를 지우므로, 삭제된 세션을 캐시가 계속 내줌 |
+| 캐시 갱신은 영속화와 쌍을 이룬다 | `engine.save_session` | 재시작·다른 인스턴스의 캐시 미스 이후 변경이 사라짐 |
+| 외부 호출자는 캐시를 직접 순회하지 않는다 | `api/context.py` → `list_sessions()` + `engine.get_session()` | 만료 세션이 걸러지지 않고 응답에 실림 |
+| 목록 필터는 저장소 질의에 있다 | `SessionService.list_sessions(project_id=...)` | `limit` 이 필터보다 먼저 적용돼 대상 세션이 상위 N 개 밖으로 밀려남 |
+
+`is_session_expired` 는 프로세스 로컬 메타데이터만 본다 — 다중 인스턴스 배포에서는
+다른 인스턴스의 `refresh_session` 갱신을 보지 못해 유효한 세션을 만료로 볼 수 있다.
+단일 인스턴스 전제이며, 해소하려면 만료 판정을 공유 저장소로 옮겨야 한다.
+
 ## HITL 승인 생명주기
 
 ```

--- a/src/backend/api/agents/orchestrate.py
+++ b/src/backend/api/agents/orchestrate.py
@@ -467,8 +467,9 @@ async def execute_analysis(
             "pre_analyzed_execution_plan": entry.analysis.get("execution_plan", {}),
             "analysis_id": request.analysis_id,
         }
-        # 세션 업데이트
-        engine._sessions[session_id] = state
+        # 세션 업데이트 (캐시와 영속 저장소 함께 — 캐시만 갱신하면 재시작 후
+        # 계획이 사라져 PlannerNode 가 일반 LLM 계획으로 떨어진다)
+        await engine.save_session(session_id, state)
 
     return ExecuteAnalysisResponse(
         success=True,

--- a/src/backend/api/context.py
+++ b/src/backend/api/context.py
@@ -91,17 +91,26 @@ async def get_project_context(
     # Get current session info if available
     session_info = None
 
-    # Check if there's an active session for this project
-    for session_id, state in engine._sessions.items():
-        if state.get("project_id") == project_id:
-            session_info = {
-                "session_id": session_id,
-                "tasks_count": len(state.get("tasks", {})),
-                "agents_count": len(state.get("agents", {})),
-                "iteration_count": state.get("iteration_count", 0),
-                "current_task_id": state.get("current_task_id"),
-            }
-            break
+    # Check if there's an active session for this project.
+    #
+    # 엔진 캐시(`engine._sessions`)를 직접 순회하면 만료된 세션이 걸러지지 않는다.
+    # 서비스 목록으로 후보를 찾고 `engine.get_session` 으로 다시 읽어 만료 검사를
+    # 거치게 한다. state 의 프로젝트 식별자는 `project_id` 가 아니라
+    # `project.id` 다(코드베이스 공통 관행).
+    sessions = await engine.session_service.list_sessions()
+    for candidate in (s for s in sessions if s.get("project_id") == project_id):
+        # 목록에는 만료된 항목도 남아 있다 — 살아 있는 첫 세션을 찾을 때까지 본다.
+        state = await engine.get_session(candidate["id"])
+        if not state:
+            continue
+        session_info = {
+            "session_id": candidate["id"],
+            "tasks_count": len(state.get("tasks", {})),
+            "agents_count": len(state.get("agents", {})),
+            "iteration_count": state.get("iteration_count", 0),
+            "current_task_id": state.get("current_task_id"),
+        }
+        break
 
     return ProjectContextResponse(
         project_id=project.id,

--- a/src/backend/api/context.py
+++ b/src/backend/api/context.py
@@ -95,9 +95,12 @@ async def get_project_context(
     #
     # 엔진 캐시(`engine._sessions`)를 직접 순회하면 만료된 세션이 걸러지지 않는다.
     # 서비스 목록으로 후보를 찾고 `engine.get_session` 으로 다시 읽어 만료 검사를
-    # 거치게 한다. state 의 프로젝트 식별자는 `project_id` 가 아니라
-    # `project.id` 다(코드베이스 공통 관행).
-    sessions = await engine.session_service.list_sessions()
+    # 거치게 한다. 프로젝트 필터는 `list_sessions` 에 넘긴다 — 여기서 걸러내면
+    # 서비스의 `limit` 이 먼저 적용돼 대상 세션이 잘려 나간다.
+    #
+    # 아래 `project_id` 재확인은 중복이지만 남긴다. 서비스가 필터를 놓치면 이
+    # 엔드포인트가 *다른 프로젝트의* 세션을 내주게 되고, 그건 누락보다 나쁘다.
+    sessions = await engine.session_service.list_sessions(project_id=project_id)
     for candidate in (s for s in sessions if s.get("project_id") == project_id):
         # 목록에는 만료된 항목도 남아 있다 — 살아 있는 첫 세션을 찾을 때까지 본다.
         state = await engine.get_session(candidate["id"])

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -172,11 +172,14 @@ class SessionRepository:
         organization_id: str | None = None,
         limit: int = 50,
         offset: int = 0,
+        project_id: str | None = None,
     ) -> list[SessionModel]:
-        """List sessions for a user, optionally filtered by organization."""
+        """List sessions for a user, optionally filtered by organization/project."""
         query = select(SessionModel).where(SessionModel.user_id == user_id)
         if organization_id:
             query = query.where(SessionModel.organization_id == organization_id)
+        if project_id:
+            query = query.where(SessionModel.project_id == project_id)
         query = query.order_by(SessionModel.created_at.desc()).limit(limit).offset(offset)
         result = await self.db.execute(query)
         return list(result.scalars().all())
@@ -198,14 +201,18 @@ class SessionRepository:
     async def list_active(
         self,
         limit: int = 100,
+        project_id: str | None = None,
     ) -> list[SessionModel]:
-        """List active sessions."""
-        result = await self.db.execute(
-            select(SessionModel)
-            .where(SessionModel.status == "active")
-            .order_by(SessionModel.updated_at.desc())
-            .limit(limit)
-        )
+        """List active sessions, optionally scoped to one project.
+
+        프로젝트 필터는 질의에 있어야 한다 — 호출자가 결과를 걸러내면 `limit` 이
+        먼저 적용돼 대상 프로젝트 세션이 상위 N 개 밖으로 밀려날 수 있다.
+        """
+        query = select(SessionModel).where(SessionModel.status == "active")
+        if project_id:
+            query = query.where(SessionModel.project_id == project_id)
+        query = query.order_by(SessionModel.updated_at.desc()).limit(limit)
+        result = await self.db.execute(query)
         return list(result.scalars().all())
 
     async def delete_by_project(self, project_id: str) -> int:

--- a/src/backend/orchestrator/engine.py
+++ b/src/backend/orchestrator/engine.py
@@ -255,9 +255,12 @@ class OrchestrationEngine:
 
     async def get_session(self, session_id: str) -> AgentState | None:
         """Get session state."""
-        # Check memory cache first
-        if session_id in self._sessions:
+        # 캐시는 TTL 을 모른다 — 서비스에 만료 여부를 물어 확인한다.
+        # 만료(또는 메타데이터 부재)면 캐시를 버리고 서비스 경로로 떨어뜨려
+        # 판정과 정리를 서비스 한 곳에 맡긴다.
+        if session_id in self._sessions and not self.session_service.is_session_expired(session_id):
             return self._sessions[session_id]
+        self._sessions.pop(session_id, None)
 
         # Fall back to service (database)
         state = await self.session_service.get_session(session_id)

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -369,15 +369,21 @@ class SessionService:
         self,
         user_id: str | None = None,
         limit: int = 50,
+        project_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """List sessions."""
+        """List sessions, optionally scoped to one project.
+
+        `project_id` 는 저장소 질의로 내려간다. 호출자가 결과 목록을 걸러내면
+        `limit` 이 필터보다 먼저 적용돼, 대상 프로젝트의 세션이 상위 `limit` 개
+        밖에 있으면 없는 것처럼 보인다.
+        """
         if self.use_database:
             async with async_session_factory() as db:
                 repo = SessionRepository(db)
                 if user_id:
-                    sessions = await repo.list_by_user(user_id, limit=limit)
+                    sessions = await repo.list_by_user(user_id, limit=limit, project_id=project_id)
                 else:
-                    sessions = await repo.list_active(limit=limit)
+                    sessions = await repo.list_active(limit=limit, project_id=project_id)
                 return [
                     {
                         "id": s.id,
@@ -392,7 +398,11 @@ class SessionService:
                 ]
         else:
             sessions = []
-            for sid, state in list(self._memory_sessions.items())[:limit]:
+            for sid, state in list(self._memory_sessions.items()):
+                if len(sessions) >= limit:
+                    break
+                if project_id and state.get("project", {}).get("id") != project_id:
+                    continue
                 sessions.append(
                     {
                         "id": sid,

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -230,6 +230,25 @@ class SessionService:
                 return True
             return False
 
+    def is_session_expired(self, session_id: str) -> bool:
+        """세션이 TTL 을 넘겼는지 — 메타데이터만 보므로 state 로드 없이 저렴하다.
+
+        메타데이터가 없으면 만료로 본다. 결정적인 이유는 **삭제**다 —
+        `delete_session` 이 메타데이터를 지우므로, 서비스 경로에서 만료로 삭제된
+        세션은 메타데이터가 없는 상태로 남는다(`refresh_session` 이 그 경로를
+        탄다). 부재를 "살아 있음"으로 보면 호출자의 캐시가 이미 삭제된 세션을
+        계속 내주게 된다.
+
+        만료로 보면 호출자는 캐시를 버리고 정식 조회 경로로 떨어지며, 거기서
+        세션이 없으면 None 이 나온다. 메타데이터 없는 레거시 state 는 매번
+        저장소로 떨어지지만 그건 성능 비용이고, `create_session` 이 언제나
+        `state["_metadata"]` 를 써왔으므로 사실상 도달하지 않는다.
+        """
+        metadata = self._session_metadata.get(session_id)
+        if not metadata:
+            return True
+        return metadata.is_expired()
+
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session."""
         # Remove metadata

--- a/tests/backend/test_engine_session_cache.py
+++ b/tests/backend/test_engine_session_cache.py
@@ -172,3 +172,26 @@ class TestProjectContextSessionLookup:
 
         assert response.session_info is not None
         assert response.session_info["session_id"] == live_id
+
+    @pytest.mark.asyncio
+    async def test_project_session_found_beyond_default_list_limit(
+        self, monkeypatch, tmp_path, isolated_engine
+    ):
+        """다른 프로젝트 세션이 기본 limit 을 채워도 대상 프로젝트 세션을 찾는다.
+
+        `list_sessions()` 의 기본 `limit=50` 이 프로젝트 필터보다 먼저 적용되면
+        대상 세션이 잘려 나간다. 필터는 저장소 질의에 있어야 한다.
+        """
+        project = _project()
+        project.path = str(tmp_path)
+        monkeypatch.setattr("api.context.get_project", lambda pid: project)
+
+        engine = isolated_engine
+        for index in range(50):
+            await engine.create_session(project=_project(f"p-other-{index}"))
+        session_id = await engine.create_session(project=project)
+
+        response = await get_project_context(project.id, engine)
+
+        assert response.session_info is not None
+        assert response.session_info["session_id"] == session_id

--- a/tests/backend/test_engine_session_cache.py
+++ b/tests/backend/test_engine_session_cache.py
@@ -1,0 +1,174 @@
+"""엔진 세션 캐시 경계 회귀 테스트 (issue #284).
+
+`OrchestrationEngine._sessions` 캐시가 서비스 계층을 우회하면서 세 가지 증상이
+나온다 — 만료 검사를 건너뛰고, 외부에서 직접 순회되며, 서비스 영속화 없이
+갱신된다. 셋 다 "캐시가 서비스 계층을 우회한다"는 한 원인에서 나온다.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from api.context import get_project_context
+from models.project import Project
+from orchestrator import OrchestrationEngine
+from services.session_service import SessionService
+from utils.time import utcnow
+
+
+def _project(project_id: str = "p-cache") -> Project:
+    return Project(
+        id=project_id,
+        name="Cache Project",
+        path="/tmp/cache-project",
+        description="fixture",
+        claude_md=None,
+    )
+
+
+@pytest.fixture
+def isolated_engine() -> OrchestrationEngine:
+    """테스트마다 격리된 SessionService 를 가진 엔진.
+
+    기본 생성자는 전역 싱글턴 서비스를 잡으므로, 앞선 테스트가 만든 세션이
+    `list_sessions` 에 섞여 들어와 조회 테스트를 무력화한다.
+    """
+    return OrchestrationEngine(session_service=SessionService(use_database=False))
+
+
+def _expire(engine: OrchestrationEngine, session_id: str) -> None:
+    """세션 메타데이터를 만료 상태로 만든다."""
+    metadata = engine.session_service._session_metadata[session_id]
+    metadata.expires_at = utcnow() - timedelta(seconds=1)
+
+
+class TestCacheExpiryBoundary:
+    """캐시 히트가 TTL 검사를 우회하면 안 된다."""
+
+    @pytest.mark.asyncio
+    async def test_expired_session_is_not_served_from_cache(self, isolated_engine):
+        engine = isolated_engine
+        session_id = await engine.create_session()
+        assert session_id in engine._sessions, "생성 직후 캐시에 올라와 있다(전제)"
+
+        _expire(engine, session_id)
+
+        assert await engine.get_session(session_id) is None
+        assert session_id not in engine._sessions, "만료된 항목은 캐시에서도 사라져야 한다"
+
+    @pytest.mark.asyncio
+    async def test_live_session_is_still_served_from_cache(self, isolated_engine):
+        """만료 검사가 정상 세션까지 막으면 안 된다(경계선)."""
+        engine = isolated_engine
+        session_id = await engine.create_session()
+
+        state = await engine.get_session(session_id)
+
+        assert state is not None
+        assert state["session_id"] == session_id
+
+    @pytest.mark.asyncio
+    async def test_service_reports_expiry_without_loading_state(self, isolated_engine):
+        """만료 판정은 메타데이터만 보므로 state 로드가 필요 없다."""
+        engine = isolated_engine
+        session_id = await engine.create_session()
+        service = engine.session_service
+
+        assert service.is_session_expired(session_id) is False
+        _expire(engine, session_id)
+        assert service.is_session_expired(session_id) is True
+
+    @pytest.mark.asyncio
+    async def test_missing_metadata_is_treated_as_expired(self, isolated_engine):
+        """메타데이터 부재는 만료로 본다 — 삭제된 세션이 그 상태이기 때문이다."""
+        engine = isolated_engine
+
+        assert engine.session_service.is_session_expired("no-such-session") is True
+
+    @pytest.mark.asyncio
+    async def test_deleted_session_is_not_served_from_cache(self, isolated_engine):
+        """서비스에서 삭제된 세션을 엔진 캐시가 계속 내주면 안 된다.
+
+        `delete_session` 은 메타데이터를 지운다. 부재를 "살아 있음"으로 보면
+        캐시 히트가 성립해 이미 사라진 state 가 반환된다 — `refresh_session` 이
+        만료 세션을 지우는 경로가 실제로 있다(api/sessions.py, api/websocket.py).
+        """
+        engine = isolated_engine
+        session_id = await engine.create_session()
+        assert session_id in engine._sessions
+
+        await engine.session_service.delete_session(session_id)  # 엔진을 거치지 않은 삭제
+
+        assert await engine.get_session(session_id) is None
+        assert session_id not in engine._sessions
+
+
+class TestSaveSessionPersists:
+    """캐시 갱신과 영속화를 함께 수행하는 공개 경로."""
+
+    @pytest.mark.asyncio
+    async def test_save_session_writes_through_to_service(self, isolated_engine):
+        engine = isolated_engine
+        session_id = await engine.create_session()
+        state = await engine.get_session(session_id)
+        state["plan_metadata"] = {"pre_analyzed_execution_plan": {"subtasks": {"t1": {}}}}
+
+        await engine.save_session(session_id, state)
+
+        engine._sessions.clear()  # 캐시를 비워 저장소에서 다시 읽게 한다
+        reloaded = await engine.get_session(session_id)
+
+        assert reloaded["plan_metadata"]["pre_analyzed_execution_plan"]["subtasks"] == {"t1": {}}
+
+
+class TestProjectContextSessionLookup:
+    """`/projects/{id}/context` 의 세션 조회는 서비스 계층을 거쳐야 한다."""
+
+    @pytest.mark.asyncio
+    async def test_live_session_for_project_is_found(self, monkeypatch, tmp_path, isolated_engine):
+        """활성 세션이 응답에 실린다 — state 의 project id 키를 올바르게 읽는지."""
+        project = _project()
+        project.path = str(tmp_path)
+        monkeypatch.setattr("api.context.get_project", lambda pid: project)
+
+        engine = isolated_engine
+        session_id = await engine.create_session(project=project)
+
+        response = await get_project_context(project.id, engine)
+
+        assert response.session_info is not None
+        assert response.session_info["session_id"] == session_id
+
+    @pytest.mark.asyncio
+    async def test_expired_session_is_omitted(self, monkeypatch, tmp_path, isolated_engine):
+        """만료된 세션은 응답에 나타나지 않는다 — 캐시 직접 순회로는 걸러지지 않는다."""
+        project = _project()
+        project.path = str(tmp_path)
+        monkeypatch.setattr("api.context.get_project", lambda pid: project)
+
+        engine = isolated_engine
+        session_id = await engine.create_session(project=project)
+        _expire(engine, session_id)
+
+        response = await get_project_context(project.id, engine)
+
+        assert response.session_info is None
+
+    @pytest.mark.asyncio
+    async def test_live_session_found_when_earlier_one_expired(
+        self, monkeypatch, tmp_path, isolated_engine
+    ):
+        """같은 프로젝트에 세션이 여럿이고 앞선 것이 만료면 살아 있는 쪽을 찾는다."""
+        project = _project()
+        project.path = str(tmp_path)
+        monkeypatch.setattr("api.context.get_project", lambda pid: project)
+
+        engine = isolated_engine
+        stale_id = await engine.create_session(project=project)
+        live_id = await engine.create_session(project=project)
+        _expire(engine, stale_id)
+
+        response = await get_project_context(project.id, engine)
+
+        assert response.session_info is not None
+        assert response.session_info["session_id"] == live_id


### PR DESCRIPTION
Closes #284

## 문제

`OrchestrationEngine._sessions` 캐시가 서비스 계층을 우회하면서 세 증상이 나왔다. 셋 다 같은 원인이라 함께 고친다.

1. **만료 검사 우회** — `get_session` 이 캐시 히트 시 즉시 반환해 TTL 을 건너뛰었다. 만료 판정·정리는 `SessionService.get_session` 에만 있고, 서비스가 만료 세션을 지워도 엔진 캐시는 그 사실을 모른다.
2. **캐시 직접 순회** — `api/context.py` 가 `engine._sessions` 를 직접 읽어 서비스 계층을 건너뛰었다.
3. **영속화 누락** — `api/agents/orchestrate.py` 가 사전 분석 계획을 캐시에만 넣고 `update_session` 을 호출하지 않았다. 재시작·다른 인스턴스의 캐시 미스 이후 계획이 사라져 PlannerNode 가 일반 LLM 계획으로 떨어진다.

## 수정

### 캐시를 서비스 경계 안으로

- `SessionService.is_session_expired` 추가. 메타데이터만 보므로 state 로드 없이 저렴하다.
- `OrchestrationEngine.get_session` 이 캐시 히트에도 만료를 확인하고, 만료면 캐시를 버리고 서비스 경로로 떨어진다.
- `api/context.py` 가 `list_sessions()` + `engine.get_session()` 을 거쳐 서비스 계층을 통과한다. 목록에 만료 항목이 섞여 있으므로 **후보를 순회**해 살아 있는 첫 세션을 찾는다.
- `api/agents/orchestrate.py` 가 `engine._sessions[...] = state` 대신 `engine.save_session()` 을 호출해 캐시와 저장소에 함께 반영한다.

> **리베이스 메모.** 이 브랜치를 처음 올린 뒤 PR #287(#283) 이 머지되면서 `OrchestrationEngine.save_session` 이 main 에 먼저 들어왔다. 두 작업이 같은 결함을 독립적으로 발견한 것이라 구현이 동일했고, docstring 이 더 자세한 main 쪽을 남겼다. 그래서 이 PR 의 `engine.py` 델타는 `get_session` 의 만료 검사 한 곳으로 줄었고, `orchestrate.py` 는 main 이 제공하는 `save_session` 을 소비한다.

**메타데이터 부재는 만료로 본다.** `is_session_expired` 는 메타데이터가 없을 때 `True` 를 반환한다. 결정적인 이유는 **삭제**다 — `delete_session` 이 메타데이터를 지우므로 서비스 경로에서 삭제된 세션이 그 상태로 남고, 부재를 "살아 있음" 으로 보면 캐시가 이미 삭제된 세션을 계속 내준다.

### 프로젝트 필터를 질의로 (앞 커밋의 회귀 수정)

`api/context.py` 가 캐시 직접 순회에서 `list_sessions()` 로 옮겨가면서, 서비스 기본 `limit=50` 이 프로젝트 필터보다 **먼저** 적용되게 됐다. 활성 세션이 50 개를 넘고 대상 프로젝트 세션이 상위 50 개 밖이면 살아 있는 세션을 못 찾아 `session_info: null` 이 나간다. 캐시 직접 순회(`engine._sessions.items()`)에는 이 제한이 없었으므로 **앞 커밋이 만든 회귀**다.

- `SessionRepository.list_active` / `list_by_user` 에 `project_id` 질의 필터 추가
- `SessionService.list_sessions` 가 이를 저장소로 내려보낸다. 메모리 모드도 limit 슬라이스 전에 필터한다.
- `api/context.py` 가 `project_id` 를 넘긴다. 호출부의 `project_id` 재확인은 중복이지만 남겼다 — 서비스가 필터를 놓치면 이 엔드포인트가 *다른 프로젝트의* 세션을 내주게 되고, 그건 누락보다 나쁘다.

### 문서

`docs/architecture.md` 에 **세션 캐시 경계** 절을 추가했다. 이 PR 이 고친 네 가지 계약과,
고치는 과정에서 새로 생겼다 되돌린 하나(목록 필터가 `limit` 뒤에 적용되던 회귀)를 표로 남기고,
`is_session_expired` 가 단일 인스턴스 전제라는 점도 함께 적었다.

## 검증

로컬 게이트 (CWD `src/backend`):

| 게이트 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 317 files already formatted |
| `uv run mypy . --ignore-missing-imports` | **318 source files, 0 errors** |
| `uv run pytest ../../tests/backend` | **1474 passed, 1 failed, 2 skipped** |

신규 테스트 10 건 (`tests/backend/test_engine_session_cache.py`) 전부 통과 — 만료 세션 미서빙, 삭제 세션 미서빙, 앞선 후보가 만료여도 살아있는 세션 발견, write-through, **기본 limit 을 넘긴 프로젝트 세션 조회** 포함.

회귀 테스트는 Red-Green 으로 확인했다: 필터를 질의로 내리기 전에 `test_project_session_found_beyond_default_list_limit` 이 실패(`session_info is None`)하고, 수정 후 통과한다.

위 수치는 PR #287 머지 후 main 으로 리베이스한 상태에서 다시 측정한 것이다.

유일한 실패 `test_rag_verification::test_embedding_model_consistency` 는 로컬 `.env` 의 `RAG_EMBEDDING_MODEL` 오버라이드가 원인이며 이 변경과 무관하다 (CI 는 통과).

## 리뷰 판정 기록

반영하지 않은 지적을 이유와 함께 남긴다.

최종 Codex 검증(`--scope branch --base main`, 리베이스 후 재실행): **지적 0건** —
"The changes consistently route session lookup, persistence, expiry checks, and project filtering
through the session service. No definite regression was found in the diff."

### 반영함 — Codex `--scope branch --base main`

- **[P2] 기본 50 개 너머 검색** (`api/context.py:100-101`) — 타당한 지적이었고, 조사 결과 이 PR 이 만든 회귀임이 확인돼 `5bce4cb` 로 수정했다. 최초 PR 본문은 이를 "기존 한계"로 잘못 분류했었다. main 의 이전 구현은 `engine._sessions.items()` 전체를 제한 없이 순회했으므로 이월된 제약이 아니다.

### 범위 밖 · 별도 이슈

엔진 내부 4 곳의 캐시 쓰기(`engine.py:231·337·494·530`)는 이미 캐시와 영속화를 쌍으로 수행한다. 서비스 경유로 바꾸는 것은 리팩터링이지 결함 수정이 아니므로 이 PR 에 넣지 않았다.

### 후속 — 다중 인스턴스 TTL 경합

`is_session_expired` 는 프로세스 로컬 `_session_metadata` 만 본다. 인스턴스 B 가 `refresh_session` 으로 TTL 을 갱신해도 A 는 옛 메타데이터를 들고 있어 유효한 세션을 만료로 판정할 수 있다. `refresh_session` 은 실제로 호출되므로(`api/sessions.py:198`, `api/websocket.py:126`) 이론적 시나리오가 아니다.

**이 PR 은 캐시 히트에도 서비스 경로를 타게 만들어 이 경합의 노출 빈도를 높인다.** 근본 해결(공유 저장소 기반 만료 판정)은 별도 작업이다. 원래 #283 에 기록하려던 항목이나 #283 은 이미 CLOSED 라 여기에 남긴다.

### 이 PR 과 무관한 지적 3 건 (이전 라운드)

`api/websocket.py`, `api/hitl.py`, `orchestrator/nodes/executor.py` 의 승인 락·`persist_session`·소비 기록 지적은 **#283 세션의 코드**였다. 같은 저장소를 두 세션이 공유하던 중 오염된 워킹트리를 검증해 나온 지적이며, 깨끗한 브랜치 diff 로 재검증한 결과 재현되지 않았다. 해당 작업은 PR #287 로 이미 main 에 머지됐다.
