### PR TITLE
feat(session): 세션 state 낙관적 동시성으로 다중 인스턴스 지원 (#292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,10 @@ jobs:
       - name: Run tests
         env:
           DATABASE_URL: postgresql+asyncpg://aos:aos@localhost:5432/aos_test
+          # DB 모드 동시성 테스트(tests/backend/test_session_concurrency_db.py)의
+          # opt-in 스위치. 전용 변수를 쓰는 이유는 로컬에서 실수로 개발 DB 를
+          # 건드리지 않게 하기 위해서다 — 없으면 그 파일은 skip 된다.
+          AOS_TEST_DATABASE_URL: postgresql+asyncpg://aos:aos@localhost:5432/aos_test
           REDIS_URL: redis://localhost:6379/0
           USE_DATABASE: "true"
           SESSION_SECRET_KEY: test-secret-key

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -183,6 +183,55 @@ Codex 1~10차 로그는 세션 scratchpad에만 있어 **휘발됐다** — 장�
 
 ## Session Continuity
 
+### 2026-08-22 세션 — #284 복구 → #289 → #292 낙관적 동시성 (진행 중, 다른 세션으로 이관)
+
+**끝난 것 (main 에 안착)**
+| PR | 내용 | 머지 |
+|---|---|---|
+| #288 (#284) | 엔진 세션 캐시를 서비스 계층 경계 안으로 + 프로젝트 필터를 질의로 | `93c30d8` |
+| #290 (#289) | 만료 판정이 저장소 메타데이터를 따르도록(리스 vs high-water mark) | `f6ad989` |
+
+**열린 PR — #293 (issue #292): 이 세션의 미완 작업**
+브랜치 `fix/session-state-optimistic-concurrency` · 커밋 5 개 · head `cf1988a` (푸시 완료)
+CI 8/8 pass · `MERGEABLE`/`CLEAN` · 로컬 게이트 ruff/mypy(319 files 0 errors)/pytest **1490 passed**
+(유일 실패 `test_embedding_model_consistency` 는 로컬 `.env` 오버라이드, CI 는 통과)
+
+**남은 일은 하나뿐: Codex 3 라운드 검증 후 머지.**
+3 라운드를 걸었으나 완료 전에 중단했다(로그 파기됨). 재실행:
+```
+SCRIPT=$(ls ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | sort -V | tail -1)
+cd ~/Work/Agent-System && nohup node "$SCRIPT" review --scope branch --base main > /tmp/codex-293.log 2>&1 & disown
+```
+**머지 전에 반드시 돌릴 것** — 이 PR 에서 Codex 는 1·2 라운드 모두 실제 결함을 잡았고,
+2 라운드 P1 은 *DB 를 통째로 지울 수 있는 테스트* 였다.
+
+**#292 의 방향을 착수 중 바꿨다 (이슈 본문과 다름)**
+이슈는 "`approvals` 테이블에 조건부 UPDATE" 를 제안했으나 실측 결과 그 테이블은
+**런타임 쓰기 0 건인 죽은 스키마**였다. 진실은 `state["pending_approvals"]`(세션 JSON) 에
+있고, `update_state` 가 `state_json` 을 통째로 덮으며 버전 컬럼이 없었다.
+→ 승인 이중 소비는 증상이고 원인은 통째 덮어쓰기다. `sessions.version` 으로 부류 전체를 닫았다.
+근거는 PR #293 본문 첫 절에 표로 있다.
+
+**이 작업 중 발견한 기존 결함 (함께 고침)**
+`AgentState` 미선언 키는 LangGraph 가 조용히 버린다 → `_metadata` 도 사라져서
+**그래프를 한 번 돈 세션은 영속 state 에서 TTL 정보를 잃고 있었다.** #289/#290 이 세운
+계약이 실행 후 무력화되던 상태다. 불변식 테스트 `test_agent_state_graph_keys.py` 로 고정.
+
+**후속 이슈 3 건 (미착수)**
+| 이슈 | 내용 |
+|---|---|
+| #291 | `cleanup_expired_sessions` 가 로컬 사본으로 삭제 판정. 프로덕션 호출부 0 건 |
+| #292 잔여 | 승인 소비의 진짜 경합 — 버전 검사로 중복 실행은 없으나 실패 측이 재시도 아닌 task 실패. `approvals` 테이블 이전이 답 |
+| (미등록) | `tests/backend/conftest.py:16` 의 `os.environ["USE_DATABASE"]="false"` 가 CI 의 `USE_DATABASE=true` 를 덮는다(최초 커밋 vs 2026-02-03). CI 가 Postgres 를 띄우고도 안 쓴다. `setdefault` 로 바꾸면 1478 개가 한꺼번에 DB 모드로 전환되므로 별도 PR 필요 |
+
+**환경 메모**
+- 개발용 DB `aos_test` 를 shared-postgres 에 만들었다(공용 `aos` 미접촉). 불필요하면 제거 가능.
+  DB 모드 테스트는 `AOS_TEST_DATABASE_URL` 이 있을 때만 돈다. CI 에는 배선해 두었다.
+- **다른 세션이 같은 저장소에서 작업 중이다.** 이관 시점 워킹트리에 내 것이 아닌
+  `src/dashboard/src/components/monitor/{index.ts, AgentRealtimeStatusBoard.tsx}` 가 있었다.
+  건드리지 않았다. 커밋 전 `git status` 재확인 필수.
+
+
 ### 2026-08-18 세션 — 감사 문서 청산 → 이슈 트래커 이관 → 결함 2건 수정
 
 **한 일 (완료)**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,40 @@ high-water mark** 다 — 활동은 누구의 관측이든 실제로 일어난 �
 남는 것은 두 인스턴스가 **동시에** 갱신·삭제를 시도하는 진짜 크로스 프로세스
 원자성이다. 그 답은 HITL 승인과 같다 — 저장소를 진실의 출처로 쓰는 조건부 `UPDATE`.
 
+## 세션 state 동시 쓰기
+
+`update_state` 는 `state_json` 을 **통째로** 덮어쓴다. 두 프로세스가 read-modify-write
+를 겹치면 늦게 쓴 쪽이 앞선 변경을 지운다(lost update). 승인 이중 소비와 세션 TTL
+경합은 이 부류의 사례였다.
+
+`sessions.version` 으로 낙관적 동시성을 건다 —
+`UPDATE ... SET ..., version = version + 1 WHERE id = ? AND version = ?`.
+
+| 계약 | 위치 | 없으면 |
+|------|------|--------|
+| 버전은 state 에 실려 다닌다 | `get_session` 이 `state["_version"]` 을 찍는다 | 서비스 수준 dict 로 두면 같은 프로세스의 동시 읽기 둘이 그것을 공유해 늦은 쓰기가 통과 |
+| 버전은 저장하지 않는다 | `update_state` 가 직렬화 결과에서 제거 | 컬럼과 JSON 두 벌이 되어 드리프트 |
+| 쓰기 성공 시 새 버전을 호출자에게 돌려준다 | `UPDATE ... RETURNING version` | 같은 state 로 다시 쓸 때 아무도 끼어들지 않았는데 충돌 |
+| 실패는 "행 없음" 과 "버전 불일치" 를 구분한다 | `StateWriteResult` | 재시도해도 소용없는 경우와 재시도해야 하는 경우가 뭉개짐 |
+| read-modify-write 는 `mutate_session` 을 쓴다 | 서비스/엔진 양쪽에 있음 | 직접 get + update 하면 그 사이의 다른 쓰기를 지움 |
+| 충돌 시 엔진 캐시를 버린다 | `engine.save_session` | 캐시 히트가 같은 낡은 버전을 계속 내줘 재시도가 영원히 충돌 |
+| HTTP 도달 경로에 미처리 충돌을 남기지 않는다 | 승인 API 는 재시도 후 409 | 재시도 가능한 조건이 500 으로 나감 |
+
+**`AgentState` 에 선언되지 않은 키는 그래프를 통과하며 사라진다.** LangGraph 가 노드
+출력에서 조용히 버리므로 `_metadata`(TTL)·`_version`(행 버전)은 반드시 선언돼 있어야
+한다. 선언이 지워지면 에러 없이 계약만 무너진다 —
+`tests/backend/test_agent_state_graph_keys.py` 가 그래프를 왕복시켜 지킨다.
+
+**예외: `engine.run`·`engine.stream` 의 최종 저장은 `check_version=False` 다.**
+완료된 그래프 실행의 산물이라 재시도가 도구 재실행을 뜻한다. 대신 실행 중 다른
+프로세스가 쓴 것은 유실된다 — 오래된 스냅샷을 통째로 쓰는 구조에서 오는 한계이고,
+제대로 풀려면 필드 단위 병합이 필요하다.
+
+**남는 것**: 두 인스턴스가 동시에 같은 승인을 소비하려는 진짜 경합은 이 버전 검사가
+"둘 중 하나는 실패" 로 만들지만, 실패한 쪽은 재시도가 아니라 task 실패로 처리된다
+(`executor._persist_approval_consumption`). 승인 소비를 `approvals` 테이블의 조건부
+UPDATE 로 옮기는 것이 그 답이며 별도 작업이다.
+
 ## HITL 승인 생명주기
 
 ```

--- a/src/backend/alembic/versions/b8c4e1f7a209_add_session_state_version.py
+++ b/src/backend/alembic/versions/b8c4e1f7a209_add_session_state_version.py
@@ -1,0 +1,33 @@
+"""add sessions.version for optimistic concurrency
+
+Revision ID: b8c4e1f7a209
+Revises: a7d3f1b9c2e4
+Create Date: 2026-08-22
+
+`update_state` 가 `state_json` 을 통째로 덮어쓰는데 버전이 없어, 두 프로세스가
+read-modify-write 를 겹치면 늦게 쓴 쪽이 앞선 변경을 지운다(lost update).
+승인 이중 소비(#283)와 세션 TTL 경합(#289)이 같은 부류의 사례다.
+
+`version` 은 조건부 UPDATE 의 기준이 된다 —
+`UPDATE sessions SET ..., version = version + 1 WHERE id = ? AND version = ?`.
+
+기존 행은 전부 1 로 채워진다. 컬럼 도입 전에 읽어둔 state 에는 버전이 없으므로
+그런 쓰기는 무조건 UPDATE 로 떨어진다 — 배포 순간에 충돌이 쏟아지지 않는다.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "b8c4e1f7a209"
+down_revision: str | Sequence[str] | None = "a7d3f1b9c2e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS version")

--- a/src/backend/api/agents/orchestrate.py
+++ b/src/backend/api/agents/orchestrate.py
@@ -19,6 +19,7 @@ from agents.lead_orchestrator import (
 )
 from api.deps import get_current_user, get_db_session
 from db.models import UserModel
+from models.agent_state import AgentState
 from models.task_analysis import (
     TaskAnalysisQueryParams,
     TaskAnalysisSaveRequest,
@@ -461,15 +462,17 @@ async def execute_analysis(
     )
 
     # 3. 세션 state에 사전 분석 계획 주입
-    state = await engine.get_session(session_id)
-    if state:
+    # 읽고 고쳐 쓰는 경로다. 캐시와 영속 저장소를 함께 갱신하되(캐시만 갱신하면
+    # 재시작 후 계획이 사라져 PlannerNode 가 일반 LLM 계획으로 떨어진다), 그 사이
+    # 다른 쓰기가 끼어들면 다시 읽어 재시도한다 (issue #292).
+    async def _attach_plan(state: AgentState) -> AgentState:
         state["plan_metadata"] = {
             "pre_analyzed_execution_plan": entry.analysis.get("execution_plan", {}),
             "analysis_id": request.analysis_id,
         }
-        # 세션 업데이트 (캐시와 영속 저장소 함께 — 캐시만 갱신하면 재시작 후
-        # 계획이 사라져 PlannerNode 가 일반 LLM 계획으로 떨어진다)
-        await engine.save_session(session_id, state)
+        return state
+
+    await engine.mutate_session(session_id, _attach_plan)
 
     return ExecuteAnalysisResponse(
         success=True,

--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -498,6 +498,20 @@ else:
                 "docs": "/docs",
             }
 
+        # 세션 쓰기 경합은 장애가 아니다 — 다른 쓰기가 먼저 반영됐을 뿐이고
+        # 클라이언트가 다시 시도하면 된다. 아래 전역 핸들러에 맡기면 500 이 나가
+        # 재시도 가능한 조건이 서버 오류처럼 보인다 (issue #292).
+        from services.session_service import SessionVersionConflictError
+
+        @app.exception_handler(SessionVersionConflictError)
+        async def session_conflict_handler(request: Request, exc: SessionVersionConflictError):
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse(
+                status_code=409,
+                content={"detail": "Session was modified concurrently; retry the request"},
+            )
+
         # Global exception handler - always return JSON
         @app.exception_handler(Exception)
         async def global_exception_handler(request: Request, exc: Exception):

--- a/src/backend/api/hitl.py
+++ b/src/backend/api/hitl.py
@@ -13,9 +13,13 @@ from models.agent_state import AgentState, TaskStatus
 from models.hitl import APPROVAL_STATE_LOCK, ApprovalResponse, ApprovalStatus
 from orchestrator import OrchestrationEngine
 from services.audit_service import AuditAction, AuditService, ResourceType
+from services.session_service import SessionVersionConflictError
 from utils.time import utcnow
 
 router = APIRouter(tags=["orchestration"])
+
+# 버전 충돌 재시도 횟수 — 락은 프로세스 로컬이라 다른 인스턴스의 쓰기는 막지 못한다.
+_APPROVAL_WRITE_RETRIES = 3
 
 # 승인 전이(조회 → 검사 → 변경 → 영속화)는 `APPROVAL_STATE_LOCK` 으로 직렬화한다.
 #
@@ -50,74 +54,103 @@ async def resolve_approval(
         HTTPException: 404(세션·승인 없음) / 400(이미 해소된 승인)
     """
     async with APPROVAL_STATE_LOCK.lock():
-        state = await engine.get_session(session_id)
-        if not state:
-            raise HTTPException(status_code=404, detail="Session not found")
-
-        pending_approvals = state.get("pending_approvals", {})
-        if approval_id not in pending_approvals:
-            raise HTTPException(status_code=404, detail="Approval request not found")
-
-        approval = pending_approvals[approval_id]
-        if approval["status"] != ApprovalStatus.PENDING.value:
-            raise HTTPException(
-                status_code=400, detail=f"Approval already resolved: {approval['status']}"
-            )
-
-        # 영속화가 실패하면 되돌리기 위해 이전 값을 잡아 둔다. 되돌리지 않으면
-        # 캐시는 `approved`, 저장소는 `pending` 으로 갈라져 재시도가 400 을 받고
-        # 그 승인은 영영 해소할 수 없게 된다.
-        before_approval = dict(approval)
-        before_waiting = state.get("waiting_for_approval")
-        before_task: tuple[TaskStatus, str | None, str | None] | None = None
-
-        approval["status"] = (
-            ApprovalStatus.APPROVED.value if approved else ApprovalStatus.DENIED.value
+        # 락은 프로세스 로컬이라 다른 인스턴스의 쓰기는 막지 못한다. 버전 충돌은
+        # 거기서 오고, 재시도 가능한 조건이다 — 그대로 올리면 승인 API 가 500 을
+        # 낸다(#283 이 닫은 "승인이 가끔 실패" 의 재발). 다시 읽어 검사부터 한다.
+        for _attempt in range(_APPROVAL_WRITE_RETRIES):
+            resolved = await _resolve_once(session_id, approval_id, approved, note, engine)
+            if resolved is not None:
+                return resolved
+        raise HTTPException(
+            status_code=409,
+            detail="Approval could not be resolved due to concurrent updates; retry",
         )
-        approval["resolver_note"] = note if approved else (note or "Denied by user")
-        approval["resolved_at"] = utcnow().isoformat()
-        state["pending_approvals"] = pending_approvals
-        state["waiting_for_approval"] = False
 
-        task_id = approval["task_id"]
-        if not approved:
-            tasks = state.get("tasks", {})
-            if task_id in tasks:
-                task = tasks[task_id]
-                before_task = (task.status, task.error, task.pending_approval_id)
-                task.status = TaskStatus.FAILED
-                task.error = f"Operation denied: {approval['resolver_note']}"
-                task.pending_approval_id = None
 
-        # 그래프 실행 **전에** 저장한다. `engine.run` 의 일괄 저장에만 기대면
-        # 실행이 실패했을 때 승인이 통째로 사라지고, 도구가 부수효과를 낸 뒤
-        # 저장 전에 죽으면 재시작 후 같은 승인이 다시 PENDING 으로 보인다.
-        # 거부는 그래프를 돌리지도 않으므로 여기서 저장하지 않으면 아무 데도 남지 않는다.
-        try:
-            await engine.save_session(session_id, state)
-        except Exception:
-            approval.clear()
-            approval.update(before_approval)
-            state["waiting_for_approval"] = before_waiting
-            if before_task is not None:
-                task = state["tasks"][task_id]
-                task.status, task.error, task.pending_approval_id = before_task
-            raise
+async def _resolve_once(
+    session_id: str,
+    approval_id: str,
+    approved: bool,
+    note: str | None,
+    engine: OrchestrationEngine,
+) -> ApprovalResponse | None:
+    """승인 전이 1 회 시도. 버전 충돌이면 `None` 을 돌려 호출자가 재시도한다."""
+    state = await engine.get_session(session_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Session not found")
 
-        # 감사 로그는 **저장에 성공한 뒤**에 남긴다. 먼저 남기면 롤백된 전이가
-        # "승인됨"으로 기록돼 감사 기록만 홀로 어긋난다.
-        AuditService.log(
-            action=AuditAction.APPROVAL_GRANTED if approved else AuditAction.APPROVAL_DENIED,
-            resource_type=ResourceType.APPROVAL,
-            resource_id=approval_id,
-            session_id=session_id,
-            project_id=state.get("project", {}).get("id"),
-            metadata={
-                "task_id": task_id,
-                "tool_name": approval.get("tool_name"),
-                "note": approval["resolver_note"],
-            },
+    pending_approvals = state.get("pending_approvals", {})
+    if approval_id not in pending_approvals:
+        raise HTTPException(status_code=404, detail="Approval request not found")
+
+    approval = pending_approvals[approval_id]
+    if approval["status"] != ApprovalStatus.PENDING.value:
+        raise HTTPException(
+            status_code=400, detail=f"Approval already resolved: {approval['status']}"
         )
+
+    # 영속화가 실패하면 되돌리기 위해 이전 값을 잡아 둔다. 되돌리지 않으면
+    # 캐시는 `approved`, 저장소는 `pending` 으로 갈라져 재시도가 400 을 받고
+    # 그 승인은 영영 해소할 수 없게 된다.
+    before_approval = dict(approval)
+    before_waiting = state.get("waiting_for_approval")
+    before_task: tuple[TaskStatus, str | None, str | None] | None = None
+
+    approval["status"] = ApprovalStatus.APPROVED.value if approved else ApprovalStatus.DENIED.value
+    approval["resolver_note"] = note if approved else (note or "Denied by user")
+    approval["resolved_at"] = utcnow().isoformat()
+    state["pending_approvals"] = pending_approvals
+    state["waiting_for_approval"] = False
+
+    task_id = approval["task_id"]
+    if not approved:
+        tasks = state.get("tasks", {})
+        if task_id in tasks:
+            task = tasks[task_id]
+            before_task = (task.status, task.error, task.pending_approval_id)
+            task.status = TaskStatus.FAILED
+            task.error = f"Operation denied: {approval['resolver_note']}"
+            task.pending_approval_id = None
+
+    # 그래프 실행 **전에** 저장한다. `engine.run` 의 일괄 저장에만 기대면
+    # 실행이 실패했을 때 승인이 통째로 사라지고, 도구가 부수효과를 낸 뒤
+    # 저장 전에 죽으면 재시작 후 같은 승인이 다시 PENDING 으로 보인다.
+    # 거부는 그래프를 돌리지도 않으므로 여기서 저장하지 않으면 아무 데도 남지 않는다.
+    try:
+        await engine.save_session(session_id, state)
+    except SessionVersionConflictError:
+        # 다른 쓰기가 먼저 반영됐다. 로컬 변경은 버리고 (엔진 캐시는
+        # `save_session` 이 이미 무효화했다) 다시 읽어 검사부터 한다.
+        approval.clear()
+        approval.update(before_approval)
+        state["waiting_for_approval"] = before_waiting
+        if before_task is not None:
+            task = state["tasks"][task_id]
+            task.status, task.error, task.pending_approval_id = before_task
+        return None
+    except Exception:
+        approval.clear()
+        approval.update(before_approval)
+        state["waiting_for_approval"] = before_waiting
+        if before_task is not None:
+            task = state["tasks"][task_id]
+            task.status, task.error, task.pending_approval_id = before_task
+        raise
+
+    # 감사 로그는 **저장에 성공한 뒤**에 남긴다. 먼저 남기면 롤백된 전이가
+    # "승인됨"으로 기록돼 감사 기록만 홀로 어긋난다.
+    AuditService.log(
+        action=AuditAction.APPROVAL_GRANTED if approved else AuditAction.APPROVAL_DENIED,
+        resource_type=ResourceType.APPROVAL,
+        resource_id=approval_id,
+        session_id=session_id,
+        project_id=state.get("project", {}).get("id"),
+        metadata={
+            "task_id": task_id,
+            "tool_name": approval.get("tool_name"),
+            "note": approval["resolver_note"],
+        },
+    )
 
     return state, approval
 

--- a/src/backend/api/hitl.py
+++ b/src/backend/api/hitl.py
@@ -73,7 +73,7 @@ async def _resolve_once(
     approved: bool,
     note: str | None,
     engine: OrchestrationEngine,
-) -> ApprovalResponse | None:
+) -> tuple[AgentState, dict[str, Any]] | None:
     """승인 전이 1 회 시도. 버전 충돌이면 `None` 을 돌려 호출자가 재시도한다."""
     state = await engine.get_session(session_id)
     if not state:

--- a/src/backend/api/websocket.py
+++ b/src/backend/api/websocket.py
@@ -1,6 +1,7 @@
 """WebSocket endpoint for real-time updates."""
 
 import asyncio
+import logging
 import os
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
@@ -16,10 +17,13 @@ from models.message import (
     MessageType,
     TaskCreatePayload,
 )
+from services.session_service import SessionVersionConflictError
 
 # Heartbeat configuration
 WS_HEARTBEAT_INTERVAL = int(os.getenv("WS_HEARTBEAT_INTERVAL", "20"))
 
+
+logger = logging.getLogger(__name__)
 
 websocket_router = APIRouter()
 
@@ -122,7 +126,17 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                 from services.session_service import get_session_service
 
                 session_service = get_session_service()
-                await session_service.refresh_session(session_id)
+                try:
+                    await session_service.refresh_session(session_id)
+                except SessionVersionConflictError:
+                    # 하트비트다. FastAPI 예외 핸들러는 HTTP 스코프에만 걸리므로
+                    # 여기서 잡지 않으면 연결이 끊긴다. TTL 연장이 경합으로
+                    # 실패했다는 건 다른 쪽이 방금 갱신했다는 뜻이라 세션이 살아
+                    # 있다는 신호에 가깝다 — PONG 은 그대로 보낸다 (issue #292).
+                    logger.debug(
+                        "Session TTL refresh skipped due to write contention",
+                        extra={"session_id": session_id},
+                    )
 
                 await manager.send_message(
                     session_id,
@@ -151,7 +165,25 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     )
 
             elif message.type == MessageType.TASK_CANCEL:
-                await engine.cancel(session_id)
+                try:
+                    await engine.cancel(session_id)
+                except SessionVersionConflictError:
+                    # HTTP 예외 핸들러는 WebSocket 스코프에 걸리지 않는다 —
+                    # 여기서 잡지 않으면 경합 한 번에 연결이 끊긴다. 재시도
+                    # 가능한 조건이므로 프로토콜 오류로 알리고 연결은 유지한다.
+                    await manager.send_message(
+                        session_id,
+                        Message(
+                            type=MessageType.ERROR,
+                            payload={
+                                "code": "SESSION_CONFLICT",
+                                "message": "Session was modified concurrently; retry the cancel",
+                            },
+                            session_id=session_id,
+                        ),
+                    )
+                    continue
+
                 await manager.send_message(
                     session_id,
                     Message(

--- a/src/backend/db/database.py
+++ b/src/backend/db/database.py
@@ -429,6 +429,17 @@ async def _run_migrations() -> None:
             except Exception:
                 pass  # FK may already exist or users table may not exist yet
 
+        # Migration 12: Add 'version' column to sessions for optimistic concurrency
+        #
+        # `update_state` 가 state_json 을 통째로 덮으므로, 겹친 read-modify-write 를
+        # 조건부 UPDATE 로 걸러낸다 (issue #292). Alembic 에도 같은 변경이 있지만
+        # 기동 경로는 create_all + 이 함수라 여기에도 있어야 한다 — create_all 은
+        # 기존 테이블에 컬럼을 추가하지 않으므로, 없으면 배포 직후 SELECT 가
+        # UndefinedColumn 으로 죽는다.
+        await conn.execute(
+            text("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1")
+        )
+
 
 async def close_db() -> None:
     """Close database connection pool."""

--- a/src/backend/db/models/session.py
+++ b/src/backend/db/models/session.py
@@ -29,6 +29,9 @@ class SessionModel(Base):
 
     # Session state stored as JSON
     state_json = Column(JSONB, nullable=False, default=dict)
+    # 낙관적 동시성 — `update_state` 가 state_json 을 통째로 덮으므로, 겹친
+    # read-modify-write 를 조건부 UPDATE 로 걸러낸다 (issue #292).
+    version = Column(Integer, nullable=False, default=1, server_default="1")
 
     # Metadata
     status = Column(String(50), default="active", index=True)

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -148,7 +148,7 @@ class SessionRepository:
         session_id: str,
         state: dict[str, Any],
         expected_version: int | None = None,
-    ) -> "StateWriteResult":
+    ) -> tuple["StateWriteResult", int | None]:
         """세션 state 를 쓴다. `expected_version` 이 있으면 조건부 UPDATE.
 
         `expected_version` 이 None 이면 무조건 덮어쓴다 — 버전을 모르는 호출자

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime
+from enum import Enum
 from typing import Any
 
 from sqlalchemy import delete, select, update
@@ -32,6 +33,19 @@ def serialize_value(value: Any) -> Any:
         return [serialize_value(item) for item in value]
     else:
         return value
+
+
+# 세션 state 에 실려 다니는 행 버전. 저장하지 않는다 — 진실은 `sessions.version`
+# 컬럼 하나이고, state_json 에도 넣으면 두 벌이 되어 드리프트한다 (issue #292).
+STATE_VERSION_KEY = "_version"
+
+
+class StateWriteResult(str, Enum):
+    """`update_state` 의 결과. 실패 두 가지는 호출자의 대응이 다르다."""
+
+    WRITTEN = "written"
+    MISSING = "missing"  # 행이 없다 — 재시도해도 소용없다
+    CONFLICT = "conflict"  # 버전이 어긋났다 — 다시 읽어 재시도해야 한다
 
 
 def serialize_state(state: dict[str, Any]) -> dict[str, Any]:
@@ -118,30 +132,57 @@ class SessionRepository:
         result = await self.db.execute(select(SessionModel).where(SessionModel.id == session_id))
         return result.scalar_one_or_none()
 
-    async def get_state(self, session_id: str) -> dict[str, Any] | None:
-        """Get session state as dict."""
+    async def get_state_with_version(self, session_id: str) -> tuple[dict[str, Any], int] | None:
+        """세션 state 와 그 행의 버전을 함께 읽는다.
+
+        버전을 state 와 **같은 읽기에서** 가져와야 조건부 UPDATE 의 기준이 맞는다.
+        따로 읽으면 그 사이의 쓰기를 놓친다.
+        """
         session = await self.get(session_id)
-        if session:
-            return session.state_json
-        return None
+        if session is None:
+            return None
+        return session.state_json, int(session.version)
 
     async def update_state(
         self,
         session_id: str,
         state: dict[str, Any],
-    ) -> bool:
-        """Update session state."""
+        expected_version: int | None = None,
+    ) -> "StateWriteResult":
+        """세션 state 를 쓴다. `expected_version` 이 있으면 조건부 UPDATE.
+
+        `expected_version` 이 None 이면 무조건 덮어쓴다 — 버전을 모르는 호출자
+        (컬럼 도입 이전에 읽은 state, 서비스를 거치지 않고 만든 state)의 기존
+        동작을 유지한다.
+
+        실패는 두 가지고 호출자의 대응이 다르다 — 행이 없으면 재시도해도 소용없고,
+        버전이 어긋났으면 다시 읽어 재시도해야 한다. rowcount 0 만으로는 구분되지
+        않으므로 실패 경로에서만 존재 확인 질의를 한 번 더 한다.
+        """
         # Serialize state to handle TaskNode and other Pydantic objects
         serialized = serialize_state(state)
+        serialized.pop(STATE_VERSION_KEY, None)  # 버전의 진실은 컬럼 하나뿐이다
+        stmt = update(SessionModel).where(SessionModel.id == session_id)
+        if expected_version is not None:
+            stmt = stmt.where(SessionModel.version == expected_version)
         result = await self.db.execute(
-            update(SessionModel)
-            .where(SessionModel.id == session_id)
-            .values(
+            stmt.values(
                 state_json=serialized,
                 updated_at=utcnow(),
+                version=SessionModel.version + 1,
             )
         )
-        return result.rowcount > 0
+        if result.rowcount > 0:
+            return StateWriteResult.WRITTEN
+        if expected_version is None:
+            return StateWriteResult.MISSING
+        # 조건부였으니 실패 이유가 둘이다 — 행이 사라졌나, 버전이 어긋났나.
+        exists = await self.db.execute(select(SessionModel.id).where(SessionModel.id == session_id))
+        return (
+            StateWriteResult.CONFLICT
+            if exists.scalar_one_or_none() is not None
+            else StateWriteResult.MISSING
+        )
 
     async def update_cost(
         self,

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -170,19 +170,21 @@ class SessionRepository:
                 state_json=serialized,
                 updated_at=utcnow(),
                 version=SessionModel.version + 1,
-            )
+            ).returning(SessionModel.version)
         )
-        if result.rowcount > 0:
-            return StateWriteResult.WRITTEN
+        new_version = result.scalar_one_or_none()
+        if new_version is not None:
+            return StateWriteResult.WRITTEN, int(new_version)
         if expected_version is None:
-            return StateWriteResult.MISSING
+            return StateWriteResult.MISSING, None
         # 조건부였으니 실패 이유가 둘이다 — 행이 사라졌나, 버전이 어긋났나.
         exists = await self.db.execute(select(SessionModel.id).where(SessionModel.id == session_id))
-        return (
+        outcome = (
             StateWriteResult.CONFLICT
             if exists.scalar_one_or_none() is not None
             else StateWriteResult.MISSING
         )
+        return outcome, None
 
     async def update_cost(
         self,

--- a/src/backend/models/agent_state.py
+++ b/src/backend/models/agent_state.py
@@ -107,6 +107,16 @@ class AgentState(TypedDict):
     # Schema version for forward-compatible migrations
     _schema_version: int
 
+    # 그래프 밖에서 관리하는 키. LangGraph 는 `AgentState` 에 없는 키를 노드
+    # 출력에서 **조용히 버리므로**, 선언하지 않으면 `compiled_graph.ainvoke` 를
+    # 통과한 state 에서 사라진다 (실측 확인, issue #292).
+    #  - `_metadata`: 세션 TTL. 사라지면 그래프를 한 번 돈 세션이 영속 state 에서
+    #    만료 정보를 잃는다.
+    #  - `_version`: 낙관적 동시성의 기준 행 버전. 사라지면 조건부 UPDATE 가
+    #    무조건 쓰기로 떨어져 lost update 가 그대로 남는다. 저장되지는 않는다.
+    _metadata: dict[str, Any]
+    _version: int
+
     # Session information
     session_id: str
     user_id: str | None

--- a/src/backend/orchestrator/engine.py
+++ b/src/backend/orchestrator/engine.py
@@ -2,7 +2,7 @@
 
 import os
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 from dotenv import load_dotenv
@@ -102,7 +102,11 @@ from services.audit_service import (
     ResourceType,
 )
 from services.context_compressor import ContextCompressor
-from services.session_service import SessionService, get_session_service
+from services.session_service import (
+    SessionService,
+    SessionVersionConflictError,
+    get_session_service,
+)
 from tools import ALL_TOOLS
 
 
@@ -230,11 +234,14 @@ class OrchestrationEngine:
         )
 
         # Also cache the state in memory for fast access
-        state = await self.session_service.get_session(session_id)
-        if state:
-            if self._apply_llm_access(state, llm_access):
-                await self.session_service.update_session(session_id, state)
-            self._sessions[session_id] = state
+        async def _apply(current: AgentState) -> AgentState | None:
+            return current if self._apply_llm_access(current, llm_access) else None
+
+        state = await self.mutate_session(session_id, _apply)
+        if state is None:
+            state = await self.session_service.get_session(session_id)
+            if state:
+                self._sessions[session_id] = state
 
         # Audit log: Session created
         AuditService.log(
@@ -277,7 +284,29 @@ class OrchestrationEngine:
         `run` 이 실패하면 그 저장은 아예 일어나지 않는다.
         """
         self._sessions[session_id] = state
-        await self.session_service.update_session(session_id, state)
+        try:
+            await self.session_service.update_session(session_id, state)
+        except SessionVersionConflictError:
+            # 캐시를 버려야 호출자의 재시도가 저장소를 다시 읽는다. 안 그러면
+            # 캐시 히트가 같은 낡은 `_version` 을 계속 내줘 영원히 충돌한다.
+            self._sessions.pop(session_id, None)
+            raise
+
+    async def mutate_session(
+        self,
+        session_id: str,
+        mutate: Callable[[AgentState], Awaitable[AgentState | None]],
+    ) -> AgentState | None:
+        """서비스의 read-modify-write 재시도 경로 + 엔진 캐시 갱신.
+
+        `session_service.mutate_session` 만 쓰면 엔진 캐시가 낡은 채로 남는다.
+        """
+        mutated = await self.session_service.mutate_session(session_id, mutate)
+        if mutated is not None:
+            self._sessions[session_id] = mutated
+        else:
+            self._sessions.pop(session_id, None)
+        return mutated
 
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session."""
@@ -353,8 +382,14 @@ class OrchestrationEngine:
         final_state = await self.compiled_graph.ainvoke(state)
 
         # Update session (both cache and persistence)
+        #
+        # `check_version=False` — last-writer-wins 를 **의도적으로** 고른다.
+        # `final_state` 는 완료된 그래프 실행의 산물이라 버전 충돌 시 재시도가
+        # 그래프 재실행(= 도구 재실행)을 뜻한다. 대신 실행 중 다른 프로세스가
+        # 쓴 것은 유실된다 — 오래된 스냅샷을 통째로 쓰는 구조에서 오는 기존
+        # 동작이고, 제대로 풀려면 필드 단위 병합이 필요하다 (issue #292).
         self._sessions[session_id] = final_state
-        await self.session_service.update_session(session_id, final_state)
+        await self.session_service.update_session(session_id, final_state, check_version=False)
 
         return final_state
 
@@ -510,8 +545,10 @@ class OrchestrationEngine:
                             )
 
         # Update session with final state (both cache and persistence)
+        # `run` 과 같은 이유로 last-writer-wins — 그래프 실행의 산물이라
+        # 재시도가 도구 재실행을 뜻한다.
         self._sessions[session_id] = state
-        await self.session_service.update_session(session_id, state)
+        await self.session_service.update_session(session_id, state, check_version=False)
 
         # Update cost tracking in database
         total_tokens = sum(u.get("total_tokens", 0) for u in state.get("token_usage", {}).values())
@@ -537,16 +574,12 @@ class OrchestrationEngine:
 
     async def cancel(self, session_id: str) -> bool:
         """Cancel an active orchestration."""
-        state = await self.get_session(session_id)
-        if not state:
-            return False
 
-        # Set cancellation flag
-        state["next_action"] = None
-        state["errors"] = state.get("errors", []) + ["Cancelled by user"]
+        # 읽고 고쳐 쓰는 경로라 충돌 시 다시 읽어 재시도한다. 여기서 미리
+        # state 를 고치면 캐시 객체에 취소 표시가 두 번 쌓인다.
+        async def _mark_cancelled(current: AgentState) -> AgentState:
+            current["next_action"] = None
+            current["errors"] = current.get("errors", []) + ["Cancelled by user"]
+            return current
 
-        # Update session
-        self._sessions[session_id] = state
-        await self.session_service.update_session(session_id, state)
-
-        return True
+        return await self.mutate_session(session_id, _mark_cancelled) is not None

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -6,7 +6,7 @@ Provides an abstraction layer over storage (in-memory or database).
 import logging
 import os
 import uuid
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -25,6 +25,10 @@ from models.project import Project
 from utils.time import utcnow
 
 logger = logging.getLogger(__name__)
+
+# 버전 충돌 재시도 횟수. 충돌은 "다른 쓰기가 먼저 반영됐다" 는 뜻이라 재시도
+# 가능한 조건이다 — 소진되면 그때는 지속적 경합이므로 올려 보낸다.
+SESSION_WRITE_RETRIES = 3
 
 
 class SessionVersionConflictError(RuntimeError):
@@ -289,11 +293,15 @@ class SessionService:
             expected = state.get(STATE_VERSION_KEY) if check_version else None
             async with async_session_factory() as db:
                 repo = SessionRepository(db)
-                outcome = await repo.update_state(session_id, state, expected)
+                outcome, new_version = await repo.update_state(session_id, state, expected)
                 if outcome is StateWriteResult.CONFLICT:
                     await db.rollback()
                     raise SessionVersionConflictError(session_id)
                 await db.commit()
+                if new_version is not None:
+                    # 쓴 뒤의 버전을 호출자 state 에 되돌려준다. 안 그러면 같은
+                    # state 로 다시 쓸 때 아무도 끼어들지 않았는데 충돌한다.
+                    state[STATE_VERSION_KEY] = new_version
                 return outcome is StateWriteResult.WRITTEN
         else:
             if session_id in self._memory_sessions:
@@ -323,15 +331,16 @@ class SessionService:
     async def mutate_session(
         self,
         session_id: str,
-        mutate: Callable[[AgentState], AgentState | None],
-        retries: int = 3,
+        mutate: Callable[[AgentState], Awaitable[AgentState | None]],
+        retries: int = SESSION_WRITE_RETRIES,
     ) -> AgentState | None:
         """read → 수정 → 조건부 쓰기. 충돌하면 다시 읽어 재시도한다.
 
         `state_json` 을 통째로 쓰는 구조에서 read-modify-write 의 **정식 경로**다.
         직접 `get_session` + `update_session` 을 부르면 그 사이의 다른 쓰기를 지운다.
 
-        `mutate` 는 읽어온 state 를 받아 쓸 state 를 돌려준다. `None` 을 돌려주면
+        `mutate` 는 읽어온 state 를 받아 쓸 state 를 돌려주는 **async** 함수다
+        (저장소를 다시 읽어 판정하는 compare-and-set 을 안에 둘 수 있어야 한다). `None` 을 돌려주면
         쓰지 않고 중단한다(수정할 것이 없을 때). 재시도 시 **다시 호출되므로**
         부작용 없이 순수하게 state 만 다뤄야 한다.
 
@@ -345,7 +354,7 @@ class SessionService:
             if state is None:
                 return None
 
-            mutated = mutate(state)
+            mutated = await mutate(state)
             if mutated is None:
                 return None
 
@@ -389,25 +398,33 @@ class SessionService:
         Returns:
             True if session was refreshed
         """
-        state = await self.get_session(session_id, update_activity=False)
-        if not state:
-            return False
+        # 읽고 고쳐 쓰는 경로다. 버전 충돌은 재시도한다 — 다른 쓰기가 먼저
+        # 반영됐다는 뜻일 뿐이고, 호출자(`api/sessions.py`, `api/websocket.py`)는
+        # 불리언으로 분기하므로 그대로 올리면 재시도 가능한 조건이 500 이 된다.
+        for _ in range(SESSION_WRITE_RETRIES):
+            state = await self.get_session(session_id, update_activity=False)
+            if not state:
+                return False
 
-        metadata = self._session_metadata.get(session_id)
-        if metadata:
+            metadata = self._session_metadata.get(session_id)
+            if not metadata:
+                return False
+
             previous = metadata.to_dict()
             extend = extend_days or SESSION_TTL_DAYS
             metadata.expires_at = utcnow() + timedelta(days=extend)
             metadata.touch()
             state["_metadata"] = metadata.to_dict()
             # 영속화가 실패하면 메모리만 연장된 상태가 되어 저장소와 갈라진다.
-            # 실패 형태는 둘이다 — False 반환(행이 없음)과 저장소 예외.
+            # 실패 형태는 셋이다 — 버전 충돌(재시도), False 반환(행이 없음),
+            # 저장소 예외(장애).
             try:
                 persisted = await self.update_session(session_id, state)
+            except SessionVersionConflictError:
+                self._session_metadata[session_id] = SessionMetadata.from_dict(previous)
+                continue
             except Exception:
-                # 예외는 삼키지 않는다. DB 장애는 "갱신 거절" 이 아니고,
-                # 호출자(`api/sessions.py`, `api/websocket.py`)는 불리언으로
-                # 분기하므로 False 로 바꾸면 장애가 정상 흐름처럼 보인다.
+                # 예외는 삼키지 않는다. DB 장애는 "갱신 거절" 이 아니다.
                 self._session_metadata[session_id] = SessionMetadata.from_dict(previous)
                 raise
             if not persisted:
@@ -415,7 +432,7 @@ class SessionService:
                 return False
             return True
 
-        return False
+        raise SessionVersionConflictError(session_id)
 
     async def get_session_info(self, session_id: str) -> dict | None:
         """Get session metadata info without loading full state.

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -6,14 +6,17 @@ Provides an abstraction layer over storage (in-memory or database).
 import logging
 import os
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any
 
 from db.database import async_session_factory
 from db.repository import (
+    STATE_VERSION_KEY,
     ApprovalRepository,
     MessageRepository,
     SessionRepository,
+    StateWriteResult,
     TaskRepository,
     deserialize_state,
 )
@@ -22,6 +25,18 @@ from models.project import Project
 from utils.time import utcnow
 
 logger = logging.getLogger(__name__)
+
+
+class SessionVersionConflictError(RuntimeError):
+    """다른 쓰기가 먼저 반영돼 이 쓰기의 기준 버전이 낡았다.
+
+    재시도 가능한 조건이다 — 다시 읽어 수정을 얹으면 된다. 500 이 아니다.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(f"session {session_id} was modified by another writer")
+        self.session_id = session_id
+
 
 # Environment variable to control storage mode
 USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
@@ -181,10 +196,13 @@ class SessionService:
         """
         state = None
 
+        version: int | None = None
         if self.use_database:
             async with async_session_factory() as db:
                 repo = SessionRepository(db)
-                state = await repo.get_state(session_id)
+                row = await repo.get_state_with_version(session_id)
+                if row is not None:
+                    state, version = row
         else:
             state = self._memory_sessions.get(session_id)
 
@@ -238,16 +256,45 @@ class SessionService:
             metadata.touch()
             state["_metadata"] = metadata.to_dict()
 
+        # 이 읽기의 행 버전을 state 에 실어 보낸다 — 읽는 쪽마다 자기 스냅샷을
+        # 들고 가야 겹친 read-modify-write 가 조건부 UPDATE 에서 걸린다.
+        # 서비스 수준 dict 로 두면 같은 프로세스의 동시 읽기 둘이 그것을 공유해
+        # 늦은 쓰기가 통과한다 (issue #292). 메모리 모드는 단일 프로세스라 없음.
+        if version is not None:
+            state[STATE_VERSION_KEY] = version
+
         return state
 
-    async def update_session(self, session_id: str, state: AgentState) -> bool:
-        """Update session state."""
+    async def update_session(
+        self,
+        session_id: str,
+        state: AgentState,
+        *,
+        check_version: bool = True,
+    ) -> bool:
+        """Update session state.
+
+        `check_version=True` 이고 state 가 읽기 시점의 버전을 들고 있으면 조건부
+        UPDATE 를 한다. 그 사이 다른 쓰기가 반영됐으면 `SessionVersionConflictError` 를
+        던진다 — 이 쓰기의 기준이 낡았다는 뜻이고, 다시 읽어 재시도해야 한다.
+        반환 `bool` 은 예전과 같은 뜻이다(행이 있어 썼는가).
+
+        `check_version=False` 는 last-writer-wins 를 **의도적으로** 고르는 경로다.
+        완료된 그래프 실행의 최종 state 처럼 재시도가 불가능한 쓰기에만 쓴다.
+
+        메모리 모드는 버전이 없어 언제나 무조건 쓰기다 — 단일 프로세스라 겹칠
+        상대가 없다. 재시도 루프는 DB 모드에서만 실제로 돈다.
+        """
         if self.use_database:
+            expected = state.get(STATE_VERSION_KEY) if check_version else None
             async with async_session_factory() as db:
                 repo = SessionRepository(db)
-                result = await repo.update_state(session_id, state)
+                outcome = await repo.update_state(session_id, state, expected)
+                if outcome is StateWriteResult.CONFLICT:
+                    await db.rollback()
+                    raise SessionVersionConflictError(session_id)
                 await db.commit()
-                return result
+                return outcome is StateWriteResult.WRITTEN
         else:
             if session_id in self._memory_sessions:
                 self._memory_sessions[session_id] = state
@@ -272,6 +319,48 @@ class SessionService:
         if not metadata:
             return True
         return metadata.is_expired()
+
+    async def mutate_session(
+        self,
+        session_id: str,
+        mutate: Callable[[AgentState], AgentState | None],
+        retries: int = 3,
+    ) -> AgentState | None:
+        """read → 수정 → 조건부 쓰기. 충돌하면 다시 읽어 재시도한다.
+
+        `state_json` 을 통째로 쓰는 구조에서 read-modify-write 의 **정식 경로**다.
+        직접 `get_session` + `update_session` 을 부르면 그 사이의 다른 쓰기를 지운다.
+
+        `mutate` 는 읽어온 state 를 받아 쓸 state 를 돌려준다. `None` 을 돌려주면
+        쓰지 않고 중단한다(수정할 것이 없을 때). 재시도 시 **다시 호출되므로**
+        부작용 없이 순수하게 state 만 다뤄야 한다.
+
+        반환은 실제로 저장된 state, 세션이 없거나 `mutate` 가 중단하면 `None`.
+
+        메모리 모드는 버전이 없어 충돌하지 않는다 — 재시도 루프는 DB 모드에서만
+        실제로 돈다. 메모리 모드 테스트로는 이 루프가 검증되지 않는다.
+        """
+        for attempt in range(retries):
+            state = await self.get_session(session_id)
+            if state is None:
+                return None
+
+            mutated = mutate(state)
+            if mutated is None:
+                return None
+
+            try:
+                if not await self.update_session(session_id, mutated):
+                    return None  # 행이 사라졌다 — 재시도해도 소용없다
+            except SessionVersionConflictError:
+                logger.info(
+                    "Session write conflicted, retrying",
+                    extra={"session_id": session_id, "attempt": attempt + 1},
+                )
+                continue
+            return mutated
+
+        raise SessionVersionConflictError(session_id)
 
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session."""

--- a/tests/backend/test_agent_state_graph_keys.py
+++ b/tests/backend/test_agent_state_graph_keys.py
@@ -1,0 +1,60 @@
+"""`AgentState` 미선언 키가 그래프를 통과하며 사라지는 문제 (issue #292).
+
+LangGraph 는 `StateGraph(AgentState)` 의 TypedDict 에 없는 키를 노드 출력에서
+**조용히 버린다** — 에러도 경고도 없다. 그래서 정적 검사로는 잡히지 않고,
+`AgentState` 에서 선언 한 줄이 사라지면 다음 두 계약이 함께 무너진다:
+
+- `_metadata` — 세션 TTL. 사라지면 그래프를 한 번 돈 세션이 영속 state 에서
+  만료 정보를 잃어, 재시작·다른 인스턴스에서 TTL 이 강제되지 않는다.
+- `_version` — 낙관적 동시성의 기준 행 버전. 사라지면 조건부 UPDATE 가 무조건
+  쓰기로 떨어져 lost update 가 그대로 남는다.
+
+선언 여부를 `__annotations__` 로 확인하는 것은 동어반복이다. 실제로 그래프를
+왕복시켜 살아남는지 본다.
+"""
+
+import pytest
+from langgraph.graph import END, StateGraph
+
+from models.agent_state import AgentState, create_initial_state
+
+
+async def _bump(state: AgentState) -> dict:
+    return {"iteration_count": state.get("iteration_count", 0) + 1}
+
+
+def _one_node_graph():
+    graph = StateGraph(AgentState)
+    graph.add_node("bump", _bump)
+    graph.set_entry_point("bump")
+    graph.add_edge("bump", END)
+    return graph.compile()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("_metadata", {"session_id": "s-292", "expires_at": "2099-01-01T00:00:00"}),
+        ("_version", 7),
+    ],
+)
+async def test_out_of_graph_key_survives_invocation(key, value):
+    state = create_initial_state(session_id="s-292")
+    state[key] = value
+
+    result = await _one_node_graph().ainvoke(state)
+
+    assert key in result, f"{key} 가 그래프 통과 중 유실됐다 — AgentState 선언을 확인하라"
+    assert result[key] == value
+
+
+@pytest.mark.asyncio
+async def test_declared_node_output_still_applies():
+    """대조군 — 노드가 실제로 돌았는지. 위 단언이 빈 그래프로 통과하지 않게."""
+    state = create_initial_state(session_id="s-292")
+    before = state["iteration_count"]
+
+    result = await _one_node_graph().ainvoke(state)
+
+    assert result["iteration_count"] == before + 1

--- a/tests/backend/test_session_concurrency_db.py
+++ b/tests/backend/test_session_concurrency_db.py
@@ -1,0 +1,171 @@
+"""세션 state 낙관적 동시성 — 실제 DB 가 있어야 검증되는 것들 (issue #292).
+
+메모리 모드로는 이 시나리오를 만들 수 없다. `deserialize_state` 가 저장된 객체를
+그대로 돌려주므로(#289 에서 확인) 저장소와 로컬 사본이 분리되지 않고, 조건부
+UPDATE 가 행을 잡지 못하는 상황 자체가 재현되지 않는다.
+
+`AOS_TEST_DATABASE_URL` 이 있을 때만 돈다 — 실수로 개발 DB 를 건드리지 않도록
+전용 변수를 쓴다. CI 는 Postgres 서비스를 띄우므로 실제로 돈다.
+"""
+
+import asyncio
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from db.models.base import Base
+from db.repository import STATE_VERSION_KEY, SessionRepository, StateWriteResult
+from models.agent_state import create_initial_state
+from services.session_service import SessionService, SessionVersionConflictError
+
+TEST_DATABASE_URL = os.getenv("AOS_TEST_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL,
+    reason="AOS_TEST_DATABASE_URL 미설정 — DB 모드 동시성 테스트를 건너뛴다",
+)
+
+
+@pytest_asyncio.fixture
+async def db_factory():
+    """테스트 전용 엔진 + 테이블. 끝나면 스키마를 지운다."""
+    engine = create_async_engine(TEST_DATABASE_URL, poolclass=None)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def service(db_factory, monkeypatch):
+    monkeypatch.setattr("services.session_service.async_session_factory", db_factory)
+    return SessionService(use_database=True)
+
+
+async def _new_session(service: SessionService) -> str:
+    return await service.create_session(session_id=str(uuid.uuid4()))
+
+
+@pytest.mark.asyncio
+async def test_read_stamps_row_version(service):
+    sid = await _new_session(service)
+
+    state = await service.get_session(sid)
+
+    assert state is not None
+    assert isinstance(state.get(STATE_VERSION_KEY), int)
+
+
+@pytest.mark.asyncio
+async def test_write_advances_version_on_caller_state(service):
+    """쓰기 성공 후 호출자 state 의 버전이 올라야 같은 state 로 또 쓸 수 있다."""
+    sid = await _new_session(service)
+    state = await service.get_session(sid)
+    first = state[STATE_VERSION_KEY]
+
+    await service.update_session(sid, state)
+
+    assert state[STATE_VERSION_KEY] == first + 1
+    # 아무도 끼어들지 않았으니 같은 state 로 다시 써도 충돌하면 안 된다
+    await service.update_session(sid, state)
+
+
+@pytest.mark.asyncio
+async def test_stale_write_conflicts(service):
+    """겹친 read-modify-write 중 늦은 쪽은 통과하지 못한다."""
+    sid = await _new_session(service)
+    first = await service.get_session(sid)
+    second = await service.get_session(sid)  # 같은 버전을 본 두 번째 독자
+
+    first["iteration_count"] = 1
+    await service.update_session(sid, first)
+
+    second["iteration_count"] = 99
+    with pytest.raises(SessionVersionConflictError):
+        await service.update_session(sid, second)
+
+    # 앞선 쓰기가 살아 있어야 한다 — 이것이 lost update 가 없다는 증거다
+    reloaded = await service.get_session(sid)
+    assert reloaded["iteration_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unversioned_write_is_last_writer_wins(service):
+    """`check_version=False` 는 낡은 스냅샷이어도 덮어쓴다 (그래프 최종 저장 경로)."""
+    sid = await _new_session(service)
+    stale = await service.get_session(sid)
+    fresh = await service.get_session(sid)
+
+    fresh["iteration_count"] = 1
+    await service.update_session(sid, fresh)
+
+    stale["iteration_count"] = 99
+    await service.update_session(sid, stale, check_version=False)
+
+    reloaded = await service.get_session(sid)
+    assert reloaded["iteration_count"] == 99
+
+
+@pytest.mark.asyncio
+async def test_mutate_session_retries_until_it_wins(service):
+    """`mutate_session` 은 충돌하면 다시 읽어 재시도한다 — 두 변경이 모두 남는다."""
+    sid = await _new_session(service)
+    interfered = {"done": False}
+
+    async def _bump(state):
+        # 첫 시도 때만 다른 writer 가 끼어든다 → 이 쓰기는 충돌해야 한다
+        if not interfered["done"]:
+            interfered["done"] = True
+            other = await service.get_session(sid)
+            other["context"] = {**other.get("context", {}), "other": True}
+            await service.update_session(sid, other)
+        state["iteration_count"] = state.get("iteration_count", 0) + 1
+        return state
+
+    result = await service.mutate_session(sid, _bump)
+
+    assert result is not None
+    reloaded = await service.get_session(sid)
+    assert reloaded["iteration_count"] == 1
+    assert reloaded["context"]["other"] is True  # 끼어든 쓰기도 살아 있다
+
+
+@pytest.mark.asyncio
+async def test_missing_row_is_distinguished_from_conflict(db_factory):
+    """행 없음과 버전 불일치는 호출자의 대응이 달라 구분돼야 한다."""
+    async with db_factory() as db:
+        repo = SessionRepository(db)
+        outcome, version = await repo.update_state(
+            "no-such-session", create_initial_state(session_id="x"), expected_version=1
+        )
+
+    assert outcome is StateWriteResult.MISSING
+    assert version is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writers_only_one_wins(service):
+    """동시에 출발한 두 쓰기 중 하나만 성공한다."""
+    sid = await _new_session(service)
+    a = await service.get_session(sid)
+    b = await service.get_session(sid)
+
+    async def _write(state, value):
+        state["iteration_count"] = value
+        try:
+            await service.update_session(sid, state)
+            return "ok"
+        except SessionVersionConflictError:
+            return "conflict"
+
+    results = await asyncio.gather(_write(a, 1), _write(b, 2))
+
+    assert sorted(results) == ["conflict", "ok"]

--- a/tests/backend/test_session_concurrency_db.py
+++ b/tests/backend/test_session_concurrency_db.py
@@ -14,7 +14,9 @@ import uuid
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
 from db.models.base import Base
 from db.repository import STATE_VERSION_KEY, SessionRepository, StateWriteResult
@@ -31,17 +33,35 @@ pytestmark = pytest.mark.skipif(
 
 @pytest_asyncio.fixture
 async def db_factory():
-    """테스트 전용 엔진 + 테이블. 끝나면 스키마를 지운다."""
-    engine = create_async_engine(TEST_DATABASE_URL, poolclass=None)
+    """랜덤 이름의 전용 스키마 안에서만 동작한다.
+
+    `Base.metadata.drop_all()` 로 정리하면 `AOS_TEST_DATABASE_URL` 이 실수로
+    개발·공용 DB 를 가리켰을 때 **애플리케이션 테이블을 전부 삭제한다** —
+    변수 이름은 관례이지 보증이 아니다. 대신 여기서 만든 스키마 하나만 만들고
+    그것만 제거한다. 잘못 가리켜도 남의 데이터에 닿지 않는다.
+    """
+    schema = f"aos_conc_test_{uuid.uuid4().hex[:12]}"
+    admin = create_async_engine(TEST_DATABASE_URL, poolclass=NullPool)
+    async with admin.begin() as conn:
+        await conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+    # 이 엔진의 모든 연결이 전용 스키마만 보게 한다 (asyncpg server_settings).
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        poolclass=NullPool,
+        connect_args={"server_settings": {"search_path": schema}},
+    )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, expire_on_commit=False)
     try:
         yield factory
     finally:
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+        async with admin.begin() as conn:
+            # 이 픽스처가 만든 스키마 하나만 대상으로 한다.
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await admin.dispose()
 
 
 @pytest_asyncio.fixture

--- a/tests/backend/test_session_conflict_response.py
+++ b/tests/backend/test_session_conflict_response.py
@@ -40,3 +40,42 @@ async def test_version_conflict_returns_409_not_500():
         f"버전 충돌이 {response.status_code} 로 나갔다 — 재시도 가능한 조건은 500 이 아니다"
     )
     assert "retry" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_ping_survives_ttl_refresh_contention(monkeypatch):
+    """하트비트는 TTL 연장이 경합해도 끊기지 않는다 (issue #292).
+
+    FastAPI 예외 핸들러는 HTTP 스코프에만 걸린다 — WebSocket 에서 잡지 않으면
+    경합 한 번에 연결이 끊긴다. 연장 실패는 "다른 쪽이 방금 갱신했다" 는 뜻이라
+    세션이 살아 있다는 신호에 가깝다.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.deps import clear_engine, set_engine
+    from api.websocket import websocket_endpoint
+    from orchestrator import OrchestrationEngine
+
+    class _AlwaysConflicts:
+        """TTL 연장이 언제나 경합하는 서비스."""
+
+        async def refresh_session(self, session_id):
+            raise SessionVersionConflictError(session_id)
+
+    monkeypatch.setattr(
+        "services.session_service.get_session_service", lambda: _AlwaysConflicts()
+    )
+
+    set_engine(OrchestrationEngine())
+    app = FastAPI()
+    app.add_api_websocket_route("/ws/{session_id}", websocket_endpoint)
+
+    try:
+        with TestClient(app).websocket_connect("/ws/s-292") as ws:
+            ws.send_json({"type": "ping", "session_id": "s-292"})
+            reply = ws.receive_json()
+    finally:
+        clear_engine()
+
+    assert reply["type"] == "pong", f"경합으로 하트비트가 깨졌다: {reply}"

--- a/tests/backend/test_session_conflict_response.py
+++ b/tests/backend/test_session_conflict_response.py
@@ -1,0 +1,42 @@
+"""세션 쓰기 경합이 500 이 아니라 409 로 나가는지 (issue #292).
+
+버전 충돌은 "다른 쓰기가 먼저 반영됐다" 는 뜻이라 클라이언트가 다시 시도하면
+된다. 전역 예외 핸들러에 맡기면 500 이 나가 재시도 가능한 조건이 서버 오류처럼
+보이고, 승인 API 에서는 #283 이 닫은 "승인이 가끔 실패" 가 재발한다.
+
+핸들러 **등록 여부**만 보면 잘못된 상태 코드를 내도 통과한다. 실제로 예외를
+던져 응답을 확인한다.
+"""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from services.session_service import SessionVersionConflictError
+
+
+def _app_with_handler() -> FastAPI:
+    """`create_app` 이 등록하는 것과 같은 핸들러를 가진 최소 앱."""
+    from api.app import create_app
+
+    app = create_app()
+
+    @app.get("/__conflict_probe")
+    async def _probe():
+        raise SessionVersionConflictError("s-292")
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_version_conflict_returns_409_not_500():
+    app = _app_with_handler()
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/__conflict_probe")
+
+    assert response.status_code == 409, (
+        f"버전 충돌이 {response.status_code} 로 나갔다 — 재시도 가능한 조건은 500 이 아니다"
+    )
+    assert "retry" in response.json()["detail"].lower()

--- a/tests/backend/test_session_service.py
+++ b/tests/backend/test_session_service.py
@@ -687,10 +687,10 @@ def _full_agent() -> AgentInfo:
     )
 
 
-def _db_service_returning(raw_state: dict, monkeypatch) -> SessionService:
-    """`get_state` 가 raw JSON 을 돌려주는 DB 모드 SessionService 를 만든다."""
+def _db_service_returning(raw_state: dict, monkeypatch, version: int = 1) -> SessionService:
+    """`get_state_with_version` 이 (raw JSON, 버전) 을 돌려주는 DB 모드 서비스."""
     repo = MagicMock()
-    repo.get_state = AsyncMock(return_value=raw_state)
+    repo.get_state_with_version = AsyncMock(return_value=(raw_state, version))
     monkeypatch.setattr("services.session_service.SessionRepository", MagicMock(return_value=repo))
     monkeypatch.setattr("services.session_service.async_session_factory", _FakeSessionFactory())
     return SessionService(use_database=True)


### PR DESCRIPTION
#292 의 (a) — 다중 인스턴스 지원 — 을 구현한다.

## 이슈에 적었던 방향을 바꿨다

#292 는 "`approvals` 테이블에 조건부 `UPDATE`" 를 제안했다. 착수하며 그 전제를 실측한 결과 **틀렸다**:

| 확인 | 결과 |
|---|---|
| `approvals` 테이블 런타임 쓰기 | **0 건** — `save_approval_request`/`approve_operation`/`deny_operation` 모두 호출부 없음 |
| 실제 진실의 출처 | `state["pending_approvals"]` — 세션 state JSON 안 |
| `update_state` | `state_json` **전체를 덮어씀** |
| `sessions` 의 version 컬럼 | 없음 |

승인 이중 소비는 **증상이지 원인이 아니다.** 원인은 통째 덮어쓰기 + 버전 부재이고, #289 의 TTL 경합도 `_persist_approval_consumption` 의 `{**state, ...}` 쓰기도 같은 read-modify-write 의 다른 사례다. 승인만 테이블로 옮기면 부류 중 하나만 고치고 나머지는 남으며, diff 는 훨씬 크다.

→ **버전 컬럼으로 부류 전체를 닫는다.** 승인 테이블 이전은 이 뒤에 남는 구체 사례가 있을 때만.

## 설계

### 버전은 state 에 실려 다닌다

서비스 수준 dict(`self._session_versions[sid]`)를 검토하고 기각했다. 같은 프로세스의 동시 읽기 둘이 그 dict 를 공유한다 — A 가 v5 읽고, B 가 v5 읽고, B 가 써서 dict 가 6 이 되면, A 의 쓰기가 6 으로 나가 **통과한다**. 막으려던 lost update 가 그대로 난다.

`state["_version"]` 은 읽는 쪽마다 자기 스냅샷을 들고 가므로 이 함정을 피한다. 저장하지는 않는다 — 진실은 컬럼 하나이고, JSON 에도 넣으면 두 벌이 되어 드리프트한다.

### 실패는 두 가지고 대응이 다르다

`rowcount == 0` 은 "행이 없음" 과 "버전 불일치" 를 구분하지 못하는데, 전자는 재시도해도 소용없고 후자는 재시도해야 한다. 실패 경로에서만 존재 확인 질의를 한 번 더 해 `StateWriteResult` 로 구분한다.

### 호출부

| 처리 | 대상 |
|---|---|
| 재시도(`mutate_session`) | `engine.create_session`, `engine.cancel`, `orchestrate.execute_analysis`, `SessionService.refresh_session`, `api/hitl.resolve_approval` |
| last-writer-wins 명시(`check_version=False`) | `engine.run`, `engine.stream` |
| 캐시 무효화 | `engine.save_session` |

`run`/`stream` 의 최종 저장은 완료된 그래프 실행의 산물이라 **재시도가 도구 재실행을 뜻한다.** 그래서 의도적으로 버전 검사를 끈다. 대신 실행 중 다른 프로세스가 쓴 것은 유실된다 — 오래된 스냅샷을 통째로 쓰는 구조에서 오는 기존 동작이고(이 PR 이 만든 회귀가 아니다), 제대로 풀려면 필드 단위 병합이 필요하다.

`engine.save_session` 이 충돌 시 엔진 캐시를 버리는 것은 **재시도 성립의 전제**다. 캐시 히트가 같은 낡은 `_version` 을 계속 내주면 재시도가 영원히 충돌한다.

**HTTP 로 도달 가능한 경로에 미처리 충돌을 남기지 않았다.** 버전 충돌은 예상되고 재시도 가능한 조건이지 500 이 아니다. 승인 API 는 재시도 소진 시 409 를 준다 — #283 이 닫은 "승인이 가끔 실패" 를 되살리지 않기 위해서다.

## 중간 Codex 검증에서 나온 P1 3 건 (전부 반영)

호출부를 전환하기 **전에** 코어만 먼저 검증했다. 잘못된 프리미티브를 9 곳에 퍼뜨리기 전에 잡는 게 싸다.

1. **기동 경로에 마이그레이션이 없었다.** `init_db()` 는 Alembic 이 아니라 `create_all` + 손으로 쓴 `_run_migrations()` 를 쓴다. `create_all` 은 기존 테이블에 컬럼을 추가하지 않으므로 배포 직후 SELECT 가 UndefinedColumn 으로 죽는다. → `_run_migrations()` 에 Migration 12 추가(Alembic 파일도 유지).
2. **LangGraph 가 `_version` 을 버렸다.** `AgentState` TypedDict 에 없는 키는 노드 출력에서 조용히 사라진다(프로브로 실측). → 선언 추가.
3. **쓰기 성공 후 버전이 안 올랐다.** 같은 state 로 다시 쓰면 아무도 끼어들지 않았는데 충돌했다. → `UPDATE ... RETURNING version`.

## 최종 Codex 검증에서 나온 3 건 (전부 반영)

1. **[P1] 테스트 teardown 이 DB 를 통째로 지울 수 있었다.** 픽스처가 `Base.metadata.drop_all()` 로 정리했는데, `AOS_TEST_DATABASE_URL` 이 실수로 개발·공용 DB 를 가리키면 애플리케이션 테이블이 전부 사라진다. 유일한 방어가 변수 이름이었고, **이름은 관례이지 보증이 아니다.** 이 저장소는 shared-infra 를 세 프로젝트가 공유하므로 특히 위험하다.
   → 랜덤 이름의 전용 스키마 안에서만 동작하게 바꿨다. `CREATE SCHEMA` → asyncpg `server_settings.search_path` 로 고정 → 끝나면 그 스키마 하나만 제거. 잘못 가리켜도 남의 데이터에 닿지 않는다. 실행 후 잔여 스키마 0 을 확인했다.
2. **[P2] 재시도 소진이 500 으로 나갔다.** `engine.cancel` 과 세션 갱신 엔드포인트가 `SessionVersionConflictError` 를 잡지 않아 전역 핸들러의 500 이 됐다. → FastAPI 예외 핸들러로 **409** 매핑(전 엔드포인트 일괄). 등록 여부만 보는 테스트는 잘못된 상태 코드를 놓치므로 실제로 예외를 던져 응답을 확인한다.
3. **[P2] `update_state` 반환 타입 어노테이션 불일치.** 모든 분기가 튜플을 돌려주는데 선언은 단일 값이었다(앞선 패치가 중간 실패해 유실).

## 이 작업 중 발견한 기존 결함

위 2 번을 파다 나왔다. **`_metadata` 도 같은 이유로 그래프를 통과하며 사라진다.** 즉 그래프를 한 번 돈 세션은 영속 state 에서 TTL 정보를 잃어, 재시작·다른 인스턴스에서 만료가 강제되지 않았다. #289/#290 이 세운 계약이 실행 후에 무력화되고 있었다.

같은 TypedDict 를 고치는 중이라 함께 선언했다. 불변식 테스트(`test_agent_state_graph_keys.py`)를 붙였는데, 선언 여부를 `__annotations__` 로 확인하는 것은 동어반복이라 **실제로 그래프를 왕복시켜** 살아남는지 본다. 노드가 실제로 돌았는지 보는 대조군도 함께 둬서 빈 그래프로 통과하지 않게 했다.

## 검증

| 게이트 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 318 files already formatted |
| `uv run mypy . --ignore-missing-imports` | **319 source files, 0 errors** |
| `uv run pytest ../../tests/backend` | **1489 passed, 1 failed, 2 skipped** |

유일한 실패 `test_rag_verification::test_embedding_model_consistency` 는 로컬 `.env` 의 `RAG_EMBEDDING_MODEL` 오버라이드가 원인이며 이 변경과 무관하다 (CI 는 통과).

### DB 모드 동시성 테스트 (신규 7 건)

메모리 모드로는 이 부류를 검증할 수 없다 — `deserialize_state` 가 저장된 객체를 그대로 돌려주므로 저장소와 로컬 사본이 분리되지 않고, 조건부 UPDATE 가 행을 잡지 못하는 상황 자체가 재현되지 않는다.

`AOS_TEST_DATABASE_URL` opt-in 으로 실제 Postgres 에 붙는다. 전용 변수를 쓰는 이유는 로컬에서 실수로 개발 DB 를 건드리지 않게 하기 위해서다 — 없으면 skip 된다. CI 는 이미 Postgres 를 띄우므로 env 한 줄만 배선했다.

**RED 확인**: 버전 검사를 끄면 `test_concurrent_writers_only_one_wins` 가 `['ok', 'ok']` 를 낸다 — 두 쓰기가 다 통과하는 lost update 가 그대로 재현된다. 다른 두 건도 함께 실패한다.

`test_stale_write_conflicts` 는 늦은 쓰기가 막히는 것뿐 아니라 **앞선 쓰기가 살아 있는지** 까지 단언한다. 차단만 검사하면 "둘 다 실패시키는" 수정도 통과한다.

## 범위 밖

- **승인 소비의 진짜 경합.** 버전 검사가 "둘 중 하나는 실패" 로 만들지만, 실패한 쪽은 재시도가 아니라 task 실패로 처리된다(`executor._persist_approval_consumption` — 기존 영속화 실패 계약 그대로). 안전하지만(중복 실행 없음) 최적은 아니다. `approvals` 테이블의 조건부 UPDATE 로 옮기는 것이 그 답이며 별도 작업이다.
- **`conftest.py:16` 의 `os.environ["USE_DATABASE"] = "false"`.** 최초 커밋(2026-01-17)부터 있었고 CI 의 Postgres + `USE_DATABASE=true` 는 2026-02-03 에 따로 들어왔다 — 오래된 쪽이 새 쪽을 덮어 CI 가 DB 를 띄우고도 쓰지 않는다. 실수로 보이지만 `setdefault` 로 바꾸면 1478 개 테스트가 한꺼번에 DB 모드로 전환돼 이 PR 의 diff 에 섞을 수 없다. 별도 이슈로 올린다.
- **#291** `cleanup_expired_sessions` — 프로덕션 호출부 0 건.

## 배포 주의

`sessions.version` 컬럼이 추가된다. 기동 시 `_run_migrations()` 가 idempotent 하게 처리하므로 별도 조치는 필요 없다. 컬럼 도입 전에 읽어둔 state 에는 버전이 없어 그런 쓰기는 무조건 UPDATE 로 떨어진다 — 배포 순간에 충돌이 쏟아지지 않는다.
