### PR TITLE
fix(session): 재시도 소진 충돌도 엔진 캐시를 버리도록 (#292)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -232,6 +232,27 @@ cd ~/Work/Agent-System && nohup node "$SCRIPT" review --scope branch --base main
   건드리지 않았다. 커밋 전 `git status` 재확인 필수.
 
 
+#### 이어받은 세션 (같은 날 21:20~) — Codex 3 라운드 완료, #293 머지, P2 는 #294 로
+
+위 항목의 "남은 일은 하나뿐: Codex 3 라운드" 를 실행했다. **다 끝났다.**
+
+| 결과 | |
+|---|---|
+| Codex 3 라운드 | 완료 — **P2 1 건**. `engine.mutate_session` 이 재시도 소진 충돌에서 엔진 캐시를 버리지 않아, 이후 `get_session` 이 낡은 스냅샷을 TTL 까지 계속 내준다(`save_session` 은 이미 버린다 — 대칭이 깨져 있었다) |
+| PR #293 | **머지됨** — squash `9154e13`. 리뷰가 도는 사이 머지돼, P2 는 main 에 남았다 |
+| PR #294 | 그 P2 수정. `origin/main` 위 `fix/session-conflict-cache-invalidation`. RED 확인 후 GREEN, 전체 pytest 베이스라인 일치 |
+| 이슈 #295 | 새로 등록 — 아래 참조 |
+
+**리뷰 3 라운드가 전부 실제 결함을 잡았다.** 1 라운드는 DB 를 통째로 지울 수 있는 테스트 teardown, 2 라운드는 HTTP 예외 핸들러가 WebSocket 스코프에 안 걸리는 것, 3 라운드는 이 캐시 무효화. 머지 전 Codex 게이트를 생략하지 말 것.
+
+**게이트 자체에 구멍이 있었다 (이슈 #295).**
+`pyproject.toml` 의 mypy 래칫이 `disable_error_code` 에 `return-value` 를 담고 있어, 이 PR 에서 같은 모양의 버그 두 건(`update_state`·`_resolve_once` 의 반환 타입 오선언)이 **mypy 를 통과했다**. 수정 전 파일로 실측 확인했다. 재활성화 비용은 **9 건**(전체 에러도 9 건). 설정의 TODO 도 재활성화 1 순위로 `return-value` 를 지목한다.
+→ **"Backend Type Check 초록" 은 반환 계약의 증거가 아니다.** 그 계열을 바꿀 때는 선언 arity 와 실제 `return` arity 를 AST 로 직접 대조하고, 탐지기는 알려진 양성으로 RED 검증한 뒤에 "0 건" 을 믿을 것.
+
+**환경 메모 (위 항목 이어서)**
+- `src/dashboard/src/components/monitor/{index.ts, AgentRealtimeStatusBoard.tsx}` 는 여전히 워킹트리에 있다. **어느 세션 것인지 확인되지 않았다** — 이관한 세션도 자기 것이 아니라고 적었다. 건드리지 않았다.
+- 메인 체크아웃이 삭제된 브랜치 `fix/session-state-optimistic-concurrency` 에 그대로 있다(upstream 없음). #294 작업은 별도 worktree 에서 해 공유 체크아웃을 흔들지 않았다.
+
 ### 2026-08-18 세션 — 감사 문서 청산 → 이슈 트래커 이관 → 결함 2건 수정
 
 **한 일 (완료)**

--- a/src/backend/orchestrator/engine.py
+++ b/src/backend/orchestrator/engine.py
@@ -301,7 +301,14 @@ class OrchestrationEngine:
 
         `session_service.mutate_session` 만 쓰면 엔진 캐시가 낡은 채로 남는다.
         """
-        mutated = await self.session_service.mutate_session(session_id, mutate)
+        try:
+            mutated = await self.session_service.mutate_session(session_id, mutate)
+        except SessionVersionConflictError:
+            # `save_session` 과 같은 이유다 — 캐시를 남기면 이후 `get_session` 이
+            # 캐시 히트로 낡은 스냅샷을 계속 내줘, 그 사이 다른 인스턴스가 쓴
+            # 최신 상태가 TTL 이 끝날 때까지 가려진다.
+            self._sessions.pop(session_id, None)
+            raise
         if mutated is not None:
             self._sessions[session_id] = mutated
         else:

--- a/tests/backend/test_engine_session_cache.py
+++ b/tests/backend/test_engine_session_cache.py
@@ -12,7 +12,7 @@ import pytest
 from api.context import get_project_context
 from models.project import Project
 from orchestrator import OrchestrationEngine
-from services.session_service import SessionService
+from services.session_service import SessionService, SessionVersionConflictError
 from utils.time import utcnow
 
 
@@ -201,3 +201,33 @@ class TestProjectContextSessionLookup:
 
         assert response.session_info is not None
         assert response.session_info["session_id"] == session_id
+
+
+class TestConflictInvalidatesCache:
+    """재시도 소진 충돌은 캐시를 버려야 한다 (issue #292).
+
+    `save_session` 은 이미 그렇게 한다. `mutate_session` 이 예외 경로에서만
+    캐시를 남기면, 이후 `get_session` 이 캐시 히트로 낡은 스냅샷을 계속 내줘
+    다른 인스턴스가 쓴 최신 상태가 TTL 이 끝날 때까지 가려진다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_exhausted_mutate_conflict_drops_cached_state(self, isolated_engine, monkeypatch):
+        engine = isolated_engine
+        session_id = await engine.create_session()
+        assert session_id in engine._sessions, "생성 직후 캐시에 올라와 있다(전제)"
+
+        async def _always_conflicts(sid, mutate, *args, **kwargs):
+            raise SessionVersionConflictError(sid)
+
+        monkeypatch.setattr(engine.session_service, "mutate_session", _always_conflicts)
+
+        async def _noop(state):
+            return state
+
+        with pytest.raises(SessionVersionConflictError):
+            await engine.mutate_session(session_id, _noop)
+
+        assert session_id not in engine._sessions, (
+            "충돌 후에도 캐시가 남아 낡은 스냅샷을 계속 내준다"
+        )


### PR DESCRIPTION
## 배경

PR #293(issue #292)의 **Codex 3 라운드**가 그 PR 머지 직후에 끝났다. 지적 1 건(P2)이 남아 main 에 그대로 있다.

## 무엇이 문제인가

`OrchestrationEngine` 에는 캐시와 저장소가 갈라질 수 있는 쓰기 경로가 둘 있고, 둘은 같은 불변식을 진다 — **버전 충돌이 나면 캐시를 버린다.** 캐시를 남기면 이후 읽기가 같은 낡은 `_version` 을 계속 내주기 때문이다.

`save_session` 은 그렇게 한다(`engine.py:287-293`, 주석에 이유까지 적혀 있다). `mutate_session` 래퍼는 같은 의무를 `mutated is None` 분기에서만 이행하고 **예외 경로에서는 캐시를 남겼다** — `session_service.mutate_session` 이 재시도를 소진해 `SessionVersionConflictError` 를 던지면 `mutated is None` 분기 자체에 도달하지 못한다.

`get_session` 은 만료가 아닌 한 캐시 히트를 그대로 돌려주므로(`engine.py:268-269`), 충돌 예외가 지나간 뒤 그 세션은 낡은 스냅샷을 계속 서빙한다. **그 사이 다른 인스턴스가 쓴 최신 상태가 TTL 이 끝날 때까지 가려진다** — 다중 인스턴스를 지원하려고 #292 에서 넣은 버전 검사가 정작 읽기 쪽에서 무력화되는 셈이다.

## 수정

`save_session` 과 대칭이 되게 예외 경로에서도 캐시를 버리고 다시 던진다. 9 줄.

## 테스트 계획

`tests/backend/test_engine_session_cache.py` 에 `TestConflictInvalidatesCache` 추가 — 서비스의 `mutate_session` 이 항상 충돌하게 두고, 예외 이후 엔진 캐시가 비었는지 본다.

- **RED 확인**: 수정 전에는 `충돌 후에도 캐시가 남아 낡은 스냅샷을 계속 내준다` 로 실패
- **GREEN**: `test_engine_session_cache.py` 11/11 통과
- 전체 백엔드: `1 failed, 1484 passed, 9 skipped` — 유일 실패는 로컬 `.env` 의 `RAG_EMBEDDING_MODEL` 오버라이드에서 오는 알려진 플레이크(CI 는 통과), 베이스라인 일치
- ruff check · ruff format --check · mypy 전부 통과

## 참고

- issue #292 / PR #293 — 이 수정이 닫는 지적의 출처
- 이 브랜치는 #293 이 squash 머지된 `9154e13` 위에서 시작한다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017r4f96LoYTrNBTheVFB1NM
