### PR TITLE
fix(mcp): 존재하지 않는 Playwright 패키지를 공식 패키지로 교체

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "langgraph>=1.2.11",
     "langchain>=1.3.15",
     "langchain-anthropic>=1.5.6",
+    "anthropic>=0.120.0,<1.0.0",
     "langchain-openai>=1.5.0",
     "langchain-ollama>=1.1.0",
     "langchain-google-genai>=4.3.3",

--- a/src/backend/services/mcp_manager.py
+++ b/src/backend/services/mcp_manager.py
@@ -154,7 +154,7 @@ DEFAULT_MCP_SERVERS: list[MCPServerConfig] = [
         name="Playwright MCP",
         description="브라우저 자동화 및 스크린샷",
         command="npx",
-        args=["-y", "@anthropic/mcp-server-playwright"],
+        args=["-y", "@playwright/mcp@latest"],
         allowed_tools=[
             "browser_navigate",
             "browser_click",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -16,6 +16,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
     { name = "alembic" },
+    { name = "anthropic" },
     { name = "apscheduler" },
     { name = "asyncpg" },
     { name = "bcrypt" },
@@ -70,6 +71,7 @@ monitoring = [
 requires-dist = [
     { name = "aiosmtplib", specifier = ">=3.0.0" },
     { name = "alembic", specifier = ">=1.19.1" },
+    { name = "anthropic", specifier = ">=0.120.0,<1.0.0" },
     { name = "apscheduler", specifier = ">=3.11.3" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "bcrypt", specifier = ">=4.1.0" },

--- a/tests/backend/test_mcp_manager.py
+++ b/tests/backend/test_mcp_manager.py
@@ -1,19 +1,20 @@
 """Tests for MCP Manager."""
 
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
 
 from services.mcp_manager import (
+    DEFAULT_MCP_SERVERS,
+    MCPBatchToolCall,
+    MCPBatchToolResult,
     MCPManager,
     MCPServerConfig,
-    MCPServerType,
     MCPServerStatus,
+    MCPServerType,
     MCPToolCall,
     MCPToolResult,
     MCPToolSchema,
-    MCPBatchToolCall,
-    MCPBatchToolResult,
-    get_mcp_manager_sync,
 )
 
 
@@ -28,6 +29,13 @@ class TestMCPManager:
         """초기화 테스트."""
         assert self.manager._initialized is False
         assert len(self.manager._servers) == 0
+
+    def test_default_playwright_server_uses_official_package(self):
+        """기본 Playwright 서버가 공식 MCP 패키지와 실행 인자를 사용한다."""
+        config = next(server for server in DEFAULT_MCP_SERVERS if server.id == "playwright")
+
+        assert config.command == "npx"
+        assert config.args == ["-y", "@playwright/mcp@latest"]
 
     @pytest.mark.asyncio
     async def test_initialize_with_default_servers(self):
@@ -401,10 +409,7 @@ class TestMCPManagerBatchCall:
     async def test_call_tools_batch_respects_max_concurrent(self):
         """max_concurrent 설정 준수 테스트."""
         # 많은 호출 생성
-        calls = [
-            MCPToolCall(server_id=f"server{i}", tool_name="test")
-            for i in range(10)
-        ]
+        calls = [MCPToolCall(server_id=f"server{i}", tool_name="test") for i in range(10)]
         batch_call = MCPBatchToolCall(calls=calls, max_concurrent=2)
         result = await self.manager.call_tools_batch(batch_call)
 
@@ -415,7 +420,7 @@ class TestMCPManagerBatchCall:
     @pytest.mark.asyncio
     async def test_call_tools_batch_handles_exceptions(self):
         """예외 처리 테스트."""
-        with patch.object(self.manager, 'call_tool', side_effect=Exception("Test error")):
+        with patch.object(self.manager, "call_tool", side_effect=Exception("Test error")):
             # 서버 등록
             config = MCPServerConfig(
                 id="error-server",


### PR DESCRIPTION
## Summary

- `DEFAULT_MCP_SERVERS` 의 Playwright 항목이 **npm 에 존재하지 않는 패키지**를 가리키고 있었다 → 공식 패키지로 교체
- `anthropic` 을 전이 의존에서 **명시적 의존성**으로 승격 (상한 `<1.0.0`)
- 회귀 테스트 1건 추가 (RED 확인 완료)

## Changes

### `@anthropic/mcp-server-playwright` → `@playwright/mcp@latest`

```
$ npm view @anthropic/mcp-server-playwright version
npm error 404

$ npm view @playwright/mcp version
0.0.79
```

기본 MCP 서버 설정이 **없는 패키지**를 가리켜, Playwright MCP 는 등록된 이래 `npx` 단계에서 항상 기동에 실패했다. 설정 파일에만 존재하고 실제로는 한 번도 동작하지 않은 서버였다.

### `anthropic>=0.120.0,<1.0.0` 명시

지금까지는 `langchain-anthropic` 의 전이 의존으로만 들어왔다. 상류가 범위를 바꾸면 조용히 따라 움직이는 상태였으므로 직접 선언한다. 상한은 1.0 메이저에서 호환이 깨질 수 있어 두었다.

`uv lock --check` → **exit 0** (CI 가 `--locked` 로 소비하므로 lock 정합이 필수).

### 테스트

`DEFAULT_MCP_SERVERS` 에서 실제 config 를 꺼내 `command`·`args` 를 단언한다 — 설정을 되돌리면 실패하는 형태다.

```
RED (패키지명 되돌림) → 1 failed, 26 passed  ← 그 테스트만 정확히 실패
GREEN (복원)          → 27 passed
```

테스트 파일의 미사용 import 정리(`AsyncMock`·`MagicMock`·`get_mcp_manager_sync`)와 `ruff format` 적용이 함께 들어갔다.

## Test Plan

- [x] `pytest tests/backend/test_mcp_manager.py` — **27 passed**
- [x] `ruff check` — All checks passed
- [x] `ruff format --check` — 통과
- [x] `mypy services/mcp_manager.py` — Success, no issues
- [x] `uv lock --check` — exit 0
- [x] Red-Green 검증 — 수정을 되돌리면 새 테스트만 실패
- [ ] CI 전체 통과 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017r4f96LoYTrNBTheVFB1NM
