### PR TITLE
chore(backend): mypy 래칫에서 return-value 활성화 (#295)

### DIFF
--- a/src/backend/api/analytics.py
+++ b/src/backend/api/analytics.py
@@ -14,6 +14,8 @@ so the service returns an empty result set instead of silently aggregating
 across projects.
 """
 
+from typing import cast
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -63,7 +65,7 @@ async def _resolve_project_path(project_id: str | None, db: AsyncSession) -> str
     if project is None or not project.path:
         return _NO_MATCH_PATH
 
-    return project.path
+    return cast(str, project.path)
 
 
 @router.get("/overview", response_model=OverviewMetrics)

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -141,7 +141,7 @@ class SessionRepository:
         session = await self.get(session_id)
         if session is None:
             return None
-        return session.state_json, int(session.version)
+        return cast(dict[str, Any], session.state_json), int(session.version)
 
     async def update_state(
         self,

--- a/src/backend/orchestrator/nodes/executor.py
+++ b/src/backend/orchestrator/nodes/executor.py
@@ -622,7 +622,7 @@ After completing all necessary tool calls, provide a final summary."""
                     metadata={"task_id": current_task_id},
                 )
 
-            result = {
+            node_result: dict[str, Any] = {
                 "tasks": {current_task_id: task},
                 "agents": agents,
                 "messages": [self._create_message("assistant", f"Completed task: {task.title}")],
@@ -634,9 +634,9 @@ After completing all necessary tool calls, provide a final summary."""
 
             # Include token usage updates
             if accumulated_token_updates:
-                result.update(accumulated_token_updates)
+                node_result.update(accumulated_token_updates)
 
-            return result
+            return node_result
 
         except Exception as e:
             task.status = TaskStatus.FAILED
@@ -658,7 +658,7 @@ After completing all necessary tool calls, provide a final summary."""
                 agents[agent_id].status = TaskStatus.FAILED
                 agents[agent_id].current_task = None
 
-            result = {
+            error_result: dict[str, Any] = {
                 "tasks": {current_task_id: task},
                 "agents": agents,
                 "last_error": str(e),
@@ -669,6 +669,6 @@ After completing all necessary tool calls, provide a final summary."""
 
             # Include token usage even on failure
             if accumulated_token_updates:
-                result.update(accumulated_token_updates)
+                error_result.update(accumulated_token_updates)
 
-            return result
+            return error_result

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -110,7 +110,9 @@ explicit_package_bases = true
 mypy_path = "."
 # 래칫(ratchet) 전략: 기존 위반 에러 코드는 비활성화.
 # mypy는 실행되며, 새로운 타입의 에러는 차단됨.
-# TODO: 에러 코드별로 점진적 활성화 (return-value → no-redef → call-arg 순)
+# `return-value` 는 2026-08-24 활성화 (issue #295) — 껐던 대가로 반환 계약
+# 버그가 두 건 통과했다(#292 / PR #293). 위반 9 건을 정리하고 목록에서 뺐다.
+# TODO: 에러 코드별로 점진적 활성화 (no-redef → call-arg 순)
 disable_error_code = [
     "arg-type",           # 471건 — 인자 타입 불일치
     "assignment",         # 156건 — 대입 타입 불일치
@@ -121,7 +123,6 @@ disable_error_code = [
     "index",              #  19건 — 인덱스 타입
     "var-annotated",      #  18건 — 변수 어노테이션
     "call-arg",           #  12건 — 함수 호출 인자
-    "return-value",       #   6건 — 반환값 타입
     "operator",           #   5건 — 연산자 타입
     "call-overload",      #   5건 — 오버로드 매칭
     "literal-required",   #   5건 — 리터럴 타입 필요

--- a/src/backend/services/credential_service.py
+++ b/src/backend/services/credential_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from typing import cast
 
 import httpx
 from sqlalchemy import and_, select
@@ -226,4 +227,4 @@ async def get_raw_key(db: AsyncSession, user_id: str, provider: ExternalProvider
         .limit(1)
     )
     row = result.scalar_one_or_none()
-    return row.api_key if row else None
+    return cast(str, row.api_key) if row else None

--- a/src/backend/services/deployment_usage_credential_service.py
+++ b/src/backend/services/deployment_usage_credential_service.py
@@ -20,6 +20,7 @@ import logging
 import os
 import time
 from datetime import UTC, datetime, timedelta
+from typing import cast
 
 import httpx
 from sqlalchemy import select
@@ -88,7 +89,7 @@ async def resolve_admin_key(db: AsyncSession, provider: ExternalProvider) -> str
     """Resolve the usage admin key: active DB row > env var > None."""
     row = await _get_active_row(db, provider)
     if row is not None:
-        return row.api_key  # decrypted automatically by EncryptedString
+        return cast(str, row.api_key)  # decrypted automatically by EncryptedString
 
     env_name = ENV_MAP.get(provider)
     if env_name:

--- a/src/backend/services/llm_usage_ledger_service.py
+++ b/src/backend/services/llm_usage_ledger_service.py
@@ -6,7 +6,7 @@ import logging
 import os
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -102,7 +102,7 @@ async def resolve_user_organization_id(db: AsyncSession, user_id: str | None) ->
         if getattr(row, "organization_id", None)
     }
     if len(org_ids) == 1:
-        return next(iter(org_ids))
+        return cast(str, next(iter(org_ids)))
     return None
 
 

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -8,7 +8,7 @@ import os
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 from db.database import async_session_factory
 from db.repository import (
@@ -267,7 +267,9 @@ class SessionService:
         if version is not None:
             state[STATE_VERSION_KEY] = version
 
-        return state
+        # `deserialize_state` 는 저장 포맷(dict) 을 다루는 헬퍼라 `dict` 를 돌려준다.
+        # `AgentState` 계약을 세우는 곳은 저장소를 감싸는 이 관문 하나뿐이다.
+        return cast(AgentState, state)
 
     async def update_session(
         self,
@@ -540,13 +542,13 @@ class SessionService:
                     for s in sessions
                 ]
         else:
-            sessions = []
+            memory_rows: list[dict[str, Any]] = []
             for sid, state in list(self._memory_sessions.items()):
-                if len(sessions) >= limit:
+                if len(memory_rows) >= limit:
                     break
                 if project_id and state.get("project", {}).get("id") != project_id:
                     continue
-                sessions.append(
+                memory_rows.append(
                     {
                         "id": sid,
                         "user_id": state.get("user_id"),
@@ -559,7 +561,7 @@ class SessionService:
                         "total_cost_usd": state.get("total_cost", 0),
                     }
                 )
-            return sessions
+            return memory_rows
 
     async def update_cost(
         self,


### PR DESCRIPTION
## 왜

`src/backend/pyproject.toml` 의 `[tool.mypy]` 래칫이 `disable_error_code` 에 **`return-value`** 를 담고 있어, "선언은 단일 값인데 실제로는 튜플을 반환" 같은 **반환 계약 불일치를 mypy 가 조용히 통과**시켰다. CI 의 `Backend Type Check` 초록은 이 계열에 대해 아무것도 보증하지 않았다.

가설이 아니다 — PR #293 에서 같은 모양의 버그가 두 건 나왔고 **둘 다 Codex 가 잡고 mypy 는 놓쳤다**:

| 위치 | 선언 | 실제 반환 |
|---|---|---|
| `db/repository.py` `update_state` | `StateWriteResult` | `(StateWriteResult, new_version)` |
| `api/hitl.py` `_resolve_once` | `ApprovalResponse \| None` | `(state, approval)` |

## 무엇을

위반 9 건을 세 갈래로 정리하고 `disable_error_code` 에서 `return-value` 를 뺐다.

**① SQLAlchemy 레거시 `Column(...)` 계열 5 건 — 반환 지점 `cast`**
`db/models/` 는 아직 `Mapped[...]` 로 가지 않아 인스턴스 속성이 `Column[Any]` 로 잡힌다. 모델 전면 마이그레이션은 이 이슈의 범위 밖이라 반환 지점에서만 좁게 단언한다.
`db/repository.py:144` · `services/credential_service.py:229` · `services/deployment_usage_credential_service.py:91` · `services/llm_usage_ledger_service.py:105` · `api/analytics.py:66`

**② 변수 재바인딩 3 건 — 이름 분리**
mypy 는 첫 바인딩의 추론 타입을 그 변수의 선언 타입으로 고정한다. 그래서 `sessions`(DB 분기 `list[SessionModel]` → 메모리 분기 `list[dict]`) 와 `result`(`str` → `dict`) 재사용이 엉뚱한 지점에서 에러로 나타났다. `cast` 로 덮지 않고 이름을 갈랐다 — 사람이 읽기에도 이쪽이 낫다.
`services/session_service.py:562` → `memory_rows` · `orchestrator/nodes/executor.py:625/661` → `node_result` / `error_result`

**③ 계약 경계 1 건 — `cast` + 주석**
`deserialize_state` 는 저장 포맷(dict) 헬퍼라 `dict` 를 돌려준다. `AgentState` 계약이 세워지는 곳은 저장소를 감싸는 `get_session` 관문 하나뿐이라 거기서 명시한다.

동작 변화 없음 — `cast` 는 런타임 no-op 이고 이름 변경은 함수 지역이다.

## 검증

**RED — 게이트가 실제로 발화하는가** (이게 이 PR 의 산출물이다. 에러 0 건만으로는 "설정 편집이 반영됐는지" 를 구분하지 못한다)

PR #293 의 수정 **전** 파일(`bea44876`)을 되돌려 놓고, **CI 와 동일한 bare 호출**(플래그 없이)로 실행:

```
$ .venv/bin/python -m mypy db/repository.py api/hitl.py --ignore-missing-imports --no-error-summary
db/repository.py:177: error: Incompatible return value type (got "tuple[StateWriteResult, int]", expected "StateWriteResult")  [return-value]
db/repository.py:179: error: ... [return-value]
db/repository.py:187: error: ... [return-value]
api/hitl.py:155:     error: Incompatible return value type (got "tuple[AgentState, dict[str, Any]]", expected "ApprovalResponse | None")  [return-value]
```

두 버그 다 잡힌다.

**GREEN**

- `mypy . --ignore-missing-imports --no-error-summary` → **exit 0, 에러 0 건** (CI `ci.yml:79` 와 동일한 호출·cwd)
- `ruff check` / `ruff format --check` → 통과
- `pytest ../../tests/backend` → **1485 passed, 9 skipped, 1 failed**. 유일한 실패 `test_embedding_model_consistency` 는 로컬 `.env` 의 `RAG_EMBEDDING_MODEL` 오버라이드가 원인인 기지 건이고 CI 는 통과한다 (회귀 아님)
- Codex 리뷰(`--scope working-tree`) → **지적 0 건**, 리뷰어가 전체 mypy 를 독립 재실행해 exit 0 확인

회귀 테스트는 추가하지 않았다 — **mypy 게이트 자체가 테스트**이고 위 RED 검증이 그 증거다.

## 남긴 것

설정의 TODO 를 `no-redef → call-arg` 로 갱신했다(다음 래칫 차례). `llm_usage_ledger_service.py` 는 `org_ids: set[str]` 어노테이션 대신 반환 지점 `cast` 를 썼다 — 전자는 지금 꺼져 있는 `assignment` 코드로 에러를 옮길 뿐이라, 다음 래칫 턴에 되살아난다.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMbGtFHy4gKcyCntfqpU4y