### PR TITLE
fix(hitl): 무조건 저장이 소비된 승인을 되살리지 못하게 (#292)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,13 +113,18 @@ high-water mark** 다 — 활동은 누구의 관측이든 실제로 일어난 �
 
 **예외: `engine.run`·`engine.stream` 의 최종 저장은 `check_version=False` 다.**
 완료된 그래프 실행의 산물이라 재시도가 도구 재실행을 뜻한다. 대신 실행 중 다른
-프로세스가 쓴 것은 유실된다 — 오래된 스냅샷을 통째로 쓰는 구조에서 오는 한계이고,
-제대로 풀려면 필드 단위 병합이 필요하다.
+프로세스가 쓴 것은 유실된다 — 오래된 스냅샷을 통째로 쓰는 구조에서 오는 한계다.
 
-**남는 것**: 두 인스턴스가 동시에 같은 승인을 소비하려는 진짜 경합은 이 버전 검사가
-"둘 중 하나는 실패" 로 만들지만, 실패한 쪽은 재시도가 아니라 task 실패로 처리된다
-(`executor._persist_approval_consumption`). 승인 소비를 `approvals` 테이블의 조건부
-UPDATE 로 옮기는 것이 그 답이며 별도 작업이다.
+**단, 터미널 승인은 예외의 예외다 (issue #292).** 승인 상태는 단조롭다
+(`pending → approved → consumed/denied`). 무조건 쓰기가 `consumed` 를 `approved` 로
+되돌리면 그 승인으로 도구가 **다시** 실행될 수 있으므로, `update_state` 는
+`expected_version` 이 없을 때 행을 `FOR UPDATE` 로 잠그고 저장소의 터미널 승인을
+병합해 넣는다(`_preserve_terminal_approvals`). 병합 규칙은 "나중에 쓴 쪽" 이 아니라
+**"더 앞선 쪽"** 이다. 나머지 필드의 필드 단위 병합은 여전히 없다.
+
+**남는 것**: 진 쪽은 재시도가 아니라 task 실패로 처리된다
+(`executor._persist_approval_consumption`). 승인은 저장소에 `approved` 로 남아
+사람이 다시 시도할 수 있으므로 안전하지만, 자동 재개는 아니다.
 
 ## HITL 승인 생명주기
 
@@ -163,9 +168,24 @@ status 만 보고 통과시키면 이전 승인의 권한으로 그 호출이 �
 스케줄러가 그 task 를 집어 재개한다(`is_task_resumable_after_approval`). 승인 API 를 다시
 호출하는 방식의 재개는 없다 — 중복 승인 요청과 구분할 수 없기 때문이다.
 
-크로스 프로세스 원자성(다중 워커)은 아직 없다. 현재 배포는 단일 인스턴스이고
-(`render.yaml`, `--workers` 없음) `approvals` 테이블을 진실의 출처로 쓰는 조건부
-UPDATE 는 다중 워커 도입 시점의 과제다.
+**크로스 프로세스 at-most-once 는 확보돼 있다 (issue #292).** 진실의 출처는
+`approvals` 테이블이 아니라 `sessions.state_json` + `sessions.version` 이다 —
+소비는 `_persist_approval_consumption` 의 조건부 UPDATE 로 기록되므로, 두 인스턴스가
+같은 승인을 동시에 소비하려 하면 진 쪽이 `SessionVersionConflictError` 를 받고
+**도구를 실행하지 않는다**(소비 기록이 실행보다 앞선다).
+
+| 계약 | 위치 | 없으면 |
+|------|------|--------|
+| 소비 경로는 행 버전을 **요구**한다 | `_persist_approval_consumption` 의 `ApprovalConsumptionUnsafeError` | 버전 없는 state 는 무조건 쓰기로 내려가 두 인스턴스가 모두 소비에 성공 — 비가역 도구가 두 번 실행 |
+| 무조건 쓰기는 터미널 승인을 되돌리지 않는다 | `SessionRepository._preserve_terminal_approvals` (`FOR UPDATE` 병합) | 그래프 최종 저장이 소비 이전 스냅샷으로 `consumed` 를 `approved` 로 되살려 재실행이 열림 |
+
+`tests/backend/test_hitl_cross_process_atomicity.py` 가 서비스 인스턴스 둘로
+(= 프로세스 둘) 지킨다. 그 파일은 이 검증을 무력화하는 거짓 초록 둘도 함께
+막는다 — 공유 이벤트 루프의 in-process 락, 그리고 읽기·소비를 함께 띄워
+경합이 아니라 순차 실행이 되는 것.
+
+`approvals` 테이블은 현재 **쓰이지 않는다**(`save_approval` 계열 호출부 0건).
+정확성에는 불필요하며, 감사·조회용으로 되살리는 것은 별도 작업이다.
 
 ## Directory Structure (Backend)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -960,6 +960,17 @@ class ProjectAccessService:
 - non-root 유저, HEALTHCHECK
 - Dashboard: nginx-alpine 기반 SPA 호스팅
 
+**다중 레플리카 정합성** (issue #292):
+매니페스트가 backend 를 2 개 이상으로 띄우므로 프로세스 로컬 락은 보장이 되지
+못한다. 정확성은 저장소에서 온다 — 세션 state 의 낙관적 동시성(`sessions.version`)
+이 겹친 쓰기를 걸러내고, HITL 승인의 at-most-once 는 그 위에 선다.
+계약과 검증은 `docs/architecture.md` 의 "세션 state 동시 쓰기" · "HITL 승인
+생명주기" 절 참조.
+
+**남은 단일 인스턴스 전제**: 세션 TTL 정리(`cleanup_expired_sessions`)는 아직
+로컬 사본으로 삭제를 판정한다 — 어느 인스턴스의 캐시에도 없는 세션은 아무도
+정리하지 않는다 (issue #291).
+
 ---
 
 ## 38. DB 기반 프로젝트 레지스트리

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -17,6 +17,7 @@ from db.models import (
     TaskModel,
 )
 from models.agent_state import AgentInfo, TaskNode
+from models.hitl import ApprovalStatus
 from utils.time import utcnow
 
 
@@ -38,6 +39,16 @@ def serialize_value(value: Any) -> Any:
 # 세션 state 에 실려 다니는 행 버전. 저장하지 않는다 — 진실은 `sessions.version`
 # 컬럼 하나이고, state_json 에도 넣으면 두 벌이 되어 드리프트한다 (issue #292).
 STATE_VERSION_KEY = "_version"
+
+# 되돌아가서는 안 되는 승인 상태. 소비·거부·만료는 종착점이고, 특히 `consumed` 는
+# **비가역 도구가 이미 실행됐다**는 뜻이라 `approved` 로 되돌리면 재실행이 열린다.
+_TERMINAL_APPROVAL_STATUSES = frozenset(
+    {
+        ApprovalStatus.CONSUMED.value,
+        ApprovalStatus.DENIED.value,
+        ApprovalStatus.EXPIRED.value,
+    }
+)
 
 
 class StateWriteResult(str, Enum):
@@ -162,6 +173,8 @@ class SessionRepository:
         # Serialize state to handle TaskNode and other Pydantic objects
         serialized = serialize_state(state)
         serialized.pop(STATE_VERSION_KEY, None)  # 버전의 진실은 컬럼 하나뿐이다
+        if expected_version is None:
+            serialized = await self._preserve_terminal_approvals(session_id, serialized)
         stmt = update(SessionModel).where(SessionModel.id == session_id)
         if expected_version is not None:
             stmt = stmt.where(SessionModel.version == expected_version)
@@ -185,6 +198,52 @@ class SessionRepository:
             else StateWriteResult.MISSING
         )
         return outcome, None
+
+    async def _preserve_terminal_approvals(
+        self,
+        session_id: str,
+        serialized: dict[str, Any],
+    ) -> dict[str, Any]:
+        """무조건 쓰기가 **터미널 승인을 되돌리거나 지우지 못하게** 병합한다.
+
+        조건부 쓰기는 버전이 어긋나면 실패하므로 낡은 스냅샷이 반영되지 않는다.
+        무조건 쓰기(`expected_version is None`)에는 그 방어가 없다 — 그래프 최종
+        저장(`engine.run`·`engine.stream`)이 대표적이고, 그쪽은 재시도가 도구
+        재실행을 뜻해 **의도적으로** 버전 검사를 끈다. 그래서 소비 이전에 읽은
+        스냅샷이 그래프를 마치고 도착하면 `state_json` 을 통째로 덮어
+        `consumed` 를 `approved` 로 되살린다. 그 승인으로 도구가 다시 실행될 수
+        있으므로 at-most-once 가 시간을 가로질러 깨진다 (issue #292).
+
+        승인 상태는 단조롭다 — `pending → approved → consumed/denied` 로만
+        전진한다. 그래서 병합 규칙은 "나중에 쓴 쪽" 이 아니라 **"더 앞선 쪽"** 이다:
+        저장소가 터미널이면 그 기록이 이긴다. 들어온 state 에 그 승인이 아예
+        없어도 되살려 넣는다 — 사라지는 것도 되돌아가는 것과 같은 결과다.
+
+        행을 `FOR UPDATE` 로 잠근 채 읽는다. 잠그지 않으면 읽기와 쓰기 사이가
+        다시 TOCTOU 창이 되어, 겹친 무조건 쓰기 둘이 각자 병합한 뒤 늦은 쪽이
+        앞선 병합을 덮는다 — 락을 저장소로 옮긴 의미가 사라진다.
+        """
+        result = await self.db.execute(
+            select(SessionModel.state_json).where(SessionModel.id == session_id).with_for_update()
+        )
+        stored = result.scalar_one_or_none()
+        if not stored:
+            return serialized
+
+        stored_approvals = stored.get("pending_approvals") or {}
+        terminal = {
+            approval_id: record
+            for approval_id, record in stored_approvals.items()
+            if isinstance(record, dict) and record.get("status") in _TERMINAL_APPROVAL_STATUSES
+        }
+        if not terminal:
+            return serialized
+
+        merged = dict(serialized)
+        approvals = dict(merged.get("pending_approvals") or {})
+        approvals.update(terminal)
+        merged["pending_approvals"] = approvals
+        return merged
 
     async def update_cost(
         self,

--- a/src/backend/orchestrator/nodes/executor.py
+++ b/src/backend/orchestrator/nodes/executor.py
@@ -16,6 +16,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool
 
+from db.repository import STATE_VERSION_KEY
 from models.agent_state import AgentInfo, AgentRole, AgentState, TaskStatus
 from models.hitl import APPROVAL_STATE_LOCK, ApprovalStatus, assess_operation_risk
 from models.llm_usage import LLMUsageSource
@@ -32,6 +33,24 @@ from utils.time import utcnow
 from .base import BaseNode
 
 logger = logging.getLogger(__name__)
+
+
+class ApprovalConsumptionUnsafeError(RuntimeError):
+    """소비를 안전하게 기록할 수 없어 도구 실행을 막았다 (issue #292).
+
+    `RuntimeError` 를 고른 이유: executor 의 바깥 try/except 가 그대로 잡아
+    task 실패로 처리한다 — 승인은 저장소에 `approved` 로 남아 있으므로 사람이
+    다시 시도할 수 있고, **도구는 실행되지 않는다**. 실행해 놓고 기록을 못 남기는
+    것보다 실행하지 않는 쪽이 항상 안전하다.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(
+            f"Cannot safely record approval consumption for session {session_id}: "
+            "state carries no row version (cross-process at-most-once would be lost)"
+        )
+        self.session_id = session_id
+
 
 try:
     from orchestrator.tools import MCPToolExecutor
@@ -268,9 +287,19 @@ After completing all necessary tool calls, provide a final summary."""
 
         저장 실패(예외)는 삼키지 않는다 — 소비를 기록할 수 없으면 실행해서도
         안 된다. 호출자의 try/except 가 task 실패로 처리한다.
+
+        DB 모드에서 state 에 행 버전이 없으면 **소비하지 않는다**. 크로스 프로세스
+        at-most-once 는 전적으로 이 버전의 조건부 UPDATE 에 기대고 있고
+        (`update_session` 은 버전이 없으면 조용히 무조건 쓰기로 내려간다),
+        그 상태로 겹치면 두 인스턴스가 모두 소비에 성공해 비가역 도구가 두 번
+        실행된다 — issue #292 의 RED 실험에서 실제로 재현된 결과다. 버전 없는
+        state 는 `get_session` 을 거치지 않고 만들어진 것이므로, 막아도 정상
+        경로를 해치지 않는다.
         """
         session_id = state.get("session_id", "")
         service = self.session_service or get_session_service()
+        if service.use_database and state.get(STATE_VERSION_KEY) is None:
+            raise ApprovalConsumptionUnsafeError(session_id)
         persisted = await service.update_session(
             session_id,
             cast(AgentState, {**state, "pending_approvals": pending_approvals}),

--- a/tests/backend/test_hitl_approval_atomicity.py
+++ b/tests/backend/test_hitl_approval_atomicity.py
@@ -259,6 +259,11 @@ def test_websocket_does_not_bypass_the_transition_gateway():
 class RecordingSessionService:
     """`update_session` 호출 시점의 승인 상태를 기록한다."""
 
+    # `SessionService` 대역이므로 그 계약을 따른다. 이 파일의 double 들은 전부
+    # **in-process** 저장소를 흉내내므로 DB 모드가 아니다 — executor 의 소비
+    # 경로는 DB 모드에서만 행 버전을 요구한다 (issue #292).
+    use_database = False
+
     def __init__(self, events: list[tuple[str, Any]]):
         self.events = events
 
@@ -353,7 +358,10 @@ async def test_consumption_persisted_before_tool_execution(monkeypatch, executor
 @pytest.mark.asyncio
 async def test_tool_not_executed_when_consumption_persist_fails(monkeypatch, executor_env):
     """소비를 기록하지 못하면 도구를 실행하지 않는다 (at-most-once)."""
+
     class FailingService:
+        use_database = False  # in-process double (issue #292)
+
         async def get_session(self, session_id: str, update_activity: bool = True):
             return None
 
@@ -419,6 +427,7 @@ class JitteryRecordingService:
     직렬화가 없으면 늦게 커밋된 낡은 스냅샷이 다른 소비를 되돌린다.
     """
 
+    use_database = False  # in-process double (issue #292)
     FIRST_WRITE_DELAY = 0.02
 
     def __init__(self) -> None:
@@ -509,6 +518,8 @@ class StoreBackedService:
     DB 모드의 `SessionService` 가 그렇다(`repo.get_state` 가 JSONB 를 매번 디코딩).
     따라서 캐시가 비어 있으면 동시에 시작한 두 실행이 서로 독립된 state 를 든다.
     """
+
+    use_database = False  # in-process double (issue #292)
 
     def __init__(self, state: dict[str, Any]):
         self.stored = state

--- a/tests/backend/test_hitl_cross_process_atomicity.py
+++ b/tests/backend/test_hitl_cross_process_atomicity.py
@@ -1,0 +1,237 @@
+"""HITL 승인 소비의 **크로스 프로세스** at-most-once (issue #292).
+
+기존 `test_hitl_approval_atomicity.py` 는 엔진 하나에 `asyncio.gather` 로 요청을
+겹친다 — 그건 같은 프로세스 안의 경합이라 `APPROVAL_STATE_LOCK`(in-process
+asyncio 락) 이 직렬화해 준다. 다중 레플리카에서 깨지는 것은 그 락이 **없는**
+경우이고, 이 코드에게 "프로세스 둘" 은 각자의 `_session_metadata` ·
+`_memory_sessions` · 엔진 캐시를 가진 **서비스 인스턴스 둘이 하나의 DB 를 보는**
+상태를 뜻한다.
+
+여기서 검증하는 명제: 두 인스턴스가 같은 승인을 동시에 소비하려 하면 **정확히
+하나만** 성공하고, 진 쪽은 도구를 실행하지 않는다.
+
+`AOS_TEST_DATABASE_URL` 이 있을 때만 돈다 (`test_session_concurrency_db.py` 와
+같은 이유 — 실수로 개발 DB 를 건드리지 않도록 전용 변수를 쓴다).
+"""
+
+import asyncio
+import os
+import uuid
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from db.models.base import Base
+from models.agent_state import AgentState
+from models.hitl import APPROVAL_STATE_LOCK, ApprovalStatus
+from orchestrator.nodes.executor import ExecutorNode
+from services.session_service import SessionService, SessionVersionConflictError
+from utils.time import utcnow
+
+TEST_DATABASE_URL = os.getenv("AOS_TEST_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL,
+    reason="AOS_TEST_DATABASE_URL 미설정 — 크로스 프로세스 승인 테스트를 건너뛴다",
+)
+
+
+@pytest_asyncio.fixture
+async def db_factory():
+    """전용 스키마 하나만 만들고 그것만 제거한다.
+
+    `Base.metadata.drop_all()` 로 정리하면 변수가 실수로 개발 DB 를 가리켰을 때
+    애플리케이션 테이블을 전부 지운다 — 변수 이름은 관례이지 보증이 아니다.
+    """
+    schema = f"aos_hitl_xproc_{uuid.uuid4().hex[:12]}"
+    admin = create_async_engine(TEST_DATABASE_URL, poolclass=NullPool)
+    async with admin.begin() as conn:
+        await conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        poolclass=NullPool,
+        connect_args={"server_settings": {"search_path": schema}},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+        async with admin.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await admin.dispose()
+
+
+@pytest.fixture
+def no_shared_lock(monkeypatch):
+    """`APPROVAL_STATE_LOCK` 의 상호배제를 없앤다 — **이 테스트의 핵심 장치**.
+
+    `LoopBoundLockPool` 은 `asyncio.get_running_loop()` 로 **루프마다** 락을 하나씩
+    내준다. 서비스 인스턴스를 둘 만들어도 한 테스트 루프 안에서 돌면 둘은 같은
+    락을 받아 직렬화되고, 그 결과는 "크로스 프로세스 안전" 이 아니라 **in-process
+    락이 막아준 것**이다. 그대로 두면 통과가 아무것도 증명하지 못한다.
+
+    프로세스가 둘이면 공유 락은 존재하지 않는다. 매 호출마다 새 락을 내주어
+    그 조건을 만든다 — 남는 방어선은 저장소(조건부 UPDATE) 하나뿐이고, 이 파일이
+    검증하려는 것이 바로 그 방어선이다.
+    """
+    monkeypatch.setattr(APPROVAL_STATE_LOCK, "lock", lambda: asyncio.Lock())
+
+
+@pytest_asyncio.fixture
+async def services(db_factory, no_shared_lock, monkeypatch):
+    """서비스 인스턴스 **둘**. 각자 캐시를 따로 들고 같은 DB 를 본다 = 프로세스 둘."""
+    monkeypatch.setattr("services.session_service.async_session_factory", db_factory)
+    return SessionService(use_database=True), SessionService(use_database=True)
+
+
+APPROVAL_ID = "apr-292"
+
+
+def _approval_record() -> dict[str, Any]:
+    return {
+        "id": APPROVAL_ID,
+        "task_id": "t-292",
+        "tool_name": "execute_bash",
+        "tool_args": {"command": "echo aos-292"},
+        "risk_level": "high",
+        "status": ApprovalStatus.APPROVED.value,
+        "requested_at": utcnow().isoformat(),
+    }
+
+
+async def _seed_approved_session(service: SessionService) -> str:
+    """`approved` 승인 하나를 들고 있는 세션을 만든다."""
+    sid = str(uuid.uuid4())
+    await service.create_session(session_id=sid)
+    state = await service.get_session(sid)
+    assert state is not None
+    state["pending_approvals"] = {APPROVAL_ID: _approval_record()}
+    await service.update_session(sid, state)
+    return sid
+
+
+async def _read(service: SessionService, session_id: str) -> AgentState:
+    state = await service.get_session(session_id)
+    assert state is not None
+    return state
+
+
+async def _consume_read_state(service: SessionService, state: AgentState) -> bool:
+    """이미 읽어 둔 state 로 소비를 시도한다. 소비에 성공했을 때만 True.
+
+    읽기를 분리하는 이유: `gather` 로 "읽기+쓰기" 를 통째로 띄우면 한쪽이 완주한
+    뒤에 다른 쪽이 읽어버릴 수 있고, 그러면 두 번째는 저장소에서 `consumed` 를
+    보고 정상 거부한다 — 그건 경합이 아니라 순차 실행이라 아무것도 검증하지
+    못한다. 진짜 창은 **둘 다 쓰기 전에 둘 다 읽은** 상태다.
+
+    `_consume_approval` 은 저장 실패를 예외로 올린다 — 도구 실행 **전**이므로
+    호출자가 task 실패로 처리한다. 여기서는 "실행하지 않았다" 로 접는다.
+    """
+    node = ExecutorNode(llm=None, tools=[], session_service=service)
+    pending = state.get("pending_approvals", {})
+    approval = pending[APPROVAL_ID]
+    try:
+        return await node._consume_approval(state, pending, approval)
+    except SessionVersionConflictError:
+        return False
+
+
+async def _try_consume(service: SessionService, session_id: str) -> bool:
+    """읽기부터 소비까지 한 번에 (순차 시나리오용)."""
+    return await _consume_read_state(service, await _read(service, session_id))
+
+
+@pytest.mark.asyncio
+async def test_two_instances_consume_same_approval_only_one_wins(services):
+    """두 인스턴스가 같은 승인을 동시에 소비 → 정확히 하나만 성공."""
+    a, b = services
+    sid = await _seed_approved_session(a)
+
+    # **둘 다 쓰기 전에 둘 다 읽는다** — 이것이 두 프로세스가 각자 `approved` 를
+    # 손에 쥔 그 창이다. 읽기를 소비와 함께 띄우면 한쪽이 완주해 버려 창이 닫힌다.
+    state_a = await _read(a, sid)
+    state_b = await _read(b, sid)
+
+    results = await asyncio.gather(
+        _consume_read_state(a, state_a),
+        _consume_read_state(b, state_b),
+        return_exceptions=True,
+    )
+
+    for r in results:
+        assert not isinstance(r, BaseException), f"예상치 못한 예외: {r!r}"
+
+    winners = [r for r in results if r is True]
+    assert len(winners) == 1, (
+        f"정확히 하나만 소비해야 한다 (실제 성공 {len(winners)} 건) — "
+        "둘 다 성공하면 비가역 도구가 두 번 실행된다"
+    )
+
+
+@pytest.mark.asyncio
+async def test_storage_holds_consumed_after_race(services):
+    """경합이 끝난 뒤 저장소의 승인은 `consumed` 하나뿐이어야 한다."""
+    a, b = services
+    sid = await _seed_approved_session(a)
+
+    state_a = await _read(a, sid)
+    state_b = await _read(b, sid)
+    await asyncio.gather(
+        _consume_read_state(a, state_a),
+        _consume_read_state(b, state_b),
+        return_exceptions=True,
+    )
+
+    fresh = SessionService(use_database=True)
+    stored: AgentState | None = await fresh.get_session(sid)
+    assert stored is not None
+    approval = stored["pending_approvals"][APPROVAL_ID]
+    assert approval["status"] == ApprovalStatus.CONSUMED.value
+
+
+@pytest.mark.asyncio
+async def test_sequential_second_consume_is_refused(services):
+    """앞선 인스턴스가 소비를 끝낸 뒤라면, 다음 인스턴스는 거부당한다."""
+    a, b = services
+    sid = await _seed_approved_session(a)
+
+    assert await _try_consume(a, sid) is True
+    assert await _try_consume(b, sid) is False
+
+
+@pytest.mark.asyncio
+async def test_unconditional_final_save_does_not_revive_consumed_approval(services):
+    """그래프 최종 저장(`check_version=False`)이 소비를 되살리면 안 된다.
+
+    `engine.run`·`engine.stream` 의 마지막 저장은 **의도적으로** 버전 검사를 끈다
+    (`orchestrator/engine.py:399,558`) — 완료된 그래프의 산물이라 충돌 시 재시도가
+    도구 재실행을 뜻하기 때문이다. 그 대가로 그 쓰기는 낡은 스냅샷을 통째로 덮는다.
+
+    시나리오: 인스턴스 A 가 승인을 소비해 저장소를 `consumed` 로 만든 뒤, 인스턴스
+    B 가 **소비 이전에 읽어 둔** 스냅샷(승인이 아직 `approved`)으로 그래프를 끝내고
+    무조건 저장한다. 저장소가 `approved` 로 되돌아가면 그 승인은 다음 실행에서 다시
+    쓰일 수 있다 — 시간을 가로지르는 at-most-once 위반이다.
+    """
+    a, b = services
+    sid = await _seed_approved_session(a)
+
+    stale_for_b = await _read(b, sid)  # B 는 소비 이전 상태를 손에 쥔다
+    assert await _try_consume(a, sid) is True  # A 가 먼저 소비 (저장소 = consumed)
+
+    # B 의 그래프가 끝나고 최종 state 를 무조건 저장한다.
+    await b.update_session(sid, stale_for_b, check_version=False)
+
+    fresh = SessionService(use_database=True)
+    stored = await fresh.get_session(sid)
+    assert stored is not None
+    assert stored["pending_approvals"][APPROVAL_ID]["status"] == ApprovalStatus.CONSUMED.value, (
+        "무조건 저장이 소비된 승인을 되살렸다 — 같은 승인으로 도구가 다시 실행될 수 있다"
+    )

--- a/tests/backend/test_hitl_cross_process_atomicity.py
+++ b/tests/backend/test_hitl_cross_process_atomicity.py
@@ -26,9 +26,10 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
 from db.models.base import Base
+from db.repository import STATE_VERSION_KEY
 from models.agent_state import AgentState
 from models.hitl import APPROVAL_STATE_LOCK, ApprovalStatus
-from orchestrator.nodes.executor import ExecutorNode
+from orchestrator.nodes.executor import ApprovalConsumptionUnsafeError, ExecutorNode
 from services.session_service import SessionService, SessionVersionConflictError
 from utils.time import utcnow
 
@@ -205,6 +206,32 @@ async def test_sequential_second_consume_is_refused(services):
 
     assert await _try_consume(a, sid) is True
     assert await _try_consume(b, sid) is False
+
+
+@pytest.mark.asyncio
+async def test_versionless_state_refuses_to_consume(services):
+    """DB 모드에서 행 버전이 없으면 소비를 거부한다 — 도구를 실행하지 않는다.
+
+    버전이 없으면 `update_session` 은 조용히 무조건 쓰기로 내려가고, 그러면 겹친
+    두 인스턴스가 **둘 다** 소비에 성공한다(이 파일의 RED 실험에서 재현됨).
+    조용히 보장을 잃느니 실행을 막는다 — 승인은 `approved` 로 남아 재시도 가능하다.
+    """
+    a, _ = services
+    sid = await _seed_approved_session(a)
+
+    state = await _read(a, sid)
+    state.pop(STATE_VERSION_KEY, None)  # `get_session` 을 거치지 않은 state 를 모사
+
+    node = ExecutorNode(llm=None, tools=[], session_service=a)
+    pending = state["pending_approvals"]
+    with pytest.raises(ApprovalConsumptionUnsafeError):
+        await node._consume_approval(state, pending, pending[APPROVAL_ID])
+
+    # 거부는 저장소를 건드리지 않아야 한다 — 승인은 그대로 재시도 가능해야 한다.
+    fresh = SessionService(use_database=True)
+    stored = await fresh.get_session(sid)
+    assert stored is not None
+    assert stored["pending_approvals"][APPROVAL_ID]["status"] == ApprovalStatus.APPROVED.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 요약

이슈 #292 의 **(a) 다중 인스턴스 지원** 갈래. 조사해 보니 이슈의 전제가 절반 틀렸고, 대신 **다른 곳에 진짜 구멍이 있었다.** 이 PR 은 그것을 닫는다.

## 이슈의 전제가 틀린 부분 — at-most-once 는 이미 있었다

이슈는 "승인 소비의 크로스 프로세스 원자성이 없다" 며 `approvals` 테이블의 조건부 UPDATE 를 제안했다. 실측 결과 **PR #293 의 `sessions.version` 낙관적 동시성이 이미 닫아 뒀다.**

`_persist_approval_consumption` → `update_session` 은 기본 `check_version=True` 다. 두 인스턴스가 같은 창에서 소비를 시도하면 진 쪽이 `SessionVersionConflictError` 를 받고 **도구를 실행하지 않는다** (소비 기록이 실행보다 앞서므로).

새 테스트로 확인했고, **RED 검증**도 했다 — 버전 검사를 끄면 즉시 잡힌다:

```
AssertionError: 정확히 하나만 소비해야 한다 (실제 성공 2 건)
```

따라서 `approvals` 테이블 마이그레이션은 **정확성에 불필요**하다. 그 테이블은 현재 **쓰이지도 않는다** (`save_approval`·`approve_operation`·`deny_operation` 호출부 0 건). 살릴지는 별도 이슈 #306 으로 옮겼다.

## 진짜 구멍 ① — 무조건 저장이 소비된 승인을 되살린다

`engine.run`·`engine.stream` 의 최종 저장은 **의도적으로** `check_version=False` 다 (`engine.py:399,558`) — 완료된 그래프의 산물이라 재시도가 도구 재실행을 뜻하기 때문이다. 그 대가로 그 쓰기는 낡은 스냅샷을 통째로 덮는다.

1. 인스턴스 A 가 승인을 소비 → 저장소 `consumed`
2. 인스턴스 B 는 **소비 이전에 읽은** 스냅샷(승인이 `approved`)으로 그래프를 마침
3. B 의 최종 저장이 `state_json` 을 통째로 덮음 → 저장소가 **`approved` 로 되돌아감**
4. 그 승인으로 도구가 **다시 실행 가능** — 시간을 가로지르는 at-most-once 위반

코드 주석이 그 자리에 이미 `필드 단위 병합이 필요하다 (issue #292)` 라고 적어 둔 항목이다.

**수정**: `update_state` 는 무조건 쓰기일 때 행을 `FOR UPDATE` 로 잠그고 저장소의 터미널 승인(`consumed`·`denied`·`expired`)을 병합한다. 승인 상태는 단조로우므로(`pending → approved → consumed/denied`) 병합 규칙은 "나중에 쓴 쪽" 이 아니라 **"더 앞선 쪽"** 이다. 잠그지 않으면 읽기와 쓰기 사이가 다시 TOCTOU 창이 되어 겹친 무조건 쓰기 둘이 서로의 병합을 덮는다.

## 진짜 구멍 ② — 버전 없는 state 의 조용한 강등

`update_session` 은 state 에 `_version` 이 없으면 **조용히** 무조건 쓰기로 내려간다. 소비 경로가 그렇게 되면 위 RED 실험과 똑같이 두 인스턴스가 모두 소비에 성공한다. 즉 이 보장은 전적으로 `_version` 존재에 기대고 있는데, 그것을 강제하는 곳이 없었다.

**수정**: DB 모드에서 버전이 없으면 `ApprovalConsumptionUnsafeError` 로 **소비를 거부**한다. 승인은 `approved` 로 남아 재시도 가능하고 도구는 실행되지 않는다 — 실행해 놓고 기록을 못 남기는 것보다 항상 안전하다.

## 테스트

새 파일 `tests/backend/test_hitl_cross_process_atomicity.py` (5 건). 기존 `test_hitl_approval_atomicity.py` 는 엔진 하나에 요청을 겹치므로 in-process 락이 직렬화해 준다 — 다중 레플리카에서 깨지는 경로는 지금까지 **테스트되지 않았다.** 새 파일은 서비스 인스턴스 둘이 하나의 DB 를 보게 한다 (= 프로세스 둘).

그 과정에서 **거짓 초록 둘**을 발견해 주석으로 박았다:

- `LoopBoundLockPool` 은 **루프마다** 락을 하나 내준다. 인스턴스를 둘 만들어도 한 테스트 루프에서 돌면 같은 락을 받아 직렬화된다 — 통과가 "크로스 프로세스 안전" 이 아니라 "in-process 락이 막아줌" 을 뜻하게 된다. 매 호출 새 락을 내주도록 패치해 공유 락 없는 조건을 만든다.
- 읽기와 소비를 함께 `gather` 로 띄우면 한쪽이 완주한 뒤 다른 쪽이 읽어, 두 번째가 저장소의 `consumed` 를 보고 정상 거부한다 — 경합이 아니라 순차 실행이다. 읽기를 앞으로 당겨 진짜 창을 강제한다.

기존 `test_hitl_approval_atomicity.py` 의 double 4 개에 `use_database = False` 를 추가했다 (순수 추가 11 줄, 기존 코드 변경 0). `SessionService` 대역이므로 그 계약을 따라야 하고, 넷 다 in-process 저장소를 흉내내므로 DB 모드가 아니다. `getattr` 로 덮지 않은 이유는 그게 증상 가드이기 때문이다.

## 검증

- **RED 검증 2 건** — 병합을 빼면 `'approved' == 'consumed'` 로, 가드를 빼면 `DID NOT RAISE` 로 잡힌다. 두 수정 모두 알려진 양성에서 발화를 확인했다.
- `ruff check` / `ruff format --check` (src/backend, CI 범위) 통과
- `mypy . --ignore-missing-imports --no-error-summary` → **exit 0, error 0**
- `pytest ../../tests/backend` → **1497 passed, 2 skipped, 1 failed**. 유일한 실패 `test_embedding_model_consistency` 는 로컬 `.env` 의 `RAG_EMBEDDING_MODEL` 오버라이드가 원인인 기지 건이고 CI 는 통과한다 (회귀 아님)
- 새 DB 테스트는 CI 에서 실제로 돈다 — `AOS_TEST_DATABASE_URL` 이 `ci.yml:136` 에 설정돼 있어 skip 되지 않는다

## 범위 밖 (의도적)

- **매니페스트 미변경** — (a) 는 코드가 체크인된 매니페스트를 따라잡는 것이다. `replicas: 1` 고정은 반대 갈래인 (b) 다.
- **세션 TTL 정리** — `cleanup_expired_sessions` 는 여전히 로컬 사본으로 판정한다. 그 절반("어느 인스턴스도 캐시에 없는 세션은 아무도 정리하지 않음")은 #291 의 영역이라 거기서 함께 푸는 편이 낫다. `features.md` #37 에 남은 전제로 명시했다.
- **`approvals` 테이블** — #306 으로 분리.

## 문서

`docs/architecture.md` 의 "크로스 프로세스 원자성은 아직 없다" 문단을 실제 상태로 정정하고 새 계약 2 줄을 표에 추가했다. `features.md` #37 에 다중 레플리카 정합성 근거와 남은 전제를 적었다.

Refs #292 · #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMbGtFHy4gKcyCntfqpU4y