### PR TITLE
chore(db): 죽어 있던 approvals 테이블과 그 코드를 제거 (#306)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,8 +208,14 @@ status 만 보고 통과시키면 이전 승인의 권한으로 그 호출이 �
 막는다 — 공유 이벤트 루프의 in-process 락, 그리고 읽기·소비를 함께 띄워
 경합이 아니라 순차 실행이 되는 것.
 
-`approvals` 테이블은 현재 **쓰이지 않는다**(`save_approval` 계열 호출부 0건).
-정확성에는 불필요하며, 감사·조회용으로 되살리는 것은 별도 작업이다.
+`approvals` 테이블과 그 코드(`ApprovalModel`·`ApprovalRepository`·`save_approval`
+계열 3 메서드)는 **제거했다** (#306). 한 번도 채워진 적이 없었고, 위에서 보듯
+정확성은 `sessions.state_json` + `sessions.version` 이 지킨다. 감사·조회 목적으로
+승인 이력이 필요해지면 이중 쓰기·백필을 갖춘 설계로 새로 만든다 — 비어 있는 테이블을
+남겨 두면 "쓰이는 줄 알았는데 비어 있다" 는 오독만 남는다.
+
+기존 배포에는 빈 `approvals` 테이블이 그대로 남는다. 지우는 DDL 은 넣지 않았다 —
+되돌릴 수 없는 작업이고, 남아 있어도 비용이 없다.
 
 ## Directory Structure (Backend)
 
@@ -579,7 +585,6 @@ USE_DATABASE=false
 | `sessions` | 세션 정보 |
 | `tasks` | 태스크 트리 |
 | `messages` | 대화 메시지 |
-| `approvals` | HITL 승인 요청 |
 | `users` | 사용자 (OAuth + Email) |
 | `organizations` | 멀티테넌트 조직 |
 | `organization_members` | 조직 멤버 |

--- a/src/backend/api/deps.py
+++ b/src/backend/api/deps.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.database import async_session_factory
 from db.models import OrganizationMemberModel, UserModel
-from db.repository import ApprovalRepository, MessageRepository, SessionRepository, TaskRepository
+from db.repository import MessageRepository, SessionRepository, TaskRepository
 from models.organization import MemberRole
 from orchestrator import OrchestrationEngine
 from services.auth_service import AuthService
@@ -69,11 +69,6 @@ def get_task_repository(db: AsyncSession) -> TaskRepository:
 def get_message_repository(db: AsyncSession) -> MessageRepository:
     """Get message repository."""
     return MessageRepository(db)
-
-
-def get_approval_repository(db: AsyncSession) -> ApprovalRepository:
-    """Get approval repository."""
-    return ApprovalRepository(db)
 
 
 # ─────────────────────────────────────────────────────────────

--- a/src/backend/db/__init__.py
+++ b/src/backend/db/__init__.py
@@ -1,9 +1,8 @@
 """Database module for session and task persistence."""
 
 from db.database import Base, close_db, get_db, init_db
-from db.models import ApprovalModel, MessageModel, SessionModel, TaskModel
+from db.models import MessageModel, SessionModel, TaskModel
 from db.repository import (
-    ApprovalRepository,
     MessageRepository,
     SessionRepository,
     TaskRepository,
@@ -19,10 +18,8 @@ __all__ = [
     "SessionModel",
     "TaskModel",
     "MessageModel",
-    "ApprovalModel",
     # Repositories
     "SessionRepository",
     "TaskRepository",
     "MessageRepository",
-    "ApprovalRepository",
 ]

--- a/src/backend/db/models/__init__.py
+++ b/src/backend/db/models/__init__.py
@@ -84,7 +84,6 @@ from db.models.project import (
     ProjectModel,
 )
 from db.models.session import (
-    ApprovalModel,
     MessageModel,
     SessionModel,
     TaskModel,
@@ -107,7 +106,6 @@ __all__ = [
     "SessionModel",
     "TaskModel",
     "MessageModel",
-    "ApprovalModel",
     # Feedback
     "FeedbackModel",
     "DatasetEntryModel",

--- a/src/backend/db/models/session.py
+++ b/src/backend/db/models/session.py
@@ -1,4 +1,4 @@
-"""Session, Task, Message, Approval models."""
+"""Session, Task, Message models."""
 
 from db.models.base import (
     JSONB,
@@ -154,34 +154,3 @@ class MessageModel(Base):
     session = relationship("SessionModel", back_populates="messages")
 
     __table_args__ = (Index("ix_messages_session_timestamp", "session_id", "timestamp"),)
-
-
-class ApprovalModel(Base):
-    """Approval model for storing HITL approval history."""
-
-    __tablename__ = "approvals"
-
-    id = Column(String(36), primary_key=True)
-    session_id = Column(
-        String(36), ForeignKey("sessions.id", ondelete="CASCADE"), nullable=False, index=True
-    )
-    task_id = Column(String(36), ForeignKey("tasks.id", ondelete="SET NULL"), nullable=True)
-
-    # Approval details
-    tool_name = Column(String(100), nullable=False)
-    tool_args = Column(JSONB, nullable=False)
-    risk_level = Column(String(20), nullable=False)
-    risk_description = Column(Text, nullable=True)
-
-    # Status
-    status = Column(String(20), default="pending", index=True)
-    approved_by = Column(String(255), nullable=True)
-    denial_reason = Column(Text, nullable=True)
-
-    # Timestamps
-    created_at = Column(
-        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
-    )
-    resolved_at = Column(DateTime(timezone=True), nullable=True)
-
-    __table_args__ = (Index("ix_approvals_session_status", "session_id", "status"),)

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -9,7 +9,6 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import (
-    ApprovalModel,
     BranchProtectionRuleModel,
     MergeRequestModel,
     MessageModel,
@@ -460,12 +459,6 @@ class SessionRepository:
         )
         counts["messages"] = result.scalar() or 0
 
-        # Count approvals
-        result = await self.db.execute(
-            select(func.count()).where(ApprovalModel.session_id.in_(session_ids))
-        )
-        counts["approvals"] = result.scalar() or 0
-
         # Count feedbacks
         try:
             from db.models import DatasetEntryModel, FeedbackModel
@@ -632,92 +625,6 @@ class MessageRepository:
             .where(MessageModel.session_id == session_id)
             .order_by(MessageModel.timestamp)
             .limit(limit)
-        )
-        return list(result.scalars().all())
-
-
-class ApprovalRepository:
-    """Repository for approval operations."""
-
-    def __init__(self, session: AsyncSession):
-        self.db = session
-
-    async def create(
-        self,
-        approval_id: str,
-        session_id: str,
-        task_id: str,
-        tool_name: str,
-        tool_args: dict,
-        risk_level: str,
-        risk_description: str,
-    ) -> ApprovalModel:
-        """Create a new approval request."""
-        approval = ApprovalModel(
-            id=approval_id,
-            session_id=session_id,
-            task_id=task_id,
-            tool_name=tool_name,
-            tool_args=tool_args,
-            risk_level=risk_level,
-            risk_description=risk_description,
-            status="pending",
-        )
-        self.db.add(approval)
-        await self.db.flush()
-        return approval
-
-    async def get(self, approval_id: str) -> ApprovalModel | None:
-        """Get approval by ID."""
-        result = await self.db.execute(select(ApprovalModel).where(ApprovalModel.id == approval_id))
-        return result.scalar_one_or_none()
-
-    async def approve(
-        self,
-        approval_id: str,
-        approved_by: str | None = None,
-    ) -> bool:
-        """Approve an approval request."""
-        result = await self.db.execute(
-            update(ApprovalModel)
-            .where(ApprovalModel.id == approval_id)
-            .values(
-                status="approved",
-                approved_by=approved_by,
-                resolved_at=utcnow(),
-            )
-        )
-        return result.rowcount > 0
-
-    async def deny(
-        self,
-        approval_id: str,
-        reason: str | None = None,
-    ) -> bool:
-        """Deny an approval request."""
-        result = await self.db.execute(
-            update(ApprovalModel)
-            .where(ApprovalModel.id == approval_id)
-            .values(
-                status="denied",
-                denial_reason=reason,
-                resolved_at=utcnow(),
-            )
-        )
-        return result.rowcount > 0
-
-    async def list_pending_by_session(
-        self,
-        session_id: str,
-    ) -> list[ApprovalModel]:
-        """List pending approvals for a session."""
-        result = await self.db.execute(
-            select(ApprovalModel)
-            .where(
-                ApprovalModel.session_id == session_id,
-                ApprovalModel.status == "pending",
-            )
-            .order_by(ApprovalModel.created_at)
         )
         return list(result.scalars().all())
 

--- a/src/backend/services/project_cleanup_service.py
+++ b/src/backend/services/project_cleanup_service.py
@@ -27,6 +27,8 @@ class DeletionPreview(BaseModel):
     sessions_count: int = 0
     tasks_count: int = 0
     messages_count: int = 0
+    # 항상 0 이다. `approvals` 테이블은 #306 에서 제거했다. 대시보드의 삭제
+    # 프리뷰가 이 필드를 합계에 더하므로 응답 형태 유지를 위해 남긴다.
     approvals_count: int = 0
     feedbacks_count: int = 0
     dataset_entries_count: int = 0
@@ -91,7 +93,6 @@ class ProjectCleanupService:
             preview.sessions_count = db_counts.get("sessions", 0)
             preview.tasks_count = db_counts.get("tasks", 0)
             preview.messages_count = db_counts.get("messages", 0)
-            preview.approvals_count = db_counts.get("approvals", 0)
             preview.feedbacks_count = db_counts.get("feedbacks", 0)
             preview.dataset_entries_count = db_counts.get("dataset_entries", 0)
         except Exception as e:

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -13,7 +13,6 @@ from typing import Any, cast
 from db.database import async_session_factory
 from db.repository import (
     STATE_VERSION_KEY,
-    ApprovalRepository,
     MessageRepository,
     SessionRepository,
     StateWriteResult,
@@ -733,59 +732,6 @@ class SessionService:
                 repo = TaskRepository(db)
                 await repo.update_status(task_id, status, result, error)
                 await db.commit()
-
-    async def save_approval(
-        self,
-        approval_id: str,
-        session_id: str,
-        task_id: str,
-        tool_name: str,
-        tool_args: dict,
-        risk_level: str,
-        risk_description: str,
-    ) -> None:
-        """Save an approval request to the database (if enabled)."""
-        if self.use_database:
-            async with async_session_factory() as db:
-                repo = ApprovalRepository(db)
-                await repo.create(
-                    approval_id=approval_id,
-                    session_id=session_id,
-                    task_id=task_id,
-                    tool_name=tool_name,
-                    tool_args=tool_args,
-                    risk_level=risk_level,
-                    risk_description=risk_description,
-                )
-                await db.commit()
-
-    async def approve_operation(
-        self,
-        approval_id: str,
-        approved_by: str | None = None,
-    ) -> bool:
-        """Approve an operation in the database (if enabled)."""
-        if self.use_database:
-            async with async_session_factory() as db:
-                repo = ApprovalRepository(db)
-                result = await repo.approve(approval_id, approved_by)
-                await db.commit()
-                return result
-        return True
-
-    async def deny_operation(
-        self,
-        approval_id: str,
-        reason: str | None = None,
-    ) -> bool:
-        """Deny an operation in the database (if enabled)."""
-        if self.use_database:
-            async with async_session_factory() as db:
-                repo = ApprovalRepository(db)
-                result = await repo.deny(approval_id, reason)
-                await db.commit()
-                return result
-        return True
 
 
 # Global service instance


### PR DESCRIPTION
Closes #306

## 무엇을

`approvals` 테이블과 그것을 쓰는 코드를 제거한다. 한 번도 채워진 적이 없다.

## 왜

이슈가 올라온 뒤 결정이 필요했던 것은 "정확성에 필요한가" 가 아니라 **"감사·조회용으로 살릴 가치가 있는가"** 였다. 정확성 쪽은 이미 답이 나와 있었다 — 크로스 프로세스 at-most-once 는 `sessions.state_json` + `sessions.version` 이 지키고(#292 조사, PR #293), 승인의 진실의 출처도 `state_json["pending_approvals"]` 다.

살리려면 `consumed_at` 마이그레이션 · `state_json` 과의 이중 쓰기 · 백필이 전부 필요한데, 요구하는 소비자가 없다. 이중 쓰기는 어긋났을 때 어느 쪽이 맞는지 판단할 근거가 없다는 위험을 새로 만든다.

비어 있는 채로 두는 것이 가장 나쁘다 — "쓰이는 줄 알았는데 비어 있는 테이블" 로 오독된다.

## 제거 대상

| 대상 | 위치 |
|---|---|
| `ApprovalModel` | `db/models/session.py` |
| `ApprovalRepository` | `db/repository.py` |
| `SessionService.save_approval` / `approve_operation` / `deny_operation` | `services/session_service.py` |
| `api.deps.get_approval_repository` | `api/deps.py` — 이슈에 없던 것. 호출부 0 건이었다 |
| 세션 삭제 카운트 질의 | `db/repository.py` — 삭제된 모델을 참조하므로 함께 간다 |

`models.hitl.ApprovalStatus` 는 **남긴다.** 이름이 비슷하지만 `state_json` 승인의 살아 있는 enum 이다.

## 주의해서 남긴 것

`ProjectCleanupPreview.approvals_count` 는 필드를 남겼다. 대시보드의 삭제 프리뷰(`DeleteProjectModal.tsx`)가 이 값을 합계에 더하므로 응답 형태를 유지한다.

대입 라인만 지웠고, 필드는 기본값 `0` 이 된다. 테이블이 늘 비어 있었으므로 이전에도 값은 `0` 이었다 — **관측되는 동작 변화는 없다.**

## 기존 배포

빈 `approvals` 테이블은 그대로 남는다. 지우는 DDL 은 넣지 않았다 — 비가역이고, 남아 있어도 비용이 없다. (참고로 이 리포의 alembic 경로는 별건으로 죽어 있다 — #310)

## 검증

- `ruff check` 통과
- `mypy` 통과 (319 files)
- `pytest` **1506 passed**, 2 skipped — `AOS_TEST_DATABASE_URL` 설정 + `TZ=Asia/Seoul` 로 DB 모드 포함 실행
- Codex 리뷰 (`--scope branch --base main`): 지적 0 건

## 문서

`docs/architecture.md` HITL 절과 테이블 목록을 갱신했다.
