### PR TITLE
fix(db): utcnow()를 aware로 전환해 timestamptz TZ 어긋남 수정

### DIFF
--- a/src/backend/api/project_access.py
+++ b/src/backend/api/project_access.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.deps import get_current_user, get_db_session, require_project_role
 from db.models import UserModel
 from services.project_access_service import ProjectAccessService
+from utils.time import to_aware_utc, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -332,8 +333,6 @@ async def preview_invitation(
     db: AsyncSession = Depends(get_db_session),
 ):
     """토큰으로 초대 미리보기 (인증 불필요)."""
-    from datetime import datetime as dt
-
     from sqlalchemy import select
 
     from db.models import ProjectModel
@@ -343,7 +342,9 @@ async def preview_invitation(
     if not inv:
         raise HTTPException(status_code=404, detail="Invitation not found")
 
-    valid = inv.status == "pending" and inv.expires_at > dt.utcnow()
+    # `dt.utcnow()` 는 naive 를 돌려주는데 `expires_at` 은 timestamptz 라 aware 다.
+    # 그대로 비교하면 TypeError — 이 엔드포인트는 이 변경 이전부터 깨져 있었다.
+    valid = inv.status == "pending" and to_aware_utc(inv.expires_at) > utcnow()
 
     proj_result = await db.execute(select(ProjectModel).where(ProjectModel.id == inv.project_id))
     project = proj_result.scalar_one_or_none()

--- a/src/backend/db/repository.py
+++ b/src/backend/db/repository.py
@@ -303,9 +303,11 @@ class SessionRepository:
 
         시각 컬럼은 커서로 쓰지 않는다. `created_at` 은 nullable 이라 NULL 이 커서에
         들어가면 행 값 비교가 unknown 이 되어 이후 페이지가 통째로 비고 sweep 이
-        조용히 멈춘다. `updated_at` 은 거기에 더해 시계가 둘이다 — `update_state` 가
-        `utcnow()`(naive)로 덮으므로 컬럼 기본값(aware)과 섞여, UTC 가 아닌 타임존에서
-        도는 프로세스에서는 값이 오프셋만큼 어긋난다 (issue #309).
+        조용히 멈춘다. `updated_at` 은 nullable 은 아니지만 갱신마다 움직여
+        불변 조건을 깨므로 역시 커서가 될 수 없다.
+
+        (`updated_at` 이 컬럼 기본값과 다른 시계를 쓰던 문제는 #309 에서 `utcnow()`
+        를 aware 로 바꿔 해소했다. 커서를 기본키로 두는 이유는 그와 무관하게 유지된다.)
 
         `version` 을 함께 돌려주는 것이 계약의 핵심이다 — 판정과 삭제 사이에 다른
         인스턴스가 연장할 수 있으므로, 삭제는 이 버전을 조건으로 걸어야 한다.

--- a/src/backend/models/config_version.py
+++ b/src/backend/models/config_version.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from utils.time import utcnow
+from utils.time import utcnow_naive
 
 
 class ConfigType(str, Enum):
@@ -48,7 +48,9 @@ class ConfigVersion(BaseModel):
     diff_from_previous: dict[str, Any] | None = None  # JSON diff
     # Metadata
     created_by: str | None = None
-    created_at: datetime = Field(default_factory=utcnow)
+    # `config_versions.created_at` 는 naive 컬럼이다. aware 를 기본값으로 두면
+    # DB 에서 읽어온 naive 행과 섞여 정렬이 TypeError 로 죽는다.
+    created_at: datetime = Field(default_factory=utcnow_naive)
     # Rollback tracking
     rolled_back_from: str | None = None  # Version ID this was rolled back from
     rolled_back_at: datetime | None = None

--- a/src/backend/models/organization.py
+++ b/src/backend/models/organization.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
-from utils.time import utcnow
+from utils.time import normalize_aware_utc, utcnow
 
 
 class OrganizationPlan(str, Enum):
@@ -67,6 +67,10 @@ class Organization(BaseModel):
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime = Field(default_factory=utcnow)
 
+    # JSON 으로 저장됐다 다시 읽히는 모델이다. 구버전이 남긴 offset 없는 문자열이
+    # naive 로 파싱돼 aware 인 `utcnow()` 와 비교되면 TypeError 가 난다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
+
 
 class OrganizationCreate(BaseModel):
     """Request to create a new organization."""
@@ -111,6 +115,10 @@ class OrganizationMember(BaseModel):
     # Metadata
     created_at: datetime = Field(default_factory=utcnow)
 
+    # JSON 으로 저장됐다 다시 읽히는 모델이다. 구버전이 남긴 offset 없는 문자열이
+    # naive 로 파싱돼 aware 인 `utcnow()` 와 비교되면 TypeError 가 난다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
+
 
 class InviteMemberRequest(BaseModel):
     """Request to invite a member to an organization."""
@@ -135,6 +143,10 @@ class OrganizationInvitation(BaseModel):
     accepted: bool = False
     accepted_at: datetime | None = None
     created_at: datetime = Field(default_factory=utcnow)
+
+    # JSON 으로 저장됐다 다시 읽히는 모델이다. 구버전이 남긴 offset 없는 문자열이
+    # naive 로 파싱돼 aware 인 `utcnow()` 와 비교되면 TypeError 가 난다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
 
 
 class OrganizationStats(BaseModel):
@@ -174,6 +186,10 @@ class MemberUsageRecord(BaseModel):
     session_id: str | None = None
     model: str | None = None  # LLM model used
     timestamp: datetime = Field(default_factory=utcnow)
+
+    # JSON 으로 저장됐다 다시 읽히는 모델이다. 구버전이 남긴 offset 없는 문자열이
+    # naive 로 파싱돼 aware 인 `utcnow()` 와 비교되면 TypeError 가 난다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
 
 
 class MemberUsageSummary(BaseModel):

--- a/src/backend/models/playground.py
+++ b/src/backend/models/playground.py
@@ -47,7 +47,6 @@ class PlaygroundMessage(BaseModel):
     _ensure_aware = field_validator("*")(normalize_aware_utc)
 
 
-
 class PlaygroundExecution(BaseModel):
     """A single execution in the playground."""
 
@@ -83,7 +82,6 @@ class PlaygroundExecution(BaseModel):
     # 문자열이 naive 로 파싱되면, aware 인 새 값과 섞여 `list_sessions()` 의
     # 정렬이 TypeError 로 죽는다 (#309).
     _ensure_aware = field_validator("*")(normalize_aware_utc)
-
 
 
 class PlaygroundSession(BaseModel):
@@ -153,7 +151,6 @@ class PlaygroundSession(BaseModel):
     # 문자열이 naive 로 파싱되면, aware 인 새 값과 섞여 `list_sessions()` 의
     # 정렬이 TypeError 로 죽는다 (#309).
     _ensure_aware = field_validator("*")(normalize_aware_utc)
-
 
 
 class PlaygroundSessionCreate(BaseModel):

--- a/src/backend/models/playground.py
+++ b/src/backend/models/playground.py
@@ -6,10 +6,10 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from models.llm_models import LLMModelRegistry
-from utils.time import utcnow
+from utils.time import normalize_aware_utc, utcnow
 
 
 # Get default model from central registry
@@ -40,6 +40,12 @@ class PlaygroundMessage(BaseModel):
     tokens: int = 0
     latency_ms: int = 0
     rag_sources: list[dict] | None = None
+
+    # 세션은 JSON 파일로 영속화됐다 다시 읽힌다. 구버전이 남긴 offset 없는
+    # 문자열이 naive 로 파싱되면, aware 인 새 값과 섞여 `list_sessions()` 의
+    # 정렬이 TypeError 로 죽는다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
+
 
 
 class PlaygroundExecution(BaseModel):
@@ -72,6 +78,12 @@ class PlaygroundExecution(BaseModel):
     created_at: datetime = Field(default_factory=utcnow)
     started_at: datetime | None = None
     completed_at: datetime | None = None
+
+    # 세션은 JSON 파일로 영속화됐다 다시 읽힌다. 구버전이 남긴 offset 없는
+    # 문자열이 naive 로 파싱되면, aware 인 새 값과 섞여 `list_sessions()` 의
+    # 정렬이 TypeError 로 죽는다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
+
 
 
 class PlaygroundSession(BaseModel):
@@ -136,6 +148,12 @@ class PlaygroundSession(BaseModel):
     # Timestamps
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime = Field(default_factory=utcnow)
+
+    # 세션은 JSON 파일로 영속화됐다 다시 읽힌다. 구버전이 남긴 offset 없는
+    # 문자열이 naive 로 파싱되면, aware 인 새 값과 섞여 `list_sessions()` 의
+    # 정렬이 TypeError 로 죽는다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
+
 
 
 class PlaygroundSessionCreate(BaseModel):

--- a/src/backend/models/rate_limit.py
+++ b/src/backend/models/rate_limit.py
@@ -3,9 +3,9 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
-from utils.time import utcnow
+from utils.time import normalize_aware_utc, utcnow
 
 
 class RateLimitTier(str, Enum):
@@ -119,3 +119,7 @@ class RateLimitOverride(BaseModel):
     reason: str | None = None
     created_by: str | None = None
     created_at: datetime = Field(default_factory=utcnow)
+
+    # `expires_at` 은 API 쿼리 파라미터로 들어온다. 호출자가 offset 없는 ISO 를 주면
+    # FastAPI 가 naive 로 파싱하고, aware 인 `utcnow()` 와 비교돼 TypeError 가 난다.
+    _ensure_aware = field_validator("*")(normalize_aware_utc)

--- a/src/backend/services/analytics_service.py
+++ b/src/backend/services/analytics_service.py
@@ -500,7 +500,6 @@ class AnalyticsService:
             now = utcnow()
             start = now - delta
 
-
             sessions = [s for s in sessions if to_aware_utc(s.created_at) >= start]
 
         total = len(sessions)
@@ -612,7 +611,6 @@ class AnalyticsService:
         delta = _get_time_delta(time_range)
         start = utcnow() - delta
 
-
         range_sessions = [s for s in sessions if to_aware_utc(s.created_at) >= start]
 
         # Group by model
@@ -666,7 +664,6 @@ class AnalyticsService:
         sessions = AnalyticsService._get_sessions(project_path)
         delta = _get_time_delta(time_range)
         start = utcnow() - delta
-
 
         range_sessions = [s for s in sessions if to_aware_utc(s.created_at) >= start]
 
@@ -750,7 +747,6 @@ class AnalyticsService:
         sessions = AnalyticsService._get_sessions(project_path)
         delta = _get_time_delta(time_range)
         start = utcnow() - delta
-
 
         # last_activity 기준 윈도우: 시작은 윈도우 밖이지만 여전히 활성인 세션도 포함.
         range_sessions = [s for s in sessions if to_aware_utc(s.last_activity) >= start]

--- a/src/backend/services/analytics_service.py
+++ b/src/backend/services/analytics_service.py
@@ -4,7 +4,7 @@ import logging
 import os
 import random
 from collections import defaultdict
-from datetime import UTC, timedelta
+from datetime import timedelta
 
 from sqlalchemy import and_, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,7 +29,7 @@ from models.analytics import (
     TrendDataPoint,
 )
 from models.project import get_project
-from utils.time import to_display_tz, utcnow
+from utils.time import to_aware_utc, to_display_tz, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -500,13 +500,8 @@ class AnalyticsService:
             now = utcnow()
             start = now - delta
 
-            def _normalize_dt(dt):
-                """Convert to naive UTC for consistent comparison."""
-                if dt.tzinfo is not None:
-                    return dt.astimezone(UTC).replace(tzinfo=None)
-                return dt
 
-            sessions = [s for s in sessions if _normalize_dt(s.created_at) >= start]
+            sessions = [s for s in sessions if to_aware_utc(s.created_at) >= start]
 
         total = len(sessions)
         active = sum(1 for s in sessions if s.status.value == "active")
@@ -518,10 +513,8 @@ class AnalyticsService:
         # Avg session duration in ms
         durations = []
         for s in sessions:
-            created = s.created_at.replace(tzinfo=None) if s.created_at.tzinfo else s.created_at
-            last = (
-                s.last_activity.replace(tzinfo=None) if s.last_activity.tzinfo else s.last_activity
-            )
+            created = to_aware_utc(s.created_at)
+            last = to_aware_utc(s.last_activity)
             dur = (last - created).total_seconds() * 1000
             if dur > 0:
                 durations.append(dur)
@@ -558,13 +551,8 @@ class AnalyticsService:
         start = now - delta
 
         # Filter sessions in time range
-        def _normalize_dt(dt):
-            """Convert to naive UTC for consistent comparison."""
-            if dt.tzinfo is not None:
-                return dt.astimezone(UTC).replace(tzinfo=None)
-            return dt
 
-        range_sessions = [s for s in sessions if _normalize_dt(s.created_at) >= start]
+        range_sessions = [s for s in sessions if to_aware_utc(s.created_at) >= start]
 
         tasks_data = []
         costs_data = []
@@ -576,7 +564,7 @@ class AnalyticsService:
             bucket_end = current + interval
 
             bucket = [
-                s for s in range_sessions if current <= _normalize_dt(s.created_at) < bucket_end
+                s for s in range_sessions if current <= to_aware_utc(s.created_at) < bucket_end
             ]
 
             bucket_completed = sum(1 for s in bucket if s.status.value == "completed")
@@ -624,13 +612,8 @@ class AnalyticsService:
         delta = _get_time_delta(time_range)
         start = utcnow() - delta
 
-        def _normalize_dt(dt):
-            """Convert to naive UTC for consistent comparison."""
-            if dt.tzinfo is not None:
-                return dt.astimezone(UTC).replace(tzinfo=None)
-            return dt
 
-        range_sessions = [s for s in sessions if _normalize_dt(s.created_at) >= start]
+        range_sessions = [s for s in sessions if to_aware_utc(s.created_at) >= start]
 
         # Group by model
         by_model: dict[str, list] = defaultdict(list)
@@ -648,8 +631,8 @@ class AnalyticsService:
 
             durations = []
             for s in model_sessions:
-                created = _normalize_dt(s.created_at)
-                last = _normalize_dt(s.last_activity)
+                created = to_aware_utc(s.created_at)
+                last = to_aware_utc(s.last_activity)
                 dur = (last - created).total_seconds() * 1000
                 if dur > 0:
                     durations.append(dur)
@@ -684,13 +667,8 @@ class AnalyticsService:
         delta = _get_time_delta(time_range)
         start = utcnow() - delta
 
-        def _normalize_dt(dt):
-            """Convert to naive UTC for consistent comparison."""
-            if dt.tzinfo is not None:
-                return dt.astimezone(UTC).replace(tzinfo=None)
-            return dt
 
-        range_sessions = [s for s in sessions if _normalize_dt(s.created_at) >= start]
+        range_sessions = [s for s in sessions if to_aware_utc(s.created_at) >= start]
 
         total_cost = sum(s.estimated_cost for s in range_sessions)
         total_tokens = sum(s.total_input_tokens + s.total_output_tokens for s in range_sessions)
@@ -773,14 +751,9 @@ class AnalyticsService:
         delta = _get_time_delta(time_range)
         start = utcnow() - delta
 
-        def _normalize_dt(dt):
-            """Convert to naive UTC for consistent comparison."""
-            if dt.tzinfo is not None:
-                return dt.astimezone(UTC).replace(tzinfo=None)
-            return dt
 
         # last_activity 기준 윈도우: 시작은 윈도우 밖이지만 여전히 활성인 세션도 포함.
-        range_sessions = [s for s in sessions if _normalize_dt(s.last_activity) >= start]
+        range_sessions = [s for s in sessions if to_aware_utc(s.last_activity) >= start]
 
         heatmap: dict[tuple[int, int], int] = {}
         for day in range(7):

--- a/src/backend/services/claude_session_monitor.py
+++ b/src/backend/services/claude_session_monitor.py
@@ -57,7 +57,7 @@ from models.claude_session import (
     TokenUsage,
     calculate_cost,
 )
-from utils.time import utcnow
+from utils.time import to_aware_utc, utcnow
 
 
 @dataclass
@@ -317,15 +317,9 @@ class ClaudeSessionMonitor:
                         print(f"Error parsing {jsonl_file}: {e}")
                         continue
 
-        # Sort by last activity (most recent first)
-        # Normalize datetimes for comparison (strip timezone info for sorting)
-        def get_sort_key(s):
-            ts = s.last_activity
-            if ts.tzinfo is not None:
-                return ts.replace(tzinfo=None)
-            return ts
-
-        sessions.sort(key=get_sort_key, reverse=True)
+        # Sort by last activity (most recent first).
+        # aware/naive 가 섞인 리스트는 정렬 자체가 TypeError 다. 전부 aware 로 맞춘다.
+        sessions.sort(key=lambda s: to_aware_utc(s.last_activity), reverse=True)
         return sessions
 
     def get_unique_source_users(self) -> list[str]:
@@ -458,12 +452,11 @@ class ClaudeSessionMonitor:
         if last_activity is None:
             last_activity = created_at
 
-        # Determine status based on last activity and message type
-        # Normalize to naive UTC for comparison (utcnow() returns naive UTC)
-        last_activity_naive = (
-            last_activity.replace(tzinfo=None) if last_activity.tzinfo else last_activity
-        )
-        time_since_activity = utcnow() - last_activity_naive
+        # Determine status based on last activity and message type.
+        # `utcnow()` 는 aware 이므로 상대도 aware 로 맞춘다. 이전 코드는 tzinfo 를
+        # 그냥 떼어냈는데, 그러면 UTC 가 아닌 값이 UTC 인 척하게 되어 오프셋만큼
+        # 어긋난 경과 시간이 나온다.
+        time_since_activity = utcnow() - to_aware_utc(last_activity)
         if time_since_activity < timedelta(minutes=5):
             status = SessionStatus.ACTIVE
         elif time_since_activity < timedelta(hours=1):
@@ -1210,9 +1203,7 @@ class ClaudeSessionMonitor:
 
                 # Filter by since timestamp
                 if since is not None:
-                    since_naive = since.replace(tzinfo=None) if since.tzinfo else since
-                    ts_naive = timestamp.replace(tzinfo=None) if timestamp.tzinfo else timestamp
-                    if ts_naive <= since_naive:
+                    if to_aware_utc(timestamp) <= to_aware_utc(since):
                         continue
 
                 msg_type = entry.get("type", "")

--- a/src/backend/services/organization_service.py
+++ b/src/backend/services/organization_service.py
@@ -27,7 +27,7 @@ from models.organization import (
     OrganizationUpdate,
     TenantContext,
 )
-from utils.time import to_naive_utc, utcnow
+from utils.time import to_aware_utc, utcnow
 
 # ─────────────────────────────────────────────────────────────
 # Database Toggle
@@ -431,13 +431,9 @@ class OrganizationService:
         if not invitation:
             raise ValueError("Invalid or expired invitation")
 
-        # Strip tzinfo for naive UTC comparison (DB may return aware datetimes)
-        expires_at = (
-            invitation.expires_at.replace(tzinfo=None)
-            if invitation.expires_at.tzinfo
-            else invitation.expires_at
-        )
-        if expires_at < utcnow():
+        # `utcnow()` 가 aware 이므로 상대도 aware 로 맞춘다. tzinfo 를 그냥 떼면
+        # UTC 가 아닌 offset 이 조용히 UTC 로 둔갑한다.
+        if to_aware_utc(invitation.expires_at) < utcnow():
             raise ValueError("Invitation has expired")
 
         org = _organizations.get(invitation.organization_id)
@@ -1307,13 +1303,9 @@ class OrganizationService:
         if not invitation:
             raise ValueError("Invalid or expired invitation")
 
-        # Strip tzinfo for naive UTC comparison (DB may return aware datetimes)
-        expires_at = (
-            invitation.expires_at.replace(tzinfo=None)
-            if invitation.expires_at.tzinfo
-            else invitation.expires_at
-        )
-        if expires_at < utcnow():
+        # `utcnow()` 가 aware 이므로 상대도 aware 로 맞춘다. tzinfo 를 그냥 떼면
+        # UTC 가 아닌 offset 이 조용히 UTC 로 둔갑한다.
+        if to_aware_utc(invitation.expires_at) < utcnow():
             raise ValueError("Invitation has expired")
 
         # Get org
@@ -1491,7 +1483,8 @@ class OrganizationService:
 
     @staticmethod
     def _ledger_started_at(record) -> datetime:
-        return to_naive_utc(getattr(record, "started_at", None) or utcnow())
+        # aware 로 통일한다 — 이 값은 `utcnow()` 에서 파생된 기간 경계와 비교된다.
+        return to_aware_utc(getattr(record, "started_at", None) or utcnow())
 
     @staticmethod
     def _ledger_session_key(record) -> str:
@@ -1749,9 +1742,7 @@ class OrganizationService:
             snapshots = result.scalars().all()
 
             for snap in snapshots:
-                ts = snap.session_created_at or snap.created_at
-                if ts.tzinfo is not None:
-                    ts = ts.replace(tzinfo=None)
+                ts = to_aware_utc(snap.session_created_at or snap.created_at)
                 tok = (snap.total_input_tokens or 0) + (snap.total_output_tokens or 0)
                 sessions_all += 1
                 if ts >= month_start:
@@ -1907,9 +1898,7 @@ class OrganizationService:
                 uid = source_to_uid.get(snap.source_user)
                 if not uid:
                     continue
-                ts = snap.session_created_at or snap.created_at
-                if ts.tzinfo is not None:
-                    ts = ts.replace(tzinfo=None)
+                ts = to_aware_utc(snap.session_created_at or snap.created_at)
                 tok = (snap.total_input_tokens or 0) + (snap.total_output_tokens or 0)
 
                 if ts >= month_start:
@@ -2144,9 +2133,7 @@ class OrganizationService:
                 )
             )
             for snap in result.scalars().all():
-                ts = snap.session_created_at or snap.created_at
-                if ts.tzinfo is not None:
-                    ts = ts.replace(tzinfo=None)
+                ts = to_aware_utc(snap.session_created_at or snap.created_at)
                 tok = (snap.total_input_tokens or 0) + (snap.total_output_tokens or 0)
 
                 if ts >= month_start:

--- a/src/backend/services/project_invitation_service.py
+++ b/src/backend/services/project_invitation_service.py
@@ -8,7 +8,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import ProjectAccessModel, ProjectInvitationModel
-from utils.time import utcnow
+from utils.time import to_aware_utc, utcnow
 
 INVITATION_EXPIRE_DAYS = 7
 
@@ -81,7 +81,10 @@ class ProjectInvitationService:
             raise ValueError("유효하지 않은 초대 토큰입니다")
         if inv.status != "pending":
             raise ValueError(f"이미 처리된 초대입니다: {inv.status}")
-        if inv.expires_at < utcnow():
+        # `to_aware_utc` 를 거친다. 이 컬럼은 모델상 timestamptz 지만
+        # 마이그레이션(`f3a8b2c1d4e5`)은 naive 로 만든다 — 스키마가 어느 쪽으로
+        # 만들어졌든 비교가 성립해야 한다 (드리프트 자체는 #310).
+        if to_aware_utc(inv.expires_at) < utcnow():
             inv.status = "expired"
             await db.flush()
             raise ValueError("만료된 초대입니다")

--- a/src/backend/services/session_service.py
+++ b/src/backend/services/session_service.py
@@ -22,7 +22,7 @@ from db.repository import (
 )
 from models.agent_state import AgentState, create_initial_state, migrate_state
 from models.project import Project
-from utils.time import utcnow
+from utils.time import to_aware_utc, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -95,12 +95,19 @@ class SessionMetadata:
 
     @classmethod
     def from_dict(cls, data: dict) -> "SessionMetadata":
-        """Create from dictionary."""
+        """Create from dictionary.
+
+        **파싱 결과를 aware 로 정규화한다.** offset 유무가 문자열에 좌우되기
+        때문이다 — `utcnow()` 가 naive 이던 시절에 저장된 세션의 `_metadata` 는
+        suffix 가 없어 `fromisoformat` 이 naive 를 돌려준다. 그것을 aware 인
+        `utcnow()` 와 비교하면 TypeError 가 나고, sweep 의 `except` 절이 그것을
+        "손상된 메타데이터" 로 삼켜 **만료 세션이 영영 지워지지 않는다** (#309).
+        """
         return cls(
             session_id=data["session_id"],
-            created_at=datetime.fromisoformat(data["created_at"]),
-            last_activity=datetime.fromisoformat(data["last_activity"]),
-            expires_at=datetime.fromisoformat(data["expires_at"]),
+            created_at=to_aware_utc(datetime.fromisoformat(data["created_at"])),
+            last_activity=to_aware_utc(datetime.fromisoformat(data["last_activity"])),
+            expires_at=to_aware_utc(datetime.fromisoformat(data["expires_at"])),
         )
 
 
@@ -589,7 +596,7 @@ class SessionService:
                 metadata = state.get("_metadata")
                 if metadata:
                     try:
-                        created = datetime.fromisoformat(metadata["created_at"])
+                        created = to_aware_utc(datetime.fromisoformat(metadata["created_at"]))
                         if created >= today_start:
                             count += 1
                     except (KeyError, ValueError):

--- a/src/backend/services/version_service.py
+++ b/src/backend/services/version_service.py
@@ -16,7 +16,7 @@ from models.config_version import (
     RollbackResult,
     VersionStatus,
 )
-from utils.time import utcnow
+from utils.time import utcnow_naive
 
 logger = logging.getLogger(__name__)
 
@@ -263,7 +263,9 @@ class VersionService:
 
         # Mark as rolled back
         new_version.rolled_back_from = current.id
-        new_version.rolled_back_at = utcnow()
+        # `config_versions` 는 이 코드베이스에 둘뿐인 naive(`TIMESTAMP WITHOUT TIME
+        # ZONE`) 컬럼이다. aware 를 넣으면 드라이버가 거부하거나 tzinfo 를 흘린다.
+        new_version.rolled_back_at = utcnow_naive()
 
         # Sync rollback metadata to DB
         VersionService._fire_and_forget_save(new_version)
@@ -458,7 +460,7 @@ class VersionService:
                     changes_summary=row.changes_summary,
                     diff_from_previous=row.diff_from_previous,
                     created_by=row.created_by,
-                    created_at=row.created_at or utcnow(),
+                    created_at=row.created_at or utcnow_naive(),
                     rolled_back_from=row.rolled_back_from,
                     rolled_back_at=row.rolled_back_at,
                 )

--- a/src/backend/utils/time.py
+++ b/src/backend/utils/time.py
@@ -76,6 +76,17 @@ def to_naive_utc(dt: datetime) -> datetime:
     return dt
 
 
+def normalize_aware_utc(value: object) -> object:
+    """Pydantic 밸리데이터용 — datetime 이면 aware UTC 로, 나머지는 그대로.
+
+    JSON 으로 영속화된 뒤 다시 읽히는 모델을 위한 것이다. `utcnow()` 가 naive 이던
+    시절에 쓰인 파일은 offset 없는 문자열을 담고 있어 Pydantic 이 naive 로 파싱하는데,
+    그 값을 aware 인 `utcnow()` 와 비교하면 TypeError 가 난다. 기존 배포의 데이터가
+    그대로 남아 있으므로 읽는 쪽에서 흡수해야 한다.
+    """
+    return to_aware_utc(value) if isinstance(value, datetime) else value
+
+
 _DEFAULT_DISPLAY_TZ = "Asia/Seoul"
 
 

--- a/src/backend/utils/time.py
+++ b/src/backend/utils/time.py
@@ -52,12 +52,16 @@ def to_utc_iso(dt: datetime | None) -> str | None:
     naive datetime은 백엔드 컨벤션상 UTC로 간주하고 offset을 부여한다.
     JS `new Date(iso)`가 timezone suffix 없는 입력을 로컬 시간으로 해석해
     9시간 어긋나는 문제를 응답 경계에서 차단하기 위함.
+
+    aware 입력은 UTC로 **변환**한다. 그냥 통과시키면 `+09:00` 을 단 문자열이 나가는데,
+    순간으로는 옳아도 이 함수가 약속한 `+00:00` 형식이 아니다. 같은 순간이 표면마다
+    다른 문자열로 직렬화되면 문자열 비교로 값을 잇는 소비자가 조용히 어긋난다.
     """
     if dt is None:
         return None
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=UTC)
-    return dt.isoformat()
+        return dt.replace(tzinfo=UTC).isoformat()
+    return dt.astimezone(UTC).isoformat()
 
 
 def to_naive_utc(dt: datetime) -> datetime:

--- a/src/backend/utils/time.py
+++ b/src/backend/utils/time.py
@@ -1,4 +1,16 @@
-"""UTC datetime helpers (DB-compatible naive datetimes)."""
+"""UTC datetime helpers.
+
+**기본형은 aware 다.** 이 코드베이스의 시각 컬럼은 거의 전부
+`DateTime(timezone=True)`(= Postgres `timestamptz`) 이고, naive 컬럼은
+`config_versions` 의 두 개뿐이다.
+
+asyncpg 는 naive datetime 을 timestamptz 에 넣을 때 **프로세스 로컬 타임존**으로
+해석한다. 변환이 클라이언트에서 일어나므로 서버의 `TimeZone` 설정으로는 못 고치고,
+UTC 가 아닌 머신에서 도는 프로세스는 오프셋만큼 어긋난 값을 쓴다 (issue #309).
+그래서 naive 를 돌려주는 것은 기본값이 될 수 없다.
+
+naive 가 필요한 자리에는 `utcnow_naive()` 를 **명시적으로** 쓴다.
+"""
 
 import os
 from datetime import UTC, datetime
@@ -6,11 +18,32 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 def utcnow() -> datetime:
-    """Return naive UTC now. Avoids deprecated datetime.utcnow() while staying DB-compatible.
+    """Return timezone-aware UTC now.
 
-    All DB columns use TIMESTAMP WITHOUT TIME ZONE, so we strip tzinfo.
+    시각 컬럼의 절대다수가 `timestamptz` 라 aware 가 기본이다. naive 를 쓰면
+    asyncpg 가 프로세스 로컬 TZ 로 해석해 오프셋만큼 어긋난다 (issue #309).
+    """
+    return datetime.now(UTC)
+
+
+def utcnow_naive() -> datetime:
+    """Return naive UTC now — `TIMESTAMP WITHOUT TIME ZONE` 컬럼 전용.
+
+    이 코드베이스에서 대상은 `config_versions.created_at` / `.rolled_back_at`
+    둘뿐이다. 그 밖에는 `utcnow()` 를 쓴다.
     """
     return datetime.now(UTC).replace(tzinfo=None)
+
+
+def to_aware_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to tz-aware UTC.
+
+    naive 입력은 백엔드 컨벤션대로 UTC 로 간주해 tzinfo 를 붙인다. 저장된
+    문자열을 `fromisoformat` 으로 파싱한 값처럼 offset 유무가 입력에 좌우되는
+    자리에서, `utcnow()` 와 비교하기 전에 통과시킨다 — 그러지 않으면 naive 와
+    aware 가 만나 TypeError 가 난다.
+    """
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
 
 
 def to_utc_iso(dt: datetime | None) -> str | None:
@@ -31,8 +64,8 @@ def to_naive_utc(dt: datetime) -> datetime:
     """Normalize datetime to naive UTC for consistent comparison.
 
     tz-aware는 UTC로 변환 후 tzinfo 제거, naive는 그대로 반환.
-    DB 컬럼이 TIMESTAMP WITHOUT TIME ZONE이고 utcnow()도 naive UTC를 쓰는
-    내부 컨벤션과 일치한다. 응답 직렬화 시점에는 to_utc_iso()를 사용.
+    `TIMESTAMP WITHOUT TIME ZONE` 컬럼에 쓰거나, 이미 naive 로 모인 값끼리
+    비교할 때만 쓴다. 응답 직렬화 시점에는 to_utc_iso()를 사용.
     """
     if dt.tzinfo is not None:
         return dt.astimezone(UTC).replace(tzinfo=None)

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -27,6 +27,9 @@ from sqlalchemy.pool import NullPool
 from db.models.base import Base
 from db.models.session import SessionModel
 from db.repository import SessionRepository
+from models.config_version import ConfigVersion
+from models.organization import MemberUsageRecord, OrganizationInvitation
+from models.rate_limit import RateLimitOverride
 from services.session_service import SessionMetadata
 from utils.time import to_utc_iso, utcnow
 
@@ -111,6 +114,44 @@ def test_to_utc_iso_always_emits_utc_offset():
     assert emitted is not None and emitted.endswith("+00:00"), emitted
     assert datetime.fromisoformat(emitted) == kst  # 같은 순간이어야 한다
     assert to_utc_iso(None) is None
+
+
+def test_legacy_json_records_normalize_to_aware():
+    """JSON 으로 영속화됐다 다시 읽히는 모델은 구버전 문자열을 흡수해야 한다.
+
+    `utcnow()` 가 naive 이던 시절에 쓰인 파일은 offset 없는 문자열을 담고 있다.
+    Pydantic 이 그것을 naive 로 파싱하면 aware 인 `utcnow()` 와 비교되는 순간
+    TypeError 가 나고, 기존 데이터가 있는 배포에서 통계·초대 수락이 죽는다.
+    """
+    legacy = "2026-01-01T00:00:00"  # offset suffix 없음
+
+    invitation = OrganizationInvitation(
+        id="i", organization_id="o", email="a@b.co", invited_by="u",
+        expires_at="2099-01-01T00:00:00", created_at=legacy,
+    )
+    assert invitation.expires_at.tzinfo is not None
+    assert invitation.expires_at > utcnow()  # 비교가 TypeError 없이 성립한다
+
+    usage = MemberUsageRecord(organization_id="o", user_id="u", timestamp=legacy)
+    assert usage.timestamp.tzinfo is not None
+    assert usage.timestamp < utcnow()
+
+
+def test_rate_limit_override_normalizes_naive_api_input():
+    """`expires_at` 은 API 쿼리 파라미터라 offset 없는 값이 들어올 수 있다."""
+    override = RateLimitOverride(identifier="u", expires_at="2099-01-01T00:00:00")
+
+    assert override.expires_at is not None and override.expires_at.tzinfo is not None
+    assert override.expires_at > utcnow()
+
+
+def test_config_version_stays_naive():
+    """`config_versions` 는 naive 컬럼이다 — 그 모델만 aware 규칙에서 빠진다.
+
+    aware 를 기본값으로 두면 DB 에서 읽어온 naive 행과 섞여 정렬이 죽는다.
+    """
+    version = ConfigVersion(id="v1", config_type="agent", config_id="a", version=1)
+    assert version.created_at.tzinfo is None
 
 
 # --------------------------------------------------------------------------

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -16,6 +16,7 @@ import os
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 import pytest_asyncio
@@ -27,7 +28,7 @@ from db.models.base import Base
 from db.models.session import SessionModel
 from db.repository import SessionRepository
 from services.session_service import SessionMetadata
-from utils.time import utcnow
+from utils.time import to_utc_iso, utcnow
 
 TEST_DATABASE_URL = os.getenv("AOS_TEST_DATABASE_URL")
 
@@ -74,6 +75,42 @@ def test_session_metadata_reads_legacy_naive_strings():
     assert metadata.is_inactive() is True
     metadata.touch()
     assert metadata.is_inactive() is False
+
+
+def test_session_metadata_survives_a_write_read_roundtrip():
+    """`to_dict()` 가 쓴 문자열을 `from_dict()` 가 같은 순간으로 되읽어야 한다.
+
+    이 값들은 `state_json` 에 실려 `serialize_state`/`deserialize_state` 왕복을
+    탄다. 레거시(naive) 입력만 검증하면 정작 이번에 바뀐 **새로 쓰는** 형식의
+    왕복이 비어 있는 채로 남는다.
+    """
+    before = SessionMetadata(
+        session_id="rt-1",
+        created_at=utcnow(),
+        last_activity=utcnow(),
+        expires_at=utcnow() + timedelta(days=1),
+    )
+    after = SessionMetadata.from_dict(before.to_dict())
+
+    for field in ("created_at", "last_activity", "expires_at"):
+        original, restored = getattr(before, field), getattr(after, field)
+        assert restored == original, f"{field} 왕복에서 순간이 바뀌었다"
+        assert restored.tzinfo is not None, f"{field} 가 naive 로 돌아왔다"
+    assert after.is_expired() is False
+
+
+def test_to_utc_iso_always_emits_utc_offset():
+    """aware 입력이 UTC 가 아니어도 `+00:00` 형식으로 나가야 한다.
+
+    통과시키면 같은 순간이 표면마다 다른 문자열이 되어, 문자열로 값을 잇는
+    소비자가 조용히 어긋난다.
+    """
+    kst = datetime(2026, 8, 25, 16, 28, tzinfo=ZoneInfo("Asia/Seoul"))
+    emitted = to_utc_iso(kst)
+
+    assert emitted is not None and emitted.endswith("+00:00"), emitted
+    assert datetime.fromisoformat(emitted) == kst  # 같은 순간이어야 한다
+    assert to_utc_iso(None) is None
 
 
 # --------------------------------------------------------------------------

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -32,7 +32,7 @@ from models.organization import MemberUsageRecord, OrganizationInvitation
 from models.playground import PlaygroundMessage, PlaygroundSession
 from models.rate_limit import RateLimitOverride
 from services.session_service import SessionMetadata
-from utils.time import to_utc_iso, utcnow
+from utils.time import to_aware_utc, to_utc_iso, utcnow
 
 TEST_DATABASE_URL = os.getenv("AOS_TEST_DATABASE_URL")
 
@@ -196,6 +196,25 @@ def test_json_persisted_models_absorb_naive_timestamps(model, kwargs, field):
 
     assert value.tzinfo is not None, f"{model.__name__}.{field} 가 naive 로 남았다"
     assert value < utcnow()  # 비교가 TypeError 없이 성립한다
+
+
+@pytest.mark.parametrize(
+    "stored_expiry",
+    [
+        pytest.param(datetime(2099, 1, 1, tzinfo=UTC), id="timestamptz-컬럼(aware)"),
+        pytest.param(datetime(2099, 1, 1), id="naive-컬럼(마이그레이션 경로)"),
+    ],
+)
+def test_invitation_expiry_compares_under_either_schema(stored_expiry):
+    """초대 만료 비교는 컬럼이 어느 쪽으로 만들어졌든 성립해야 한다.
+
+    `project_invitations.expires_at` 은 모델상 `timestamptz` 지만 마이그레이션
+    `f3a8b2c1d4e5` 는 `TIMESTAMP WITHOUT TIME ZONE` 으로 만든다. 스키마가 어떻게
+    만들어졌는지에 따라 asyncpg 가 aware 를 주기도 naive 를 주기도 한다.
+    (드리프트 자체는 #310 에서 따로 다룬다.)
+    """
+    assert to_aware_utc(stored_expiry) > utcnow()
+    assert to_aware_utc(stored_expiry).tzinfo is not None
 
 
 # --------------------------------------------------------------------------

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -1,0 +1,195 @@
+"""#309 회귀: naive datetime 을 timestamptz 컬럼에 쓰면 프로세스 TZ 만큼 어긋난다.
+
+`utcnow()` 는 naive UTC 를 돌려주면서 docstring 이 "All DB columns use TIMESTAMP
+WITHOUT TIME ZONE" 이라고 적고 있었다. 실측은 그 반대다 — `DateTime(timezone=True)`
+컬럼이 96 개, naive 컬럼은 `config_versions` 의 2 개뿐이다.
+
+asyncpg 는 naive datetime 을 timestamptz 에 넣을 때 **프로세스 로컬 타임존**으로
+해석한다. 변환은 클라이언트에서 일어나므로 서버의 `TimeZone` 설정으로는 못 고친다.
+
+여기 테스트가 TZ 를 강제로 고정하는 것이 핵심이다. 주변 TZ 에 맡기면 UTC 로 도는
+CI 에서는 오프셋이 0 이라 **영원히 초록**이고, 회귀를 잡지 못한다 (#291 이 겪은
+"틀린 이유로 통과" 와 같은 함정).
+"""
+
+import os
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from db.models.base import Base
+from db.models.session import SessionModel
+from db.repository import SessionRepository
+from services.session_service import SessionMetadata
+from utils.time import utcnow
+
+TEST_DATABASE_URL = os.getenv("AOS_TEST_DATABASE_URL")
+
+# UTC 가 아닌 고정 오프셋. DST 가 없어 계산이 흔들리지 않는다.
+NON_UTC_TZ = "Asia/Seoul"
+OFFSET_SECONDS = 9 * 3600
+
+
+def _as_aware(dt: datetime) -> datetime:
+    """naive 는 백엔드 컨벤션대로 UTC 로 간주한다."""
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+# --------------------------------------------------------------------------
+# DB 없이 도는 계약 — 모든 환경에서 실행된다
+# --------------------------------------------------------------------------
+
+
+def test_utcnow_is_timezone_aware():
+    """`utcnow()` 는 aware 여야 한다 — 쓰기 대상의 절대다수가 timestamptz 다."""
+    now = utcnow()
+    assert now.tzinfo is not None, "utcnow() 가 naive 면 timestamptz 에서 TZ 만큼 어긋난다"
+    assert now.utcoffset() == timedelta(0)
+
+
+def test_session_metadata_reads_legacy_naive_strings():
+    """이미 저장된 세션의 `_metadata` 는 offset 없는 naive 문자열이다.
+
+    `utcnow()` 를 aware 로 바꾸면 그 문자열을 그대로 파싱한 naive 값과 비교하게 되어
+    `is_expired()` 가 TypeError 로 죽는다. 읽는 쪽이 정규화해야 기존 세션이 산다.
+    (`session_service.py` 의 except 절은 KeyError/ValueError 만 잡는다 — TypeError 는
+    그대로 올라온다.)
+    """
+    legacy = {
+        "session_id": "legacy-1",
+        # offset suffix 없음 = 구버전이 남긴 형식
+        "created_at": "2026-01-01T00:00:00",
+        "last_activity": "2026-01-01T00:00:00",
+        "expires_at": "2099-01-01T00:00:00",
+    }
+    metadata = SessionMetadata.from_dict(legacy)
+
+    assert metadata.is_expired() is False
+    assert metadata.is_inactive() is True
+    metadata.touch()
+    assert metadata.is_inactive() is False
+
+
+# --------------------------------------------------------------------------
+# 실제 timestamptz 왕복 — Postgres 가 있을 때만
+# --------------------------------------------------------------------------
+
+pg = pytest.mark.skipif(
+    not TEST_DATABASE_URL,
+    reason="AOS_TEST_DATABASE_URL 미설정 — timestamptz 왕복 테스트를 건너뛴다",
+)
+
+
+@pytest.fixture
+def forced_non_utc_tz():
+    """프로세스 TZ 를 UTC 가 아닌 값으로 고정한다.
+
+    asyncpg 의 naive->timestamptz 변환은 인코딩 시점의 프로세스 TZ 를 쓴다.
+    주변 환경에 맡기면 UTC 로 도는 CI 에서 이 테스트가 무의미해진다.
+    """
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = NON_UTC_TZ
+    time.tzset()
+    assert time.timezone != 0, "TZ 고정 실패 — 이 테스트는 UTC 가 아닌 TZ 를 전제한다"
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time.tzset()
+
+
+@pytest_asyncio.fixture
+async def db_factory(forced_non_utc_tz):
+    """전용 스키마 하나만 만들고 그것만 제거한다.
+
+    `Base.metadata.drop_all()` 로 정리하면 변수가 실수로 개발 DB 를 가리켰을 때
+    애플리케이션 테이블을 전부 지운다 — 변수 이름은 관례이지 보증이 아니다.
+    """
+    schema = f"aos_tz_test_{uuid.uuid4().hex[:12]}"
+    admin = create_async_engine(TEST_DATABASE_URL, poolclass=NullPool)
+    async with admin.begin() as conn:
+        await conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        poolclass=NullPool,
+        connect_args={"server_settings": {"search_path": schema}},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+        async with admin.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await admin.dispose()
+
+
+@pg
+@pytest.mark.asyncio
+async def test_utcnow_roundtrips_through_timestamptz(db_factory):
+    """`utcnow()` 로 쓴 값이 읽을 때 같은 순간이어야 한다."""
+    session_id = f"tz-{uuid.uuid4().hex[:8]}"
+    written = utcnow()
+
+    async with db_factory() as db:
+        db.add(SessionModel(id=session_id, status="active", state_json={}, updated_at=written))
+        await db.commit()
+
+    async with db_factory() as db:
+        stored = (
+            await db.execute(select(SessionModel.updated_at).where(SessionModel.id == session_id))
+        ).scalar_one()
+
+    # 저장된 값은 aware 로 돌아온다. 같은 순간이면 차이가 0 이다.
+    skew = abs((stored - _as_aware(written)).total_seconds())
+    assert skew < 1, (
+        f"timestamptz 왕복에서 {skew}초 어긋났다 "
+        f"(프로세스 TZ 오프셋 {OFFSET_SECONDS}초와 비교하라)"
+    )
+
+
+@pg
+@pytest.mark.asyncio
+async def test_update_state_cannot_write_a_timestamp_older_than_creation(db_factory):
+    """갱신이 생성보다 과거일 수는 없다.
+
+    `created_at` 은 컬럼 기본값(aware)이, `updated_at` 은 `update_state` 의
+    `utcnow()` 가 쓴다. 시계가 둘로 갈리면 UTC 가 아닌 TZ 에서 갱신 시각이
+    생성 시각보다 오프셋만큼 **과거**가 되어 `ORDER BY updated_at` 이 뒤집힌다.
+    """
+    session_id = f"tz-{uuid.uuid4().hex[:8]}"
+
+    async with db_factory() as db:
+        db.add(SessionModel(id=session_id, status="active", state_json={}))
+        await db.commit()
+
+    async with db_factory() as db:
+        repo = SessionRepository(db)
+        await repo.update_state(session_id, {"touched": True})
+        await db.commit()
+
+    async with db_factory() as db:
+        row = (
+            await db.execute(
+                select(SessionModel.created_at, SessionModel.updated_at).where(
+                    SessionModel.id == session_id
+                )
+            )
+        ).one()
+
+    created_at, updated_at = row
+    assert updated_at >= created_at, (
+        f"갱신 시각이 생성 시각보다 과거다 (차이 {(created_at - updated_at).total_seconds()}초)"
+    )

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -29,6 +29,7 @@ from db.models.session import SessionModel
 from db.repository import SessionRepository
 from models.config_version import ConfigVersion
 from models.organization import MemberUsageRecord, OrganizationInvitation
+from models.playground import PlaygroundMessage, PlaygroundSession
 from models.rate_limit import RateLimitOverride
 from services.session_service import SessionMetadata
 from utils.time import to_utc_iso, utcnow
@@ -152,6 +153,49 @@ def test_config_version_stays_naive():
     """
     version = ConfigVersion(id="v1", config_type="agent", config_id="a", version=1)
     assert version.created_at.tzinfo is None
+
+
+def test_playground_session_sorts_legacy_and_new_together():
+    """레거시 세션과 새 세션을 섞어 정렬해도 죽지 않아야 한다.
+
+    `playground_sessions.json` 은 `utcnow()` 가 naive 이던 시절에 쓰였다. 정규화가
+    없으면 파일에서 읽은 naive 와 새로 만든 aware 가 섞여 `list_sessions()` 의
+    정렬이 TypeError 로 죽고 목록이 통째로 안 나온다.
+    """
+    legacy = PlaygroundSession(
+        name="legacy", user_id="u",
+        created_at="2026-02-05T00:59:49.044250",   # offset 없음 = 구버전 형식
+        updated_at="2026-04-23T13:42:57.712906",
+    )
+    assert legacy.updated_at.tzinfo is not None
+
+    fresh = PlaygroundSession(name="fresh", user_id="u")
+    ordered = sorted([legacy, fresh], key=lambda x: x.updated_at, reverse=True)
+    assert ordered[0].name == "fresh"
+
+
+# JSON 파일로 영속화됐다 다시 읽히는 모델들. 그 파일에는 `utcnow()` 가 naive 이던
+# 시절의 offset 없는 문자열이 남아 있으므로, 읽는 쪽이 aware 로 흡수해야 한다.
+# 새로 JSON 에 영속화되는 모델을 추가하면 여기에도 넣는다.
+JSON_PERSISTED_MODELS = [
+    (PlaygroundSession, {"name": "n", "user_id": "u"}, "updated_at"),
+    (PlaygroundMessage, {"role": "user", "content": "c"}, "timestamp"),
+    (MemberUsageRecord, {"organization_id": "o", "user_id": "u"}, "timestamp"),
+    (OrganizationInvitation,
+     {"id": "i", "organization_id": "o", "email": "a@b.co", "invited_by": "u",
+      "expires_at": "2099-01-01T00:00:00"}, "created_at"),
+    (RateLimitOverride, {"identifier": "u"}, "created_at"),
+]
+
+
+@pytest.mark.parametrize("model, kwargs, field", JSON_PERSISTED_MODELS)
+def test_json_persisted_models_absorb_naive_timestamps(model, kwargs, field):
+    """offset 없는 문자열을 넣어도 aware 로 나와야 한다."""
+    instance = model(**{**kwargs, field: "2026-01-01T00:00:00"})
+    value = getattr(instance, field)
+
+    assert value.tzinfo is not None, f"{model.__name__}.{field} 가 naive 로 남았다"
+    assert value < utcnow()  # 비교가 TypeError 없이 성립한다
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
`utcnow()`가 naive UTC를 반환했는데, DB의 시각 컬럼 대부분(96개)은 `timestamptz`였습니다. asyncpg는 naive datetime을 timestamptz에 쓸 때 프로세스의 로컬 타임존으로 해석하므로, UTC가 아닌 서버에서 도는 프로세스는 값이 타임존 오프셋만큼(예: KST +9시간) 어긋났습니다 (#309).

비유하자면, 시계 없이 "지금"이라고만 적어둔 메모를 서울에서 읽으면 서울 시간으로, 뉴욕에서 읽으면 뉴욕 시간으로 오인하는 것과 같습니다. `utcnow()`가 "이건 UTC 기준 몇 시"라는 표시(timezone-aware)를 달지 않았던 것이 원인입니다.

## Solution
- `utcnow()`가 이제 timezone-aware UTC를 반환하도록 변경하고, naive가 필요한 두 개의 `TIMESTAMP WITHOUT TIME ZONE` 컬럼(`config_versions.created_at`/`.rolled_back_at`)에는 별도의 `utcnow_naive()`를 명시적으로 사용하도록 분리했습니다.
- `to_utc_iso()`가 aware 입력도 항상 `+00:00` 형식의 UTC로 정규화해 직렬화하도록 수정 — 같은 순간이 표면마다 다른 문자열로 나가 문자열 비교 소비자가 어긋나는 문제를 막았습니다.
- aware 전환 이후 남아 있던 naive 비교 지점 3곳(repository, organization_service, session comparisons)을 `to_aware_utc()`로 통일했습니다.
- 레거시 JSON 세션(`utcnow()`가 naive였던 시절에 저장된 playground/organization 모델)의 offset 없는 타임스탬프 문자열을 읽을 때 aware로 정규화하는 Pydantic validator(`normalize_aware_utc`)를 추가해, 기존 배포 데이터와의 호환성을 유지했습니다.
- `tests/backend/test_time_timestamptz.py`를 추가해 DB 없이 도는 계약 테스트(aware 여부, 레거시 문자열 흡수, 왕복 일관성)와, `AOS_TEST_DATABASE_URL`이 있을 때 프로세스 TZ를 강제로 UTC가 아닌 값으로 고정한 실제 timestamptz 왕복 회귀 테스트를 함께 검증합니다.

### Testing
- `tests/backend/test_time_timestamptz.py` 신규 테스트 추가 (DB 미설정 환경에서도 계약 테스트는 실행됨, timestamptz 왕복 테스트는 `AOS_TEST_DATABASE_URL` 설정 시에만 skip 해제)

---

## 추가 (Codex 3 회차 + 재현 근거)

### 재현 (L1)

로컬 KST 에서 같은 순간을 naive/aware 로 각각 timestamptz 에 넣고 읽었다:

```
프로세스 TZ : ('KST', 'KST')
  aware: 2026-08-25 16:28:00.034334+00:00
  naive: 2026-08-25 07:28:00.034334+00:00
같은 순간인데 차이(초): -32400.0
```

수정을 되돌리면 회귀 테스트가 다시 실패하는 것도 확인했다 (RED → GREEN → 되돌림 RED → 복원 GREEN).

### 초대 만료 비교 — 스키마 모양에 무관하게

`project_invitations.expires_at` 은 모델상 `timestamptz` 지만 마이그레이션
`f3a8b2c1d4e5` 는 `TIMESTAMP WITHOUT TIME ZONE` 으로 만든다. **오늘 이 리포에서는
도달 불가한 전제다** — 라이브 DB 를 조회해 확인했고 `timestamp with time zone` 이다
(스키마는 `create_all()` 이 만들고 `alembic upgrade` 를 부르는 실행 경로가 없다, #310).
그래도 드리프트가 실재하므로 비교 지점을 `to_aware_utc()` 로 방어했다. 드리프트
해소 자체는 #310 소관이라 이 PR 에서 다루지 않는다.

### 별건 — 이 변경 이전부터 깨져 있던 엔드포인트

`api/project_access.py:346` 의 초대 미리보기가 `dt.utcnow()`(naive, deprecated)를
timestamptz 값과 비교하고 있었다. 실제 컬럼 타입으로 재현:

```
asyncpg 가 돌려준 값: 2026-08-26 17:15:34.999090+00:00 | tzinfo: UTC
TypeError: can't compare offset-naive and offset-aware datetimes
```

main 에서 이미 죽는 경로다. 인접한 같은 결함이라 함께 고쳤다.

### 범위를 어디서 끊었나

`models/` 에 datetime 필드를 가진 모델이 86 개 있지만 전부에 정규화를 걸지 않았다.
위험은 **(a) JSON 으로 영속화됐다 다시 읽히고 (b) 그 값이 `utcnow()` 와 비교·정렬되는**
모델에만 있다. DB 를 타는 값은 asyncpg 가 aware 로 돌려주므로 해당 없다.

whack-a-mole 을 끊기 위해 `JSON_PERSISTED_MODELS` 목록을 테스트에 두고 parametrize
로 불변식을 건다 — 새 모델을 JSON 에 영속화하면 여기에 추가하게 된다.

### 검증

- `ruff check` · `ruff format --check` 통과 (318 files)
- `mypy` 통과 (319 files)
- `pytest` **1523 passed**, 2 skipped — `AOS_TEST_DATABASE_URL` + `TZ=Asia/Seoul` 로 DB 모드 포함
- Codex 리뷰 3 회차. 매 회차 지적을 재현 확인 후 반영했다

Closes #309 (별건인 alembic 발판은 #310 으로 분리)
