### PR TITLE
fix(db): naive datetime 유입원 3 종 정규화 (#309 후속)

### DIFF
--- a/src/backend/auth/token_service.py
+++ b/src/backend/auth/token_service.py
@@ -1,7 +1,7 @@
 """Token service with JWT management and blacklist support."""
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import jwt
@@ -174,8 +174,11 @@ class TokenService:
             return TokenPayload(
                 sub=payload["sub"],
                 type=payload["type"],
-                exp=datetime.fromtimestamp(payload["exp"]),
-                iat=datetime.fromtimestamp(payload["iat"]),
+                # JWT 의 exp/iat 는 epoch UTC 다. `tz=UTC` 없이 읽으면 로컬 시각
+                # naive 가 나와, aware 인 `utcnow()` 와 빼는 순간 TypeError 다
+                # (`blacklist_token` 의 TTL 계산).
+                exp=datetime.fromtimestamp(payload["exp"], UTC),
+                iat=datetime.fromtimestamp(payload["iat"], UTC),
                 jti=payload.get("jti"),
                 email=payload.get("email"),
                 name=payload.get("name"),
@@ -215,8 +218,11 @@ class TokenService:
             return TokenPayload(
                 sub=payload["sub"],
                 type=payload["type"],
-                exp=datetime.fromtimestamp(payload["exp"]),
-                iat=datetime.fromtimestamp(payload["iat"]),
+                # JWT 의 exp/iat 는 epoch UTC 다. `tz=UTC` 없이 읽으면 로컬 시각
+                # naive 가 나와, aware 인 `utcnow()` 와 빼는 순간 TypeError 다
+                # (`blacklist_token` 의 TTL 계산).
+                exp=datetime.fromtimestamp(payload["exp"], UTC),
+                iat=datetime.fromtimestamp(payload["iat"], UTC),
                 jti=payload.get("jti"),
                 email=payload.get("email"),
                 name=payload.get("name"),

--- a/src/backend/models/feedback.py
+++ b/src/backend/models/feedback.py
@@ -9,7 +9,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from utils.time import normalize_aware_utc
 
 
 class FeedbackType(str, Enum):
@@ -119,6 +121,12 @@ class FeedbackQueryParams(BaseModel):
     limit: int = Field(50, ge=1, le=200)
     offset: int = Field(0, ge=0)
 
+    # 날짜 필터는 API 로 들어와 offset 이 없으면 naive 다. 메모리 경로는 비교에서
+    # TypeError 로 터지지만 **DB 경로는 조용히 틀린다** — asyncpg 가 naive 를
+    # 프로세스 로컬 TZ 로 해석해 timestamptz 조건에 바인딩하므로 조회 구간이
+    # 오프셋만큼 밀린다. 모델에서 흡수해 두 경로가 같은 값을 본다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
+
 
 class FeedbackStats(BaseModel):
     """피드백 통계"""
@@ -159,6 +167,12 @@ class DatasetExportOptions(BaseModel):
     agent_filter: list[str] | None = Field(None, description="특정 에이전트만 필터")
     start_date: datetime | None = None
     end_date: datetime | None = None
+
+    # 날짜 필터는 API 로 들어와 offset 이 없으면 naive 다. 메모리 경로는 비교에서
+    # TypeError 로 터지지만 **DB 경로는 조용히 틀린다** — asyncpg 가 naive 를
+    # 프로세스 로컬 TZ 로 해석해 timestamptz 조건에 바인딩하므로 조회 구간이
+    # 오프셋만큼 밀린다. 모델에서 흡수해 두 경로가 같은 값을 본다 (#309).
+    _ensure_aware = field_validator("*")(normalize_aware_utc)
 
 
 class DatasetStats(BaseModel):

--- a/src/backend/services/audit_integrity.py
+++ b/src/backend/services/audit_integrity.py
@@ -15,7 +15,7 @@ from models.audit import (
     RetentionApplyResult,
     RetentionPolicy,
 )
-from utils.time import utcnow
+from utils.time import to_aware_utc, utcnow
 
 
 class AuditIntegrityService:
@@ -190,6 +190,9 @@ class AuditIntegrityService:
         entries = entries or self._entries
 
         # Filter by date range
+        # API 로 들어온 날짜 필터는 offset 이 없으면 naive 다. 비교 상대는 `utcnow()` 로
+        # 만들어진 aware 값이라 그대로 재면 TypeError 다 (#309).
+        start_date, end_date = to_aware_utc(start_date), to_aware_utc(end_date)
         filtered = [e for e in entries if start_date <= e.created_at <= end_date]
 
         # Compute statistics

--- a/src/backend/services/context_compressor.py
+++ b/src/backend/services/context_compressor.py
@@ -20,10 +20,10 @@ Each tier always uses LLM summarisation. Extractive fallback is the
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import Any
 
 from models.context_usage import get_context_limit
+from utils.time import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class CompressionResult:
             "tokens_before": self.tokens_before,
             "tokens_after": self.tokens_after,
             "tier": self.tier,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utcnow().isoformat(),
         }
 
 

--- a/src/backend/services/cost_allocation_service.py
+++ b/src/backend/services/cost_allocation_service.py
@@ -688,10 +688,12 @@ class CostAllocationService:
             conditions.append(CostAllocationModel.project_id == project_id)
         if user_id:
             conditions.append(CostAllocationModel.user_id == user_id)
+        # DB 경로도 정규화한다. naive 를 timestamptz 조건에 바인딩하면 asyncpg 가
+        # 프로세스 로컬 TZ 로 해석해, 예외 없이 조회 구간만 오프셋만큼 밀린다.
         if start_date:
-            conditions.append(CostAllocationModel.created_at >= start_date)
+            conditions.append(CostAllocationModel.created_at >= to_aware_utc(start_date))
         if end_date:
-            conditions.append(CostAllocationModel.created_at <= end_date)
+            conditions.append(CostAllocationModel.created_at <= to_aware_utc(end_date))
 
         if conditions:
             query = query.where(and_(*conditions))

--- a/src/backend/services/cost_allocation_service.py
+++ b/src/backend/services/cost_allocation_service.py
@@ -16,7 +16,7 @@ from models.cost import (
     CostReport,
     SessionTokenUsage,
 )
-from utils.time import utcnow
+from utils.time import to_aware_utc, utcnow
 
 USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
 
@@ -196,11 +196,13 @@ class CostAllocationService:
         if user_id:
             results = [a for a in results if a.user_id == user_id]
 
+        # API 로 들어온 날짜 필터는 offset 이 없으면 naive 다. 비교 상대는 `utcnow()` 로
+        # 만들어진 aware 값이라 그대로 재면 TypeError 다 (#309).
         if start_date:
-            results = [a for a in results if a.created_at >= start_date]
+            results = [a for a in results if a.created_at >= to_aware_utc(start_date)]
 
         if end_date:
-            results = [a for a in results if a.created_at <= end_date]
+            results = [a for a in results if a.created_at <= to_aware_utc(end_date)]
 
         return results
 
@@ -490,7 +492,7 @@ class CostAllocationService:
             results = [a for a in results if a.alert_type == alert_type]
 
         if since:
-            results = [a for a in results if a.created_at >= since]
+            results = [a for a in results if a.created_at >= to_aware_utc(since)]
 
         return sorted(results, key=lambda x: x.created_at, reverse=True)
 

--- a/src/backend/services/feedback_service.py
+++ b/src/backend/services/feedback_service.py
@@ -154,7 +154,10 @@ class FeedbackService:
     ) -> FeedbackStats:
         """피드백 통계 조회 (DB + in-memory fallback 병합)"""
         if self.use_database:
-            db_stats = await self._get_stats_from_db(start_date, end_date)
+            db_stats = await self._get_stats_from_db(
+                to_aware_utc(start_date) if start_date else None,
+                to_aware_utc(end_date) if end_date else None,
+            )
             # In-memory fallback 데이터 통계도 병합
             if self._feedbacks:
                 mem_stats = self._get_stats_memory(start_date, end_date)

--- a/src/backend/services/feedback_service.py
+++ b/src/backend/services/feedback_service.py
@@ -30,7 +30,7 @@ from models.feedback import (
     TaskEvaluationStats,
     TaskEvaluationSubmit,
 )
-from utils.time import utcnow
+from utils.time import to_aware_utc, utcnow
 
 # Environment variable to control storage mode
 USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
@@ -590,9 +590,11 @@ class FeedbackService:
                 continue
             if params.agent_id and data["agent_id"] != params.agent_id:
                 continue
-            if params.start_date and data["created_at"] < params.start_date:
+            # API 로 들어온 날짜 필터는 offset 이 없으면 naive 다. 비교 상대는 `utcnow()` 로
+            # 만들어진 aware 값이라 그대로 재면 TypeError 다 (#309).
+            if params.start_date and data["created_at"] < to_aware_utc(params.start_date):
                 continue
-            if params.end_date and data["created_at"] > params.end_date:
+            if params.end_date and data["created_at"] > to_aware_utc(params.end_date):
                 continue
 
             results.append(self._to_feedback_entry(data))
@@ -619,9 +621,11 @@ class FeedbackService:
 
         for data in self._feedbacks.values():
             # 날짜 필터
-            if start_date and data["created_at"] < start_date:
+            # API 로 들어온 날짜 필터는 offset 이 없으면 naive 다. 비교 상대는 `utcnow()` 로
+            # 만들어진 aware 값이라 그대로 재면 TypeError 다 (#309).
+            if start_date and data["created_at"] < to_aware_utc(start_date):
                 continue
-            if end_date and data["created_at"] > end_date:
+            if end_date and data["created_at"] > to_aware_utc(end_date):
                 continue
 
             total += 1
@@ -786,9 +790,9 @@ class FeedbackService:
                 if options.agent_filter and metadata.get("agent_id") not in options.agent_filter:
                     continue
 
-                if options.start_date and data["created_at"] < options.start_date:
+                if options.start_date and data["created_at"] < to_aware_utc(options.start_date):
                     continue
-                if options.end_date and data["created_at"] > options.end_date:
+                if options.end_date and data["created_at"] > to_aware_utc(options.end_date):
                     continue
 
                 entries.append(

--- a/src/backend/services/project_discovery.py
+++ b/src/backend/services/project_discovery.py
@@ -7,7 +7,7 @@ and scans projects for configuration metadata.
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from models.project_config import ProjectInfo
@@ -376,7 +376,10 @@ class ProjectDiscovery:
         for check_path in [skills_dir, agents_dir, commands_dir, mcp_file, hooks_file]:
             if check_path.exists():
                 try:
-                    mtime = datetime.fromtimestamp(check_path.stat().st_mtime)
+                    # `tz=UTC` 를 명시한다. 없으면 **로컬 시각** naive 가 나와
+                    # aware 인 `last_modified` 와 비교되며 TypeError 가 나고,
+                    # 설령 비교가 됐더라도 UTC 가 아닌 값끼리 재던 셈이다.
+                    mtime = datetime.fromtimestamp(check_path.stat().st_mtime, UTC)
                     if mtime > last_modified:
                         last_modified = mtime
                 except OSError:

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -13,6 +13,7 @@ CI 에서는 오프셋이 0 이라 **영원히 초록**이고, 회귀를 잡지 
 """
 
 import os
+import tempfile
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -24,6 +25,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
+from auth.token_service import TokenService
 from db.models.base import Base
 from db.models.session import SessionModel
 from db.repository import SessionRepository
@@ -215,6 +217,62 @@ def test_invitation_expiry_compares_under_either_schema(stored_expiry):
     """
     assert to_aware_utc(stored_expiry) > utcnow()
     assert to_aware_utc(stored_expiry).tzinfo is not None
+
+
+def test_file_mtime_is_read_as_utc():
+    """파일 mtime 은 `tz=UTC` 로 읽어야 한다.
+
+    `datetime.fromtimestamp(x)` 는 **로컬 시각** naive 를 준다. aware 인 `utcnow()` 와
+    비교하면 TypeError 고, 설령 비교가 됐더라도 UTC 가 아닌 값끼리 재는 셈이다
+    (`ProjectDiscovery.scan_project` 이 그 경로였다).
+    """
+    with tempfile.NamedTemporaryFile() as f:
+        mtime = os.stat(f.name).st_mtime
+
+    naive = datetime.fromtimestamp(mtime)
+    aware = datetime.fromtimestamp(mtime, UTC)
+
+    assert aware.tzinfo is not None
+    assert aware < utcnow() + timedelta(seconds=5)  # 비교가 성립한다
+    with pytest.raises(TypeError):
+        _ = naive > utcnow()  # tz 를 빠뜨리면 이렇게 죽는다
+
+
+def test_jwt_expiry_decodes_as_aware(monkeypatch):
+    """JWT 의 exp/iat 는 epoch UTC 다 — `tz=UTC` 로 읽어야 TTL 계산이 산다.
+
+    `TokenService.blacklist_token` 이 `expires_at - utcnow()` 를 하므로, naive 로
+    읽으면 Redis 블랙리스트 기록 전에 TypeError 로 죽는다.
+    """
+    from config import get_settings
+
+    monkeypatch.setenv("SESSION_SECRET_KEY", "x" * 48)
+    get_settings.cache_clear()
+    try:
+        service = TokenService()
+        decoded = service.verify_token(service.create_access_token("u"))
+
+        assert decoded is not None
+        assert decoded.exp.tzinfo is not None and decoded.iat.tzinfo is not None
+        # blacklist_token 의 TTL 계산과 같은 식
+        assert int((decoded.exp - utcnow()).total_seconds()) > 0
+    finally:
+        get_settings.cache_clear()
+
+
+def test_api_date_filters_compare_against_aware_records():
+    """offset 없는 날짜 필터가 들어와도 aware 레코드와 비교돼야 한다.
+
+    FastAPI 는 offset 없는 ISO 를 naive 로 파싱한다. 레코드의 `created_at` 은
+    `utcnow()` 가 만든 aware 라 그대로 재면 TypeError 다.
+    """
+    created_at = utcnow()
+    naive_bound = datetime(2020, 1, 1)  # 클라이언트가 offset 없이 보낸 값
+
+    with pytest.raises(TypeError):
+        _ = created_at < naive_bound  # 정규화 없이는 이렇게 죽는다
+
+    assert created_at > to_aware_utc(naive_bound)
 
 
 # --------------------------------------------------------------------------

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -31,6 +31,7 @@ from db.models.session import SessionModel
 from db.repository import SessionRepository
 from models.config_version import ConfigVersion
 from models.organization import MemberUsageRecord, OrganizationInvitation
+from models.feedback import DatasetExportOptions, FeedbackQueryParams
 from models.playground import PlaygroundMessage, PlaygroundSession
 from models.rate_limit import RateLimitOverride
 from services.session_service import SessionMetadata
@@ -187,6 +188,10 @@ JSON_PERSISTED_MODELS = [
      {"id": "i", "organization_id": "o", "email": "a@b.co", "invited_by": "u",
       "expires_at": "2099-01-01T00:00:00"}, "created_at"),
     (RateLimitOverride, {"identifier": "u"}, "created_at"),
+    # 날짜 필터 모델. DB 경로에서는 예외 없이 **조용히** 조회 구간이 밀리므로
+    # 메모리 경로 테스트만으로는 회귀를 잡지 못한다.
+    (FeedbackQueryParams, {}, "start_date"),
+    (DatasetExportOptions, {}, "end_date"),
 ]
 
 


### PR DESCRIPTION
#312 후속. Codex 리뷰 4 회차가 짚은 세 지점이며, **종류가 앞선 라운드와 다르다.**

#312 는 `utcnow()` 호출부를 훑었다. 여기는 **naive 값이 시스템에 들어오는 입구**다 — 호출부가 아예 없어서 `utcnow()` 기준 감사로는 구조적으로 안 잡힌다. 감사를 뒤집어(utcnow 찾기 → naive 유입원 찾기) 같은 부류를 한 번에 훑었다.

## 1. 파일 mtime — 프로젝트 목록이 통째로 빈다

`datetime.fromtimestamp(x)` 는 **로컬 시각** naive 를 준다. `ProjectDiscovery.scan_project()` 이 그것을 aware 인 `utcnow()` 와 비교해 `TypeError` 를 내고, `discover_projects()` 가 그 프로젝트를 떨어뜨린다.

`tz=UTC` 를 명시했다. 참고로 이건 **비교가 되던 시절에도 UTC 가 아닌 값끼리 재고 있었다** — 기존 로직 오류도 함께 해소된다.

## 2. JWT exp/iat — Redis 배포에서 토큰 폐기가 죽는다

`TokenPayload` 의 `exp`/`iat` 를 naive 로 채우고 있었다. `blacklist_token()` 이 `expires_at - utcnow()` 로 Redis TTL 을 계산하므로, Redis 를 쓰는 배포에서 블랙리스트 기록 **전에** `TypeError` 로 죽는다. epoch 는 UTC 이므로 `tz=UTC` 로 읽는다.

## 3. API 날짜 필터

클라이언트가 offset 없이 보내면 FastAPI 가 naive 로 파싱한다. 레코드의 `created_at` 은 `utcnow()` 가 만든 aware 라 그대로 재면 `TypeError` 다. `feedback_service` · `cost_allocation_service` · `audit_integrity` 의 비교 지점을 `to_aware_utc()` 로 통과시킨다.

## 범위를 어디서 끊었나

`fromtimestamp()` 를 tz 없이 쓰는 지점이 **21 곳 더** 있다. 그것들이 비교에 참여하지 않는다는 것은 **추정이 아니라 실측**이다 — taint 전파 감사를 `fromtimestamp` 를 소스로 돌렸다:

```
fromtimestamp 를 소스로 한 비교/뺄셈 지점: 0 건
(대조군: 같은 스크립트에 utcnow 를 소스로 주면 72 건 — 감사가 작동함을 확인)
```

그래서 이 변경으로 깨지지 않는다. 다만 **로컬 시각을 UTC 로 표기해 내보내는 별개의 결함**이 있다(`to_utc_iso` 가 naive 를 UTC 로 간주하므로 응답이 TZ 오프셋만큼 틀린다). 응답 값이 실제로 바뀌는 변경이라 분리했다 — **#314**.

같은 방식으로 `fromisoformat` 도 레포 전역을 훑었다(레거시 JSON 과 같은 모양이라). 10 건이 나왔고 전부 이미 처리됐거나 오탐이다(`sandbox_manager.py:308` 은 float 산술).

## 테스트

3 건 추가. 각각 **tz 를 빠뜨렸을 때 실제로 `TypeError` 가 나는 것까지** 함께 고정한다 — 수정이 되돌아가면 테스트가 잡는다.

## 검증

- `ruff check` · `ruff format --check` (318 files) · `mypy` (319 files) 통과
- `pytest` **1526 passed**, 2 skipped — `AOS_TEST_DATABASE_URL` + `TZ=Asia/Seoul` 로 DB 모드 포함

Refs #309


---

**추가 커밋**: `context_compressor.py` 의 `datetime.utcnow()` 를 헬퍼로 교체했다. 트리에 남은 마지막 deprecated 호출이었고, JSON 타임스탬프라 비교 상대가 없다. 이제 시각은 전부 `utils.time` 을 지난다.


---

## 4. DB 경로의 날짜 필터 (Codex 5 회차)

위 3 번은 **메모리 경로**의 비교만 고쳤다. DB 모드에서는 같은 naive 값이 그대로 `timestamptz` 조건에 바인딩된다.

**이쪽이 더 위험하다.** 메모리 경로는 `TypeError` 로 터져서 보이지만, DB 경로는 **예외가 없다** — asyncpg 가 naive 를 프로세스 로컬 TZ 로 해석해 조회 구간만 오프셋만큼 밀린다. 청구 기간·통계·데이터셋 export 가 조용히 틀린 레코드 집합을 본다. #309 의 원래 버그가 SELECT 쪽에서 재현되는 셈이다.

- `FeedbackQueryParams` · `DatasetExportOptions` 에 정규화를 건다 — 모델이 두 경로가 공유하는 유일한 관문이라, 여기서 흡수하면 메모리·DB 가 같은 값을 본다
- 평범한 인자로 받는 진입점(`_get_stats_from_db`, `get_allocations_async` 의 날짜 조건)은 호출 지점에서 정규화

## Codex 검증

`--scope branch --base main` 으로 **6 회차**까지 돌렸다. 매 회차 지적을 재현 확인 후 반영했고, 마지막 회차는 **지적 0 건**으로 수렴했다.

## 최종 검증

- `ruff check` · `ruff format --check` (318 files) · `mypy` (319 files) 통과
- `pytest` **1528 passed**, 2 skipped — `AOS_TEST_DATABASE_URL` + `TZ=Asia/Seoul`
