### PR TITLE
fix(dashboard): Codex 사용량을 잔류가 아닌 소요량으로 표시

### DIFF
--- a/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
+++ b/src/dashboard/src/components/usage/ClaudeUsageDashboard.tsx
@@ -337,11 +337,10 @@ export function ClaudeUsageDashboard() {
                 <UsageRadialMetric
                   key={window.windowDurationMins ?? idx}
                   label={formatCodexWindowLabel(window)}
-                  value={`${Math.round(window.remainingPercent)}% left`}
+                  value={`${Math.round(window.usedPercent)}% used`}
                   detail={formatCodexPlanDetail(window, codexLimit?.planType)}
-                  percent={window.remainingPercent}
-                  tone={getRemainingTone(window.remainingPercent)}
-                  centerText={`${Math.round(window.remainingPercent)}%`}
+                  percent={window.usedPercent}
+                  tone={getCodexUsedTone(window.usedPercent)}
                 />
               ))
             ) : (
@@ -525,9 +524,13 @@ function getLimitTone(percentUsed: number): UsageTone {
   return 'blue'
 }
 
-function getRemainingTone(percentRemaining: number): UsageTone {
-  if (percentRemaining <= 10) return 'red'
-  if (percentRemaining <= 30) return 'yellow'
+/**
+ * Codex 창은 Claude 카드와 같은 "소요량" 임계치(70/90%)를 쓰되,
+ * 안전 구간 색만 purple 로 남겨 같은 그리드에서 프로바이더를 구분한다.
+ */
+function getCodexUsedTone(percentUsed: number): UsageTone {
+  if (percentUsed >= 90) return 'red'
+  if (percentUsed >= 70) return 'yellow'
   return 'purple'
 }
 
@@ -546,7 +549,7 @@ function formatCodexWindowLabel(window: CodexPlanWindow): string {
 
 function formatCodexPlanDetail(window: CodexPlanWindow, planType?: string | null): string {
   const pieces = [
-    `${Math.round(window.usedPercent)}% used`,
+    `${Math.round(window.remainingPercent)}% left`,
     `${formatCodexWindowReset(window)} reset`,
   ]
   if (planType) {

--- a/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
+++ b/src/dashboard/src/components/usage/__tests__/ClaudeUsageDashboard.test.tsx
@@ -203,8 +203,8 @@ describe('ClaudeUsageDashboard', () => {
     // primary(300분)→"Codex 5h", secondary(10080분)→"Codex Weekly"로 창 길이 기준 라벨링된다.
     expect(utils.getByText('Codex 5h')).toBeInTheDocument()
     expect(utils.getByText('Codex Weekly')).toBeInTheDocument()
-    expect(utils.getByText('44% left')).toBeInTheDocument()
-    expect(utils.getByText('60% left')).toBeInTheDocument()
+    expect(utils.getByText('56% used')).toBeInTheDocument()
+    expect(utils.getByText('40% used')).toBeInTheDocument()
   })
 
   it('labels a weekly-only codex window as "Codex Weekly" (5h window removed)', async () => {
@@ -244,7 +244,7 @@ describe('ClaudeUsageDashboard', () => {
     const utils = within(container)
 
     expect(await utils.findByText('Codex Weekly')).toBeInTheDocument()
-    expect(utils.getByText('25% left')).toBeInTheDocument()
+    expect(utils.getByText('75% used')).toBeInTheDocument()
     expect(utils.queryByText('Codex 5h')).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## 문제

대시보드 첫 화면의 Plan Usage Limits 그리드에서, 바로 옆 Claude 카드는 `utilization`(**소요량**)을 렌더하는데 Codex 창만 `remainingPercent`(**잔류**)를 렌더했다. 같은 줄에 나란히 놓인 두 숫자가 서로 반대 방향을 가리켜 오독을 부른다.

실제 데이터 기준 (`GET /api/usage/codex-plan`, plus 플랜):

| 카드 | 이전 | 이후 |
|---|---|---|
| Codex 5h | `65% left` | **`35% used`** |
| Codex Weekly | `85% left` | **`15% used`** |
| detail 줄 | `Plus / 35% used / …reset` | `Plus / 65% left / …reset` |

## 변경

- `ClaudeUsageDashboard.tsx` — Codex 라디얼의 값·링·중앙 텍스트를 `usedPercent` 기준으로 전환. 링도 **쓴 만큼** 채워져 Claude 카드와 방향이 일치한다.
- detail 줄은 카드 안 문자열 중복을 피해 `% used` → `% left` 로 뒤집었다. 정보는 보존된다.
- `getRemainingTone` → `getCodexUsedTone`: 임계치를 Claude 와 동일한 소요량 기준(70% yellow / 90% red)으로 뒤집되, **안전 구간 purple 은 유지**했다. 그냥 `getLimitTone` 으로 갈아끼우면 Codex 링이 purple→blue 로 조용히 바뀌는데, 색은 tsc·eslint·vitest 어느 것도 검증하지 않아 아무도 잡지 못한다. 프로바이더 구분색은 의도된 것이라 보존했다.

백엔드는 변경 없음 — `api/usage/codex.py` 가 `usedPercent`·`remainingPercent` 를 이미 모두 내려준다. 표시 계약만의 문제였다.

## 테스트 계획

Red → Green 으로 검증했다. mock 데이터가 `56/44`, `40/60`, `75/25` 로 **비대칭**이라 잘못된 필드를 읽으면 반드시 실패한다 (`50/50` 이었다면 어느 쪽을 읽어도 통과하는 거짓 초록이 됐을 것).

1. 기대값을 `56% used` / `40% used` / `75% used` 로 먼저 변경 → **RED** (`2 failed | 14 passed`)
2. 소스 수정 → **GREEN** (`16 passed`)

프론트 게이트 전체:

| 게이트 | 결과 |
|---|---|
| `tsc --noEmit` | exit 0 |
| `eslint .` | 0 |
| `vitest run` | **207 files / 4397 tests pass** |
| `npm run build` | ✓ |

추가로 Codex 적대적 리뷰(`adversarial-review`)를 이 2파일 diff 에 한정해 실행 → `Verdict: approve` ("backend contract, radial direction, thresholds, and consumers are consistent").
