### PR TITLE
fix(test): RAG_EMBEDDING_MODEL 이 기본값과 다를 때만 기본값 테스트를 skip

### DIFF
--- a/tests/backend/test_rag_verification.py
+++ b/tests/backend/test_rag_verification.py
@@ -461,16 +461,32 @@ class TestTroubleshooting:
         """
         import services.rag_service as rag_mod
 
-        # 기본 임베딩 제공자가 일관되는지
+        # provider 유효성은 오버라이드와 무관하게 항상 검증한다 — 아래 skip 이 이
+        # 검사까지 가리면 provider 설정 오류를 놓친다.
         assert rag_mod.EMBEDDING_PROVIDER in ("huggingface", "openai", "google")
 
-        # HuggingFace 기본값 확인 (BAAI/bge-m3 — 다국어, 1024-dim)
-        if rag_mod.EMBEDDING_PROVIDER == "huggingface":
-            assert rag_mod.DEFAULT_EMBEDDING_MODEL == "BAAI/bge-m3"
-        elif rag_mod.EMBEDDING_PROVIDER == "openai":
-            assert rag_mod.DEFAULT_EMBEDDING_MODEL == "text-embedding-3-small"
-        elif rag_mod.EMBEDDING_PROVIDER == "google":
-            assert rag_mod.DEFAULT_EMBEDDING_MODEL == "models/text-embedding-004"
+        expected_default = {
+            "huggingface": "BAAI/bge-m3",  # 다국어, 1024-dim
+            "openai": "text-embedding-3-small",
+            "google": "models/text-embedding-004",
+        }[rag_mod.EMBEDDING_PROVIDER]
+
+        # RAG_EMBEDDING_MODEL 이 설정되면 rag_service 는 provider 별 기본값 대신 그 값을
+        # 쓴다(rag_service.py 의 _RAG_EMBEDDING_MODEL_OVERRIDE 분기). 이 테스트는 기본값을
+        # 검증하므로, 오버라이드가 기본값과 "다를" 때만 대상이 아니다 — 값이 같으면
+        # (.env.example 구성) 그대로 검증한다.
+        # os.getenv 가 아니라 모듈이 실제로 사용한 값으로 판단한다: .env 가 언제
+        # os.environ 에 로드되는지는 테스트 실행 순서에 따라 달라진다. 오버라이드가 없는데
+        # 값이 다르다면 그것은 skip 대상이 아니라 실패해야 할 회귀이므로, 두 조건을 함께 본다.
+        if (
+            rag_mod._RAG_EMBEDDING_MODEL_OVERRIDE
+            and rag_mod.DEFAULT_EMBEDDING_MODEL != expected_default
+        ):
+            pytest.skip(
+                "RAG_EMBEDDING_MODEL 오버라이드가 provider 기본값과 다름 — 기본값 검증 대상 아님"
+            )
+
+        assert rag_mod.DEFAULT_EMBEDDING_MODEL == expected_default
 
     def test_distance_metric_is_cosine(self):
         """거리 계산 방식이 Cosine으로 올바르게 설정되어 있는지."""


### PR DESCRIPTION
## 문제

`test_embedding_model_consistency` 는 provider 별 임베딩 **기본값**(`huggingface` → `BAAI/bge-m3` 등)을 검증한다. 그러나 `rag_service` 는 `RAG_EMBEDDING_MODEL` 이 설정되면 그 값으로 `DEFAULT_EMBEDDING_MODEL` 을 덮어쓴다:

```python
# src/backend/services/rag_service.py:83-86
_RAG_EMBEDDING_MODEL_OVERRIDE = os.getenv("RAG_EMBEDDING_MODEL", "").strip()
if _RAG_EMBEDDING_MODEL_OVERRIDE:
    DEFAULT_EMBEDDING_MODEL = _RAG_EMBEDDING_MODEL_OVERRIDE
```

따라서 다른 모델을 지정한 로컬 환경에서는 기본값 assert 가 **필연적으로** 깨진다. 코드 결함이 아니라 검증 대상이 아닌 구성이다.

## 변경

```python
# provider 유효성은 오버라이드와 무관하게 항상 검증한다
assert rag_mod.EMBEDDING_PROVIDER in ("huggingface", "openai", "google")

expected_default = {
    "huggingface": "BAAI/bge-m3",  # 다국어, 1024-dim
    "openai": "text-embedding-3-small",
    "google": "models/text-embedding-004",
}[rag_mod.EMBEDDING_PROVIDER]

if (
    rag_mod._RAG_EMBEDDING_MODEL_OVERRIDE
    and rag_mod.DEFAULT_EMBEDDING_MODEL != expected_default
):
    pytest.skip("RAG_EMBEDDING_MODEL 오버라이드가 provider 기본값과 다름 — 기본값 검증 대상 아님")

assert rag_mod.DEFAULT_EMBEDDING_MODEL == expected_default
```

두 가지를 지킨다:

1. **provider 유효성 assert 를 skip 위로** — 오버라이드 설정이 provider 설정 오류까지 함께 가리면 안 된다.
2. **"설정 여부"가 아니라 "기본값과 다른지"로 skip** — `.env.example:180` 은 `RAG_EMBEDDING_MODEL=BAAI/bge-m3` 을 설정하는데 이는 huggingface 기대값과 **같다**. 설정 여부로만 판단하면 문서화된 기본 구성에서 이 테스트가 영구 skip 되어 커버리지를 잃는다.

### private 심볼을 참조하는 이유

`_RAG_EMBEDDING_MODEL_OVERRIDE` 없이 `DEFAULT != expected` 만 보면 다음 두 경우를 구분할 수 없다:

| 상황 | 있어야 할 결과 |
|---|---|
| 오버라이드 있음 + 다른 모델 | **skip** (검증 대상 아님) |
| 오버라이드 없음 + 기본값 드리프트 | **FAIL** (진짜 회귀) |

또한 판단 기준을 `os.getenv` 가 아니라 **모듈이 import 시점에 확정한 값**으로 둔다 — `.env` 가 `os.environ` 에 로드되는 시점이 테스트 실행 순서에 따라 달라지기 때문이다. 실제로 같은 코드가 실행 경로에 따라 PASS 도 SKIP 도 되는 것을 확인했다.

## 검증

| 조건 | 결과 |
|---|---|
| 오버라이드 없음 | `1 passed` |
| `RAG_EMBEDDING_MODEL=BAAI/bge-m3` (.env.example 구성) | `1 passed` — skip 아님 |
| `RAG_EMBEDDING_MODEL=intfloat/multilingual-e5-base` | `1 skipped` |
| `TestTroubleshooting` 전체 | `7 passed` |
| `EMBEDDING_PROVIDER=not-a-provider` | dict `KeyError` 아닌 provider assert 에서 실패 |

- **ruff**: 신규 위반 0건. 기존 8건은 `main` 과 완전히 동일하며 라인 번호만 `477 → 493` 이동. (`tests/` 는 CI 린트 대상이 아님 — CI 는 `src/backend` 를 cwd 로 `ruff check .` 실행)
- **CI 영향 없음**: `.github/` 어디에도 `RAG_EMBEDDING_MODEL` 설정이 없어 CI 에서는 항상 assert 가 실행된다.

## 후속 (이번 범위 밖)

- 오버라이드가 **적용되었는지** 자체(`DEFAULT == override 값`)는 이 테스트가 검증하지 않는다. 현재 `rag_service.py:85-86` 이 보장하지만, 별도 테스트로 두는 편이 낫다.
- 시그니처의 미사용 `monkeypatch` 픽스처는 기존 코드라 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyjsL7z5KSgGLyj2o2zqG2
