### PR TITLE
fix(ci): main push 의 CI 가 다른 커밋의 run 에 취소되지 않도록

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,13 @@ on:
   push:
     branches: [main]
 
+# PR 은 ref 로 묶어 stale run 을 취소한다(새 push 가 오면 이전 run 을 낭비하지 않음).
+# main push 는 커밋 SHA 로 묶어 그룹을 커밋마다 유일하게 만든다 — ref 로 묶으면
+# 한 그룹에 running 1 + pending 1 만 허용되는 규칙 때문에 pending 이 다음 run 에
+# 밀려 취소되고(cancel-in-progress 와 무관), 중간 커밋이 미검증으로 남는다.
+# 2026-08-26 실측: acfb004 의 run 이 tip 7908609 의 CI 를 cancelled 로 만들었다.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## 문제

`ci.yml` 의 concurrency 그룹이 `github.ref` 기준이라 main 의 모든 push 가 한 그룹(`CI-refs/heads/main`)에 묶인다. 한 그룹에는 **running 1 + pending 1** 만 허용되므로 두 경로로 커밋이 미검증으로 남는다.

**경로 1 — in-progress 취소.** 큐가 커밋 역순으로 풀리면 조상 커밋의 늦게 시작한 run 이 먼저 시작한 tip 의 run 을 취소한다.

2026-08-26 실측:

| 시각(UTC) | 사건 |
|---|---|
| 16:49:49 | `7908609`(main tip, 머지 커밋) CI 시작 |
| 16:51:24 | `acfb004`(#315 squash, **조상**) CI 시작 → tip 의 run 을 **cancel** |
| 16:55:55 | `gh run rerun` 수동 복구 |
| 17:11:5x | 재실행 완주, 12/12 success |

즉 **조상만 초록이 되고 main tip 이 미검증으로 남는 역전**이 실제로 발생했다. GitHub UI 에서 main 은 초록으로 보이지만 그건 조상의 결과였다.

**경로 2 — pending 대체.** 다음 run 이 큐에 들어오면 기존 pending 이 취소된다. 이건 `cancel-in-progress` 설정과 **무관한 별개 규칙**이라 `false` 로 둬도 막히지 않는다. (Codex 리뷰 P2 지적으로 발견 — 초기 수정안이 이 경로를 놓쳤다.)

## 수정

그룹을 이벤트별로 가른다.

```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
cancel-in-progress: true
```

- **main push**: 커밋 SHA 로 묶여 그룹이 커밋마다 유일 → 대체·취소 대상이 없다
- **PR**: 기존대로 ref(`refs/pull/N/merge`) 로 묶여 stale run 취소 유지 → 러너 절약 그대로

`cancel-in-progress: true` 는 그대로 두되, 그룹이 유일해진 push 에는 실질적으로 작동하지 않고 PR 에만 적용된다.

`build.yml` 에는 concurrency 가 없어 영향받지 않았으므로 건드리지 않았다.

## 테스트 계획

- `actionlint .github/workflows/ci.yml` → exit 0 (`origin/main` 베이스라인과 동일 — 회귀 아님을 대조 확인)
- YAML 파싱 OK, jobs 9개 유지
- Codex 리뷰 2회 (1차 P2 반영 → 2차 지적 0건)
- **이 PR 자체의 CI 가 `pull_request` 분기의 라이브 검증**이다. push 분기는 머지 후 main 에서 확인된다.

## 주의

표현식이 잘못되면 워크플로우가 에러 없이 **조용히 미실행**된다. 그래서 actionlint 를 베이스라인 대조까지 포함해 게이트로 썼다.