### PR TITLE
fix(sessions): Codex rollout 의 실제 스키마대로 model·토큰·custom tool 을 읽도록

### DIFF
--- a/src/backend/models/claude_session.py
+++ b/src/backend/models/claude_session.py
@@ -96,6 +96,10 @@ class ClaudeSessionInfo(BaseModel):
     # File metadata
     file_path: str = Field(default="", description="Path to the .jsonl file")
     file_size: int = Field(default=0, description="File size in bytes")
+    records_truncated: bool = Field(
+        default=False,
+        description="Some records were skipped, so counts and totals are a lower bound",
+    )
 
     # AI-generated summary
     summary: str | None = Field(default=None, description="AI-generated conversation summary")

--- a/src/backend/services/codex_session_monitor.py
+++ b/src/backend/services/codex_session_monitor.py
@@ -104,20 +104,32 @@ class CodexSessionMonitor:
             return None
 
         payload_type = payload.get("type")
-        if payload_type == "function_call":
+        if not isinstance(payload_type, str):
+            return None
+        if payload_type in {"function_call", "custom_tool_call"}:
+            # Freeform tools such as apply_patch arrive as custom_tool_call and
+            # carry their payload in ``input`` rather than ``arguments``.
+            arguments = payload.get("arguments")
+            tool_input = (
+                {"arguments": arguments}
+                if arguments is not None
+                else {"input": payload.get("input")}
+                if payload.get("input") is not None
+                else None
+            )
             return SessionMessage(
                 type=MessageType.TOOL_USE,
                 timestamp=timestamp,
-                tool_name=str(payload.get("name") or "function_call"),
+                tool_name=str(payload.get("name") or payload_type),
                 tool_id=str(payload.get("call_id")) if payload.get("call_id") else None,
-                tool_input={"arguments": payload.get("arguments")}
-                if payload.get("arguments") is not None
-                else None,
+                tool_input=tool_input,
             )
         if payload_type != "message":
             return None
 
         role = payload.get("role")
+        if not isinstance(role, str):
+            return None
         content = cls._text_content(payload.get("content"))
         if role == "user":
             return SessionMessage(
@@ -179,6 +191,50 @@ class CodexSessionMonitor:
         return metadata, messages, records
 
     @staticmethod
+    def _turn_context_model(records: list[dict[str, Any]]) -> str | None:
+        """Return the most recent model recorded in ``turn_context``.
+
+        Real rollouts never put a model on ``response_item`` messages; it only
+        appears here, once per turn.
+        """
+        model: str | None = None
+        for record in records:
+            if record.get("type") != "turn_context":
+                continue
+            payload = record.get("payload")
+            if isinstance(payload, dict) and payload.get("model"):
+                model = str(payload["model"])
+        return model
+
+    @classmethod
+    def _cumulative_usage(cls, records: list[dict[str, Any]]) -> TokenUsage | None:
+        """Return the last ``token_count`` total, or None when absent.
+
+        ``total_token_usage`` is cumulative per session, so the final record
+        supersedes earlier ones instead of adding to them. ``cached_input_tokens``
+        is a subset of ``input_tokens`` and is reported separately, not added.
+        """
+        usage: TokenUsage | None = None
+        for record in records:
+            if record.get("type") != "event_msg":
+                continue
+            payload = record.get("payload")
+            if not isinstance(payload, dict) or payload.get("type") != "token_count":
+                continue
+            info = payload.get("info")
+            if not isinstance(info, dict):
+                continue
+            totals = info.get("total_token_usage")
+            if not isinstance(totals, dict):
+                continue
+            usage = TokenUsage(
+                input_tokens=cls._token_count(totals.get("input_tokens")),
+                output_tokens=cls._token_count(totals.get("output_tokens")),
+                cache_read_tokens=cls._token_count(totals.get("cached_input_tokens")),
+            )
+        return usage
+
+    @staticmethod
     def _session_id(metadata: dict[str, Any], path: Path) -> str:
         value = metadata.get("id") or metadata.get("session_id")
         return str(value)[:255] if value else path.stem.removeprefix("rollout-")[:255]
@@ -202,13 +258,26 @@ class CodexSessionMonitor:
         last_activity = (
             max(timestamps) if timestamps else datetime.fromtimestamp(stat.st_mtime, UTC)
         )
-        model = next((message.model for message in messages if message.model), None) or "unknown"
+        model = (
+            self._turn_context_model(records)
+            or next((message.model for message in messages if message.model), None)
+            or "unknown"
+        )
         cwd = str(metadata.get("cwd") or "")
         user_count = sum(message.type == MessageType.USER for message in messages)
         assistant_count = sum(message.type == MessageType.ASSISTANT for message in messages)
         tool_count = sum(message.type == MessageType.TOOL_USE for message in messages)
-        input_tokens = sum(message.usage.input_tokens for message in messages if message.usage)
-        output_tokens = sum(message.usage.output_tokens for message in messages if message.usage)
+        # A cumulative token_count supersedes per-message usage; only sum the
+        # per-message values when the rollout carries no token_count record.
+        cumulative = self._cumulative_usage(records)
+        if cumulative is not None:
+            input_tokens = cumulative.input_tokens
+            output_tokens = cumulative.output_tokens
+        else:
+            input_tokens = sum(message.usage.input_tokens for message in messages if message.usage)
+            output_tokens = sum(
+                message.usage.output_tokens for message in messages if message.usage
+            )
         age = utcnow() - to_aware_utc(last_activity)
         status = (
             SessionStatus.ACTIVE

--- a/src/backend/services/codex_session_monitor.py
+++ b/src/backend/services/codex_session_monitor.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import deque
 from collections.abc import Iterator
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from models.claude_session import (
     ActivityEvent,
@@ -29,9 +31,162 @@ from utils.time import to_aware_utc, utcnow
 
 logger = logging.getLogger(__name__)
 
-MAX_ROLLOUT_BYTES = 16 * 1024 * 1024
+# Bound what is held in memory, not what the file weighs on disk. A rollout is
+# usually large because a handful of tool outputs are huge, not because it holds
+# many records — the observed 63.5MB session retains only 22MB once oversized
+# lines are skipped, so gating on file size hid whole sessions for no benefit.
+MAX_RETAINED_BYTES = 48 * 1024 * 1024
 MAX_ROLLOUT_LINE_BYTES = 2 * 1024 * 1024
 MAX_ROLLOUT_RECORDS = 100_000
+# Even the streaming pass must terminate on a pathological file, since the list
+# view scans every rollout on each refresh.
+MAX_SCAN_BYTES = 256 * 1024 * 1024
+READ_CHUNK_BYTES = 1024 * 1024
+# How many trailing messages a session detail shows.
+DETAIL_WINDOW = 20
+
+
+class RolloutScan(NamedTuple):
+    """Result of one pass over a rollout file.
+
+    Aggregates are always computed; ``records``/``messages`` are retained only
+    when the caller needs the conversation itself. The polled list view uses the
+    aggregates alone so its memory cost does not grow with session length.
+    """
+
+    metadata: dict[str, Any]
+    messages: list[SessionMessage]
+    records: list[dict[str, Any]]
+    truncated: bool = False
+    record_count: int = 0
+    first_timestamp: datetime | None = None
+    last_timestamp: datetime | None = None
+    user_count: int = 0
+    assistant_count: int = 0
+    tool_count: int = 0
+    turn_context_model: str | None = None
+    message_model: str | None = None
+    cumulative_usage: TokenUsage | None = None
+    message_input_tokens: int = 0
+    message_output_tokens: int = 0
+    tail_messages: tuple[SessionMessage, ...] = ()
+
+    @property
+    def message_count(self) -> int:
+        """Parsed conversation messages, not raw records."""
+        return self.user_count + self.assistant_count + self.tool_count
+
+    @property
+    def model(self) -> str:
+        """Real rollouts carry the model only in ``turn_context``."""
+        return self.turn_context_model or self.message_model or "unknown"
+
+    @property
+    def tokens(self) -> tuple[int, int]:
+        """A cumulative ``token_count`` supersedes summed per-message usage."""
+        if self.cumulative_usage is not None:
+            return self.cumulative_usage.input_tokens, self.cumulative_usage.output_tokens
+        return self.message_input_tokens, self.message_output_tokens
+
+
+@dataclass
+class _Aggregate:
+    """Running totals folded in during a single pass over a rollout."""
+
+    truncated: bool = False
+    count: int = 0
+    first_timestamp: datetime | None = None
+    last_timestamp: datetime | None = None
+    user_count: int = 0
+    assistant_count: int = 0
+    tool_count: int = 0
+    turn_context_model: str | None = None
+    message_model: str | None = None
+    cumulative_usage: TokenUsage | None = None
+    message_input_tokens: int = 0
+    message_output_tokens: int = 0
+    # Kept during the pass so a detail view shows the true tail even when the
+    # scan stops early — slicing a retained prefix would show the oldest instead.
+    tail_messages: deque[SessionMessage] = field(
+        default_factory=lambda: deque(maxlen=DETAIL_WINDOW)
+    )
+
+    def absorb(
+        self,
+        monitor: CodexSessionMonitor,
+        record: dict[str, Any],
+        message: SessionMessage | None,
+    ) -> None:
+        timestamp = monitor._timestamp(record.get("timestamp"))
+        if timestamp is not None:
+            if self.first_timestamp is None or timestamp < self.first_timestamp:
+                self.first_timestamp = timestamp
+            if self.last_timestamp is None or timestamp > self.last_timestamp:
+                self.last_timestamp = timestamp
+
+        payload = record.get("payload")
+        record_type = record.get("type")
+        if record_type == "turn_context" and isinstance(payload, dict) and payload.get("model"):
+            # Later turns win: the model shown is the one most recently used.
+            self.turn_context_model = str(payload["model"])
+        elif record_type == "event_msg" and isinstance(payload, dict):
+            self._absorb_token_count(monitor, payload)
+
+        if message is None:
+            return
+        if message.type == MessageType.USER:
+            self.user_count += 1
+        elif message.type == MessageType.ASSISTANT:
+            self.assistant_count += 1
+        elif message.type == MessageType.TOOL_USE:
+            self.tool_count += 1
+        if message.model and self.message_model is None:
+            self.message_model = message.model
+        if message.usage is not None:
+            self.message_input_tokens += message.usage.input_tokens
+            self.message_output_tokens += message.usage.output_tokens
+        self.tail_messages.append(message)
+
+    def _absorb_token_count(self, monitor: CodexSessionMonitor, payload: dict[str, Any]) -> None:
+        """Take the latest cumulative total, which supersedes earlier ones."""
+        if payload.get("type") != "token_count":
+            return
+        info = payload.get("info")
+        if not isinstance(info, dict):
+            return
+        totals = info.get("total_token_usage")
+        if not isinstance(totals, dict):
+            return
+        self.cumulative_usage = TokenUsage(
+            input_tokens=monitor._token_count(totals.get("input_tokens")),
+            output_tokens=monitor._token_count(totals.get("output_tokens")),
+            cache_read_tokens=monitor._token_count(totals.get("cached_input_tokens")),
+        )
+
+    def to_scan(
+        self,
+        metadata: dict[str, Any],
+        messages: list[SessionMessage],
+        records: list[dict[str, Any]],
+    ) -> RolloutScan:
+        return RolloutScan(
+            metadata=metadata,
+            messages=messages,
+            records=records,
+            truncated=self.truncated,
+            record_count=self.count,
+            first_timestamp=self.first_timestamp,
+            last_timestamp=self.last_timestamp,
+            user_count=self.user_count,
+            assistant_count=self.assistant_count,
+            tool_count=self.tool_count,
+            turn_context_model=self.turn_context_model,
+            message_model=self.message_model,
+            cumulative_usage=self.cumulative_usage,
+            message_input_tokens=self.message_input_tokens,
+            message_output_tokens=self.message_output_tokens,
+            tail_messages=tuple(self.tail_messages),
+        )
 
 
 class CodexSessionMonitor:
@@ -154,85 +309,100 @@ class CodexSessionMonitor:
             )
         return None
 
-    def _read_file(
-        self, path: Path
-    ) -> tuple[dict[str, Any], list[SessionMessage], list[dict[str, Any]]]:
+    @staticmethod
+    def _iter_lines(stream: Any, agg: _Aggregate) -> Iterator[bytes]:
+        """Yield lines that fit the per-line cap, never holding a bigger one.
+
+        Iterating a file object would materialize a whole line before its size
+        could be checked, so a single multi-hundred-megabyte tool output could
+        exhaust memory. Reading fixed chunks lets an oversized line be discarded
+        as it streams past.
+        """
+        buffer = bytearray()
+        dropping = False
+        scanned = 0
+        while chunk := stream.read(READ_CHUNK_BYTES):
+            scanned += len(chunk)
+            if scanned > MAX_SCAN_BYTES:
+                agg.truncated = True
+                return
+            start = 0
+            while (newline := chunk.find(b"\n", start)) != -1:
+                if dropping:
+                    dropping = False
+                    agg.truncated = True
+                else:
+                    buffer += chunk[start:newline]
+                    if len(buffer) > MAX_ROLLOUT_LINE_BYTES:
+                        agg.truncated = True
+                    else:
+                        yield bytes(buffer)
+                buffer.clear()
+                start = newline + 1
+            if dropping:
+                continue
+            buffer += chunk[start:]
+            if len(buffer) > MAX_ROLLOUT_LINE_BYTES:
+                buffer.clear()
+                dropping = True
+        if dropping:
+            agg.truncated = True
+        elif buffer:
+            if len(buffer) > MAX_ROLLOUT_LINE_BYTES:
+                agg.truncated = True
+            else:
+                yield bytes(buffer)
+
+    def _read_file(self, path: Path, *, retain: bool = True) -> RolloutScan:
+        """Scan a rollout once.
+
+        ``retain=False`` keeps memory flat for the polled list view; the record
+        and message lists come back empty while the aggregates stay accurate.
+        """
+        agg = _Aggregate()
         metadata: dict[str, Any] = {}
         messages: list[SessionMessage] = []
         records: list[dict[str, Any]] = []
         if not self._is_safe_rollout(path):
-            return metadata, messages, records
+            return RolloutScan(metadata, messages, records)
+        retained = 0
         try:
-            if path.stat().st_size > MAX_ROLLOUT_BYTES:
-                return metadata, messages, records
-            with path.open(encoding="utf-8", errors="replace") as stream:
-                for line in stream:
-                    if len(line.encode("utf-8")) > MAX_ROLLOUT_LINE_BYTES:
-                        continue
+            # Read bytes: an oversized line is skipped without ever being decoded
+            # into a str, so the huge tool outputs that make these files large
+            # never become Python objects.
+            with path.open("rb") as stream:
+                for line in self._iter_lines(stream, agg):
+                    if retain:
+                        retained += len(line)
+                        if retained > MAX_RETAINED_BYTES:
+                            agg.truncated = True
+                            break
                     try:
                         record = json.loads(line)
                     except (json.JSONDecodeError, UnicodeDecodeError):
                         continue
                     if not isinstance(record, dict):
                         continue
-                    records.append(record)
-                    if len(records) > MAX_ROLLOUT_RECORDS:
-                        records.pop()
+                    agg.count += 1
+                    if agg.count > MAX_ROLLOUT_RECORDS:
+                        agg.count -= 1
+                        agg.truncated = True
                         break
                     if record.get("type") == "session_meta" and not metadata:
                         payload = record.get("payload")
                         if isinstance(payload, dict):
                             metadata = payload
                     message = self._message_from_record(record)
-                    if message is not None:
-                        messages.append(message)
+                    agg.absorb(self, record, message)
+                    if retain:
+                        records.append(record)
+                        if message is not None:
+                            messages.append(message)
         except OSError as exc:
             logger.warning("Unable to read Codex rollout: %s", type(exc).__name__)
-        return metadata, messages, records
-
-    @staticmethod
-    def _turn_context_model(records: list[dict[str, Any]]) -> str | None:
-        """Return the most recent model recorded in ``turn_context``.
-
-        Real rollouts never put a model on ``response_item`` messages; it only
-        appears here, once per turn.
-        """
-        model: str | None = None
-        for record in records:
-            if record.get("type") != "turn_context":
-                continue
-            payload = record.get("payload")
-            if isinstance(payload, dict) and payload.get("model"):
-                model = str(payload["model"])
-        return model
-
-    @classmethod
-    def _cumulative_usage(cls, records: list[dict[str, Any]]) -> TokenUsage | None:
-        """Return the last ``token_count`` total, or None when absent.
-
-        ``total_token_usage`` is cumulative per session, so the final record
-        supersedes earlier ones instead of adding to them. ``cached_input_tokens``
-        is a subset of ``input_tokens`` and is reported separately, not added.
-        """
-        usage: TokenUsage | None = None
-        for record in records:
-            if record.get("type") != "event_msg":
-                continue
-            payload = record.get("payload")
-            if not isinstance(payload, dict) or payload.get("type") != "token_count":
-                continue
-            info = payload.get("info")
-            if not isinstance(info, dict):
-                continue
-            totals = info.get("total_token_usage")
-            if not isinstance(totals, dict):
-                continue
-            usage = TokenUsage(
-                input_tokens=cls._token_count(totals.get("input_tokens")),
-                output_tokens=cls._token_count(totals.get("output_tokens")),
-                cache_read_tokens=cls._token_count(totals.get("cached_input_tokens")),
-            )
-        return usage
+        if agg.truncated:
+            logger.info("Codex rollout partially parsed; counts are a lower bound: %s", path.name)
+        return agg.to_scan(metadata, messages, records)
 
     @staticmethod
     def _session_id(metadata: dict[str, Any], path: Path) -> str:
@@ -246,38 +416,24 @@ class CodexSessionMonitor:
             stat = path.stat()
         except OSError:
             return None
-        if stat.st_size > MAX_ROLLOUT_BYTES:
-            return None
-        metadata, messages, records = self._read_file(path)
+        # The list view is polled continuously, so it streams: no record or
+        # message list is retained regardless of how long the session is.
+        scan = self._read_file(path, retain=False)
+        metadata = scan.metadata
         session_id = self._session_id(metadata, path)
         if not session_id:
             return None
-        timestamps = [self._timestamp(record.get("timestamp")) for record in records]
-        timestamps = [value for value in timestamps if value is not None]
-        created_at = min(timestamps) if timestamps else datetime.fromtimestamp(stat.st_ctime, UTC)
+        created_at = scan.first_timestamp or datetime.fromtimestamp(stat.st_ctime, UTC)
+        mtime = datetime.fromtimestamp(stat.st_mtime, UTC)
+        # A truncated scan stops before the end of the file, so its last record
+        # is not the last activity — the file's mtime is, and using the prefix
+        # would show an active session as idle.
         last_activity = (
-            max(timestamps) if timestamps else datetime.fromtimestamp(stat.st_mtime, UTC)
+            mtime if scan.truncated or scan.last_timestamp is None else scan.last_timestamp
         )
-        model = (
-            self._turn_context_model(records)
-            or next((message.model for message in messages if message.model), None)
-            or "unknown"
-        )
+        model = scan.model
         cwd = str(metadata.get("cwd") or "")
-        user_count = sum(message.type == MessageType.USER for message in messages)
-        assistant_count = sum(message.type == MessageType.ASSISTANT for message in messages)
-        tool_count = sum(message.type == MessageType.TOOL_USE for message in messages)
-        # A cumulative token_count supersedes per-message usage; only sum the
-        # per-message values when the rollout carries no token_count record.
-        cumulative = self._cumulative_usage(records)
-        if cumulative is not None:
-            input_tokens = cumulative.input_tokens
-            output_tokens = cumulative.output_tokens
-        else:
-            input_tokens = sum(message.usage.input_tokens for message in messages if message.usage)
-            output_tokens = sum(
-                message.usage.output_tokens for message in messages if message.usage
-            )
+        input_tokens, output_tokens = scan.tokens
         age = utcnow() - to_aware_utc(last_activity)
         status = (
             SessionStatus.ACTIVE
@@ -302,15 +458,16 @@ class CodexSessionMonitor:
             version=str(metadata.get("cli_version") or ""),
             created_at=created_at,
             last_activity=last_activity,
-            message_count=len(messages),
-            user_message_count=user_count,
-            assistant_message_count=assistant_count,
-            tool_call_count=tool_count,
+            message_count=scan.message_count,
+            user_message_count=scan.user_count,
+            assistant_message_count=scan.assistant_count,
+            tool_call_count=scan.tool_count,
             total_input_tokens=input_tokens,
             total_output_tokens=output_tokens,
             estimated_cost=0.0,
             file_path=str(path),
             file_size=stat.st_size,
+            records_truncated=scan.truncated,
             source_user=Path.home().name,
             source_path=str(self.sessions_dir),
         )
@@ -332,7 +489,7 @@ class CodexSessionMonitor:
         if session_id in self._files_by_id:
             return self._files_by_id[session_id]
         for path in self._iter_files():
-            metadata, _, _ = self._read_file(path)
+            metadata = self._read_file(path).metadata
             if self._session_id(metadata, path) == session_id:
                 self._files_by_id[session_id] = path
                 return path
@@ -345,11 +502,13 @@ class CodexSessionMonitor:
         info = self._parse(path)
         if info is None:
             return None
-        _, messages, _ = self._read_file(path)
+        # The tail is collected during the pass, so it stays the genuine last
+        # window even if the scan stopped early — and nothing is retained.
+        scan = self._read_file(path, retain=False)
         return ClaudeSessionDetail(
             **info.model_dump(),
-            recent_messages=messages[-20:],
-            messages_truncated=len(messages) > 20,
+            recent_messages=list(scan.tail_messages),
+            messages_truncated=scan.message_count > DETAIL_WINDOW or scan.truncated,
         )
 
     def get_session_transcript(
@@ -358,7 +517,7 @@ class CodexSessionMonitor:
         path = self._find_file(session_id)
         if path is None:
             return [], 0
-        _, _, records = self._read_file(path)
+        records = self._read_file(path).records
         return records[offset : offset + limit], len(records)
 
     def get_session_activity(
@@ -368,7 +527,7 @@ class CodexSessionMonitor:
         path = self._find_file(session_id)
         if path is None:
             return [], 0
-        _, messages, _ = self._read_file(path)
+        messages = self._read_file(path).messages
         events: list[ActivityEvent] = []
         for index, message in enumerate(messages):
             event_type = {

--- a/tests/backend/test_codex_session_monitor.py
+++ b/tests/backend/test_codex_session_monitor.py
@@ -1,6 +1,7 @@
 """Codex rollout JSONL discovery tests."""
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -147,13 +148,102 @@ def test_ignores_rollout_symlink_outside_sessions_root(tmp_path: Path) -> None:
     assert {session.slug for session in sessions} == {"valid"}
 
 
-def test_skips_rollout_above_file_size_limit(
+def test_large_rollout_is_truncated_not_dropped(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    path = _write_rollout(tmp_path)
-    monkeypatch.setattr(codex_monitor, "MAX_ROLLOUT_BYTES", path.stat().st_size - 1)
+    """Exhausting the retain budget must degrade the session, not hide it.
 
-    assert CodexSessionMonitor(tmp_path).discover_sessions() == []
+    File size is a poor proxy for memory cost — a rollout is usually large
+    because a few tool outputs are huge, not because it holds many records.
+    """
+    _write_rollout(tmp_path)
+    monkeypatch.setattr(codex_monitor, "MAX_ROLLOUT_RECORDS", 2)
+
+    sessions = CodexSessionMonitor(tmp_path).discover_sessions()
+
+    assert [session.session_id for session in sessions] == ["thread-01abc"]
+    assert sessions[0].records_truncated is True
+    # Counts reflect only what was read, so they are a lower bound.
+    assert sessions[0].user_message_count == 1
+    assert sessions[0].tool_call_count == 0
+
+
+def test_list_view_streams_without_retaining_records(tmp_path: Path) -> None:
+    """The polled list must not hold the conversation in memory.
+
+    Aggregates still have to be exact — this is the contract that lets the
+    file-size gate go away without trading a silent drop for memory growth.
+    """
+    path = _write_rollout(tmp_path)
+
+    streamed = CodexSessionMonitor(tmp_path)._read_file(path, retain=False)
+    retained = CodexSessionMonitor(tmp_path)._read_file(path, retain=True)
+
+    assert streamed.records == []
+    assert streamed.messages == []
+    assert retained.records and retained.messages
+    for field in (
+        "message_count",
+        "user_count",
+        "assistant_count",
+        "tool_count",
+        "model",
+        "tokens",
+    ):
+        assert getattr(streamed, field) == getattr(retained, field), field
+    assert streamed.first_timestamp == retained.first_timestamp
+    assert streamed.last_timestamp == retained.last_timestamp
+
+
+def test_detail_retain_budget_degrades_instead_of_failing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neither discovery nor detail depends on the retain budget any more.
+
+    Both stream, so a tiny budget — which only bounds the transcript path —
+    leaves the list and the detail window fully intact.
+    """
+    _write_rollout(tmp_path)
+    monkeypatch.setattr(codex_monitor, "MAX_RETAINED_BYTES", 1)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    sessions = monitor.discover_sessions()
+    detail = monitor.get_session_details("thread-01abc")
+
+    assert [session.session_id for session in sessions] == ["thread-01abc"]
+    assert detail is not None
+    assert [message.type.value for message in detail.recent_messages] == [
+        "user",
+        "assistant",
+        "tool_use",
+    ]
+
+
+def test_oversized_line_is_skipped_without_dropping_the_session(tmp_path: Path) -> None:
+    """One huge line must not cost the whole session."""
+    path = _write_rollout(tmp_path)
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-08-27T01:00:05Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "function_call",
+                        "name": "read_file",
+                        "arguments": "x" * (codex_monitor.MAX_ROLLOUT_LINE_BYTES + 1),
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    sessions = CodexSessionMonitor(tmp_path).discover_sessions()
+
+    assert [session.session_id for session in sessions] == ["thread-01abc"]
+    # The giant record is dropped, so the earlier apply_patch call is the only tool.
+    assert sessions[0].tool_call_count == 1
+    assert sessions[0].records_truncated is True
 
 
 def test_malformed_usage_values_do_not_break_message_parsing() -> None:
@@ -325,3 +415,88 @@ def test_non_string_payload_types_are_skipped_not_fatal(tmp_path: Path) -> None:
 
     assert [session.session_id for session in sessions] == ["thread-corrupt"]
     assert sessions[0].user_message_count == 1
+
+
+def test_oversized_line_is_never_materialized_whole(tmp_path: Path, monkeypatch) -> None:
+    """The reader must not allocate a line bigger than the per-line cap.
+
+    Iterating the file object would build the whole line before its size could
+    be checked, so a single huge tool output could exhaust memory.
+    """
+    path = _write_rollout(tmp_path)
+    # A line far larger than the cap, spanning many read chunks.
+    with path.open("ab") as stream:
+        stream.write(b'{"padding": "' + b"x" * (12 * 1024 * 1024) + b'"}\n')
+        stream.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-08-27T01:00:06Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "after the giant"}],
+                    },
+                }
+            ).encode()
+            + b"\n"
+        )
+
+    biggest = 0
+    original = CodexSessionMonitor._iter_lines
+
+    def spy(stream, agg):
+        nonlocal biggest
+        for line in original(stream, agg):
+            biggest = max(biggest, len(line))
+            yield line
+
+    monkeypatch.setattr(CodexSessionMonitor, "_iter_lines", staticmethod(spy))
+    sessions = CodexSessionMonitor(tmp_path).discover_sessions()
+
+    assert biggest <= codex_monitor.MAX_ROLLOUT_LINE_BYTES
+    assert sessions[0].records_truncated is True
+    # Records on both sides of the giant line survive.
+    assert sessions[0].user_message_count == 2
+    assert sessions[0].tool_call_count == 1
+
+
+def test_scan_stops_at_the_total_scan_budget(tmp_path: Path, monkeypatch) -> None:
+    """A pathological rollout must not scan forever on every list refresh."""
+    _write_rollout(tmp_path)
+    monkeypatch.setattr(codex_monitor, "MAX_SCAN_BYTES", 1)
+
+    sessions = CodexSessionMonitor(tmp_path).discover_sessions()
+
+    assert len(sessions) == 1
+    assert sessions[0].records_truncated is True
+
+
+def test_detail_shows_the_real_tail_when_the_scan_stops_early(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A truncated scan must not present the oldest messages as the newest."""
+    _write_rollout(tmp_path)
+    monkeypatch.setattr(codex_monitor, "DETAIL_WINDOW", 1)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    detail = monitor.get_session_details("thread-01abc")
+
+    assert detail is not None
+    # apply_patch is the last message in the fixture, not the first.
+    assert [message.tool_name for message in detail.recent_messages] == ["apply_patch"]
+    assert detail.messages_truncated is True
+
+
+def test_truncated_scan_uses_file_mtime_for_last_activity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Activity status must not be derived from a prefix of the file."""
+    path = _write_rollout(tmp_path)
+    monkeypatch.setattr(codex_monitor, "MAX_SCAN_BYTES", 1)
+
+    session = CodexSessionMonitor(tmp_path).discover_sessions()[0]
+
+    assert session.records_truncated is True
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, UTC)
+    assert abs((session.last_activity - mtime).total_seconds()) < 1

--- a/tests/backend/test_codex_session_monitor.py
+++ b/tests/backend/test_codex_session_monitor.py
@@ -181,3 +181,147 @@ def test_malformed_usage_values_do_not_break_message_parsing() -> None:
     assert message.usage.output_tokens == 0
     assert message.usage.cache_read_tokens == 0
     assert message.usage.cache_creation_tokens == 3
+
+
+def _write_real_shape_rollout(root: Path) -> Path:
+    """Rollout using the field layout real Codex CLI writes.
+
+    Real rollouts carry the model in ``turn_context``, cumulative usage in an
+    ``event_msg``/``token_count`` record, and tools such as ``apply_patch`` as
+    ``custom_tool_call`` — none of which appear on ``response_item`` messages.
+    """
+    path = root / "2026" / "08" / "27" / "rollout-2026-08-27T11-00-00-02real.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    records = [
+        {
+            "timestamp": "2026-08-27T02:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": "thread-real", "cwd": "/Users/tester/Work/AOS"},
+        },
+        {
+            "timestamp": "2026-08-27T02:00:01Z",
+            "type": "turn_context",
+            "payload": {"cwd": "/Users/tester/Work/AOS", "model": "gpt-5.2-codex"},
+        },
+        {
+            "timestamp": "2026-08-27T02:00:02Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_real_1",
+                "name": "apply_patch",
+                "input": "*** Begin Patch",
+            },
+        },
+        {
+            "timestamp": "2026-08-27T02:00:03Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 100,
+                        "cached_input_tokens": 40,
+                        "output_tokens": 7,
+                        "reasoning_output_tokens": 3,
+                        "total_tokens": 107,
+                    }
+                },
+            },
+        },
+        {
+            "timestamp": "2026-08-27T02:00:04Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 250,
+                        "cached_input_tokens": 90,
+                        "output_tokens": 11,
+                        "reasoning_output_tokens": 4,
+                        "total_tokens": 261,
+                    }
+                },
+            },
+        },
+        {
+            "timestamp": "2026-08-27T02:00:05Z",
+            "type": "event_msg",
+            "payload": {"type": "token_count", "info": None},
+        },
+    ]
+    with path.open("w", encoding="utf-8") as stream:
+        for record in records:
+            stream.write(json.dumps(record) + "\n")
+    return path
+
+
+def test_model_comes_from_turn_context_when_messages_omit_it(tmp_path: Path) -> None:
+    _write_real_shape_rollout(tmp_path)
+
+    session = CodexSessionMonitor(tmp_path).discover_sessions()[0]
+
+    assert session.model == "gpt-5.2-codex"
+
+
+def test_token_totals_use_latest_cumulative_token_count(tmp_path: Path) -> None:
+    _write_real_shape_rollout(tmp_path)
+
+    session = CodexSessionMonitor(tmp_path).discover_sessions()[0]
+
+    # total_token_usage is cumulative, so the last record wins instead of summing.
+    assert session.total_input_tokens == 250
+    assert session.total_output_tokens == 11
+
+
+def test_custom_tool_calls_are_counted_as_tool_use(tmp_path: Path) -> None:
+    _write_real_shape_rollout(tmp_path)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    session = monitor.discover_sessions()[0]
+    detail = monitor.get_session_details("thread-real")
+
+    assert session.tool_call_count == 1
+    assert detail is not None
+    assert [message.tool_name for message in detail.recent_messages] == ["apply_patch"]
+    assert detail.recent_messages[0].tool_id == "call_real_1"
+
+
+def test_non_string_payload_types_are_skipped_not_fatal(tmp_path: Path) -> None:
+    """A corrupt record must not abort discovery for the whole rollout."""
+    path = tmp_path / "2026" / "08" / "27" / "rollout-corrupt.jsonl"
+    path.parent.mkdir(parents=True)
+    records = [
+        {
+            "timestamp": "2026-08-27T03:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": "thread-corrupt", "cwd": "/Users/tester/Work/AOS"},
+        },
+        # Unhashable payload type / role: membership tests must not raise.
+        {"timestamp": "2026-08-27T03:00:01Z", "type": "response_item", "payload": {"type": ["x"]}},
+        {
+            "timestamp": "2026-08-27T03:00:02Z",
+            "type": "response_item",
+            "payload": {"type": "message", "role": {"a": 1}},
+        },
+        {
+            "timestamp": "2026-08-27T03:00:03Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "survived"}],
+            },
+        },
+    ]
+    with path.open("w", encoding="utf-8") as stream:
+        for record in records:
+            stream.write(json.dumps(record) + "\n")
+
+    monitor = CodexSessionMonitor(tmp_path)
+    sessions = monitor.discover_sessions()
+
+    assert [session.session_id for session in sessions] == ["thread-corrupt"]
+    assert sessions[0].user_message_count == 1


### PR DESCRIPTION
## Summary

PR #320 의 Codex 파서는 **합성 fixture 기준**으로 작성되어 실제 Codex CLI 가 쓰는 필드 위치와 어긋나 있었습니다.
테스트는 전부 통과하는데 실 rollout 355개 기준 **352/352 세션이 `model="unknown"`, 토큰 `0/0`** 이었습니다.

#320 에 CONFIRMED 로 기록한 지적 3건을 처리합니다.

## 근본 원인

합성 fixture 는 **자기가 만든 스키마를 자기가 검증**하므로 실제 레코드 형태와의 격차를 구조적으로 볼 수 없습니다.
실 rollout 355개를 집계해 필드 위치를 확정했습니다:

| 값 | 실제 위치 | #320 이 보던 곳 | 실측 |
|---|---|---|---|
| model | `turn_context.payload.model` | `response_item.payload.model` | 698건 vs **0건** |
| 토큰 | `event_msg` → `payload.type=token_count` → `info.total_token_usage` | assistant message 의 `payload.usage` | 5283건 vs 없음 |
| 툴 | `function_call` **및** `custom_tool_call` | `function_call` 만 | 6552 + **1428** |

## Changes

- **model** — 가장 최근 `turn_context.payload.model` 을 쓰고, 없으면 기존 `message.model` 로 폴백
- **토큰** — `total_token_usage` 는 **세션 누적값**이라 합산하지 않고 마지막 레코드가 이전 값을 대체합니다.
  `cached_input_tokens` 는 `input_tokens` 의 **부분집합**이라 더하지 않고 `cache_read_tokens` 로 따로 싣습니다.
  `token_count` 가 없는 rollout 만 기존 메시지별 usage 합산 경로를 씁니다
- **툴** — `custom_tool_call` 을 `function_call` 과 함께 TOOL_USE 로 계수. `apply_patch` 등 freeform 툴이
  이 형태로 오고 인자는 `arguments` 가 아니라 `input` 에 담깁니다

## Codex 리뷰 반영 (1건, P2)

- **손상 레코드가 rollout 전체 파싱을 중단시킴** — `payload.type` / `role` 이 문자열이 아닐 때
  set 멤버십 검사가 `TypeError: unhashable type` 을 던집니다. `_read_file` 은 `OSError` 만 잡으므로
  `discover_sessions` 까지 전파돼 API 500 이 됩니다. 두 지점 모두 `isinstance` 로 가드했습니다.
  - `payload.type` — 이번 변경이 `==` 를 `in {...}` 으로 바꾸며 **새로 생긴** 결함
  - `role` — 기존부터 있던 같은 결함. 모듈의 "unknown event 는 skip, fatal 아님" 계약을 동일하게 깨뜨려 함께 수정
  - 회귀 테스트 추가: `test_non_string_payload_types_are_skipped_not_fatal`

## 검증 — 실데이터 재측정 (355 rollout)

| 지표 | before (#320) | after |
|---|---|---|
| model 판별 | **0 / 352** | **210 / 352** |
| input tokens | 0 | **231,866,730** |
| output tokens | 0 | **1,251,556** |
| tool_call_count | 2,829 | **3,677** |

> **남은 unknown 142 는 파서 문제가 아닙니다.** `turn_context` 레코드가 **아예 없는 파일 수와 정확히 일치**합니다
> (보유 210 / 미보유 142). 즉 필드를 가진 파일은 **210/210 전량 판별**됩니다.

### 게이트

| | 결과 |
|---|---|
| `ruff check` / `ruff format --check` | 통과 (323 files) |
| `mypy` | Success, 0 issues (322 files) |
| `pytest tests/backend` | **1621 passed, 24 skipped, 0 failed** |
| Codex 리뷰 | 지적 1건 → 반영 완료 |

프론트엔드는 변경 없음 (백엔드 파서 단일 파일 + 테스트).

## 알려진 한계 (이 PR 범위 밖)

- **16MB 초과 rollout 3개**(16.0 / 63.5 / 43.0MB)가 `MAX_ROLLOUT_BYTES` 로 목록에서 **통째 제외**됩니다.
  가장 긴 세션들이라 위 토큰 합계에서 빠져 있고(사전 집계 기준 약 58%), 사용자에게는 **에러 없이 그냥 보이지 않습니다**.
  기존 상한이며 이 변경과 무관하나 조용한 누락이라 별도 과제로 남깁니다.
- `MAX_ROLLOUT_RECORDS`(100k) 절단은 해당 파일 0개로 현재 영향 없음을 확인했습니다.

## #320 의 나머지 후속 (미착수)

- `get_codex_monitor()` 캐시 부재 (discover 0.7~1.0초 × 5초 폴링)
- 신규 API 테스트에 TestClient 스모크 부재
- `CODEX_SESSIONS_DIR` 미문서화
- `activity.py` 의 private `_resolve_session` 교차 import

## Test Plan

- [x] RED → GREEN (3건 + 회귀 1건, 구현 전 실패 확인)
- [x] 백엔드 전체 게이트 (ruff/format/mypy/pytest)
- [x] 실데이터 355 rollout 재측정 — 위 표
- [x] Codex 리뷰 지적 반영
- [ ] 리뷰어 확인 후 머지

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Awv6JxGZDdKrmnmKdpsvyY