### PR TITLE
docs(planning): 삭제한 브랜치 2건의 복원 지점과 revert 위험을 기록

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -248,6 +248,13 @@ Codex 2 라운드 + 실행 스모크로 지적 4 P1 / 3 P2 중 확인된 것을 
   `git push origin 4219ce7:refs/heads/wip/security-followup-20260827`
   (고유 테스트 `test_missing_and_forbidden_are_indistinguishable` 는 유실이 아니라
    위 403 결정으로 `test_forbidden_and_missing_are_distinct_statuses` 에 의도적으로 대체된 것)
+- **`provider-agnostic-sessions` 종료**: PR #320 이 squash 머지되어 내용은 main 에 전부 있었다.
+  그 상태로 다시 열린 PR #321 은 보탤 것 0 인데 #318 을 되돌리는 diff 였고, 사용자 판단으로 닫혔다.
+  2026-08-27 main 을 되머지(`394ca48`)해 삭제 위험을 없앤 뒤 브랜치를 로컬·원격 모두 삭제했다.
+  삭제 시점 트리는 main 과 바이트 동일이고 `--diff-filter=A`·`--diff-filter=D` 모두 0 건이었다.
+  복원이 필요하면 tip `394ca481d98f29e88b571e8d298b2ee05faa70ab` 로:
+  `git push origin 394ca48:refs/heads/provider-agnostic-sessions`
+  원 작업 커밋 `8930f29` 는 `refs/pull/320/head` 로도 남아 있어 PR #320 에서 계속 열람된다.
 - **CI 에서만 드러난 결함 1 건** (`fe25821`): 새 authz 스위트가 `RateLimitService` 전역 싱글턴의
   카운터를 소진해, 뒤따르는 모든 테스트 모듈이 429 로 실패했다(로컬 44 failed 재현).
   로컬이 통과한 이유는 `src/backend/.env`(루트 `.env` 심링크)의 `RATE_LIMIT_ENABLED=false` 다 —

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -240,7 +240,14 @@ Codex 2 라운드 + 실행 스모크로 지적 4 P1 / 3 P2 중 확인된 것을 
   (인증된 호출자는 존재/부재 구분 가능)는 `test_forbidden_and_missing_are_distinct_statuses`
   에 근거와 함께 고정.
 - **`wip/security-followup-20260827` 종료**: 커밋 A·B 는 #318 에 403 계약으로 적응돼 반영됐고,
-  고유 자산이던 이 STATE.md 기록은 main 으로 옮겼다(이 커밋). 브랜치는 삭제했다.
+  고유 자산이던 이 STATE.md 기록은 main 으로 옮겼다(이 커밋).
+  로컬만 삭제돼 있었고 **원격은 2026-08-27 까지 생존**해 있었다 — 고유 추가 파일 0 인데
+  main 파일 7 개(`tests/backend/test_security_hardening.py` 포함)를 지우는 상태라
+  그대로 PR 을 열면 #321 이 #318 을 되돌리던 실패가 재현된다. 같은 날 원격도 삭제했다.
+  복원이 필요하면 tip `4219ce7551754c62b4986e1a1ccc6c05c95d2ed5` 로:
+  `git push origin 4219ce7:refs/heads/wip/security-followup-20260827`
+  (고유 테스트 `test_missing_and_forbidden_are_indistinguishable` 는 유실이 아니라
+   위 403 결정으로 `test_forbidden_and_missing_are_distinct_statuses` 에 의도적으로 대체된 것)
 - **CI 에서만 드러난 결함 1 건** (`fe25821`): 새 authz 스위트가 `RateLimitService` 전역 싱글턴의
   카운터를 소진해, 뒤따르는 모든 테스트 모듈이 429 로 실패했다(로컬 44 failed 재현).
   로컬이 통과한 이유는 `src/backend/.env`(루트 `.env` 심링크)의 `RATE_LIMIT_ENABLED=false` 다 —


### PR DESCRIPTION
정리한 브랜치 **2 건**의 삭제 사실·복원 지점·판정 근거를 `.planning/STATE.md` 에 남긴다.
기록만 "삭제했다"고 적히고 실제로는 원격에 살아 있는 상태가 다시 생기지 않게 하는 것이 목적이다.

## 1. `wip/security-followup-20260827` — 유령 브랜치였다

STATE.md 는 이미 **"브랜치는 삭제했다"** 고 적고 있었지만 **로컬만** 지워졌고 원격은 살아 있었다.

```
$ git ls-remote --heads origin | grep wip/security
4219ce7551754c62b4986e1a1ccc6c05c95d2ed5  refs/heads/wip/security-followup-20260827
```

보탤 내용은 없는데(`--diff-filter=A` 0 건) main 파일 **7 개를 삭제**하는 상태였다.

```
$ git diff --diff-filter=D --name-only origin/main <wip>
docs/plans/2026-08-27-provider-agnostic-sessions.md
src/backend/api/agent_sessions.py
src/backend/api/project_configs/access.py
src/backend/services/codex_session_monitor.py
tests/backend/api/test_agent_sessions.py
tests/backend/test_codex_session_monitor.py
tests/backend/test_security_hardening.py      ← #318 의 보안 테스트
```

그 브랜치로 PR 을 열면 **#321 이 #318 을 되돌리던 실패가 그대로 재현**된다.

**유실 여부 판정** — 분기점 `7908609` 기준으로 기여한 7 파일을 대조했다. 인가 테스트는 30 대 30 으로
같고 불일치는 1 건뿐이다.

| | 테스트 |
|---|---|
| wip | `test_missing_and_forbidden_are_indistinguishable` (404 열거 방지) |
| main | `test_forbidden_and_missing_are_distinct_statuses` (403 계약) |

이 1 건은 유실이 아니라 **의도적 대체**다 — 근거가 같은 STATE.md 의 "상태 코드 결정: 403 유지" 절에
이미 기록돼 있다. 이름만 대조했다면 "미반영 1 건"으로 읽고 정리를 막았을 지점이다.

## 2. `provider-agnostic-sessions` — 되머지 후 삭제

PR #320 이 squash 머지되어 내용은 main 에 전부 있었다. 그 상태로 다시 열린 PR #321 은 보탤 것 0 인데
#318 을 되돌리는 diff 였고 사용자 판단으로 닫혔다. main 을 되머지(`394ca48`)해 삭제 위험을 없앤 뒤
로컬·원격 모두 삭제했다.

```
$ diff <(git ls-tree -r <branch>) <(git ls-tree -r origin/main)   →  IDENTICAL TREE
$ git diff --diff-filter=A --name-only origin/main <branch>       →  0 건
$ git diff --diff-filter=D --name-only origin/main <branch>       →  0 건
$ gh pr list --state open  (base 가 이 브랜치)                     →  0 건
$ git ls-remote origin refs/pull/320/head                          →  8930f29 (열람 유지)
```

## 변경 내용

`.planning/STATE.md` 에 두 브랜치의 종료 기록을 남긴다 — 삭제 사실, tip SHA 와 복원 명령,
그리고 "고유해 보이는 1 건은 의도적 대체"라는 판정 근거.

## 테스트 계획

문서 전용 변경(`.planning/STATE.md` 15 줄 추가, 1 줄 수정). 코드 변경 없음 — 게이트 해당 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCG3iXvrcDNbZRVSw8B58u