### PR TITLE
fix(api): tz 없는 fromtimestamp 15 곳을 UTC 로 읽도록 (#314)

### DIFF
--- a/src/backend/api/context.py
+++ b/src/backend/api/context.py
@@ -65,7 +65,7 @@ async def get_project_context(
     - Dev docs from dev/active folder
     - Current session info (if active)
     """
-    from datetime import datetime
+    from datetime import UTC, datetime
     from pathlib import Path
 
     if hasattr(current_user, "role") and hasattr(db, "execute"):
@@ -90,7 +90,7 @@ async def get_project_context(
                         name=file_path.name,
                         path=str(file_path),
                         content=content,
-                        modified_at=datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                        modified_at=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
                     )
                 )
             except Exception:

--- a/src/backend/services/agent_manager.py
+++ b/src/backend/services/agent_manager.py
@@ -6,7 +6,7 @@ within .claude/agents/ directories.
 
 import logging
 import shutil
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from models.project_config import AgentConfig
@@ -118,7 +118,7 @@ class AgentManager:
             model=frontmatter.get("model"),
             role=frontmatter.get("role"),
             is_shared=is_shared,
-            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
         )
 
     def get_agent_content(self, project_id: str, agent_id: str) -> tuple[AgentConfig | None, str]:

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 # Pick a git binary that does not depend on Xcode CLT license acceptance.
@@ -281,7 +281,7 @@ class GitService:
                         commit_sha=commit.hexsha,
                         commit_message=commit.message.strip().split("\n")[0][:100],
                         commit_author=commit.author.name,
-                        commit_date=datetime.fromtimestamp(commit.committed_date),
+                        commit_date=datetime.fromtimestamp(commit.committed_date, UTC),
                         ahead=ahead,
                         behind=behind,
                         tracking_branch=tracking,
@@ -317,7 +317,7 @@ class GitService:
                             commit_sha=commit.hexsha,
                             commit_message=commit.message.strip().split("\n")[0][:100],
                             commit_author=commit.author.name,
-                            commit_date=datetime.fromtimestamp(commit.committed_date),
+                            commit_date=datetime.fromtimestamp(commit.committed_date, UTC),
                             ahead=ahead,
                             behind=behind,
                         )
@@ -353,7 +353,7 @@ class GitService:
                 commit_sha=commit.hexsha,
                 commit_message=commit.message.strip().split("\n")[0][:100],
                 commit_author=commit.author.name,
-                commit_date=datetime.fromtimestamp(commit.committed_date),
+                commit_date=datetime.fromtimestamp(commit.committed_date, UTC),
             )
         except GitCommandError as e:
             raise GitServiceError(f"Failed to create branch: {e}")
@@ -1732,10 +1732,10 @@ class GitService:
             message=commit.message.strip(),
             author_name=commit.author.name,
             author_email=commit.author.email,
-            authored_date=datetime.fromtimestamp(commit.authored_date),
+            authored_date=datetime.fromtimestamp(commit.authored_date, UTC),
             committer_name=commit.committer.name,
             committer_email=commit.committer.email,
-            committed_date=datetime.fromtimestamp(commit.committed_date),
+            committed_date=datetime.fromtimestamp(commit.committed_date, UTC),
             parent_shas=[p.hexsha for p in commit.parents],
         )
 

--- a/src/backend/services/memory_manager.py
+++ b/src/backend/services/memory_manager.py
@@ -5,7 +5,7 @@ stored in ~/.claude/projects/{encoded_path}/memory/.
 """
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from models.project_config import MemoryConfig
@@ -98,7 +98,7 @@ class MemoryManager:
             description=description,
             file_path=str(memory_file),
             memory_type=memory_type,
-            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
         )
 
     def get_memory_content(

--- a/src/backend/services/project_config_monitor.py
+++ b/src/backend/services/project_config_monitor.py
@@ -17,7 +17,7 @@ import json
 import logging
 import shutil
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from models.project_config import (
@@ -627,7 +627,7 @@ class ProjectConfigMonitor:
             file_path=str(command_file),
             allowed_tools=frontmatter.get("allowed-tools"),
             argument_hint=frontmatter.get("argument-hint"),
-            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
         )
 
     def get_command_content(
@@ -852,7 +852,7 @@ class ProjectConfigMonitor:
                             model=frontmatter.get("model"),
                             role=frontmatter.get("role"),
                             is_shared=False,
-                            modified_at=datetime.fromtimestamp(stat.st_mtime),
+                            modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
                         )
                     )
                 except Exception as e:
@@ -895,8 +895,8 @@ class ProjectConfigMonitor:
                             has_references=has_references,
                             has_scripts=has_scripts,
                             has_assets=has_assets,
-                            created_at=datetime.fromtimestamp(stat.st_ctime),
-                            modified_at=datetime.fromtimestamp(stat.st_mtime),
+                            created_at=datetime.fromtimestamp(stat.st_ctime, UTC),
+                            modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
                         )
                     )
                 except Exception as e:

--- a/src/backend/services/rules_manager.py
+++ b/src/backend/services/rules_manager.py
@@ -6,7 +6,7 @@ in both project-level (.claude/rules/) and global (~/.claude/rules/) directories
 
 import logging
 import shutil
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from models.project_config import RuleConfig
@@ -104,7 +104,7 @@ class RulesManager:
             description=description,
             file_path=str(rule_file),
             is_global=is_global,
-            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
         )
 
     def get_rule_content(

--- a/src/backend/services/skill_manager.py
+++ b/src/backend/services/skill_manager.py
@@ -6,7 +6,7 @@ within .claude/skills/ directories.
 
 import logging
 import shutil
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from models.project_config import SkillConfig
@@ -116,8 +116,8 @@ class SkillManager:
             has_references=has_references,
             has_scripts=has_scripts,
             has_assets=has_assets,
-            created_at=datetime.fromtimestamp(stat.st_ctime),
-            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            created_at=datetime.fromtimestamp(stat.st_ctime, UTC),
+            modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
         )
 
     def get_skill_content(

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -12,11 +12,13 @@ CI 에서는 오프셋이 0 이라 **영원히 초록**이고, 회귀를 잡지 
 "틀린 이유로 통과" 와 같은 함정).
 """
 
+import ast
 import os
 import tempfile
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -241,6 +243,60 @@ def test_file_mtime_is_read_as_utc():
     assert aware < utcnow() + timedelta(seconds=5)  # 비교가 성립한다
     with pytest.raises(TypeError):
         _ = naive > utcnow()  # tz 를 빠뜨리면 이렇게 죽는다
+
+
+def _naive_fromtimestamp_sites() -> list[str]:
+    """`fromtimestamp(...)` 호출 중 tz 인자가 없는 지점을 AST 로 모은다.
+
+    grep 이 아니라 AST 인 이유는 두 가지다. 인자가 여러 줄로 쪼개진 호출을 한 줄
+    정규식이 놓치고, `fromtimestamp(p.stat().st_mtime, UTC)` 처럼 인자 안에 괄호가
+    있으면 `[^)]*` 류 패턴이 tz 를 못 본다 (실측으로 둘 다 오탐/누락을 냈다).
+    """
+    backend = Path(__file__).resolve().parents[2] / "src" / "backend"
+    sites: list[str] = []
+    for path in sorted(backend.rglob("*.py")):
+        if any(part in {".venv", "__pycache__"} for part in path.parts):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "fromtimestamp"):
+                continue
+            has_tz = len(node.args) >= 2 or any(kw.arg == "tz" for kw in node.keywords)
+            if not has_tz:
+                sites.append(f"{path.relative_to(backend)}:{node.lineno}")
+    return sites
+
+
+def test_no_naive_fromtimestamp_in_backend():
+    """#314 회귀: `datetime.fromtimestamp(x)` 는 **로컬 시각** naive 를 돌려준다.
+
+    그 값이 응답 경계의 `to_utc_iso()` 를 지나면 naive 를 UTC 로 간주해 `+00:00` 이
+    붙는다. 로컬 TZ 가 UTC 가 아닌 서버에서는 표시되는 시각이 오프셋만큼 틀린다
+    (KST 면 9 시간). 비교에 참여하지 않아 TypeError 로 드러나지도 않는 부류라,
+    깨지는 대신 **조용히 틀린 값**을 낸다 — 그래서 불변식으로 고정한다.
+
+    이 스캐너는 검증 대상이 실제로 있을 때만 의미가 있다. 백엔드에 `fromtimestamp`
+    호출이 하나도 남지 않으면 단언은 공허하게 통과하므로 그것도 함께 막는다.
+    """
+    backend = Path(__file__).resolve().parents[2] / "src" / "backend"
+    total = sum(
+        1
+        for path in backend.rglob("*.py")
+        if not any(part in {".venv", "__pycache__"} for part in path.parts)
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "fromtimestamp"
+    )
+    assert total > 0, "스캐너가 아무것도 보지 못했다 — 경로가 틀렸을 가능성이 크다"
+
+    assert _naive_fromtimestamp_sites() == [], (
+        "tz 없는 fromtimestamp 는 로컬 시각을 UTC 로 표기한다. "
+        "`datetime.fromtimestamp(x, UTC)` 로 바꿀 것"
+    )
 
 
 def test_jwt_expiry_decodes_as_aware(monkeypatch):


### PR DESCRIPTION
Closes #314

## 문제 — 표시되는 시각이 서버·브라우저 TZ 차이만큼 틀린다

`datetime.fromtimestamp(x)` 는 **로컬 시각** naive 를 돌려준다. 그 값이 응답 모델의 `datetime` 필드에 실리면 **offset 없는 ISO** 로 직렬화되고, 브라우저의 `new Date(iso)` 는 offset 없는 입력을 **뷰어의 로컬 시각**으로 읽는다.

KST 서버 실측 (`models.project_config.MemoryConfig`):

| | 값 |
|---|---|
| 참값 (epoch → UTC) | `2025-08-24T01:46:40+00:00` |
| **수정 전 응답** | `{"modified_at":"2025-08-24T10:46:40"}` ← offset 없음 |
| **수정 후 응답** | `{"modified_at":"2025-08-24T01:46:40Z"}` |

수정 전 문자열은 "서버 로컬 시각인데 그 사실을 말하지 않는" 값이라, 브라우저 TZ 가 서버와 같을 때만 우연히 맞게 보인다. 다르면 그 차이만큼 어긋난다.

> **이슈 본문의 경로 설명은 정확하지 않았다.** 이슈는 "`to_utc_iso()` 가 naive 를 UTC 로 간주해 `+00:00` 을 붙인다"고 적었으나, `to_utc_iso` 의 실제 사용처는 `models/analytics.py` 3 곳뿐이고 이번 15 곳은 그 경로를 지나지 않는다. 결함과 수정은 그대로 유효하고, **틀리는 메커니즘이 "잘못된 offset 부여" 가 아니라 "offset 부재로 소비자가 로컬로 해석"** 이다.

## 변경 — 15 곳

| 파일 | 곳 | 대상 |
|---|---|---|
| `services/git_service.py` | 5 | `commit.committed_date` / `authored_date` |
| `services/project_config_monitor.py` | 4 | `st_mtime` / `st_ctime` |
| `services/skill_manager.py` | 2 | `st_ctime` / `st_mtime` |
| `services/memory_manager.py` · `rules_manager.py` · `agent_manager.py` | 각 1 | `st_mtime` |
| `api/context.py` | 1 | `st_mtime` (`.isoformat()` 직전) |

전부 `datetime.fromtimestamp(x, UTC)` 로 바꾸고 `from datetime import UTC, datetime` 로 import 를 보정했다. `st_mtime`·`st_ctime`·GitPython 의 커밋 epoch 은 **모두 epoch UTC** 라 tz 를 붙이는 것만으로 값이 바로잡힌다 (변환 아님).

기계적 적용이 아니라 AST 로 각 호출의 닫는 괄호 위치를 잡아 삽입했다 — 여러 줄로 쪼개진 호출도 안전하다.

## 회귀 방지 — AST 불변식 (`test_no_naive_fromtimestamp_in_backend`)

`tests/backend/test_time_timestamptz.py` 에 추가했다. 기존 `test_file_mtime_is_read_as_utc` 는 *현상* 을 보여주지만 **소스에 남은 호출을 세지 않는다** — 그래서 15 곳이 그대로 살아 있었다.

**grep 이 아니라 AST 인 이유는 실측으로 grep 이 틀렸기 때문이다.** 정규식은 인자 안에 괄호가 있으면(`fromtimestamp(p.stat().st_mtime, UTC)`) `[^)]*` 가 첫 `)` 에서 멈춰 tz 를 못 보고 **17 건** 을 냈다. 실제는 **15 건** 이다 (`project_discovery.py:388`, `external_usage_service/collectors.py:120` 이 오탐).

스캐너가 **아무것도 못 볼 때 공허하게 통과하지 않도록** "백엔드에 `fromtimestamp` 호출이 0 건이 아닐 것" 도 함께 단언한다 (경로 오류 시 초록이 되는 함정 차단).

## 검증

| | 결과 |
|---|---|
| RED | 새 테스트가 **15 건 목록과 함께 실패** (`api/context.py:93` 외) |
| GREEN | 수정 후 통과 |
| `ruff check` / `ruff format --check` | 통과 (321 files) |
| `mypy` | Success, 0 issues (322 files) |
| `pytest tests/backend` | **1631 passed, 24 skipped, 0 failed** |

비교 참여 여부도 재확인했다 — 이 값들을 `<`/`>`/뺄셈에 쓰는 지점은 **0 건** 이라 aware 전환이 새 `TypeError` 를 만들지 않는다. 유일한 정렬(`api/context.py:100`)은 `.isoformat()` 문자열 정렬이고 같은 형식끼리라 순서가 보존된다.

프론트엔드는 변경 없음. `modified_at`·`commit_date` 는 `string` 으로 받아 `new Date(...)` 로 렌더하므로, offset 이 붙으면 그대로 올바르게 해석된다.

## 부수 발견 (이 PR 에서 고치지 않음)

`tests/backend/test_time_timestamptz.py` 의 import 블록이 **기존부터** ruff `I001` (`models.feedback` / `models.organization` 순서) 을 낸다. 내 변경 탓인지 같은 경로에 원본을 두고 대조해 확인했다 — 원본도 동일하게 1 건 실패한다. `tests/backend` 는 lint-staged glob 과 CI 의 `working-directory: src/backend` **양쪽 범위 밖** 이라 검사된 적이 없는 것이 구조적 원인이다. Surgical 원칙대로 이 PR 에서는 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkfKZszaHqRHwmnWptJMkK