### PR TITLE
fix(security): agent-sessions alias 라우터의 인증 우회를 차단

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -88,6 +88,8 @@
 | GET | `/api/claude-sessions/{id}/activity/stream` | 활동 스트림 |
 | GET | `/api/claude-sessions/{id}/tasks` | 세션 태스크 목록 |
 
+> **인증**: 위 라우트는 전부 admin/manager 권한을 요구합니다 (`get_current_admin_or_manager_user`).
+
 **쿼리 파라미터** (`GET /api/claude-sessions`):
 - `status`: `active` | `idle` | `completed`
 - `sort_by`: `last_activity` | `created_at` | `message_count` | `estimated_cost` | `project_name`
@@ -101,3 +103,25 @@
 - `{id}` / `{id}/stream`의 `recent_messages`는 **요약 윈도**입니다 — 파일 tail 일부만 파싱하고 최근 N개 메시지만, 각 본문은 길이 캡(기본 2000자)으로 제한됩니다.
 - 절단은 더 이상 무표시가 아닙니다. 각 `SessionMessage`/`ActivityEvent`는 `content_truncated`(bool)와 `full_length`(원본 길이)를 포함하고, `ClaudeSessionDetail`은 `messages_truncated`(bool)로 부분 윈도 여부를 알립니다. 전체 대화는 `{id}/transcript`(절단 없음, 페이지네이션만)로 조회합니다.
 - `{id}/activity`의 `result` 이벤트 `tool_result`는 `json.dumps`로 직렬화 후 캡되어 잘린 결과도 유효한 JSON 접두사를 유지합니다.
+
+---
+
+## Agent Sessions (provider-neutral alias)
+
+`/api/claude-sessions` 의 provider 중립 별칭입니다 (#320). 리소스 이름에 provider 를
+넣지 않은 동일 계약을 노출하며, **원본과 동일하게 admin/manager 권한을 요구합니다**.
+provider 별 mutation 을 지원하지 않을 때는 409 를 반환합니다.
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/agent-sessions` | 세션 목록 조회 |
+| GET | `/api/agent-sessions/{id}` | 세션 상세 정보 |
+| GET | `/api/agent-sessions/{id}/transcript` | Raw 트랜스크립트 |
+| GET | `/api/agent-sessions/{id}/activity` | 정규화된 활동 내역 |
+| GET | `/api/agent-sessions/{id}/stream` | 실시간 SSE 스트리밍 |
+| POST | `/api/agent-sessions/{id}/save` | 세션 DB 저장 |
+| POST | `/api/agent-sessions/{id}/summary` | 세션 요약 생성 |
+| GET | `/api/agent-sessions/{id}/summary` | 세션 요약 조회 |
+| DELETE | `/api/agent-sessions/{id}` | 세션 삭제 |
+
+쿼리 파라미터는 `GET /api/claude-sessions` 와 동일하며, `provider` (`all` | provider 명) 가 추가됩니다.

--- a/src/backend/api/agent_sessions.py
+++ b/src/backend/api/agent_sessions.py
@@ -5,7 +5,7 @@ This router exposes the same normalized contract without encoding a provider in
 its resource name; provider-specific mutations still return a controlled 409.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from api.claude_sessions.activity import get_session_activity
 from api.claude_sessions.core import ProviderFilter, SortField, SortOrder, list_sessions
@@ -18,6 +18,7 @@ from api.claude_sessions.sessions import (
     save_session,
     stream_session,
 )
+from api.deps import get_current_admin_or_manager_user
 from models.claude_session import (
     ActivityResponse,
     ClaudeSessionDetail,
@@ -27,7 +28,15 @@ from models.claude_session import (
     SessionStatus,
 )
 
-router = APIRouter(prefix="/agent-sessions", tags=["agent-sessions"])
+# 라우터 레벨 ``dependencies`` 는 핸들러 *함수* 가 아니라 *라우터* 에 붙는다.
+# 이 alias 는 ``api.claude_sessions`` 의 핸들러를 import 해 자기 라우터에 다시
+# 등록하므로, 원본 하위 라우터 7 종이 선언한 정책은 따라오지 않는다 — 같은
+# 정책을 여기서 다시 선언하지 않으면 인증만 벗겨진 동일 기능이 노출된다.
+router = APIRouter(
+    prefix="/agent-sessions",
+    tags=["agent-sessions"],
+    dependencies=[Depends(get_current_admin_or_manager_user)],
+)
 
 
 @router.get("", response_model=ClaudeSessionResponse)

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -143,6 +143,63 @@ def test_agent_sessions_alias_matches_origin_auth_policy(app):
     assert alias == origin, f"alias auth {alias} diverged from origin {origin}"
 
 
+def _dependency_calls(dependant) -> set:
+    """dependant 트리를 재귀로 훑어 의존성 *함수 객체* 를 모은다.
+
+    라우터 레벨 의존성은 최상위에 오지만 핸들러 레벨 의존성은 중첩될 수 있으므로
+    재귀로 수집한다.
+    """
+    found = set()
+    for sub in dependant.dependencies:
+        if sub.call is not None:
+            found.add(sub.call)
+        found |= _dependency_calls(sub)
+    return found
+
+
+def test_agent_sessions_alias_enforces_admin_or_manager_role():
+    """alias 는 *스킴* 이 아니라 실제 admin/manager 의존성을 걸어야 한다.
+
+    OpenAPI ``security`` 검사만으로는 부족하다 — 의존성을 ``get_current_user`` 로
+    바꿔도 동일한 HTTPBearer 스킴을 광고하므로, 위 두 테스트는 통과하면서 일반
+    user 에게 열린다. 라우터의 의존성 트리에서 함수 객체를 직접 확인해 그 교체를
+    잡는다. OpenAPI 문서가 아니라 라우트를 보므로 ``openapi_extra`` 로 security 를
+    수동 주입하는 경우와 WebSocket 라우트도 함께 커버된다.
+
+    한계: 검사 대상은 이 alias 라우터다. 또 다른 모듈이 같은 핸들러를 제3의
+    prefix 로 재노출하면 여기서는 잡히지 않는다.
+    """
+    from api.agent_sessions import router as alias_router
+    from api.deps import get_current_admin_or_manager_user
+
+    routes = [route for route in alias_router.routes if hasattr(route, "dependant")]
+    assert routes, "alias router exposes no routes"
+
+    for route in routes:
+        methods = ",".join(sorted(getattr(route, "methods", None) or {"WS"}))
+        assert get_current_admin_or_manager_user in _dependency_calls(route.dependant), (
+            f"{methods} {route.path} lacks the admin/manager dependency"
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_sessions_alias_rejects_regular_user(app):
+    """인증됐지만 권한 없는 일반 user 는 alias 로도 세션에 닿지 못한다."""
+    from api.deps import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="regular-user", role="user", is_admin=False, is_active=True
+    )
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get(ALIAS_ROUTE_PREFIX)
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 403
+
+
 @pytest.mark.asyncio
 async def test_permission_update_requires_authentication(client, session_id):
     """Permission mutation must not be callable without a bearer token."""

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -22,6 +22,7 @@ PROTECTED_ROUTE_PREFIXES = (
 SENSITIVE_DISCOVERY_ROUTES = (
     "/api/projects",
     "/api/claude-sessions/projects",
+    "/api/agent-sessions",
     "/api/playground/sessions",
 )
 
@@ -42,6 +43,9 @@ HIGH_RISK_ROUTE_PATHS = (
     "/api/claude-sessions",
     "/api/claude-sessions/processes",
     "/api/claude-sessions/processes/kill",
+    "/api/agent-sessions",
+    "/api/agent-sessions/{session_id}",
+    "/api/agent-sessions/{session_id}/transcript",
     "/api/playground/sessions/{session_id}",
     "/api/playground/sessions/{session_id}/execute",
     "/api/audit",
@@ -91,6 +95,52 @@ def test_expanded_high_risk_routes_advertise_bearer_security(app):
             for method, operation in operations.items()
             if method in {"get", "post", "put", "patch", "delete"}
         ), f"missing auth on {path}"
+
+
+# ``/api/agent-sessions`` 는 ``/api/claude-sessions`` 의 provider-neutral alias 다
+# (#320). 라우터 레벨 ``dependencies`` 는 핸들러 함수가 아니라 라우터에 붙으므로,
+# 원본 핸들러를 import 해 다시 등록하는 alias 는 인증을 스스로 선언하지 않으면
+# 정책만 벗겨진 채 노출된다. 위 경로 목록은 allowlist 라 새 엔드포인트를 구조적으로
+# 놓치므로, alias 전체를 prefix 로 전수 검사한다.
+ALIAS_ROUTE_PREFIX = "/api/agent-sessions"
+
+
+def test_agent_sessions_alias_routes_all_require_auth(app):
+    """alias 라우터의 *모든* operation 이 인증을 요구해야 한다."""
+    paths = app.openapi()["paths"]
+    checked = []
+    for path, operations in paths.items():
+        if not path.startswith(ALIAS_ROUTE_PREFIX):
+            continue
+        for method, operation in operations.items():
+            if method not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            checked.append(f"{method.upper()} {path}")
+            assert operation.get("security"), f"missing auth on {method.upper()} {path}"
+
+    assert checked, f"expected at least one route under {ALIAS_ROUTE_PREFIX}"
+
+
+def test_agent_sessions_alias_matches_origin_auth_policy(app):
+    """alias 는 원본 ``/api/claude-sessions`` 와 동일한 보안 스킴을 광고해야 한다."""
+
+    def _schemes(prefix: str) -> set[str]:
+        found: set[str] = set()
+        for path, operations in app.openapi()["paths"].items():
+            if not path.startswith(prefix):
+                continue
+            for method, operation in operations.items():
+                if method not in {"get", "post", "put", "patch", "delete"}:
+                    continue
+                for requirement in operation.get("security") or []:
+                    found.update(requirement)
+        return found
+
+    origin = _schemes("/api/claude-sessions")
+    alias = _schemes(ALIAS_ROUTE_PREFIX)
+
+    assert origin, "origin routes must advertise a security scheme"
+    assert alias == origin, f"alias auth {alias} diverged from origin {origin}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 문제 — 인증 우회

`/api/agent-sessions` 는 `/api/claude-sessions` 의 provider 중립 alias 로 도입됐습니다 (#320). 원본의 하위 라우터 7 종은 **모두** admin/manager 를 강제합니다:

```python
router = APIRouter(dependencies=[Depends(get_current_admin_or_manager_user)])
```

그런데 alias 는 원본의 핸들러 *함수* 를 import 해 자기 라우터에 다시 등록했습니다:

```python
from api.claude_sessions.sessions import get_session_transcript, delete_session, ...
router = APIRouter(prefix="/agent-sessions", tags=["agent-sessions"])  # 의존성 없음
```

**라우터 레벨 `dependencies` 는 핸들러 함수가 아니라 라우터에 붙습니다.** 함수만 재사용하면 정책은 따라오지 않으므로, alias 경로에는 인증만 벗겨진 동일 기능이 노출됐습니다.

| | 원본 `/api/claude-sessions` | alias `/api/agent-sessions` (수정 전) |
|---|---|---|
| 인증 | admin/manager 필수 | **없음** |

무인증으로 열려 있던 9 개 엔드포인트 — 세션 대화 전문(`/transcript`), 전 사용자 세션 목록(`source_user` 필터 포함), 세션 삭제(`DELETE`), detail·activity·stream·save·summary.

## 수정

alias 라우터가 원본과 동일한 정책을 스스로 선언합니다. 프로덕션 변경은 이 한 곳입니다.

## 왜 기존 회귀 테스트가 못 잡았나

`test_security_hardening.py` 에는 이미 "session routes stay protected" 테스트가 있었지만 **경로 allowlist** 방식이라, alias 가 #320 에서 추가될 때 목록 갱신이 누락되며 구조적으로 통과했습니다. 방어 목록은 새로 생긴 것을 스스로 알지 못합니다.

## 회귀 테스트 5 종

| # | 테스트 | 담당 실패 모드 |
|---|---|---|
| 1 | `SENSITIVE_DISCOVERY_ROUTES` 에 alias 추가 | 무인증 호출 401 |
| 2 | `HIGH_RISK_ROUTE_PATHS` 에 대표 경로 3 건 | 계약 고정 |
| 3 | alias prefix **전수 스캔** | 새 엔드포인트 추가 시 자동 포착 |
| 4 | 원본과 보안 스킴 비교 | 원본 정책 강화 시 alias 뒤처짐 |
| 5 | **의존성 함수 객체 검증** + 일반 user 실호출 403 | 약한 의존성으로의 교체 |

**5 가 없으면 3·4 는 뚫립니다.** 의존성을 `get_current_admin_or_manager_user` → `get_current_user` 로 바꿔도 광고되는 스킴은 똑같이 `HTTPBearer` 라, 스킴만 보는 검사는 통과하면서 일반 user 에게 열립니다 (Codex 리뷰 지적). 5 는 `route.dependant` 트리를 재귀 순회해 **함수 객체 동일성**을 확인하므로 그 교체를 잡고, OpenAPI 가 아니라 라우트를 보므로 `openapi_extra` 수동 주입과 WebSocket 라우트도 함께 커버합니다.

## 검증

| 시나리오 | 결과 |
|---|---|
| 수정 되돌림 | **4 failed** — `assert 200 == 401` (무인증 호출이 실제 데이터 반환) |
| 의존성을 `get_current_user` 로 교체 | **신규 2 건만 failed** — `assert 200 == 403` (스킴 검사 8 건은 통과) |
| 수정 적용 | 10 passed |
| 백엔드 전체 | **1634 passed, 25 skipped** |
| mypy | 0 건 |
| ruff | 신규 위반 0 건 (`I001` 은 main 에도 있는 기존 문제, import 블록 미변경) |

두 번째 행이 스킴 검사의 한계와 5 의 필요성을 동시에 실증합니다.

## Codex 검증

- **인증 동등성 OK** — 원본 25 개 오퍼레이션 대비 alias 9 개 전부 정책 일치. `/projects` 의 추가 `get_current_user` 는 라우터 레벨 가드 위에 얹힌 것이라 더 약한 정책이 아님.
- **동일 패턴의 다른 인스턴스 없음** — 핸들러 함수를 다른 라우터에 재등록하는 곳은 이 파일뿐. `agents/`, `project_configs/`, `git/` 의 `__init__.py` 는 `include_router(...)` 를 쓰므로 의존성을 상속.
- 테스트 강화 후 **재확인 통과** — 이 PR 범위에서 추가로 막아야 할 갭 없음.

## 알려진 영향

대시보드가 유일한 소비자이며 `apiClient` 가 Bearer 를 자동 첨부하므로 admin/manager 계정은 영향 없습니다. alias 도입 전에는 같은 데이터를 admin/manager 전용 원본으로만 볼 수 있었으므로, 이 수정은 **원래 정책으로의 복귀**입니다.

다만 일반 user 계정에서는 일부 화면이 403 을 조용히 삼켜 빈 상태로 보입니다 (`refreshSessions` silent fail, `DashboardPage` 빈 통계, `SessionList` "No sessions found" 등). 권한 안내 대신 빈 데이터가 보이는 UX 문제로, 별도 이슈로 분리합니다.

## 후속 후보 (범위 밖)

- admin / manager positive 런타임 테스트 추가
- 실호출 403 테스트를 alias 전 오퍼레이션으로 parametrize
- 제3 prefix 재노출 감사 (현재 테스트는 이 alias 라우터로 범위를 한정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqJFkMTYncU14BvrgiPFM4