### PR TITLE
fix: 대시보드 Offline 배지와 DB 모드 project-config 503 해제

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -362,8 +362,22 @@ Codex 2 라운드 + 실행 스모크로 지적 4 P1 / 3 P2 중 확인된 것을 
   `project_configs/core.py` 만 쿼리 하나가 이미 접근 필터링된 상태라 두 원인이 합쳐져 있었다.
   판별자는 함수 안에 이미 있었다(admin/미인증 분기 = registry-wide). 추가 쿼리 없이 그 불리언만
   끌어올려 raise 를 게이트했다.
-- **DB 모드 posture 결정은 여전히 미해결이다** (503 유지 vs DB-backed 구현 선행).
-  다만 위 오분류와는 무관한 별개 사안임이 확인됐다.
+- ~~**DB 모드 posture 결정은 여전히 미해결이다**~~ → **2026-08-27 사용자 결정: 차단 해제.**
+  대시보드 Project Configs 가 DB 모드에서 통째로 503 을 내는 것을 사용자가 보고 결정을 내렸다.
+  실측으로 좁혀진 사실 2 가지가 결정을 쉽게 만들었다:
+  - 차단 지점은 "26 곳"이 아니라 `project_configs/access.py` **3 곳**이다. 계열 전체가
+    `require_project_config_access` 의존성 하나를 지나므로 가드 한 곳이 전부를 막고 있었다.
+  - 그 3 곳은 인가 판정(privileged / org-admin / direct ProjectAccess)을 **전부 수행한 뒤**
+    통과 자리에 놓인 플레이스홀더였다. 즉 DB-backed 구현이 없어서 막은 것이 아니라,
+    인가 결과를 쓰지 않고 덮어둔 상태였다. 503 을 걷어내면 그 판정이 그대로 발효된다.
+  자산은 양쪽 모드 모두 파일시스템에 있고 스캔 범위는 기존 monitor 그대로라 새 노출면은 없다.
+  회귀 테스트 5 건 추가(`test_security_hardening.py`) — Red-Green 판별: 503 을 복원하면
+  **통과 케이스 3 건만** 실패하고 403/404 거부 케이스 2 건은 그대로 통과한다(= 차단만 풀렸고
+  거부 로직은 불변).
+- **후속(미결)**: DB 분기는 ProjectAccess 행의 **존재만** 보고 role 을 보지 않는다. filesystem
+  분기는 04574fa 이후 GET=viewer / 그 외=editor 를 요구하므로, ACL 행이 실제로 쌓이면 두 모드의
+  쓰기 권한 기준이 갈린다. `require_project_role` 은 DB 모드에서 `ProjectModel.id`(UUID)로 조회하는데
+  라우트의 `project_id` 는 path 기반 문자열이라 그대로는 못 쓴다 — ID 해석을 통일해야 붙일 수 있다.
 
 
 ### 2026-08-22 세션 — #284 복구 → #289 → #292 낙관적 동시성 (진행 중, 다른 세션으로 이관)

--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -266,9 +266,13 @@ else:
             else:
                 print("📝 Running in memory mode (USE_DATABASE=false)")
 
-        # Filesystem discovery is only used in memory mode. In database mode
-        # the explicit ProjectModel registry is the sole project authority.
-        if PROJECTS_ENABLED and not USE_DATABASE:
+        # Filesystem discovery (projects/ symlinks) populates the in-memory
+        # PROJECTS_REGISTRY, which the Git API router (models.project.get_project)
+        # reads unconditionally — it has no DB-backed project resolver. So this
+        # must run in database mode too, otherwise every /git/projects/* endpoint
+        # 404s. GIT_REPOSITORIES is an in-memory dict, so the sync below is
+        # idempotent per reload (no DB rows, no duplicates).
+        if PROJECTS_ENABLED:
             backend_dir = Path(__file__).parent.parent
             project_root = backend_dir.parent.parent
             init_projects(str(project_root))

--- a/src/backend/api/project_configs/access.py
+++ b/src/backend/api/project_configs/access.py
@@ -26,11 +26,11 @@ async def require_project_config_access(
 
     is_privileged = current_user.role in {"admin", "manager"} or current_user.is_admin
     if project_id is None:
-        if os.getenv("USE_DATABASE", "false").lower() == "true":
-            raise HTTPException(
-                status_code=503,
-                detail="Project configuration discovery is unavailable in database mode",
-            )
+        # Global / machine-wide asset routes (/global, /stream, /external-paths).
+        # Operator-only, and that rule does not depend on the storage mode — the
+        # assets live on the filesystem either way. A database-mode 503 used to
+        # sit ahead of this check and blocked the routes outright, including for
+        # operators who were authorized to reach them.
         if not is_privileged:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -74,10 +74,7 @@ async def require_project_config_access(
         if project is None:
             raise HTTPException(status_code=404, detail="Project not found")
         if is_privileged:
-            raise HTTPException(
-                status_code=503,
-                detail="Project configuration operations are unavailable in database mode",
-            )
+            return current_user
 
         from api.projects import _get_admin_org_ids
 
@@ -90,10 +87,7 @@ async def require_project_config_access(
         )
         has_direct_access = access_result.scalar_one_or_none() is not None
         if project.organization_id in admin_org_ids or has_direct_access:
-            raise HTTPException(
-                status_code=503,
-                detail="Project configuration operations are unavailable in database mode",
-            )
+            return current_user
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Project access denied",

--- a/src/backend/api/sessions.py
+++ b/src/backend/api/sessions.py
@@ -92,17 +92,6 @@ async def _get_llm_access_for_session(
     )
 
 
-# ─────────────────────────────────────────────────────────────
-# Health
-# ─────────────────────────────────────────────────────────────
-
-
-@router.get("/health")
-async def health_check():
-    """Health check endpoint."""
-    return {"status": "healthy", "service": "agent-orchestrator"}
-
-
 async def require_session_access(
     session_id: str,
     engine: OrchestrationEngine = Depends(get_engine),

--- a/src/backend/services/health_service.py
+++ b/src/backend/services/health_service.py
@@ -354,6 +354,27 @@ class HealthService:
                     details=details,
                 )
 
+        elif provider == "codex_cli":
+            # Local Codex CLI provider — no HTTP endpoint to probe. It is the
+            # default provider (config.llm_provider), so the catch-all below
+            # marked the whole system DEGRADED in local dev. Healthy when the
+            # `codex` binary is resolvable on PATH.
+            import shutil
+
+            if shutil.which("codex"):
+                return ComponentHealth(
+                    name="llm",
+                    status=HealthStatus.HEALTHY,
+                    message="Codex CLI available",
+                    details=details,
+                )
+            return ComponentHealth(
+                name="llm",
+                status=HealthStatus.DEGRADED,
+                message="Codex CLI not found on PATH",
+                details=details,
+            )
+
         return ComponentHealth(
             name="llm",
             status=HealthStatus.DEGRADED,

--- a/src/dashboard/src/services/health.ts
+++ b/src/dashboard/src/services/health.ts
@@ -3,13 +3,21 @@
  *
  * Raw `fetch` against the auth-exempt `GET /api/health` endpoint (no
  * Authorization header). The request URL is built with the canonical
- * `getApiUrl()` so it hits the real router in both environments — dev
- * `/api/health` (via Vite proxy) and prod `${VITE_API_URL}/api/health` —
- * rather than the app-level `/health` stub (which omits version/uptime and
- * would force a permanent "offline"). `getApiUrl` is a pure URL builder, so
- * `apiClient`'s retry/backoff is not reintroduced and the "offline" signal
- * stays fast. Owns a 5s AbortController timeout and never throws — every
- * failure resolves to an `offline` state.
+ * `getApiUrl()` so it resolves the same way in both environments — dev
+ * `/api/health` (via Vite proxy) and prod `${VITE_API_URL}/api/health`.
+ *
+ * The badge needs `version` and `uptime_seconds`, which only the health
+ * router's rich handler returns; any `status`-only body here renders a
+ * permanent "offline" pill. That is a live failure mode, not a hypothetical:
+ * a bare `/health` route in `api/sessions.py` was mounted under `/api`
+ * ahead of the health router and shadowed this endpoint (FastAPI resolves
+ * first-match), so the badge sat at Offline while the backend was healthy.
+ * `tests/backend/api/test_api_health.py` now locks the full body shape.
+ *
+ * `getApiUrl` is a pure URL builder, so `apiClient`'s retry/backoff is not
+ * reintroduced and the "offline" signal stays fast. Owns a 5s
+ * AbortController timeout and never throws — every failure resolves to an
+ * `offline` state.
  */
 
 import { getApiUrl } from '@/config/api'

--- a/tests/backend/api/test_api_health.py
+++ b/tests/backend/api/test_api_health.py
@@ -7,11 +7,18 @@ import pytest
 
 @pytest.mark.anyio
 async def test_health_endpoint(client):
-    """GET /api/health should return 200 with status healthy."""
+    """GET /api/health returns 200 with a status the badge can render.
+
+    Asserting `== "healthy"` pinned the *environment*, not the endpoint: the
+    rich handler reports DEGRADED when any dependency is missing, and CI has
+    no `codex` binary so the llm component is degraded there. 200 vs 503 is
+    the contract that matters -- the handler returns 200 for HEALTHY and
+    DEGRADED, 503 only for UNHEALTHY.
+    """
     response = await client.get("/api/health")
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "healthy"
+    assert data["status"] in {"healthy", "degraded"}
 
 
 @pytest.mark.anyio

--- a/tests/backend/api/test_api_health.py
+++ b/tests/backend/api/test_api_health.py
@@ -16,10 +16,19 @@ async def test_health_endpoint(client):
 
 @pytest.mark.anyio
 async def test_health_contains_version(client):
-    """Health response should include version info."""
+    """`/api/health` must serve the rich handler, not a bare status stub.
+
+    The dashboard's HealthBadge rejects any body missing `version` or
+    `uptime_seconds` and falls back to a permanent "offline" pill, so the
+    prefixed mount has to carry the same contract as bare `/health`. A
+    `status`-only stub registered ahead of the health router silently
+    shadowed this route once (sessions.py) — assert the full shape, not
+    `"version" in data or "status" in data`, which is true for both.
+    """
     response = await client.get("/api/health")
     data = response.json()
-    assert "version" in data or "status" in data
+    assert isinstance(data.get("version"), str)
+    assert isinstance(data.get("uptime_seconds"), int | float)
 
 
 @pytest.mark.anyio

--- a/tests/backend/test_e2e_api.py
+++ b/tests/backend/test_e2e_api.py
@@ -22,7 +22,10 @@ class TestHealthEndpoint:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "healthy"
+        # Not `== "healthy"`: the handler reports the real dependency state and
+        # CI has no `codex` binary, so llm is degraded there. 200 already means
+        # HEALTHY or DEGRADED -- UNHEALTHY would have been 503.
+        assert data["status"] in {"healthy", "degraded"}
         assert isinstance(data["version"], str)
         assert isinstance(data["uptime_seconds"], int | float)
 

--- a/tests/backend/test_e2e_api.py
+++ b/tests/backend/test_e2e_api.py
@@ -11,13 +11,20 @@ class TestHealthEndpoint:
     """Health endpoint tests."""
 
     async def test_health_check(self, client: AsyncClient):
-        """Test health check endpoint returns healthy status."""
+        """Health check returns the rich handler's status/version/uptime body.
+
+        This used to assert `service == "agent-orchestrator"`, which pinned
+        `/api/health` to a bare stub in sessions.py that shadowed the health
+        router's prefixed mount. The dashboard badge needs version and uptime,
+        so the stub shape is the wrong contract to lock.
+        """
         response = await client.get("/api/health")
 
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
-        assert data["service"] == "agent-orchestrator"
+        assert isinstance(data["version"], str)
+        assert isinstance(data["uptime_seconds"], int | float)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -1497,3 +1497,145 @@ async def test_project_configs_empty_registry_still_returns_503_for_admin(monkey
             SimpleNamespace(id="admin-1", role="admin", is_admin=True),
         )
     assert exc_info.value.status_code == 503
+
+
+# ─────────────────────────────────────────────────────────────
+# Database-mode project-config authorization
+#
+# PR #318 put a blanket 503 ("unavailable in database mode") on top of these
+# branches, so the authorization below never actually ran and nothing locked
+# it. The 2026-08-27 posture decision removed the block; these tests are the
+# evidence that lifting it did not open the routes to unauthorized users.
+# ─────────────────────────────────────────────────────────────
+
+
+def _db_project(project_id: str = "proj-uuid", organization_id: str = "org-1"):
+    """Stand-in for the ProjectModel columns the guard reads."""
+    return SimpleNamespace(id=project_id, path="/tmp/proj", organization_id=organization_id)
+
+
+class _ProjectConfigDbStub:
+    """Serves the guard's two queries in order: active projects, then the grant.
+
+    The guard runs `select(ProjectModel)` first and `select(ProjectAccessModel)`
+    only for non-privileged users, so call order is the discriminator.
+    """
+
+    def __init__(self, projects, direct_grant=None):
+        self._projects = projects
+        self._direct_grant = direct_grant
+        self.calls = 0
+
+    async def execute(self, *_args, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: self._projects))
+        return SimpleNamespace(scalar_one_or_none=lambda: self._direct_grant)
+
+
+@pytest.mark.asyncio
+async def test_db_project_config_allows_privileged_operator(monkeypatch):
+    """An operator reaches a registered project's .claude assets in DB mode."""
+    from api.project_configs import access as access_module
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    admin = SimpleNamespace(id="admin-1", role="admin", is_admin=True, is_active=True)
+
+    result = await access_module.require_project_config_access(
+        _request_stub("GET", "proj-uuid", "/api/project-configs/proj-uuid/skills"),
+        admin,
+        db=_ProjectConfigDbStub([_db_project()]),
+    )
+
+    assert result is admin
+
+
+@pytest.mark.asyncio
+async def test_db_project_config_allows_explicit_grant(monkeypatch):
+    """A non-privileged user with a ProjectAccess row is authorized."""
+    from api.project_configs import access as access_module
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+
+    async def no_admin_orgs(_user):
+        return []
+
+    monkeypatch.setattr("api.projects._get_admin_org_ids", no_admin_orgs)
+    member = SimpleNamespace(id="member-1", role="user", is_admin=False, is_active=True)
+
+    result = await access_module.require_project_config_access(
+        _request_stub("GET", "proj-uuid", "/api/project-configs/proj-uuid/skills"),
+        member,
+        db=_ProjectConfigDbStub([_db_project()], direct_grant="proj-uuid"),
+    )
+
+    assert result is member
+
+
+@pytest.mark.asyncio
+async def test_db_project_config_denies_user_without_grant(monkeypatch):
+    """No org-admin scope and no ProjectAccess row still means 403, not access."""
+    from api.project_configs import access as access_module
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+
+    async def no_admin_orgs(_user):
+        return []
+
+    monkeypatch.setattr("api.projects._get_admin_org_ids", no_admin_orgs)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access_module.require_project_config_access(
+            _request_stub("GET", "proj-uuid", "/api/project-configs/proj-uuid/skills"),
+            SimpleNamespace(id="outsider", role="user", is_admin=False, is_active=True),
+            db=_ProjectConfigDbStub([_db_project()], direct_grant=None),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_db_project_config_unregistered_project_is_404(monkeypatch):
+    """An ID that matches no active DB project is still not found."""
+    from api.project_configs import access as access_module
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access_module.require_project_config_access(
+            _request_stub("GET", "other-uuid", "/api/project-configs/other-uuid/skills"),
+            SimpleNamespace(id="admin-1", role="admin", is_admin=True, is_active=True),
+            db=_ProjectConfigDbStub([_db_project()]),
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_db_global_config_route_requires_privileged_role(monkeypatch):
+    """Global asset routes stay operator-only in DB mode -- same as memory mode.
+
+    These have no project_id, so they used to hit the discovery 503 before any
+    role check. Removing it must not turn them into open routes.
+    """
+    from api.project_configs import access as access_module
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access_module.require_project_config_access(
+            _request_stub("GET", None, "/api/project-configs/global"),
+            SimpleNamespace(id="member-1", role="user", is_admin=False, is_active=True),
+            db=object(),
+        )
+
+    assert exc_info.value.status_code == 403
+
+    operator = SimpleNamespace(id="manager-1", role="manager", is_admin=False, is_active=True)
+    result = await access_module.require_project_config_access(
+        _request_stub("GET", None, "/api/project-configs/global"),
+        operator,
+        db=object(),
+    )
+
+    assert result is operator


### PR DESCRIPTION
대시보드에서 관측된 두 증상을 고친다. 처음엔 "DB 연결 장애"로 보였으나 실측 결과
**DB 는 정상**이었고(`/health/detailed`: database healthy 13ms "Primary node"),
원인이 서로 다른 두 결함이었다.

---

## 1. `f955e7e` — 배지가 Offline 에 고정되던 것 (라우트 선점)

```
api/sessions.py:100  @router.get("/health") → {"status","service"}   ← 중복 스텁
      ↓ routes.py:67  router.include_router(sessions_router)
      ↓ app.py:581    include_router(router, prefix="/api")     ← 먼저 등록
 /api/health 가 스텁에 바인딩
      ✗ app.py:628    include_router(health_router, prefix="/api")  ← 나중이라 무시
```

FastAPI 는 first-match 라 health_router 의 `/api` 마운트가 가려졌다. 대시보드
HealthBadge 는 `version`·`uptime_seconds` 가 없으면 offline 으로 떨어뜨리므로
(`services/health.ts` 의 `isHealthResponse`) 백엔드가 건강한데도 배지만 영구 회색이었다.
bare `/health` 는 rich 핸들러라 정상이었고 `/api/health` 만 스텁이었다.

스텁 라우트를 제거해 `docs/deployment.md:457` 이 이미 서술하던 상태로 런타임을 맞췄다.

**회귀 잠금 2 건이 이 결함을 오히려 고정하고 있었다** — 둘 다 초록인 채로 화면이 깨져 있었다:
- `test_e2e_api.py` 가 `service == "agent-orchestrator"` 를 단언해 **스텁 형태를 계약으로 못박고** 있었다.
- `test_api_health.py` 의 `assert "version" in data or "status" in data` 는 `or` 때문에 두 형태 모두 참이라 아무것도 검증하지 않았다.

둘 다 `version`(str)·`uptime_seconds`(number) 를 단언하도록 정렬했다.

> `docs/harness-reliability-2026-07.md:29` 에 같은 실패 모드가 반대 방향으로 기록돼 있다 —
> 그때는 프런트가 스텁에 닿았고, 이번엔 스텁이 프런트 쪽으로 옮겨왔다.

## 2. `754edc0` — DB 모드 project-config 503 해제 (posture 결정)

PR #318(`04574fa`) 이 DB 모드의 project-config 계열을 통째로 막았고,
`.planning/STATE.md` 는 이를 "503 유지 vs DB-backed 구현 선행"의 **미결 결정**으로
두 번 기록했다. 대시보드가 프로젝트를 고를 때마다 503 을 내는 것을 확인하고
**차단 해제**로 결정했다(2026-08-27).

결정을 쉽게 만든 실측 2 가지:

- 차단 지점은 "26 곳"이 아니라 `access.py` **3 곳**이다. 계열의 모든 라우트가
  `require_project_config_access` 의존성 하나를 지나므로 가드 한 곳이 전부를 막고 있었다.
- 그 3 곳은 인가 판정(privileged / org-admin / direct `ProjectAccess`)을 **전부 수행한 뒤**
  통과 자리에 놓인 플레이스홀더였다. DB-backed 구현이 없어서 막은 것이 아니라 판정 결과를
  쓰지 않고 덮어둔 상태였다.

`require_project_role` 을 DB 분기에 붙이지 않았다 — 그 함수는 DB 모드에서
`ProjectModel.id`(UUID)로 조회하는데 라우트 `project_id` 는 path 기반 문자열
(`-Users-...-Agent-System`)이라 그대로 넘기면 404 다. DB 분기가 `route_ids()` 매칭을
따로 구현한 이유가 이것이다. 두 모드의 쓰기 권한 기준 차이는 STATE.md 에 후속 미결로 남겼다.

**Red-Green 판별** — 회귀 5 건 추가(이 계약을 잠근 테스트가 하나도 없었다, 66 → 71):
503 을 복원하면 **통과 케이스 3 건만** 실패하고 403/404 거부 케이스 2 건은 그대로 통과한다.
차단만 풀렸고 거부 로직은 불변이라는 증거다.

## 3~4. `7ed7c46` · `22ca9dd` — 다른 세션이 커밋한 2 건

같은 워킹트리에서 병행 중이던 세션(`session_0128eUu1F8n1eQhuoVBArqQk`)이 커밋했다.
내용은 이 브랜치의 게이트로 함께 검증됐다.

---

## ⚠️ 리뷰 포인트 — `7ed7c46` 의 인가 원칙 역전

`app.py` 에서 `if PROJECTS_ENABLED and not USE_DATABASE:` → `if PROJECTS_ENABLED:` 로 바꿨다.
원래 주석은 **"DB 모드에서는 ProjectModel 레지스트리가 유일한 프로젝트 권위"** 였고
이 변경은 그 원칙을 뒤집는다.

- **기능 근거는 사실이다**: `models/project.py:295-297` 의 `get_project()` 는 in-memory
  `PROJECTS_REGISTRY` 만 조회하고 DB resolver 가 없다. 스캔을 끄면 `/git/projects/*` 가 전부 404 다.
- **우려**: DB 모드에서 레지스트리가 파일시스템 심링크로 채워지면 git API 가 **DB 미등록
  프로젝트에 닿을 수 있다.** PR #318 이 세운 방향과 역방향이다.
- git 라우트의 자체 인가가 이를 막는지는 **확인하지 못했다** — 단정하지 않는다. 이 PR 의
  주 리뷰 대상으로 본다.

## 머지 방식

4 개가 독립 논리 커밋이라 **통째 squash 하면 분리가 무의미해진다.**
이 리포엔 squash(`acfb004`)와 merge commit(`7908609`) 실사용 이력이 둘 다 있으니 선택 사항이다.

## 검증

최신 main(`5725ca3`) 위로 리베이스한 뒤 두 트랙 전체를 다시 돌렸다
(pull 로 들어온 `3d6bcc7` 이 이 PR 이 건드리는 `sessions.py` 와 같은 파일이라 재검증이 필요했다).

| 트랙 | 결과 |
|---|---|
| BE | ruff 0, ruff format 0, mypy 310 files 0, pytest **1640 passed** / 31 skipped |
| FE | tsc 0, eslint 0, vitest 207 files **4407 passed**, build OK |
| 실서버 | `curl /api/health` version·uptime 반환 확인, 브라우저 배지 **Healthy v0.1.0** 전환 확인 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPej1m4qTw8Byrp2SyHeno
