### PR TITLE
chore(sessions): provider 중립 세션의 배선 테스트·공용 resolver·문서를 채움

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ LLM_USAGE_PREFLIGHT_QUOTA_ENABLED=false
 # CODEX_CLI_ARGS=exec --sandbox read-only --color never
 # CODEX_CLI_TIMEOUT_SECONDS=300
 
+# 외부 에이전트 세션 모니터링 (읽기 전용)
+# Codex rollout JSONL 을 찾을 위치. 미설정이면 ~/.codex/sessions 를 쓴다.
+# 기본 경로가 아닌 환경에서 설정을 빠뜨리면 세션 목록이 조용히 0건이 된다.
+# CODEX_SESSIONS_DIR=/Users/me/.codex/sessions
+
 # Claude CLI (Claude subscription-backed runtime, opt-in via profile/entitlement)
 # Run `claude` once and sign in before starting the backend.
 # CLAUDE_CLI_COMMAND=claude

--- a/docs/api/monitoring.md
+++ b/docs/api/monitoring.md
@@ -77,6 +77,32 @@
 | POST | `/api/claude-sessions/external-paths` | 외부 경로 추가 (body: `{path}`) |
 | DELETE | `/api/claude-sessions/external-paths/{path_encoded}` | 외부 경로 삭제 (URL-encoded path) |
 
+### 외부 에이전트 세션 (Claude · Codex)
+
+세션 모니터링은 provider 인지형이다. 같은 정규화 형태(`ClaudeSessionInfo`, `provider` 필드로 구분)를
+Claude JSONL(`~/.claude/projects/`)과 Codex rollout JSONL(`~/.codex/sessions/`, `CODEX_SESSIONS_DIR` 로 재지정)
+양쪽에서 만든다. Codex 는 **읽기 전용**이다.
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/agent-sessions` | provider 중립 목록. `provider=all` 기본 |
+| GET | `/api/agent-sessions/{session_id}` | 상세 (양 provider 해석) |
+| GET | `/api/agent-sessions/{session_id}/transcript` | 원본 전사 (offset/limit) |
+| GET | `/api/agent-sessions/{session_id}/activity` | 정규화 활동 이벤트 |
+| GET | `/api/claude-sessions` | 레거시 별칭. `provider=claude` 기본으로 기존 계약 유지 |
+
+- `provider` 쿼리는 `all` · `claude` · `codex` 만 허용하며 그 외는 **422**.
+- Codex 가 안전하게 지원하지 못하는 mutation(스트리밍·요약 생성·삭제)은 **409** 로 명시 거부한다.
+  Claude 전용 OS 프로세스 정리 API 는 Codex 를 관리한다고 주장하지 않는다.
+- 두 라우터 모두 `get_current_admin_or_manager_user` 로 보호된다. `/agent-sessions` 는 핸들러를
+  import 해 자기 라우터에 재등록하는 alias 라 **라우터 레벨 의존성이 따라오지 않으므로**
+  같은 정책을 직접 선언한다.
+
+**Codex 파싱 주의** — 실제 rollout 은 합성 fixture 와 필드 위치가 다르다:
+model 은 `turn_context.payload.model`, 토큰은 `event_msg` 의 `payload.type=token_count` →
+`info.total_token_usage`(세션 **누적값**이라 합산 금지), 툴은 `function_call` 과 `custom_tool_call` 둘 다.
+일부 레코드를 건너뛴 세션은 `records_truncated=true` 로 표시되며 집계는 하한이다.
+
 **멀티 프로젝트 비교** (`GET /api/analytics/trends/compare`):
 - `project_ids`: 비교할 프로젝트 ID 목록 (최대 5개, 필수)
 - `metric`: `tasks` | `tokens` | `cost` | `success_rate` (기본: `tasks`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,6 +253,7 @@ src/backend/
 │   ├── auth_service.py            # OAuth/JWT/Email 인증
 │   ├── claude_config_service.py   # Claude OAuth 토큰 관리 (Keychain/env/파일)
 │   ├── claude_session_monitor.py  # Claude 세션 파일 스캔/파싱
+│   ├── codex_session_monitor.py   # Codex rollout JSONL 스캔/파싱 (읽기 전용)
 │   ├── code_entity_extractor.py   # RAG 메타데이터용 코드 엔티티 추출 (AST/Regex)
 │   ├── cost_allocation_service.py # 비용 추적/할당 서비스
 │   ├── credential_service.py      # 자격증명 암호화/저장
@@ -298,6 +299,7 @@ src/backend/
 │   ├── sandbox_manager.py         # Docker 격리 실행
 │   ├── scheduler_service.py       # APScheduler 기반 Cron 스케줄링
 │   ├── secret_service.py          # Fernet 암호화 시크릿 관리
+│   ├── session_file_cache.py      # 세션 파일 파싱 결과 캐시 (mtime+size 무효화, Claude·Codex 공용)
 │   ├── session_service.py         # 세션 생명주기 관리
 │   ├── skill_manager.py           # SKILL.md 파일 CRUD 관리
 │   ├── task_analysis_service.py   # 태스크 복잡도 분석

--- a/src/backend/api/claude_sessions/activity.py
+++ b/src/backend/api/claude_sessions/activity.py
@@ -20,7 +20,7 @@ from models.claude_session import (
     TasksResponse,
 )
 
-from .sessions import _resolve_session
+from .resolver import resolve_session
 
 router = APIRouter(dependencies=[Depends(get_current_admin_or_manager_user)])
 
@@ -44,7 +44,7 @@ async def get_session_activity(
     Returns:
         List of activity events with pagination info
     """
-    monitor, details = _resolve_session(session_id)
+    monitor, details = resolve_session(session_id)
     events, total_count = monitor.get_session_activity(
         session_id,
         offset=offset,
@@ -81,7 +81,7 @@ async def stream_session_activity(session_id: str):
     """
     import json
 
-    monitor, details = _resolve_session(session_id)
+    monitor, details = resolve_session(session_id)
 
     # Verify session exists
     if details is None:
@@ -153,7 +153,7 @@ async def get_session_tasks(session_id: str) -> TasksResponse:
     Returns:
         Tasks dictionary and root task IDs
     """
-    monitor, details = _resolve_session(session_id)
+    monitor, details = resolve_session(session_id)
     if details is not None and details.provider != "claude":
         return TasksResponse(
             session_id=session_id,

--- a/src/backend/api/claude_sessions/resolver.py
+++ b/src/backend/api/claude_sessions/resolver.py
@@ -1,0 +1,27 @@
+"""Provider-neutral session lookup shared by the session routes.
+
+Lives in its own module because both ``sessions`` and ``activity`` need it:
+importing a private name across sibling route modules made the dependency
+invisible to readers and easy to break during refactors.
+"""
+
+from models.claude_session import ClaudeSessionDetail
+from services.claude_session_monitor import ClaudeSessionMonitor, get_monitor
+from services.codex_session_monitor import CodexSessionMonitor, get_codex_monitor
+
+
+def resolve_session(
+    session_id: str,
+) -> tuple[ClaudeSessionMonitor | CodexSessionMonitor, ClaudeSessionDetail | None]:
+    """Resolve a session against the supported provider adapters.
+
+    Claude is tried first because its ids are the legacy contract; a Codex
+    rollout only answers when no Claude session owns the id.
+    """
+    claude_monitor = get_monitor()
+    details = claude_monitor.get_session_details(session_id)
+    if details is not None:
+        return claude_monitor, details
+
+    codex_monitor = get_codex_monitor()
+    return codex_monitor, codex_monitor.get_session_details(session_id)

--- a/src/backend/api/claude_sessions/sessions.py
+++ b/src/backend/api/claude_sessions/sessions.py
@@ -28,26 +28,15 @@ from models.claude_session import (
     ClaudeSessionSaveResponse,
     SessionStatus,
 )
-from services.claude_session_monitor import ClaudeSessionMonitor, get_monitor
-from services.codex_session_monitor import CodexSessionMonitor, get_codex_monitor
+from services.claude_session_monitor import get_monitor
+from services.codex_session_monitor import get_codex_monitor
 from utils.time import utcnow
+
+from .resolver import resolve_session
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(get_current_admin_or_manager_user)])
-
-
-def _resolve_session(
-    session_id: str,
-) -> tuple[ClaudeSessionMonitor | CodexSessionMonitor, ClaudeSessionDetail | None]:
-    """Resolve a session against the supported provider adapters."""
-    claude_monitor = get_monitor()
-    details = claude_monitor.get_session_details(session_id)
-    if details is not None:
-        return claude_monitor, details
-
-    codex_monitor = get_codex_monitor()
-    return codex_monitor, codex_monitor.get_session_details(session_id)
 
 
 @dataclass
@@ -105,7 +94,7 @@ _line_count_cache = TranscriptLineCountCache()
 @router.get("/{session_id}", response_model=ClaudeSessionDetail)
 async def get_session(session_id: str) -> ClaudeSessionDetail:
     """Get detailed information for a session from any supported provider."""
-    monitor, details = _resolve_session(session_id)
+    monitor, details = resolve_session(session_id)
 
     if details is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
@@ -129,7 +118,7 @@ async def stream_session(session_id: str):
     Returns:
         Server-Sent Events stream with session updates
     """
-    monitor, initial = _resolve_session(session_id)
+    monitor, initial = resolve_session(session_id)
 
     # Verify session exists
     if initial is None:
@@ -204,7 +193,7 @@ async def save_session(
     Returns:
         Save confirmation with timestamp
     """
-    monitor, details = _resolve_session(session_id)
+    monitor, details = resolve_session(session_id)
 
     if details is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
@@ -416,7 +405,7 @@ async def generate_session_summary(session_id: str) -> dict:
     Returns:
         Generated or cached summary
     """
-    monitor, details = _resolve_session(session_id)
+    monitor, details = resolve_session(session_id)
 
     # Verify session exists
     if details is None:
@@ -443,7 +432,7 @@ async def get_session_summary(session_id: str) -> dict:
     Returns:
         Cached summary or null
     """
-    monitor, details = _resolve_session(session_id)
+    monitor, details = resolve_session(session_id)
     if details is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
     if details.provider != "claude":

--- a/tests/backend/api/test_agent_sessions.py
+++ b/tests/backend/api/test_agent_sessions.py
@@ -80,7 +80,7 @@ async def test_legacy_list_default_is_claude_only(monkeypatch: pytest.MonkeyPatc
 
 @pytest.mark.asyncio
 async def test_unknown_summary_returns_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(session_routes, "_resolve_session", lambda _: (object(), None))
+    monkeypatch.setattr(session_routes, "resolve_session", lambda _: (object(), None))
 
     with pytest.raises(HTTPException) as error:
         await session_routes.get_session_summary("missing")
@@ -99,7 +99,7 @@ async def test_codex_session_mutations_are_rejected(
         def get_cached_summary(self, session_id: str) -> str | None:
             return None
 
-    monkeypatch.setattr(session_routes, "_resolve_session", lambda _: (_Monitor(), detail))
+    monkeypatch.setattr(session_routes, "resolve_session", lambda _: (_Monitor(), detail))
 
     with pytest.raises(HTTPException) as stream_error:
         await session_routes.stream_session("codex-1")

--- a/tests/backend/api/test_agent_sessions_wiring.py
+++ b/tests/backend/api/test_agent_sessions_wiring.py
@@ -1,0 +1,119 @@
+"""HTTP-level wiring for the provider-neutral session routes.
+
+The unit tests in ``test_agent_sessions`` call the handlers directly, which
+verifies the logic but skips everything FastAPI does around it: whether the
+router is actually mounted, whether ``provider`` survives query extraction and
+its ``Literal`` validation, and whether the routes are behind the same
+authorization as the legacy ones. A typo in the prefix or a parameter FastAPI
+cannot parse passes those unit tests and breaks only at runtime.
+"""
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app import app
+from api.claude_sessions import core
+from api.deps import get_current_user
+from models.claude_session import ClaudeSessionInfo
+
+
+def _session(provider: str, session_id: str) -> ClaudeSessionInfo:
+    now = datetime.now(UTC)
+    return ClaudeSessionInfo(
+        provider=provider,
+        session_id=session_id,
+        slug=session_id,
+        model="gpt-5.5" if provider == "codex" else "claude-sonnet-4-6",
+        project_path="/tmp/AOS",
+        project_name="AOS",
+        cwd="/tmp/AOS",
+        created_at=now,
+        last_activity=now,
+    )
+
+
+class _FakeMonitor:
+    def __init__(self, sessions: list[ClaudeSessionInfo]) -> None:
+        self.sessions = sessions
+
+    def discover_sessions(self, source_user: str | None = None) -> list[ClaudeSessionInfo]:
+        return self.sessions
+
+    def get_cached_summary(self, session_id: str) -> str | None:
+        return None
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """A client whose session data is fake but whose routing is real."""
+    monkeypatch.setattr(core, "get_monitor", lambda: _FakeMonitor([_session("claude", "c-1")]))
+    monkeypatch.setattr(core, "get_codex_monitor", lambda: _FakeMonitor([_session("codex", "x-1")]))
+
+    async def noop_sync(sessions: list[ClaudeSessionInfo]) -> None:
+        return None
+
+    monkeypatch.setattr(core, "_sync_sessions_to_db", noop_sync)
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="test-user", role="admin", is_admin=True
+    )
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_neutral_route_is_mounted_and_defaults_to_all_providers(client: TestClient) -> None:
+    response = client.get("/api/agent-sessions")
+
+    assert response.status_code == 200
+    assert {s["session_id"] for s in response.json()["sessions"]} == {"c-1", "x-1"}
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [("all", {"c-1", "x-1"}), ("claude", {"c-1"}), ("codex", {"x-1"})],
+)
+def test_provider_query_parameter_reaches_the_handler(
+    client: TestClient, provider: str, expected: set[str]
+) -> None:
+    """Proves FastAPI extracts ``provider`` — a direct handler call cannot."""
+    response = client.get("/api/agent-sessions", params={"provider": provider})
+
+    assert response.status_code == 200
+    assert {s["session_id"] for s in response.json()["sessions"]} == expected
+
+
+def test_unknown_provider_is_rejected_by_validation(client: TestClient) -> None:
+    """The Literal must be enforced at the boundary, not silently ignored."""
+    assert client.get("/api/agent-sessions", params={"provider": "bogus"}).status_code == 422
+
+
+def test_legacy_route_stays_claude_only_by_default(client: TestClient) -> None:
+    """The documented legacy contract must not start returning Codex rows."""
+    response = client.get("/api/claude-sessions")
+
+    assert response.status_code == 200
+    assert {s["session_id"] for s in response.json()["sessions"]} == {"c-1"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/agent-sessions",
+        "/api/agent-sessions/any-id",
+        "/api/agent-sessions/any-id/transcript",
+        "/api/agent-sessions/any-id/activity",
+    ],
+)
+def test_neutral_routes_require_authorization(path: str) -> None:
+    """Router-level dependencies do not follow an imported handler.
+
+    The alias re-registers handlers from ``api.claude_sessions`` on its own
+    router, so it has to declare the same policy itself — otherwise the same
+    data is served with the auth stripped off.
+    """
+    assert TestClient(app).get(path).status_code in (401, 403)


### PR DESCRIPTION
## Summary

PR #322 · #337 에 남겨둔 후속 3건과, 그 과정에서 드러난 **문서 미동기화**를 처리합니다.

## 1. 배선 테스트 — `tests/backend/api/test_agent_sessions_wiring.py` (신규, 10건)

기존 API 테스트는 핸들러를 **직접 호출**해 로직만 검증하고, FastAPI 가 그 주위에서 하는 일을 전부 건너뜁니다: 라우터가 실제로 마운트됐는지, `provider` 가 쿼리 추출과 `Literal` 검증을 통과하는지, 레거시와 같은 인가 뒤에 있는지.

**Red-Green 으로 실제 파손을 잡는지 확인했습니다:**

| 주입한 파손 | 결과 |
|---|---|
| 쿼리 파라미터 이름 `provider` → `provider_x` | **3건 실패** (같은 조건에서 기존 단위 테스트는 전부 초록) |
| 라우터 prefix 오타 (`/agent-sessionz`) | **9/10 실패** |

> prefix RED 에서 목록 인가 테스트 1건만 통과했는데, 경로가 사라져 404 가 아니라 **다른 라우터에 흡수돼 401** 이 났기 때문입니다 — 상태코드 집합으로 단언한 테스트의 한계로, 그대로 두되 기록해 둡니다.

## 2. 공용 resolver — `api/claude_sessions/resolver.py` (신규)

`activity` 가 `sessions` 의 **private `_resolve_session` 을 교차 import** 하고 있었습니다. 읽는 사람에게 의존이 보이지 않고 리팩터링 때 조용히 깨집니다 — 실제로 이번 추출에서 문자열 monkeypatch 타깃 2곳이 깨져 테스트가 잡았습니다. `resolve_session` 으로 공개하고 두 모듈이 같은 곳에서 가져옵니다.

## 3. 문서 — 기능 3개 PR 이 머지되는 동안 `docs/` 는 **전혀 반영되지 않은 상태**였습니다

- **`.env.example`** — `CODEX_SESSIONS_DIR`. 기본 경로가 아닌 환경에서 빠뜨리면 세션 목록이 **조용히 0건**이 되는 함정을 함께 적었습니다
- **`docs/architecture.md`** — `codex_session_monitor.py` · `session_file_cache.py` 를 서비스 트리에 추가
- **`docs/api/monitoring.md`** — `/api/agent-sessions` 표면, `provider` 쿼리(422 검증), Codex mutation **409** 계약, alias 가 인가를 재선언해야 하는 이유, 그리고 실제 rollout 의 필드 위치(`turn_context.model` · `token_count` 누적값 · `custom_tool_call`)

문서에 쓴 주장은 **모두 코드로 대조**해 확인했습니다 (기본값 `all`/`claude`, `Literal["all","claude","codex"]`, 409 경로 5곳, 양 라우터의 인가 의존성).

## 검증

| | 결과 |
|---|---|
| `ruff check` (src/backend + 변경 테스트) / `ruff format --check` | 통과 |
| `mypy` | Success, 0 issues (313 files) |
| `pytest` | **1657 passed, 32 skipped, 0 failed** |
| 신규 배선 테스트 | 10건 전부 실행, **스킵 0** (개별 `-v` 로 확인) |

## 남은 것

- 전사 페이지네이션 스트리밍 재설계 — PR #322 에 미반영 사유를 기록했습니다. 실측상 보유 최대 29.7MB < 예산 48MB 라 현재 데이터로는 도달 불가하고, 도달해도 `records_truncated` 로 노출됩니다. 별도 작업으로 봅니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Awv6JxGZDdKrmnmKdpsvyY