### PR TITLE
fix(config): 백엔드가 .env 를 한 파일에서만 읽게 한다

### DIFF
--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -9,8 +9,11 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 
-# Load .env file from backend directory
-load_dotenv(Path(__file__).parent.parent / ".env")
+from config import PROJECT_ROOT_ENV
+
+# Load the repo-root .env so the module-level ``os.getenv`` readers
+# (db.database, agents.base, api.llm) see the same file as ``Settings``.
+load_dotenv(PROJECT_ROOT_ENV)
 
 # Initialize structured logging (optional - graceful fallback)
 try:

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -11,8 +11,10 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 if TYPE_CHECKING:
     pass
 
-# Project root .env (two levels up from src/backend/)
-_PROJECT_ROOT_ENV = Path(__file__).resolve().parent.parent.parent / ".env"
+# Project root .env (two levels up from src/backend/). Public because
+# ``api/app.py`` loads the same file for the module-level ``os.getenv``
+# readers — recomputing it there is what let the two paths drift apart.
+PROJECT_ROOT_ENV = Path(__file__).resolve().parent.parent.parent / ".env"
 
 
 class Settings(BaseSettings):
@@ -141,7 +143,7 @@ class Settings(BaseSettings):
     rag_candidate_multiplier: int = 3
 
     model_config = SettingsConfigDict(
-        env_file=str(_PROJECT_ROOT_ENV),
+        env_file=str(PROJECT_ROOT_ENV),
         env_file_encoding="utf-8",
         extra="ignore",
     )

--- a/src/backend/orchestrator/engine.py
+++ b/src/backend/orchestrator/engine.py
@@ -7,12 +7,15 @@ from typing import Any
 
 from dotenv import load_dotenv
 
-from config import get_model_for_provider, get_settings
+from config import PROJECT_ROOT_ENV, get_model_for_provider, get_settings
 
 settings = get_settings()
 
-# Load environment variables
-load_dotenv()
+# Load environment variables from the repo-root .env. Passing the path
+# explicitly matters: a bare ``load_dotenv()`` walks up from this file and
+# stops at whichever ``.env`` it meets first, which is how the backend ended
+# up reading two different files.
+load_dotenv(PROJECT_ROOT_ENV)
 
 # LLM Provider selection
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", settings.llm_provider)

--- a/tests/backend/test_env_loading_wiring.py
+++ b/tests/backend/test_env_loading_wiring.py
@@ -1,0 +1,95 @@
+"""Wiring for where the backend reads its ``.env`` from.
+
+The backend has two config paths that must agree on one file. ``Settings``
+(``config.py``) declares ``env_file`` for pydantic; ``api/app.py`` calls
+``load_dotenv`` so the module-level ``os.getenv`` readers — ``db.database``'s
+``DATABASE_URL``, ``agents.base``'s model defaults, ``api.llm``'s
+``USE_DATABASE`` — see the same values.
+
+When they disagree, the failure is invisible to the suite. Every test passes
+because pytest injects its own environment, and the app dies only at startup,
+with an error naming the *consequence* (an auth failure against Postgres)
+rather than the cause. That is what a git worktree produces: the repo-root
+``.env`` is present, ``src/backend/.env`` is not, and only the ``load_dotenv``
+half falls back to its defaults.
+
+The independently computed ``_REPO_ROOT`` below is the point of these tests. An
+assertion that the two constants merely equal each other stays green when both
+move to the same wrong place.
+
+These compare *declared* paths and never call ``resolve()`` on the ``.env``
+component. A checkout may carry a ``src/backend/.env`` symlink pointing at the
+repo root — resolving would collapse the wrong path onto the right one and make
+the whole file pass no matter which one the code picked.
+"""
+
+import ast
+from pathlib import Path
+
+import api.app
+import config
+
+# Anchor derived from this file's own location, not from the code under test:
+# tests/backend/test_env_loading_wiring.py -> tests/backend -> tests -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_settings_env_file_is_repo_root_dotenv() -> None:
+    """``Settings`` reads the repo-root ``.env``, not a backend-local one."""
+    assert config.PROJECT_ROOT_ENV == _REPO_ROOT / ".env"
+
+
+def test_app_loads_the_same_dotenv_as_settings() -> None:
+    """``api.app`` imports the constant instead of recomputing the path.
+
+    Recomputing is what drifted: ``app.py`` resolved ``src/backend/.env`` while
+    ``config.py`` resolved the repo root. Importing the name is what keeps the
+    two halves from diverging again, so assert the import itself.
+    """
+    assert api.app.PROJECT_ROOT_ENV is config.PROJECT_ROOT_ENV
+
+
+def test_dotenv_path_is_not_inside_src_backend() -> None:
+    """The old location is stated explicitly so a revert reads as a failure."""
+    backend_local = _REPO_ROOT / "src" / "backend" / ".env"
+    assert config.PROJECT_ROOT_ENV != backend_local
+
+
+def _dotenv_call_arguments(source: Path) -> list[str]:
+    """Return the source text of every ``load_dotenv`` argument in a file.
+
+    Reading the call site rather than the runtime state is deliberate: by the
+    time a test imports the module, ``load_dotenv`` has already run and left no
+    record of which path it was handed.
+    """
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "load_dotenv"
+    ]
+    return [ast.unparse(call.args[0]) if call.args else "" for call in calls]
+
+
+def test_every_backend_load_dotenv_passes_the_shared_constant() -> None:
+    """No backend module loads a ``.env`` of its own choosing.
+
+    Importing ``PROJECT_ROOT_ENV`` is not the same as passing it. A module can
+    import the name and still call ``load_dotenv(Path(__file__).parent /
+    ".env")``, or drop the argument entirely — a bare call walks up from the
+    calling file and stops at the first ``.env`` it meets, which is how
+    ``engine.py`` drifted. Both forms are what this asserts against, across the
+    whole backend so a newly added module cannot reopen the split.
+    """
+    backend = _REPO_ROOT / "src" / "backend"
+    sources = [p for p in backend.rglob("*.py") if ".venv" not in p.parts]
+    assert sources, "backend sources not found — the anchor is wrong"
+
+    offenders: dict[str, list[str]] = {}
+    for path in sources:
+        arguments = _dotenv_call_arguments(path)
+        if any(argument != "PROJECT_ROOT_ENV" for argument in arguments):
+            offenders[str(path.relative_to(_REPO_ROOT))] = arguments
+    assert offenders == {}, f"load_dotenv called with a non-shared path: {offenders}"


### PR DESCRIPTION
## 문제

백엔드에 설정 경로가 두 갈래였고 서로 다른 파일을 가리켰다.

| 경로 | 읽는 파일 | 채우는 것 |
|---|---|---|
| `config.py` `Settings(env_file=...)` | 레포 루트 `.env` | pydantic 설정 |
| `api/app.py:13` `load_dotenv(...)` | **`src/backend/.env`** | `os.environ` |

두 번째가 `os.environ` 을 채우는 유일한 경로이고, `db/database.py:16` 의 `DATABASE_URL`, `agents/base.py` 의 모델 기본값, `api/llm.py` 의 `USE_DATABASE` 같은 **모듈 레벨 `os.getenv` 소비자**가 여기에 의존한다.

메인 체크아웃에는 `src/backend/.env -> ../../.env` 심링크가 있어 두 경로가 같은 파일로 수렴했지만, 이 심링크는 gitignore 대상이라 **워크트리에는 복제되지 않는다.** 그래서 워크트리에서는 세션 키(Settings 경로)만 읽히고 `DATABASE_URL` 은 기본값 `aos:aos` 로 떨어져 기동이 죽는다. 에러는 원인이 아니라 결과를 가리킨다:

```
asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "aos"
```

## 수정

- `config.py`: `_PROJECT_ROOT_ENV` → **`PROJECT_ROOT_ENV`** 로 공개해 SSOT 로 삼는다
- `api/app.py`: 경로를 재계산하지 않고 그 상수를 import 한다 — 재계산이 갈라짐의 원인이었으므로 import 자체가 재발 방지 장치다
- `orchestrator/engine.py`: 인자 없는 `load_dotenv()` 도 명시화. `find_dotenv` 는 호출 파일에서 위로 걸어 올라가 처음 만나는 `.env` 에서 멈추므로, 어느 파일을 읽는지가 디렉토리 구조에 달려 있었다

## 테스트 계획

**Red-Green (앱 레벨, 심링크 제거 상태에서 fresh 실행)**

| | 결과 |
|---|---|
| RED — `origin/main` 코드 | `asyncpg InvalidPasswordError`, 프로세스 DEAD |
| GREEN — 수정 코드 | `/api/health` → 200 |

**Red-Green (테스트)** — 상수를 옛 위치로 되돌리면 4건 중 2건 실패.

네 번째 단언은 호출 인자를 본다. 상수를 import 했는지만 보면 구멍이 남는다 — import 해 놓고 `load_dotenv(다른 경로)` 를 호출해도 초록이다. 런타임으로는 볼 수 없다(테스트가 모듈을 import 할 때 `load_dotenv` 는 이미 실행됐고 어떤 경로를 받았는지 흔적이 없다). 그래서 `src/backend` **전체**를 AST 로 훑어 모든 `load_dotenv` 호출 인자가 `PROJECT_ROOT_ENV` 인지 단언한다. 범위를 파일 2개가 아니라 백엔드 전체로 둔 이유는 재발 형태가 '되돌리기' 보다 **'새 모듈의 bare `load_dotenv()`'** 이기 때문이다. Red-Green: `src/backend` 에 bare 프로브를 넣으면 FAIL, 지우면 PASS.

단언은 `resolve()` 를 쓰지 않는다. 심링크가 있는 체크아웃에서는 잘못된 경로가 올바른 경로로 collapse 되어 파일 전체가 무조건 통과한다 — 첫 작성에서 실제로 이 false negative 를 냈고 그래서 선언 경로 비교로 바꿨다. 앵커도 테스트 파일 위치에서 독립적으로 계산한다(두 상수가 서로 같은지만 보면 둘이 함께 잘못된 곳으로 옮겨갔을 때 초록으로 남는다).

**게이트**

- `ruff check` / `ruff format --check` — `tests/backend` 는 훅·CI lint 범위 밖이라 명시 포함
- `mypy` 313 files, 0 issues
- `pytest` **1660 passed, 33 skipped, 0 failed**
  같은 머신 기준선(`origin/main`, 신규 테스트 제외) **1656 passed, 33 skipped** 대비 정확히 **+4** — skip·실패 변동 없음
- Codex 리뷰 (`--scope branch --base 68d09a2`, SHA 고정 격리 워크트리) — **지적 0건**. 최종 SHA `3d8da6f` 에서 재실행했고 결론이 변경 경로(`.env` 통합 + 추가된 배선 테스트)를 지목한다

**CI 영향 없음**: `.github/workflows` 전체에서 `.env` 언급 0건. 존재하지 않는 경로의 `load_dotenv` 는 무동작이므로 스위트 환경은 변하지 않는다.

## 주의

메인 체크아웃의 `src/backend/.env` 심링크는 이제 불필요하지만 무해하고 다른 세션이 쓰고 있을 수 있어 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFKXCJPyHbiU3qFwVjAyok