### PR TITLE
fix(sessions): 전사 페이지네이션이 보유 예산에 갇히지 않게 한다

### DIFF
--- a/src/backend/api/agent_sessions.py
+++ b/src/backend/api/agent_sessions.py
@@ -5,7 +5,7 @@ This router exposes the same normalized contract without encoding a provider in
 its resource name; provider-specific mutations still return a controlled 409.
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from api.claude_sessions.activity import get_session_activity
 from api.claude_sessions.core import ProviderFilter, SortField, SortOrder, list_sessions
@@ -27,6 +27,7 @@ from models.claude_session import (
     ClaudeSessionSaveResponse,
     SessionStatus,
 )
+from services.codex_session_monitor import MAX_TRANSCRIPT_LIMIT
 
 # 라우터 레벨 ``dependencies`` 는 핸들러 *함수* 가 아니라 *라우터* 에 붙는다.
 # 이 alias 는 ``api.claude_sessions`` 의 핸들러를 import 해 자기 라우터에 다시
@@ -70,7 +71,11 @@ async def get_agent_session(session_id: str) -> ClaudeSessionDetail:
 
 
 @router.get("/{session_id}/transcript")
-async def get_agent_session_transcript(session_id: str, offset: int = 0, limit: int = 100) -> dict:
+async def get_agent_session_transcript(
+    session_id: str,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(MAX_TRANSCRIPT_LIMIT, ge=1, le=MAX_TRANSCRIPT_LIMIT),
+) -> dict:
     """Get a raw provider transcript with pagination."""
     return await get_session_transcript(session_id=session_id, offset=offset, limit=limit)
 

--- a/src/backend/api/claude_sessions/sessions.py
+++ b/src/backend/api/claude_sessions/sessions.py
@@ -18,7 +18,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
 from api.deps import get_current_admin_or_manager_user
@@ -29,7 +29,7 @@ from models.claude_session import (
     SessionStatus,
 )
 from services.claude_session_monitor import get_monitor
-from services.codex_session_monitor import get_codex_monitor
+from services.codex_session_monitor import MAX_TRANSCRIPT_LIMIT, get_codex_monitor
 from utils.time import utcnow
 
 from .resolver import resolve_session
@@ -284,8 +284,8 @@ async def save_session(
 @router.get("/{session_id}/transcript")
 async def get_session_transcript(
     session_id: str,
-    offset: int = 0,
-    limit: int = 100,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(MAX_TRANSCRIPT_LIMIT, ge=1, le=MAX_TRANSCRIPT_LIMIT),
 ) -> dict:
     """Get raw transcript entries for a session.
 

--- a/src/backend/services/codex_session_monitor.py
+++ b/src/backend/services/codex_session_monitor.py
@@ -40,6 +40,11 @@ logger = logging.getLogger(__name__)
 MAX_RETAINED_BYTES = 48 * 1024 * 1024
 MAX_ROLLOUT_LINE_BYTES = 2 * 1024 * 1024
 MAX_ROLLOUT_RECORDS = 100_000
+# A transcript page is held whole, so its size is the memory lever the byte
+# budget used to be. The number comes from the only real client — the
+# dashboard's ITEMS_PER_PAGE — rather than being picked round, so the worst
+# case is as close to the old MAX_RETAINED_BYTES ceiling as the UI allows.
+MAX_TRANSCRIPT_LIMIT = 50
 # Even the streaming pass must terminate on a pathological file, since the list
 # view scans every rollout on each refresh.
 MAX_SCAN_BYTES = 256 * 1024 * 1024
@@ -112,6 +117,11 @@ class _Aggregate:
     tail_messages: deque[SessionMessage] = field(
         default_factory=lambda: deque(maxlen=DETAIL_WINDOW)
     )
+    # A paginated read wants its page and nothing else. The tail is decoded
+    # from records outside the window, so collecting it would add up to
+    # DETAIL_WINDOW messages of unrelated content on top of the page and
+    # break the bound the window exists to provide.
+    collect_tail: bool = True
 
     def absorb(
         self,
@@ -147,7 +157,8 @@ class _Aggregate:
         if message.usage is not None:
             self.message_input_tokens += message.usage.input_tokens
             self.message_output_tokens += message.usage.output_tokens
-        self.tail_messages.append(message)
+        if self.collect_tail:
+            self.tail_messages.append(message)
 
     def _absorb_token_count(self, monitor: CodexSessionMonitor, payload: dict[str, Any]) -> None:
         """Take the latest cumulative total, which supersedes earlier ones."""
@@ -356,18 +367,43 @@ class CodexSessionMonitor:
             else:
                 yield bytes(buffer)
 
-    def _read_file(self, path: Path, *, retain: bool = True) -> RolloutScan:
+    def _read_file(
+        self,
+        path: Path,
+        *,
+        retain: bool = True,
+        record_window: tuple[int, int] | None = None,
+    ) -> RolloutScan:
         """Scan a rollout once.
 
         ``retain=False`` keeps memory flat for the polled list view; the record
         and message lists come back empty while the aggregates stay accurate.
+
+        ``record_window=(offset, limit)`` keeps only that slice of records while
+        still counting every one of them. Without it a paginated read had to
+        retain the file from its start, so the byte budget cut the list short and
+        ``record_count`` became the length of that prefix — records past it were
+        unreachable at every offset and nothing in the result said so.
+
+        A window returns its whole requested range; the byte budget does not
+        apply to it. Cutting a page short would relocate the same bug rather
+        than fix it, because the dashboard pages by ``(page - 1) * size`` and
+        would step over whatever did not fit. What a window holds is a subset of
+        the file, so the ceiling is the smaller of the file and
+        ``limit * MAX_ROLLOUT_LINE_BYTES`` — and ``limit`` is clamped by the
+        callers, which is where that bound belongs.
         """
-        agg = _Aggregate()
+        agg = _Aggregate(collect_tail=record_window is None)
         metadata: dict[str, Any] = {}
         messages: list[SessionMessage] = []
         records: list[dict[str, Any]] = []
         if not self._is_safe_rollout(path):
             return RolloutScan(metadata, messages, records)
+        window_start, window_stop = (
+            (record_window[0], record_window[0] + record_window[1])
+            if record_window is not None
+            else (0, 0)
+        )
         retained = 0
         try:
             # Read bytes: an oversized line is skipped without ever being decoded
@@ -375,7 +411,7 @@ class CodexSessionMonitor:
             # never become Python objects.
             with path.open("rb") as stream:
                 for line in self._iter_lines(stream, agg):
-                    if retain:
+                    if retain and record_window is None:
                         retained += len(line)
                         if retained > MAX_RETAINED_BYTES:
                             agg.truncated = True
@@ -397,10 +433,21 @@ class CodexSessionMonitor:
                             metadata = payload
                     message = self._message_from_record(record)
                     agg.absorb(self, record, message)
-                    if retain:
+                    if not retain:
+                        continue
+                    if record_window is None:
                         records.append(record)
                         if message is not None:
                             messages.append(message)
+                        continue
+                    index = agg.count - 1
+                    if index >= window_stop:
+                        # The window is filled; keep counting so the caller
+                        # learns the true total, but stop holding records.
+                        continue
+                    if index < window_start:
+                        continue
+                    records.append(record)
         except OSError as exc:
             logger.warning("Unable to read Codex rollout: %s", type(exc).__name__)
         if agg.truncated:
@@ -530,13 +577,14 @@ class CodexSessionMonitor:
         )
 
     def get_session_transcript(
-        self, session_id: str, offset: int = 0, limit: int = 100
+        self, session_id: str, offset: int = 0, limit: int = MAX_TRANSCRIPT_LIMIT
     ) -> tuple[list[dict[str, Any]], int]:
         path = self._find_file(session_id)
         if path is None:
             return [], 0
-        records = self._read_file(path).records
-        return records[offset : offset + limit], len(records)
+        window = (max(offset, 0), min(max(limit, 0), MAX_TRANSCRIPT_LIMIT))
+        scan = self._read_file(path, record_window=window)
+        return scan.records, scan.record_count
 
     def get_session_activity(
         self, session_id: str, offset: int = 0, limit: int = 100

--- a/tests/backend/api/test_agent_sessions_wiring.py
+++ b/tests/backend/api/test_agent_sessions_wiring.py
@@ -117,3 +117,23 @@ def test_neutral_routes_require_authorization(path: str) -> None:
     data is served with the auth stripped off.
     """
     assert TestClient(app).get(path).status_code in (401, 403)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/agent-sessions/any-session/transcript",
+        "/api/claude-sessions/any-session/transcript",
+    ],
+)
+def test_transcript_limit_above_the_cap_is_rejected(client: TestClient, path: str) -> None:
+    """A transcript page is held whole, so its size is a memory lever.
+
+    ``limit`` used to be harmless because the read was capped by bytes no matter
+    what the caller asked for; a windowed read makes ``limit`` the bound itself.
+    Both routers extract the query separately, so the cap has to hold on each —
+    a handler-level unit call never runs ``Query`` validation at all.
+    """
+    assert client.get(path, params={"limit": 10_000}).status_code == 422
+    assert client.get(path, params={"limit": 0}).status_code == 422
+    assert client.get(path, params={"offset": -1}).status_code == 422

--- a/tests/backend/test_codex_session_monitor.py
+++ b/tests/backend/test_codex_session_monitor.py
@@ -201,8 +201,9 @@ def test_detail_retain_budget_degrades_instead_of_failing(
 ) -> None:
     """Neither discovery nor detail depends on the retain budget any more.
 
-    Both stream, so a tiny budget — which only bounds the transcript path —
-    leaves the list and the detail window fully intact.
+    Both stream, so a tiny budget leaves the list and the detail window fully
+    intact. The transcript no longer consults the budget either — it reads a
+    bounded window — so this now pins that nothing user-visible does.
     """
     _write_rollout(tmp_path)
     monkeypatch.setattr(codex_monitor, "MAX_RETAINED_BYTES", 1)
@@ -595,3 +596,147 @@ def test_cached_session_status_still_ages(tmp_path: Path, monkeypatch: pytest.Mo
     monkeypatch.setattr(codex_monitor, "utcnow", lambda: now + timedelta(hours=2))
 
     assert monitor.discover_sessions()[0].status.value == "completed"
+
+
+def _write_numbered_rollout(root: Path, count: int) -> Path:
+    """A rollout whose records carry their own index, so a page states its range."""
+    path = root / "2026" / "08" / "28" / "rollout-2026-08-28T10-00-00-0numb.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict] = [
+        {
+            "timestamp": "2026-08-28T01:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": "thread-numbered", "cwd": "/Users/tester/Work/AOS"},
+        }
+    ]
+    records += [
+        {
+            "timestamp": "2026-08-28T01:00:00Z",
+            "type": "response_item",
+            "index": index,
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": f"record {index}"}],
+            },
+        }
+        for index in range(1, count)
+    ]
+    path.write_text("\n".join(json.dumps(record) for record in records), encoding="utf-8")
+    return path
+
+
+def test_transcript_reaches_records_past_the_retain_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pagination is not bounded by how much of the file fits in memory.
+
+    The transcript used to retain a prefix of the file — everything up to
+    ``MAX_RETAINED_BYTES`` — then slice that prefix and report its length as the
+    total. Records past the budget were unreachable at every offset, and the
+    total under-reported them, so nothing in the response said they existed.
+
+    Real data cannot produce this (the largest rollout on hand is 29.7MB against
+    a 48MB budget), so the budget is forced small here. That is the only lever
+    that reaches the regime.
+    """
+    _write_numbered_rollout(tmp_path, 40)
+    # Fits one 10-record page (~1.8KB) but stops a whole-file read around
+    # record 11 — so the old prefix never reached offset 30.
+    monkeypatch.setattr(codex_monitor, "MAX_RETAINED_BYTES", 2048)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    head, total = monitor.get_session_transcript("thread-numbered", offset=0, limit=10)
+    tail, tail_total = monitor.get_session_transcript("thread-numbered", offset=30, limit=10)
+
+    assert total == 40, "total must count the whole file, not the retained prefix"
+    assert tail_total == total
+    assert [record["index"] for record in tail] == list(range(30, 40))
+    assert [record["index"] for record in head[1:]] == list(range(1, 10))
+
+
+def test_transcript_window_holds_only_the_requested_page(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A page costs ``limit`` records, not the whole file.
+
+    Asserted through the byte budget rather than by measuring memory: with a
+    budget far smaller than the file, a windowed read still returns a full page
+    because only the page is retained. A whole-file read cannot.
+    """
+    _write_numbered_rollout(tmp_path, 200)
+    # Fits one 25-record page (~4.6KB); a whole-file read stops near
+    # record 33 of 200.
+    monkeypatch.setattr(codex_monitor, "MAX_RETAINED_BYTES", 6144)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    page, total = monitor.get_session_transcript("thread-numbered", offset=150, limit=25)
+
+    assert total == 200
+    assert [record["index"] for record in page] == list(range(150, 175))
+
+
+def test_transcript_offset_past_the_end_is_empty_with_a_true_total(
+    tmp_path: Path,
+) -> None:
+    """Paging off the end reports the total rather than zero."""
+    _write_numbered_rollout(tmp_path, 12)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    page, total = monitor.get_session_transcript("thread-numbered", offset=99, limit=10)
+
+    assert page == []
+    assert total == 12
+
+
+def test_transcript_page_is_whole_regardless_of_the_retain_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The byte budget does not reach the transcript path at all.
+
+    Cutting a page short would relocate the bug rather than fix it: the
+    dashboard pages by ``(page - 1) * size``, so it would step over whatever did
+    not fit and those records would be hidden again. A page therefore returns
+    its whole requested range, and the page size is bounded instead.
+    """
+    _write_numbered_rollout(tmp_path, 40)
+    monkeypatch.setattr(codex_monitor, "MAX_RETAINED_BYTES", 256)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    page, total = monitor.get_session_transcript("thread-numbered", offset=30, limit=10)
+
+    assert total == 40
+    assert [record["index"] for record in page] == list(range(30, 40))
+
+
+def test_transcript_limit_is_clamped_in_the_monitor(tmp_path: Path) -> None:
+    """The monitor does not trust either router to have clamped the page size."""
+    _write_numbered_rollout(tmp_path, 400)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    page, total = monitor.get_session_transcript("thread-numbered", offset=0, limit=10_000)
+
+    assert total == 400
+    assert len(page) == codex_monitor.MAX_TRANSCRIPT_LIMIT
+
+
+def test_windowed_scan_does_not_collect_the_detail_tail(tmp_path: Path) -> None:
+    """A page holds its own records and nothing else.
+
+    ``absorb`` runs for every record, before the window filter, so the 20-entry
+    detail tail would otherwise fill with messages decoded from records outside
+    the page — content the transcript never returns. With the 2MiB line cap that
+    is up to 40MiB riding on top of the bound the window exists to provide.
+    Aggregates must survive the change, so the counts are asserted too.
+    """
+    monitor = CodexSessionMonitor(tmp_path)
+    path = _write_numbered_rollout(tmp_path, 60)
+
+    windowed = monitor._read_file(path, record_window=(50, 5))
+    whole = monitor._read_file(path, retain=False)
+
+    assert windowed.tail_messages == ()
+    assert whole.tail_messages, "the detail path still needs its tail"
+    assert windowed.record_count == whole.record_count == 60
+    assert windowed.user_count == whole.user_count
+    assert len(windowed.records) == 5


### PR DESCRIPTION
Codex 가 #322 에서 [P2] 로 지적했고 당시 **의도적으로 미반영**했던 항목이다.

## 증상

`get_session_transcript` 은 파일을 처음부터 보유하다 `MAX_RETAINED_BYTES`(48MB)에서 끊고, **그 프리픽스를 잘라 `len(records)` 를 총계로 보고**했다. 예산 너머의 레코드는 어떤 offset 으로도 도달할 수 없었고, 총계가 그것들을 세지 않아 응답 어디에도 존재한다는 신호가 없었다.

당시 보류 사유는 "정확한 총계로 바꾸면 접근 불가한 빈 페이지가 생긴다" 였다. **윈도우 읽기로 바꾸면 그 딜레마 자체가 사라진다** — 도달성과 총계가 함께 맞는다.

## 수정

`_read_file` 에 `record_window=(offset, limit)` 를 추가한다. 모든 레코드를 세되 그 구간만 보유하므로 한 페이지 비용이 파일 크기가 아니라 `limit` 에 비례한다. 총계는 이미 있던 `RolloutScan.record_count` 를 쓴다. **기존 호출자 4곳은 인자를 넘기지 않아 경로가 그대로다.**

### 페이지는 요청 범위를 통째로 반환한다

초안은 바이트 예산을 윈도우에도 걸고 "최소 1건 보장"을 뒀다. **Codex 리뷰가 그것이 버그를 옮길 뿐임을 지적했고 맞다** — 대시보드는 `(page - 1) * size` 로 페이지를 센다(`TranscriptViewer.tsx:374`). 짧은 페이지의 꼬리는 영구히 건너뛰어진다. 예산은 전사 경로에서 완전히 제거했다.

### 윈도우 스캔은 detail tail 도 모으지 않는다

`absorb` 는 윈도우 필터보다 **먼저** 돈다. 그대로 두면 페이지 밖 레코드에서 디코딩한 메시지 20건이 페이지 위에 얹혀, 2MiB 줄 상한과 곱하면 최대 **40MiB** 가 추가된다 — 윈도우가 존재하는 이유인 그 상한을 스스로 깨뜨린다. 집계는 그대로 유지하며 테스트가 고정한다.

### 상한은 경계에서 검증한다

- **라우터 2곳 모두** `Query(ge/le)` — 별칭과 레거시가 쿼리를 각자 추출하므로 한쪽만 걸면 다른 쪽이 뚫린다
- **모니터 자체도 clamp** — 두 핸들러에서 도달하므로 어느 쪽도 신뢰하지 않는다

`limit` 은 원래 **상한이 없었다.** 옛 코드에서는 보유가 바이트로 막혀 무해했지만 윈도우에서는 `limit` 이 곧 상한이라, 이 변경이 연 구멍을 함께 닫는다.

상한값 **50 은 고른 숫자가 아니라** 대시보드의 `ITEMS_PER_PAGE` 에서 온다. 기본값도 50 으로 맞췄다 — 상한보다 큰 기본값(100)은 그 자체로 모순이다. **무인자 호출자는 이제 100 이 아니라 50 을 받는다.**

## 남는 두 경계 (둘 다 이 패치가 만든 것이 아니다)

| 경계 | 성질 |
|---|---|
| `MAX_ROLLOUT_RECORDS` (100k) | **균일하다.** 총계가 100k 를 보고하고 `has_more` 가 false — 숨는 것 없음 |
| `MAX_SCAN_BYTES` (256MiB) | 그 너머는 `_iter_lines` 가 멈춰 총계가 다시 프리픽스가 된다. 이 패치는 그 천장을 **48MB → 256MiB 로 올렸을 뿐 없애지 않았다** |

후자는 보유 최대 파일이 29.7MB 라 도달 불가하고, 노출하려면 `scan.truncated` 를 응답까지 배선해야 하는데 `get_session_transcript` 는 `(records, count)` 만 반환하므로 **지금은 호출자에게 보이지 않는다.** 별도 작업이다.

## 메모리 자세 (측정)

이론 최악은 `limit × MAX_ROLLOUT_LINE_BYTES` = **100MB** 로 옛 48MB 보다 높다. 실측은 그 근처가 아니다:

| 지표 | 값 |
|---|---|
| 최대 단일 레코드 | **1,825.7 KB** — 2MB 줄 상한에 근접, 큰 레코드는 실재한다 |
| 최대 페이지 합계 (`limit=50`) | **1.92 MB** |
| 이론 최악 | 100 MB |
| 옛 천장 | 48 MB |

이론값을 48MB 아래로 내리려면 상한이 **24** 여야 하는데 대시보드 페이지가 50 이라 그것을 깬다. 대시보드 변경은 그 파일을 소유한 PR 의 몫이라 여기서 멈췄다.

## 범위 밖

`get_session_activity` 는 같은 결함이 있으나 offset 이 레코드가 아니라 **필터된 이벤트**를 센다. 레코드 윈도우로는 못 푸는 다른 계산 문제라 함께 고치지 않았다.

## 테스트 계획

**Red-Green** — `MAX_RETAINED_BYTES` 를 작게 강제. 실데이터로는 도달 불가한 조건이다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 40레코드, offset 30 | total=**3**, 페이지 `[]` | total=**40**, 30~39 **온전히** 반환 |
| 200레코드, offset 150 | total=**23** | total=**200**, 150~174 반환 |

**라우트 상한 Red-Green** — 한쪽 라우터의 `le` 를 지우면 **그 라우터만** 정확히 실패한다. `Query` 검증은 핸들러 직접 호출로는 실행되지 않아 HTTP 배선 테스트로만 잡힌다.

**tail Red-Green** — `collect_tail` 을 되돌리면 해당 테스트만 실패한다.

**실데이터 대조 (CI 가 못 보는 층)** — 버그가 현재 데이터로 도달 불가하므로 pytest 초록만으로는 이 리팩터가 만들 수 있는 회귀를 못 잡는다. `~/.codex/sessions` **355 세션 × offset 4종 = 1420건**, 구·신 구현의 `records` 와 `total` 전부 일치, **불일치 0건**.

**게이트**
- `ruff check` / `ruff format --check` (tests/backend 는 훅·CI lint 범위 밖이라 명시 포함)
- `mypy` 313 files, 0 issues
- `pytest` **1668 passed, 33 skipped, 0 failed** (기준선 1660/33 대비 **+8**)
- **Codex 리뷰 지적 0건** — SHA 고정 격리 워크트리, `--scope branch --base e82485d`, 전후 계측 불변. 4라운드에 걸쳐 [P2] 4건을 전부 반영한 뒤의 결과다

**주의**: 테스트 예산을 `1` 로 두면 페이지네이션이 아니라 **세션 조회**가 깨진다 — `_find_file` 이 메타데이터를 `retain=True` 로 읽는 기존 경로 때문이다. 256 으로 조정했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFKXCJPyHbiU3qFwVjAyok