### PR TITLE
refactor(services): audit_service 를 패키지로 승격해 한도 안에 넣는다 (B5.5 Task 1)

### DIFF
--- a/scripts/split_audit.py
+++ b/scripts/split_audit.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Verify a behavior-preserving module split by definition name, not line range.
+
+Slicing a file by line ranges and diffing the slices against the new modules is
+self-confirming: the same ranges produced both sides, so a definition dropped by
+the split is invisible to the check. This compares the *set of top-level
+definition names* before and after, and then compares each body byte for byte —
+so a lost, duplicated, or silently edited definition fails.
+
+Imports are deliberately **not** compared. A split re-imports the same names in
+several of the new modules, so requiring a one-to-one match would fail on every
+correct split. A dropped import is a real risk, but it is covered statically by
+``ruff``'s F821 (undefined name) and then by the suite — verified, not assumed:
+deleting an import from one of the new modules makes ``ruff check`` fail.
+
+Usage:
+    split_audit.py <before-ref>:<path> <after-path> [<after-path> ...]
+
+Example:
+    scripts/split_audit.py HEAD:src/backend/services/audit_service.py \\
+        src/backend/services/audit_service/*.py
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+# Names a barrel adds by existing rather than by holding a definition. Comparing
+# them would report a correct split as a failure, which is worse than not
+# comparing them: a check that cries wolf gets run with the barrel excluded, and
+# then stops covering the barrel at all.
+_BARREL_ONLY = frozenset({"__all__"})
+
+
+def _bound_names(target: ast.expr) -> list[str]:
+    """Names an assignment target binds, unpacking tuples and lists."""
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return [n for element in target.elts for n in _bound_names(element)]
+    if isinstance(target, ast.Starred):
+        return _bound_names(target.value)
+    return []
+
+
+def _definitions(source: str, origin: str) -> dict[str, tuple[str, str]]:
+    """Map module-level definition name -> (kind, source text).
+
+    Module-level assignments count as definitions too: a split that drops a
+    constant or state variable is exactly the failure this guards against.
+    """
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    found: dict[str, tuple[str, str]] = {}
+
+    def record(name: str, node: ast.AST, kind: str) -> None:
+        if name in _BARREL_ONLY:
+            return
+        # Decorators sit above ``node.lineno``. Comparing from ``def``/``class``
+        # would call a definition unchanged after its decorator was removed —
+        # the one edit most likely to change behavior while looking like none.
+        start = node.lineno
+        for decorator in getattr(node, "decorator_list", []):
+            start = min(start, decorator.lineno)
+        body = "\n".join(lines[start - 1 : node.end_lineno])
+        # One name may be bound more than once in a single file — the
+        # ``try: X = a / except ImportError: X = b`` fallback is the common case.
+        # That is not the duplication worth failing on; two *modules* claiming
+        # the same definition is, and ``main`` checks for that. Keep every
+        # occurrence in order so losing one branch still shows as a change.
+        previous = found.get(name)
+        if previous is None:
+            found[name] = (kind, body)
+        else:
+            found[name] = (previous[0], previous[1] + "\n" + body)
+
+    def walk(body: list[ast.stmt]) -> None:
+        """Recurse into module-level containers.
+
+        A definition guarded by ``if TYPE_CHECKING:``, wrapped in ``try:``, or
+        built inside a module-level loop is still a definition the split has to
+        carry. Only inspecting ``tree.body`` would let one be dropped without the
+        audit noticing — a verifier that skips a suite reports success for a
+        split that lost what was inside it.
+        """
+        for node in body:
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                record(node.name, node, type(node).__name__)
+            elif isinstance(node, ast.Assign):
+                # Unpacking (``A, B = ...``) binds names too. Recording only
+                # ``ast.Name`` targets would let one of them vanish silently.
+                for target in node.targets:
+                    for bound in _bound_names(target):
+                        record(bound, node, "Assign")
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                record(node.target.id, node, "AnnAssign")
+            elif isinstance(node, ast.If):
+                walk(node.body)
+                walk(node.orelse)
+            elif isinstance(node, ast.Try):
+                walk(node.body)
+                for handler in node.handlers:
+                    walk(handler.body)
+                walk(node.orelse)
+                walk(node.finalbody)
+            elif isinstance(node, (ast.With, ast.AsyncWith)):
+                walk(node.body)
+            elif isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+                walk(node.body)
+                walk(node.orelse)
+            elif isinstance(node, ast.Match):
+                for case in node.cases:
+                    walk(case.body)
+
+    walk(tree.body)
+    return found
+
+
+def _read_ref(spec: str) -> str:
+    ref, _, path = spec.partition(":")
+    if not path:
+        return Path(spec).read_text(encoding="utf-8")
+    out = subprocess.run(
+        ["git", "show", f"{ref}:{path}"], capture_output=True, text=True, check=True
+    )
+    return out.stdout
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__)
+        return 2
+
+    before = _definitions(_read_ref(argv[1]), argv[1])
+    after: dict[str, tuple[str, str]] = {}
+    owner: dict[str, str] = {}
+    for path in argv[2:]:
+        for name, entry in _definitions(Path(path).read_text(encoding="utf-8"), path).items():
+            if name in after:
+                raise SystemExit(f"두 모듈에 같은 정의: {name} ({owner[name]} · {path})")
+            after[name] = entry
+            owner[name] = path
+
+    missing = sorted(set(before) - set(after))
+    added = sorted(set(after) - set(before))
+    changed = sorted(name for name in set(before) & set(after) if before[name][1] != after[name][1])
+
+    print(f"이전 정의 {len(before)}종 -> 이후 {len(after)}종 ({len(argv) - 2}개 모듈)")
+    for label, names in (("유실", missing), ("신규", added), ("본문 변경", changed)):
+        if names:
+            print(f"  {label} {len(names)}종:")
+            for name in names:
+                where = owner.get(name, "-")
+                print(f"    {name}  ({where})")
+
+    if missing or added or changed:
+        print("\nFAIL — 이름 집합 또는 본문이 일치하지 않는다")
+        return 1
+    print("\nOK — 모든 정의가 이름과 본문 그대로 보존됐다")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/backend/services/audit_service/__init__.py
+++ b/src/backend/services/audit_service/__init__.py
@@ -1,0 +1,55 @@
+"""Audit trail service for logging all system actions.
+
+Split into a package so ``services.audit_service`` stays valid verbatim at every
+one of its 20-odd import sites; this module is the barrel that keeps them so.
+"""
+
+from services.audit_service.helpers import (
+    audit_approval,
+    audit_config_change,
+    audit_project_change,
+    audit_task_created,
+    audit_task_status_change,
+    audit_tool_executed,
+    audit_user_auth,
+)
+from services.audit_service.models import (
+    AuditAction,
+    AuditLogEntry,
+    AuditLogFilter,
+    AuditLogResponse,
+    ResourceType,
+)
+from services.audit_service.service import (
+    USE_DATABASE,
+    AuditService,
+    _audit_logs,
+    _filter_logs,
+)
+from services.audit_service.stats import (
+    TREND_DAYS,
+    build_recent_trend,
+    compute_stats_from_logs,
+)
+
+__all__ = [
+    "TREND_DAYS",
+    "USE_DATABASE",
+    "AuditAction",
+    "AuditLogEntry",
+    "AuditLogFilter",
+    "AuditLogResponse",
+    "AuditService",
+    "ResourceType",
+    "_audit_logs",
+    "_filter_logs",
+    "audit_approval",
+    "audit_config_change",
+    "audit_project_change",
+    "audit_task_created",
+    "audit_task_status_change",
+    "audit_tool_executed",
+    "audit_user_auth",
+    "build_recent_trend",
+    "compute_stats_from_logs",
+]

--- a/src/backend/services/audit_service/helpers.py
+++ b/src/backend/services/audit_service/helpers.py
@@ -1,0 +1,151 @@
+"""Convenience wrappers that record one specific kind of event.
+
+Callers across the API and the orchestrator import these by name rather than
+assembling an ``AuditLogEntry`` themselves.
+"""
+
+from typing import Any
+
+from services.audit_service.models import AuditAction, AuditLogEntry, ResourceType
+from services.audit_service.service import AuditService
+
+
+def audit_task_created(
+    session_id: str,
+    task_id: str,
+    task_data: dict,
+    user_id: str | None = None,
+    project_id: str | None = None,
+) -> AuditLogEntry:
+    """Log task creation."""
+    return AuditService.log(
+        action=AuditAction.TASK_CREATED,
+        resource_type=ResourceType.TASK,
+        resource_id=task_id,
+        session_id=session_id,
+        user_id=user_id,
+        project_id=project_id,
+        new_value=task_data,
+    )
+
+
+def audit_task_status_change(
+    session_id: str,
+    task_id: str,
+    old_status: str,
+    new_status: str,
+    agent_id: str | None = None,
+    project_id: str | None = None,
+) -> AuditLogEntry:
+    """Log task status change."""
+    action_map = {
+        "completed": AuditAction.TASK_COMPLETED,
+        "failed": AuditAction.TASK_FAILED,
+        "cancelled": AuditAction.TASK_CANCELLED,
+        "paused": AuditAction.TASK_PAUSED,
+        "pending": AuditAction.TASK_RESUMED if old_status == "paused" else AuditAction.TASK_UPDATED,
+    }
+    action = action_map.get(new_status, AuditAction.TASK_UPDATED)
+
+    return AuditService.log(
+        action=action,
+        resource_type=ResourceType.TASK,
+        resource_id=task_id,
+        session_id=session_id,
+        agent_id=agent_id,
+        project_id=project_id,
+        old_value={"status": old_status},
+        new_value={"status": new_status},
+    )
+
+
+def audit_tool_executed(
+    session_id: str,
+    tool_name: str,
+    tool_args: dict,
+    result: Any,
+    agent_id: str | None = None,
+    task_id: str | None = None,
+    project_id: str | None = None,
+) -> AuditLogEntry:
+    """Log tool execution."""
+    return AuditService.log(
+        action=AuditAction.TOOL_EXECUTED,
+        resource_type=ResourceType.TOOL,
+        resource_id=tool_name,
+        session_id=session_id,
+        agent_id=agent_id,
+        project_id=project_id,
+        new_value={"args": tool_args, "result": str(result)[:1000]},
+        metadata={"task_id": task_id} if task_id else None,
+    )
+
+
+def audit_approval(
+    session_id: str,
+    approval_id: str,
+    action: AuditAction,
+    user_id: str | None = None,
+    note: str | None = None,
+) -> AuditLogEntry:
+    """Log approval action."""
+    return AuditService.log(
+        action=action,
+        resource_type=ResourceType.APPROVAL,
+        resource_id=approval_id,
+        session_id=session_id,
+        user_id=user_id,
+        metadata={"note": note} if note else None,
+    )
+
+
+def audit_user_auth(
+    action: AuditAction,
+    user_id: str | None = None,
+    metadata: dict | None = None,
+    status: str = "success",
+    error_message: str | None = None,
+) -> AuditLogEntry:
+    """Log authentication event (login, logout, register, token refresh)."""
+    return AuditService.log(
+        action=action,
+        resource_type=ResourceType.USER,
+        resource_id=user_id,
+        user_id=user_id,
+        metadata=metadata or {},
+        status=status,
+        error_message=error_message,
+    )
+
+
+def audit_config_change(
+    action: AuditAction,
+    config_type: str,
+    config_id: str,
+    project_id: str | None = None,
+    user_id: str | None = None,
+) -> AuditLogEntry:
+    """Log configuration change (skill, agent, MCP, hook, command)."""
+    return AuditService.log(
+        action=action,
+        resource_type=ResourceType.CONFIG,
+        resource_id=config_id,
+        user_id=user_id,
+        project_id=project_id,
+        metadata={"config_type": config_type},
+    )
+
+
+def audit_project_change(
+    action: AuditAction,
+    project_id: str,
+    user_id: str | None = None,
+) -> AuditLogEntry:
+    """Log project change."""
+    return AuditService.log(
+        action=action,
+        resource_type=ResourceType.PROJECT,
+        resource_id=project_id,
+        user_id=user_id,
+        project_id=project_id,
+    )

--- a/src/backend/services/audit_service/models.py
+++ b/src/backend/services/audit_service/models.py
@@ -1,0 +1,155 @@
+"""Audit trail enums and Pydantic shapes.
+
+The leaf of the package: every other module depends on these and nothing here
+depends back, so the split starts from this file.
+"""
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from models.audit import DataClassification, RetentionPolicy
+from utils.time import utcnow
+
+
+class AuditAction(str, Enum):
+    """Audit action types."""
+
+    # Session actions
+    SESSION_CREATED = "session_created"
+    SESSION_DELETED = "session_deleted"
+    SESSION_EXPIRED = "session_expired"
+
+    # Task actions
+    TASK_CREATED = "task_created"
+    TASK_UPDATED = "task_updated"
+    TASK_COMPLETED = "task_completed"
+    TASK_FAILED = "task_failed"
+    TASK_CANCELLED = "task_cancelled"
+    TASK_PAUSED = "task_paused"
+    TASK_RESUMED = "task_resumed"
+    TASK_RETRIED = "task_retried"
+    TASK_DELETED = "task_deleted"
+
+    # Approval actions
+    APPROVAL_REQUESTED = "approval_requested"
+    APPROVAL_GRANTED = "approval_granted"
+    APPROVAL_DENIED = "approval_denied"
+
+    # Tool actions
+    TOOL_EXECUTED = "tool_executed"
+    TOOL_FAILED = "tool_failed"
+
+    # Agent actions
+    AGENT_ASSIGNED = "agent_assigned"
+    AGENT_COMPLETED = "agent_completed"
+
+    # Permission actions
+    PERMISSION_CHANGED = "permission_changed"
+    AGENT_DISABLED = "agent_disabled"
+    AGENT_ENABLED = "agent_enabled"
+
+    # Authentication actions
+    USER_LOGIN = "user_login"
+    USER_LOGOUT = "user_logout"
+    TOKEN_REFRESHED = "token_refreshed"
+    USER_REGISTERED = "user_registered"
+    LOGIN_FAILED = "login_failed"
+
+    # Project actions
+    PROJECT_CREATED = "project_created"
+    PROJECT_UPDATED = "project_updated"
+    PROJECT_DELETED = "project_deleted"
+
+    # Config actions (skills, agents, MCP, hooks, commands)
+    CONFIG_CREATED = "config_created"
+    CONFIG_UPDATED = "config_updated"
+    CONFIG_DELETED = "config_deleted"
+
+    # Notification actions
+    NOTIFICATION_RULE_CREATED = "notification_rule_created"
+    NOTIFICATION_RULE_UPDATED = "notification_rule_updated"
+    NOTIFICATION_RULE_DELETED = "notification_rule_deleted"
+
+    # LLM Router actions
+    LLM_PROVIDER_CHANGED = "llm_provider_changed"
+
+
+class ResourceType(str, Enum):
+    """Resource types for audit logging."""
+
+    SESSION = "session"
+    TASK = "task"
+    APPROVAL = "approval"
+    AGENT = "agent"
+    USER = "user"
+    PERMISSION = "permission"
+    TOOL = "tool"
+    PROJECT = "project"
+    CONFIG = "config"
+    NOTIFICATION = "notification"
+    LLM_PROVIDER = "llm_provider"
+
+
+class AuditLogEntry(BaseModel):
+    """Audit log entry model."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    session_id: str | None = None
+    user_id: str | None = None
+    project_id: str | None = None
+
+    action: AuditAction
+    resource_type: ResourceType
+    resource_id: str | None = None
+
+    old_value: dict[str, Any] | None = None
+    new_value: dict[str, Any] | None = None
+    changes: dict[str, Any] | None = None
+
+    agent_id: str | None = None
+    ip_address: str | None = None
+    user_agent: str | None = None
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    status: str = "success"
+    error_message: str | None = None
+
+    created_at: datetime = Field(default_factory=utcnow)
+
+    # Compliance fields (optional for backward compatibility)
+    data_classification: DataClassification | None = None
+    change_reason: str | None = None
+    compliance_flags: list[str] = Field(default_factory=list)
+    previous_hash: str | None = None
+    hash: str | None = None
+    retention_policy: RetentionPolicy | None = None
+
+
+class AuditLogFilter(BaseModel):
+    """Filter for querying audit logs."""
+
+    session_id: str | None = None
+    user_id: str | None = None
+    project_id: str | None = None
+    include_global: bool = True  # Include project_id IS NULL events when filtering by project
+    action: AuditAction | None = None
+    resource_type: ResourceType | None = None
+    resource_id: str | None = None
+    status: str | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    limit: int = 100
+    offset: int = 0
+
+
+class AuditLogResponse(BaseModel):
+    """Response model for audit log queries."""
+
+    logs: list[AuditLogEntry]
+    total: int
+    limit: int
+    offset: int

--- a/src/backend/services/audit_service/service.py
+++ b/src/backend/services/audit_service/service.py
@@ -1,226 +1,43 @@
-"""Audit trail service for logging all system actions."""
+"""The audit service and the in-memory store it owns.
+
+``_audit_logs``, ``_filter_logs`` and ``AuditService`` stay together so the store
+has one owner. ``cleanup_old_logs`` used to rebind the list through ``global``,
+which replaces only the defining module's name — after the split that left the
+package barrel exporting the pre-purge list. It now mutates in place, so every
+holder of the list sees the same contents and no layout here depends on that.
+"""
 
 import asyncio
 import os
 import uuid
-from datetime import datetime, timedelta
-from enum import Enum
+from datetime import timedelta
 from typing import Any
 
-from pydantic import BaseModel, Field
-from sqlalchemy import and_, desc, func, or_, select
+from sqlalchemy import and_, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.audit import (
-    ComplianceAuditEntry,
-    DataClassification,
-    RetentionPolicy,
+from models.audit import ComplianceAuditEntry, DataClassification
+from services.audit_service.models import (
+    AuditAction,
+    AuditLogEntry,
+    AuditLogFilter,
+    AuditLogResponse,
+    ResourceType,
+)
+from services.audit_service.stats import (
+    _APPROVAL_ACTIONS,
+    _TOOL_ACTIONS,
+    TREND_DAYS,
+    _build_conditions,
+    build_recent_trend,
+    compute_stats_from_logs,
 )
 from utils.time import utcnow
 
 USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
 
 
-class AuditAction(str, Enum):
-    """Audit action types."""
-
-    # Session actions
-    SESSION_CREATED = "session_created"
-    SESSION_DELETED = "session_deleted"
-    SESSION_EXPIRED = "session_expired"
-
-    # Task actions
-    TASK_CREATED = "task_created"
-    TASK_UPDATED = "task_updated"
-    TASK_COMPLETED = "task_completed"
-    TASK_FAILED = "task_failed"
-    TASK_CANCELLED = "task_cancelled"
-    TASK_PAUSED = "task_paused"
-    TASK_RESUMED = "task_resumed"
-    TASK_RETRIED = "task_retried"
-    TASK_DELETED = "task_deleted"
-
-    # Approval actions
-    APPROVAL_REQUESTED = "approval_requested"
-    APPROVAL_GRANTED = "approval_granted"
-    APPROVAL_DENIED = "approval_denied"
-
-    # Tool actions
-    TOOL_EXECUTED = "tool_executed"
-    TOOL_FAILED = "tool_failed"
-
-    # Agent actions
-    AGENT_ASSIGNED = "agent_assigned"
-    AGENT_COMPLETED = "agent_completed"
-
-    # Permission actions
-    PERMISSION_CHANGED = "permission_changed"
-    AGENT_DISABLED = "agent_disabled"
-    AGENT_ENABLED = "agent_enabled"
-
-    # Authentication actions
-    USER_LOGIN = "user_login"
-    USER_LOGOUT = "user_logout"
-    TOKEN_REFRESHED = "token_refreshed"
-    USER_REGISTERED = "user_registered"
-    LOGIN_FAILED = "login_failed"
-
-    # Project actions
-    PROJECT_CREATED = "project_created"
-    PROJECT_UPDATED = "project_updated"
-    PROJECT_DELETED = "project_deleted"
-
-    # Config actions (skills, agents, MCP, hooks, commands)
-    CONFIG_CREATED = "config_created"
-    CONFIG_UPDATED = "config_updated"
-    CONFIG_DELETED = "config_deleted"
-
-    # Notification actions
-    NOTIFICATION_RULE_CREATED = "notification_rule_created"
-    NOTIFICATION_RULE_UPDATED = "notification_rule_updated"
-    NOTIFICATION_RULE_DELETED = "notification_rule_deleted"
-
-    # LLM Router actions
-    LLM_PROVIDER_CHANGED = "llm_provider_changed"
-
-
-class ResourceType(str, Enum):
-    """Resource types for audit logging."""
-
-    SESSION = "session"
-    TASK = "task"
-    APPROVAL = "approval"
-    AGENT = "agent"
-    USER = "user"
-    PERMISSION = "permission"
-    TOOL = "tool"
-    PROJECT = "project"
-    CONFIG = "config"
-    NOTIFICATION = "notification"
-    LLM_PROVIDER = "llm_provider"
-
-
-class AuditLogEntry(BaseModel):
-    """Audit log entry model."""
-
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    session_id: str | None = None
-    user_id: str | None = None
-    project_id: str | None = None
-
-    action: AuditAction
-    resource_type: ResourceType
-    resource_id: str | None = None
-
-    old_value: dict[str, Any] | None = None
-    new_value: dict[str, Any] | None = None
-    changes: dict[str, Any] | None = None
-
-    agent_id: str | None = None
-    ip_address: str | None = None
-    user_agent: str | None = None
-
-    metadata: dict[str, Any] = Field(default_factory=dict)
-    status: str = "success"
-    error_message: str | None = None
-
-    created_at: datetime = Field(default_factory=utcnow)
-
-    # Compliance fields (optional for backward compatibility)
-    data_classification: DataClassification | None = None
-    change_reason: str | None = None
-    compliance_flags: list[str] = Field(default_factory=list)
-    previous_hash: str | None = None
-    hash: str | None = None
-    retention_policy: RetentionPolicy | None = None
-
-
-class AuditLogFilter(BaseModel):
-    """Filter for querying audit logs."""
-
-    session_id: str | None = None
-    user_id: str | None = None
-    project_id: str | None = None
-    include_global: bool = True  # Include project_id IS NULL events when filtering by project
-    action: AuditAction | None = None
-    resource_type: ResourceType | None = None
-    resource_id: str | None = None
-    status: str | None = None
-    start_date: datetime | None = None
-    end_date: datetime | None = None
-    limit: int = 100
-    offset: int = 0
-
-
-class AuditLogResponse(BaseModel):
-    """Response model for audit log queries."""
-
-    logs: list[AuditLogEntry]
-    total: int
-    limit: int
-    offset: int
-
-
-# In-memory storage for development fallback
 _audit_logs: list[AuditLogEntry] = []
-
-
-# ─────────────────────────────────────────────────────────────
-# Stats aggregation helpers
-# ─────────────────────────────────────────────────────────────
-
-# Action categories — explicit membership instead of fragile substring matching
-_TOOL_ACTIONS: frozenset[AuditAction] = frozenset(
-    {AuditAction.TOOL_EXECUTED, AuditAction.TOOL_FAILED}
-)
-_APPROVAL_ACTIONS: frozenset[AuditAction] = frozenset(
-    {
-        AuditAction.APPROVAL_REQUESTED,
-        AuditAction.APPROVAL_GRANTED,
-        AuditAction.APPROVAL_DENIED,
-    }
-)
-
-# Number of calendar days shown in the activity trend
-TREND_DAYS = 7
-
-
-def build_recent_trend(day_counts: dict[str, int], days: int = TREND_DAYS) -> list[dict[str, Any]]:
-    """Build a contiguous day-by-day activity trend ending today (UTC).
-
-    Unlike a bare ``GROUP BY date``, this zero-fills days with no activity, so
-    the chart always shows exactly ``days`` consecutive calendar days and the
-    "Last N days" label is literally accurate.
-    """
-    today = utcnow().date()
-    trend: list[dict[str, Any]] = []
-    for offset in range(days - 1, -1, -1):
-        date_str = (today - timedelta(days=offset)).strftime("%Y-%m-%d")
-        trend.append({"date": date_str, "count": day_counts.get(date_str, 0)})
-    return trend
-
-
-def compute_stats_from_logs(logs: list[AuditLogEntry], total: int) -> dict[str, Any]:
-    """Compute the audit statistics payload from a list of log entries."""
-    actions_by_type: dict[str, int] = {}
-    actions_by_status: dict[str, int] = {}
-    day_counts: dict[str, int] = {}
-
-    for log in logs:
-        actions_by_type[log.action.value] = actions_by_type.get(log.action.value, 0) + 1
-        actions_by_status[log.status] = actions_by_status.get(log.status, 0) + 1
-        date_str = log.created_at.strftime("%Y-%m-%d")
-        day_counts[date_str] = day_counts.get(date_str, 0) + 1
-
-    return {
-        "total_actions": total,
-        "tool_executions": sum(actions_by_type.get(a.value, 0) for a in _TOOL_ACTIONS),
-        "approvals": sum(actions_by_type.get(a.value, 0) for a in _APPROVAL_ACTIONS),
-        "errors": actions_by_status.get("failed", 0),
-        "actions_by_type": actions_by_type,
-        "actions_by_status": actions_by_status,
-        "recent_trend": build_recent_trend(day_counts),
-    }
 
 
 def _filter_logs(filter: AuditLogFilter) -> list[AuditLogEntry]:
@@ -252,40 +69,6 @@ def _filter_logs(filter: AuditLogFilter) -> list[AuditLogEntry]:
         results = [r for r in results if r.created_at <= filter.end_date]
 
     return results
-
-
-def _build_conditions(filter: AuditLogFilter) -> list:
-    """Build SQLAlchemy WHERE conditions shared by log queries and stats aggregation."""
-    from db.models import AuditLogModel
-
-    conditions: list = []
-    if filter.session_id:
-        conditions.append(AuditLogModel.session_id == filter.session_id)
-    if filter.user_id:
-        conditions.append(AuditLogModel.user_id == filter.user_id)
-    if filter.project_id:
-        if filter.include_global:
-            conditions.append(
-                or_(
-                    AuditLogModel.project_id == filter.project_id,
-                    AuditLogModel.project_id.is_(None),
-                )
-            )
-        else:
-            conditions.append(AuditLogModel.project_id == filter.project_id)
-    if filter.action:
-        conditions.append(AuditLogModel.action == filter.action.value)
-    if filter.resource_type:
-        conditions.append(AuditLogModel.resource_type == filter.resource_type.value)
-    if filter.resource_id:
-        conditions.append(AuditLogModel.resource_id == filter.resource_id)
-    if filter.status:
-        conditions.append(AuditLogModel.status == filter.status)
-    if filter.start_date:
-        conditions.append(AuditLogModel.created_at >= filter.start_date)
-    if filter.end_date:
-        conditions.append(AuditLogModel.created_at <= filter.end_date)
-    return conditions
 
 
 class AuditService:
@@ -761,11 +544,18 @@ class AuditService:
 
     @staticmethod
     def cleanup_old_logs(days: int = 30) -> int:
-        """Remove audit logs older than specified days (in-memory)."""
-        global _audit_logs
+        """Remove audit logs older than specified days (in-memory).
+
+        Mutates the list in place rather than rebinding it. Rebinding through
+        ``global`` replaces only this module's name, so the package barrel — and
+        anything else holding the list — would keep the pre-purge contents and
+        report audit data that no longer exists. Splitting the module made that
+        reachable through ``services.audit_service._audit_logs``; mutating in
+        place removes the hazard for every holder at once.
+        """
         cutoff = utcnow() - timedelta(days=days)
         original_count = len(_audit_logs)
-        _audit_logs = [log for log in _audit_logs if log.created_at >= cutoff]
+        _audit_logs[:] = [log for log in _audit_logs if log.created_at >= cutoff]
         return original_count - len(_audit_logs)
 
     @staticmethod
@@ -841,145 +631,3 @@ class AuditService:
 
         else:
             raise ValueError(f"Unsupported format: {format}")
-
-
-# Convenience functions for common audit events
-def audit_task_created(
-    session_id: str,
-    task_id: str,
-    task_data: dict,
-    user_id: str | None = None,
-    project_id: str | None = None,
-) -> AuditLogEntry:
-    """Log task creation."""
-    return AuditService.log(
-        action=AuditAction.TASK_CREATED,
-        resource_type=ResourceType.TASK,
-        resource_id=task_id,
-        session_id=session_id,
-        user_id=user_id,
-        project_id=project_id,
-        new_value=task_data,
-    )
-
-
-def audit_task_status_change(
-    session_id: str,
-    task_id: str,
-    old_status: str,
-    new_status: str,
-    agent_id: str | None = None,
-    project_id: str | None = None,
-) -> AuditLogEntry:
-    """Log task status change."""
-    action_map = {
-        "completed": AuditAction.TASK_COMPLETED,
-        "failed": AuditAction.TASK_FAILED,
-        "cancelled": AuditAction.TASK_CANCELLED,
-        "paused": AuditAction.TASK_PAUSED,
-        "pending": AuditAction.TASK_RESUMED if old_status == "paused" else AuditAction.TASK_UPDATED,
-    }
-    action = action_map.get(new_status, AuditAction.TASK_UPDATED)
-
-    return AuditService.log(
-        action=action,
-        resource_type=ResourceType.TASK,
-        resource_id=task_id,
-        session_id=session_id,
-        agent_id=agent_id,
-        project_id=project_id,
-        old_value={"status": old_status},
-        new_value={"status": new_status},
-    )
-
-
-def audit_tool_executed(
-    session_id: str,
-    tool_name: str,
-    tool_args: dict,
-    result: Any,
-    agent_id: str | None = None,
-    task_id: str | None = None,
-    project_id: str | None = None,
-) -> AuditLogEntry:
-    """Log tool execution."""
-    return AuditService.log(
-        action=AuditAction.TOOL_EXECUTED,
-        resource_type=ResourceType.TOOL,
-        resource_id=tool_name,
-        session_id=session_id,
-        agent_id=agent_id,
-        project_id=project_id,
-        new_value={"args": tool_args, "result": str(result)[:1000]},
-        metadata={"task_id": task_id} if task_id else None,
-    )
-
-
-def audit_approval(
-    session_id: str,
-    approval_id: str,
-    action: AuditAction,
-    user_id: str | None = None,
-    note: str | None = None,
-) -> AuditLogEntry:
-    """Log approval action."""
-    return AuditService.log(
-        action=action,
-        resource_type=ResourceType.APPROVAL,
-        resource_id=approval_id,
-        session_id=session_id,
-        user_id=user_id,
-        metadata={"note": note} if note else None,
-    )
-
-
-def audit_user_auth(
-    action: AuditAction,
-    user_id: str | None = None,
-    metadata: dict | None = None,
-    status: str = "success",
-    error_message: str | None = None,
-) -> AuditLogEntry:
-    """Log authentication event (login, logout, register, token refresh)."""
-    return AuditService.log(
-        action=action,
-        resource_type=ResourceType.USER,
-        resource_id=user_id,
-        user_id=user_id,
-        metadata=metadata or {},
-        status=status,
-        error_message=error_message,
-    )
-
-
-def audit_config_change(
-    action: AuditAction,
-    config_type: str,
-    config_id: str,
-    project_id: str | None = None,
-    user_id: str | None = None,
-) -> AuditLogEntry:
-    """Log configuration change (skill, agent, MCP, hook, command)."""
-    return AuditService.log(
-        action=action,
-        resource_type=ResourceType.CONFIG,
-        resource_id=config_id,
-        user_id=user_id,
-        project_id=project_id,
-        metadata={"config_type": config_type},
-    )
-
-
-def audit_project_change(
-    action: AuditAction,
-    project_id: str,
-    user_id: str | None = None,
-) -> AuditLogEntry:
-    """Log project change."""
-    return AuditService.log(
-        action=action,
-        resource_type=ResourceType.PROJECT,
-        resource_id=project_id,
-        user_id=user_id,
-        project_id=project_id,
-    )

--- a/src/backend/services/audit_service/stats.py
+++ b/src/backend/services/audit_service/stats.py
@@ -1,0 +1,101 @@
+"""Aggregation over audit log entries and query-filter translation.
+
+These take the entries handed to them and never reach for the in-memory store,
+so they are outside the rebinding constraint documented in ``service.py``.
+"""
+
+from datetime import timedelta
+from typing import Any
+
+from sqlalchemy import or_
+
+from services.audit_service.models import AuditAction, AuditLogEntry, AuditLogFilter
+from utils.time import utcnow
+
+_TOOL_ACTIONS: frozenset[AuditAction] = frozenset(
+    {AuditAction.TOOL_EXECUTED, AuditAction.TOOL_FAILED}
+)
+
+
+_APPROVAL_ACTIONS: frozenset[AuditAction] = frozenset(
+    {
+        AuditAction.APPROVAL_REQUESTED,
+        AuditAction.APPROVAL_GRANTED,
+        AuditAction.APPROVAL_DENIED,
+    }
+)
+
+
+TREND_DAYS = 7
+
+
+def build_recent_trend(day_counts: dict[str, int], days: int = TREND_DAYS) -> list[dict[str, Any]]:
+    """Build a contiguous day-by-day activity trend ending today (UTC).
+
+    Unlike a bare ``GROUP BY date``, this zero-fills days with no activity, so
+    the chart always shows exactly ``days`` consecutive calendar days and the
+    "Last N days" label is literally accurate.
+    """
+    today = utcnow().date()
+    trend: list[dict[str, Any]] = []
+    for offset in range(days - 1, -1, -1):
+        date_str = (today - timedelta(days=offset)).strftime("%Y-%m-%d")
+        trend.append({"date": date_str, "count": day_counts.get(date_str, 0)})
+    return trend
+
+
+def compute_stats_from_logs(logs: list[AuditLogEntry], total: int) -> dict[str, Any]:
+    """Compute the audit statistics payload from a list of log entries."""
+    actions_by_type: dict[str, int] = {}
+    actions_by_status: dict[str, int] = {}
+    day_counts: dict[str, int] = {}
+
+    for log in logs:
+        actions_by_type[log.action.value] = actions_by_type.get(log.action.value, 0) + 1
+        actions_by_status[log.status] = actions_by_status.get(log.status, 0) + 1
+        date_str = log.created_at.strftime("%Y-%m-%d")
+        day_counts[date_str] = day_counts.get(date_str, 0) + 1
+
+    return {
+        "total_actions": total,
+        "tool_executions": sum(actions_by_type.get(a.value, 0) for a in _TOOL_ACTIONS),
+        "approvals": sum(actions_by_type.get(a.value, 0) for a in _APPROVAL_ACTIONS),
+        "errors": actions_by_status.get("failed", 0),
+        "actions_by_type": actions_by_type,
+        "actions_by_status": actions_by_status,
+        "recent_trend": build_recent_trend(day_counts),
+    }
+
+
+def _build_conditions(filter: AuditLogFilter) -> list:
+    """Build SQLAlchemy WHERE conditions shared by log queries and stats aggregation."""
+    from db.models import AuditLogModel
+
+    conditions: list = []
+    if filter.session_id:
+        conditions.append(AuditLogModel.session_id == filter.session_id)
+    if filter.user_id:
+        conditions.append(AuditLogModel.user_id == filter.user_id)
+    if filter.project_id:
+        if filter.include_global:
+            conditions.append(
+                or_(
+                    AuditLogModel.project_id == filter.project_id,
+                    AuditLogModel.project_id.is_(None),
+                )
+            )
+        else:
+            conditions.append(AuditLogModel.project_id == filter.project_id)
+    if filter.action:
+        conditions.append(AuditLogModel.action == filter.action.value)
+    if filter.resource_type:
+        conditions.append(AuditLogModel.resource_type == filter.resource_type.value)
+    if filter.resource_id:
+        conditions.append(AuditLogModel.resource_id == filter.resource_id)
+    if filter.status:
+        conditions.append(AuditLogModel.status == filter.status)
+    if filter.start_date:
+        conditions.append(AuditLogModel.created_at >= filter.start_date)
+    if filter.end_date:
+        conditions.append(AuditLogModel.created_at <= filter.end_date)
+    return conditions

--- a/tests/backend/test_audit_service_package.py
+++ b/tests/backend/test_audit_service_package.py
@@ -1,0 +1,126 @@
+"""Invariants the ``services.audit_service`` package split has to keep.
+
+The split is behavior-preserving movement, so most of its risk is invisible to
+the existing suite — every existing test passes whether or not the barrel still
+exposes what its 20-odd import sites reach for, because those sites are imported
+at startup and a missing name fails there, not in a test of this package.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+import services.audit_service as barrel
+import services.audit_service.service as service_module
+from services.audit_service import (
+    AuditAction,
+    AuditLogEntry,
+    AuditLogFilter,
+    AuditService,
+    ResourceType,
+)
+from utils.time import utcnow
+
+# Every name an importer outside the package reaches for, measured from the
+# import sites rather than guessed. Dropping one breaks a caller at import time.
+_PUBLIC_SURFACE = (
+    "AuditAction",
+    "AuditLogEntry",
+    "AuditLogFilter",
+    "AuditLogResponse",
+    "AuditService",
+    "ResourceType",
+    "USE_DATABASE",
+    "_audit_logs",
+    "audit_config_change",
+    "audit_task_created",
+    "audit_task_status_change",
+    "audit_tool_executed",
+    "audit_user_auth",
+    "build_recent_trend",
+    "compute_stats_from_logs",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store():
+    """Reset the store around each test.
+
+    Contents only: ``cleanup_old_logs`` no longer rebinds the list, so identity
+    is stable and there is nothing else to restore. If a future change brings
+    rebinding back, the assertions below fail before this fixture matters.
+    """
+    service_module._audit_logs.clear()
+    yield
+    service_module._audit_logs.clear()
+
+
+@pytest.mark.parametrize("name", _PUBLIC_SURFACE)
+def test_barrel_still_exposes_every_imported_name(name: str) -> None:
+    """``services.audit_service`` stays valid verbatim at all of its import sites."""
+    assert hasattr(barrel, name), f"{name} 이 배럴에서 사라졌다"
+
+
+def test_purge_and_query_agree_after_the_split() -> None:
+    """The store, its purge, and the reader that filters it stay consistent.
+
+    ``_audit_logs``, ``_filter_logs`` and ``AuditService`` live in one module so
+    the store has a single owner; this pins that a purge and the reader that
+    queries the store agree afterwards.
+    """
+    stale = AuditLogEntry(
+        action=AuditAction.TOOL_EXECUTED,
+        resource_type=ResourceType.TASK,
+        resource_id="stale",
+        created_at=utcnow() - timedelta(days=90),
+    )
+    fresh = AuditLogEntry(
+        action=AuditAction.TOOL_EXECUTED,
+        resource_type=ResourceType.TASK,
+        resource_id="fresh",
+    )
+    service_module._audit_logs.extend([stale, fresh])
+
+    removed = AuditService.cleanup_old_logs(days=30)
+    surviving = service_module._filter_logs(AuditLogFilter(limit=100, offset=0))
+
+    assert removed == 1
+    assert len(service_module._audit_logs) == 1
+    assert [entry.resource_id for entry in surviving] == ["fresh"]
+
+
+def test_purge_is_visible_through_every_holder_of_the_store() -> None:
+    """The barrel, the service module, and a captured reference all agree.
+
+    Before the split this held for free: one module owned the list, so reading
+    ``audit_service._audit_logs`` after a purge read the rebound name. The split
+    broke it — the barrel's ``from .service import _audit_logs`` is a snapshot,
+    so a ``global`` rebinding left the package exporting pre-purge contents.
+
+    ``cleanup_old_logs`` now mutates in place, which restores the pre-split
+    behavior for every holder at once. This asserts all three views, because
+    checking only one of them is how the regression survived a first review.
+    """
+    captured = service_module._audit_logs
+    captured.extend(
+        [
+            AuditLogEntry(
+                action=AuditAction.TOOL_EXECUTED,
+                resource_type=ResourceType.TASK,
+                resource_id="stale",
+                created_at=utcnow() - timedelta(days=90),
+            ),
+            AuditLogEntry(
+                action=AuditAction.TOOL_EXECUTED,
+                resource_type=ResourceType.TASK,
+                resource_id="fresh",
+            ),
+        ]
+    )
+
+    removed = AuditService.cleanup_old_logs(days=30)
+
+    assert removed == 1
+    assert len(service_module._audit_logs) == 1
+    assert len(barrel._audit_logs) == 1, "배럴이 purge 이전 리스트를 노출한다"
+    assert len(captured) == 1, "미리 잡아둔 참조가 purge 를 못 본다"


### PR DESCRIPTION
파일 분할 프로그램 **B5.5 의 첫 대상**. 986줄 → 최대 모듈 **633줄**.

## 착수 전 실측이 계획서 분류를 뒤집었다

계획서는 B5.5 5개를 "집중도 48~65% → **2단계**(클래스 이동 + 메서드 추출) 필요"로 분류했다. **집중도(최대 클래스 / 파일)는 판정 지표가 아니다.** 실제 지표는 **잔여 = 전체 − 이동가능**이고, 5개 중 **4개가 정의 이동만으로** 한도에 들어간다:

| 대상 | 줄수 | 집중도 | **잔여** | 문자열패치 | 모듈객체패치 |
|---|---:|---:|---:|---:|---:|
| **audit_service** | 986 | 56% | **634** | **0** | **0** |
| tmux_service | 921 | 63% | 660 | 4 | 0 |
| merge_service | 1,329 | 48% | 693 | 6 | 0 |
| notification_service | 1,018 | 65% | 743 | 13 | 0 |
| playground_service | 1,287 | 63% | 963 | 0 | 12 |

**첫 대상의 근거는 잔여가 아니라 패치 스캔이다** — `audit_service` 만 네 형태 전부 0건이다.

## 배치

패키지 승격(`audit_service.py` → `audit_service/__init__.py`)으로 20여 개 import 사이트에서 `services.audit_service` 가 **글자 그대로 유효**하게 남는다.

| 모듈 | 줄 | 내용 |
|---|---:|---|
| `service.py` | 633 | `AuditService` · `_audit_logs` · `_filter_logs` · `USE_DATABASE` |
| `models.py` | 155 | 열거형·Pydantic 5종 |
| `helpers.py` | 151 | `audit_*` 래퍼 7종 |
| `stats.py` | 101 | 집계 3종 + 카테고리 상수 |
| `__init__.py` | 55 | 배럴 (외부 15종 재노출) |

## 순수 이동이 아닌 곳이 정확히 한 군데 — `cleanup_old_logs`

**분할이 회귀를 만들었고 Codex 리뷰가 잡았다.** 실측한 동작 차이:

```
분할 전  import services.audit_service as m; m._audit_logs  -> purge 반영 (1건)
분할 후  배럴 재노출                                        -> 낡음     (2건)
```

원인은 `global` 재바인딩이다. `global` 은 정의한 모듈의 이름만 다시 묶으므로, 단일 모듈일 때는 모듈 속성이 곧 최신이었지만 배럴의 `from .service import _audit_logs` 는 **스냅샷**이라 purge 이전 리스트를 계속 노출한다.

배럴을 동적으로 만드는 대신 **재바인딩 자체를 없앴다** — `_audit_logs[:] = [...]`. 모든 보유자가 같은 내용을 보고, "저장소·`_filter_logs`·`AuditService` 를 같은 모듈에 둬야 한다"는 제약도 함께 무의미해진다. `AuditService` 본문 변경은 **이 메서드 한 곳(13줄)뿐**이며 감사 도구가 그것을 정확히 지목한다.

### 한 번 과하게 주장했다가 되돌렸다

초안은 "저장소를 떼면 깨진다"고 단언했으나 **증명하지 못했다.** 금지 배치에서 두 모듈 전역이 갈라지는 것은 맞지만 **그 차이를 읽는 소비자가 0건**이었고, 그 증거가 초안 테스트다 — 금지 배치에서 16/16 통과했다.

그리고 그 판단에 기대어 **"배럴이 낡는 것은 기존 동작"이라고 넘긴 것이 위 회귀를 놓친 경로다.** 소비자가 없다는 사실이 동작이 안 바뀌었다는 근거가 되지는 않는다.

## 테스트 계획

**정의 보존** — `scripts/split_audit.py` 신규. 라인 범위 diff 는 자기확인이므로 **AST 이름 집합 + 본문 바이트 대조**. 22종 → 22종, 유실·신규 0, **본문 변경 1종**(위 의도된 변경).

**도구 자체를 Red-Green** 했다:

| 프로브 | 결과 |
|---|---|
| 원본 그대로 복사 | OK |
| 정의 1종 삭제 | FAIL |
| 본문 한 구절 변경 | FAIL |
| **데코레이터만 제거** | FAIL |
| **`if TYPE_CHECKING:` 안의 정의 삭제** | FAIL |
| **`try` 분기 정의 삭제** | FAIL |

**배럴 표면** — 외부 15종을 import 사이트에서 실측해 테스트로 고정. 하나라도 빠지면 소비자가 **import 시점에** 죽는데 패키지 단위 테스트로는 안 잡힌다.

**게이트** — `ruff check` / `ruff format --check` / `mypy` 317 files 0 issues / `pytest` **1685 passed, 33 skipped, 0 failed** (기준선 1668/33 + 신규 17)

### 한 번 6건이 깨졌고 원인은 분할이 아니라 신규 테스트였다

`cleanup_old_logs` 를 호출하는 테스트는 이 세션 전까지 **하나도 없었다**(프로덕션만 부른다). 신규 테스트가 처음으로 스위트 안에서 재바인딩을 일으키자 배럴 바인딩이 세션 내내 낡아 뒤따르는 6건이 실패했다. 지금은 재바인딩 자체가 없어져 원인이 사라졌다.

## Codex 리뷰가 검증 도구의 결함 3건도 잡았다

도구에 무판정 구멍이 있으면 분할이 통과한 것도 근거가 되지 않으므로 각각 RED 로 재현한 뒤 고쳤다 — 배럴 `__all__` 오탐, 데코레이터 누락, 모듈 레벨 컨테이너 미탐색. 재귀를 넣자 `try/except` 재대입이 "중복 정의"로 죽어서, 파일 안의 재대입은 이어 붙이고 중복 판정은 **모듈 간에만** 적용하도록 바꿨다.

### 반영하지 않은 지적 1건과 이유

**"import 도 바인딩이니 감사에 포함하라"** — 위험 자체는 맞다. 그러나 분할은 같은 이름을 여러 모듈에서 다시 import 하므로 1:1 대응을 요구하면 **올바른 분할이 전부 실패**한다(실제로 `AuditAction` 이 배럴과 `helpers` 에서 충돌했다). 이 층은 도구가 아니라 **`ruff` F821 이 정적으로 덮는다** — 주장이 아니라 실측이다: `helpers.py` 에서 import 한 줄을 지우면 `F821 Undefined name 'AuditService'` 가 난다. 도구 docstring 에 그 경계를 적었다.

## 남은 B5.5

`tmux_service` → `merge_service` → `notification_service` → `playground_service` 순. 위 표가 순서의 근거다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFKXCJPyHbiU3qFwVjAyok