### PR TITLE
fix(security): git API 전체에 인증 게이트를 건다

### DIFF
--- a/src/backend/api/git/__init__.py
+++ b/src/backend/api/git/__init__.py
@@ -9,7 +9,9 @@
 깨진다(Global Constraints 2 위반).
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from api.deps import get_current_user
 
 from . import (
     branches,
@@ -23,7 +25,27 @@ from . import (
 )
 from .commits import generate_draft_commits, generate_draft_commits_for_project
 
-router = APIRouter(prefix="/git", tags=["git"])
+# 인증은 **라우터 소유 모듈**에서 건다. 하위 8 모듈의 라우트가 전부 이 하나를
+# 지나므로, 여기 걸면 새 라우트가 추가돼도 자동으로 덮인다 — 라우트마다 의존성을
+# 붙이는 방식은 한 곳만 빠뜨려도 조용히 열린다.
+#
+# 2026-08-28 이전에는 이 패키지 어디에도 인증 게이트가 없었다. 실측에서 미인증
+# 요청이 `/branches`·`/commits`·`/remotes` 에 200 과 실제 저장소 데이터를 받았고,
+# 쓰기 계열도 401 이 아니라 422(본문 검증)까지 도달했다. `PROJECTS_REGISTRY` 가
+# 비어 있는 동안에는 404 로 닫혀 보였을 뿐이라, 레지스트리를 채우자 드러났다.
+#
+# 대시보드는 이미 `apiClient` 의 auth interceptor 로 Authorization 헤더를 보내고
+# 있어(그리고 git store 는 전부 apiClient 를 쓴다) 이 변경으로 깨지지 않는다.
+#
+# 이것은 **인증**(누구인지)만 건다. 프로젝트 단위 **인가**(그 프로젝트에 접근할
+# 권한이 있는지)는 아직 없다 — 라우트의 `project_id` 가 path 기반 문자열인 반면
+# `require_project_role` 은 UUID 를 기대해서, ID 해석 통일이 선행 조건이다.
+# `.planning/STATE.md` 의 후속 1·2 에 그 작업으로 묶어 두었다.
+router = APIRouter(
+    prefix="/git",
+    tags=["git"],
+    dependencies=[Depends(get_current_user)],
+)
 
 # 등록 순서는 원본 선언 순서를 재현하지 않는다 — 원본은 도메인 그룹이 불연속이라
 # (branch-protection·draft-commits·fetch/pull/push) 복원 자체가 불가능하다.

--- a/tests/backend/api/test_api_git_prune.py
+++ b/tests/backend/api/test_api_git_prune.py
@@ -15,11 +15,23 @@ from httpx import ASGITransport, AsyncClient
 
 @pytest.fixture
 def app() -> FastAPI:
-    """Create test FastAPI app with git router."""
+    """Create test FastAPI app with git router.
+
+    The git router requires authentication (2026-08-28), so an identity is
+    injected here. What this file tests is the prune endpoint's contract, not
+    the gate -- the gate itself is covered by the git authentication tests in
+    `test_security_hardening.py`.
+    """
+    from types import SimpleNamespace
+
+    from api.deps import get_current_user
     from api.git import router
 
     test_app = FastAPI()
     test_app.include_router(router)
+    test_app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="test-user", role="admin", is_admin=True, is_active=True
+    )
     return test_app
 
 

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -1665,7 +1665,9 @@ def _register_git_project(tmp_path) -> str:
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    # `-b` 로 이름을 고정한다 — init.defaultBranch 는 환경마다 다르다
+    # (로컬 main / CI 기본 master).
+    subprocess.run(["git", "init", "-q", "-b", "work"], cwd=repo, check=True)
     (repo / "f.txt").write_text("x\n")
     subprocess.run(["git", "add", "."], cwd=repo, check=True)
     subprocess.run(
@@ -1723,4 +1725,6 @@ async def test_git_route_reachable_when_authenticated(client, authenticated_app,
     response = await client.get(f"/api/git/projects/{project_id}/branches")
 
     assert response.status_code == 200
-    assert any(b["name"] == "main" for b in response.json()["branches"])
+    branches = response.json()["branches"]
+    assert [b["name"] for b in branches] == ["work"]
+    assert branches[0]["is_current"] is True

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -1639,3 +1639,88 @@ async def test_db_global_config_route_requires_privileged_role(monkeypatch):
     )
 
     assert result is operator
+
+
+# ─────────────────────────────────────────────────────────────
+# Git API authentication
+#
+# The git package had no authentication gate at all until 2026-08-28: the
+# router carried no `dependencies`, `include_router` added none, and the one
+# `get_current_user` in the package (commits.py) is the *optional* variant.
+# Unauthenticated GETs returned 200 with real repository data once a project
+# was in PROJECTS_REGISTRY; writes reached body validation (422, not 401).
+# An empty registry made it look closed -- `7ed7c46` filled the registry in
+# database mode and the surface became reachable.
+#
+# No test called a git route over HTTP, which is why nothing caught it. These
+# do.
+# ─────────────────────────────────────────────────────────────
+
+
+def _register_git_project(tmp_path) -> str:
+    """Create a real repo and register it, returning the route's project_id."""
+    import subprocess
+
+    from models.project import register_project
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "f.txt").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=a@b.c", "-c", "user.name=t", "commit", "-qm", "init"],
+        cwd=repo,
+        check=True,
+    )
+    project_id = str(repo).replace("/", "-")
+    register_project(project_id, str(repo))
+    return project_id
+
+
+@pytest.mark.anyio
+async def test_git_reads_require_authentication(client, tmp_path):
+    """A registered project must not expose its history to anonymous callers.
+
+    These returned 200 with branch names, commit SHAs, messages and author
+    identities before the router gate existed.
+    """
+    project_id = _register_git_project(tmp_path)
+
+    for path in (
+        f"/api/git/projects/{project_id}/branches",
+        f"/api/git/projects/{project_id}/commits",
+        f"/api/git/projects/{project_id}/remotes",
+    ):
+        response = await client.get(path)
+        assert response.status_code == 401, f"{path} -> {response.status_code}"
+
+
+@pytest.mark.anyio
+async def test_git_writes_require_authentication(client, tmp_path):
+    """Writes must be rejected before body validation, not after.
+
+    A 422 here would mean the request reached the handler's schema check with
+    no identity attached -- that was the pre-fix behaviour.
+    """
+    project_id = _register_git_project(tmp_path)
+
+    response = await client.post(
+        f"/api/git/projects/{project_id}/branches", json={"name": "injected"}
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_git_route_reachable_when_authenticated(client, authenticated_app, tmp_path):
+    """The gate must not break the dashboard: an authenticated read still works.
+
+    Guards against "fixed by making it always fail" -- the frontend sends a
+    bearer token via apiClient's auth interceptor, so this is the real path.
+    """
+    project_id = _register_git_project(tmp_path)
+
+    response = await client.get(f"/api/git/projects/{project_id}/branches")
+
+    assert response.status_code == 200
+    assert any(b["name"] == "main" for b in response.json()["branches"])


### PR DESCRIPTION
`#350` 이 기록한 발견의 **1 단계 수정**이다.

## 문제

`api/git` 패키지에는 인증 게이트가 **없었다.** 라우터에도 `include_router` 에도 `dependencies` 가
없고, 패키지 안의 유일한 `get_current_user` 사용처(`commits.py`)는 optional 변형이다.

| 미인증 요청 | 수정 전 | 수정 후 |
|---|---|---|
| `GET /branches`·`/commits`·`/remotes` | **200 + 실제 저장소 데이터** | 401 |
| `POST /branches` | **200 — 실제로 브랜치가 생성됨** | 401 |
| 인증된 `GET /branches` | 200 | 200 (변화 없음) |

이 라우터에는 checkout · merge · remote 조작 · 브랜치 삭제도 있다.

`PROJECTS_REGISTRY` 가 비어 있는 동안에는 404 로 닫혀 보였을 뿐이다. `7ed7c46` 이 DB 모드에서
레지스트리를 채우면서 도달 가능해졌다 — **결함을 만든 것이 아니라 드러낸 것이다.**

> `#350` 작성 시점에는 쓰기 노출을 422 로 적었으나 그것은 요청 본문 필드명을 틀린 탓이었다.
> 올바른 본문으로는 200 이다. 읽기 전용 노출이 아니었다.

## 수정

**인증을 라우터 소유 모듈에 건다** (`api/git/__init__.py`). 하위 8 모듈의 라우트가 전부 이 하나를
지나므로 새 라우트가 추가돼도 자동으로 덮인다. 라우트마다 붙이는 방식은 한 곳만 빠뜨려도 조용히 열린다.

**대시보드는 깨지지 않는다** — git store 는 전부 `apiClient` 를 쓰고 그 auth interceptor 가 매 요청에
Authorization 헤더를 붙인다(실측). `04574fa` 의 WebSocket 건처럼 백엔드만 고쳐 계약이 파손되는
경우가 아니다.

## 회귀 3 건

미인증 읽기 401 · 미인증 쓰기 401 · **인증 시 200**. 세 번째는 "항상 실패시켜 고친 것"이 아님을
잠그는 반대 방향 단언이다.

**Red-Green**: 게이트를 되돌리면 **앞의 2 건만** 실패하고 세 번째는 통과한다.

이 부재가 오래 살아남은 이유도 함께 다뤘다 — git 라우트를 HTTP 로 호출하는 테스트가 사실상 없었다.
`test_api_git_prune.py` 는 `/api` prefix 없이 경로 상수로 호출해 사전 조사의 grep 에도 걸리지 않았고,
그 `app` fixture 에 신원을 주입해 정렬했다(그 파일의 대상은 prune 계약이지 인증이 아니다).

## 범위

**인증(누구인지)만이다.** 프로젝트 단위 **인가**(그 프로젝트에 접근할 권한이 있는지)는 아직 없다 —
라우트 `project_id` 가 path 기반 문자열인 반면 `require_project_role` 은 UUID 를 기대해서 ID 해석
통일이 선행 조건이다. `#350` 의 후속 1 과 한 작업으로 묶어 두었다.

## 검증

| 트랙 | 결과 |
|---|---|
| BE | ruff 0 · ruff format 0 · mypy 313 files 0 · pytest **1671 passed** / 33 skipped |
| FE | tsc 0 · vitest 210 files **4434 passed** |

> `#350`(문서)과 순서 의존은 없다. 다만 `#350` 머지 후 STATE.md 의 해당 항목을 "1 단계 완료" 로
> 갱신해야 한다 — 이 PR 에는 넣지 못했다(그 문서 내용이 아직 main 에 없다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPej1m4qTw8Byrp2SyHeno
