### PR TITLE
refactor(services): tmux_service 를 패키지로 승격해 한도 안에 넣는다 (B5.5 Task 2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,7 +249,7 @@ src/backend/
 │   ├── analytics_service.py       # 분석 서비스 (세션 파일 + DB 이중 지원)
 │   ├── artifact_service.py        # 워크플로우 아티팩트 관리
 │   ├── audit_integrity.py         # 감사 로그 무결성 검증
-│   ├── audit_service.py           # 감사 로그 서비스
+│   ├── audit_service/             # 감사 로그 서비스 (패키지: models·helpers·stats·service)
 │   ├── auth_service.py            # OAuth/JWT/Email 인증
 │   ├── claude_config_service.py   # Claude OAuth 토큰 관리 (Keychain/env/파일)
 │   ├── claude_session_monitor.py  # Claude 세션 파일 스캔/파싱
@@ -305,7 +305,7 @@ src/backend/
 │   ├── task_analysis_service.py   # 태스크 복잡도 분석
 │   ├── task_service.py            # 태스크 CRUD/상태 관리
 │   ├── template_service.py        # 워크플로우 템플릿 관리
-│   ├── tmux_service.py            # Tmux 세션 관리
+│   ├── tmux_service/              # Tmux 세션 관리 (패키지: models·usage·service)
 │   ├── variable_expander.py       # ${{ }} 변수 치환 (steps/env/matrix/secrets)
 │   ├── version_service.py         # 설정 버전 관리/롤백
 │   ├── memory_manager.py          # Claude Code 메모리 파일 CRUD 관리
@@ -458,7 +458,7 @@ class LeadOrchestratorAgent(BaseAgent):
 | 산출물 | 경로 | 도달 지점 |
 |--------|------|-----------|
 | `execution_plan` | `POST /api/agents/orchestrate/execute-analysis` 가 `plan_metadata.pre_analyzed_execution_plan` 으로 주입(`api/agents/orchestrate.py:467`) | `PlannerNode` 가 읽어 LLM 계획 수립을 건너뛴다(`orchestrator/nodes/planner.py:229`) |
-| `safety_flags` | Claude Code CLI 프롬프트의 `## Safety Warnings` 섹션 생성 | `services/tmux_service.py:639 build_claude_prompt` 와 그 프론트엔드 포팅 `src/dashboard/src/stores/agents.ts:205 buildClaudePrompt` |
+| `safety_flags` | Claude Code CLI 프롬프트의 `## Safety Warnings` 섹션 생성 | `services/tmux_service/service.py:338 build_claude_prompt` 와 그 프론트엔드 포팅 `src/dashboard/src/stores/agents.ts:205 buildClaudePrompt` |
 
 즉 노드 그래프와 LeadOrchestrator 는 **직접 import 가 없을 뿐**(`grep -rn "LeadOrchestrator" src/backend/orchestrator` → 0건)
 `plan_metadata` 를 경유해 이미 결합돼 있다. 심볼 grep 은 이 데이터 경유 결합을 잡지 못하므로

--- a/docs/architecture/cli-subscription-llm.md
+++ b/docs/architecture/cli-subscription-llm.md
@@ -197,7 +197,7 @@ External Usage는 내부 원장 집계를 보여준다.
 
 - CLI profile secret과 API key는 서로 다른 credential type으로 관리한다.
 - API fallback은 권한이 있는 admin/manager만 활성화할 수 있다.
-- Organization token quota pre-flight는 기본적으로 비활성화한다. CLI subscription 사용량은 내부 ledger에 기록하고 post-hoc counter를 갱신하되, 운영자가 `LLM_USAGE_PREFLIGHT_QUOTA_ENABLED=true`를 설정한 경우에만 `LLMService` 호출과 `tmux_service.py` Claude CLI 실행 시작 전에 차단한다.
+- Organization token quota pre-flight는 기본적으로 비활성화한다. CLI subscription 사용량은 내부 ledger에 기록하고 post-hoc counter를 갱신하되, 운영자가 `LLM_USAGE_PREFLIGHT_QUOTA_ENABLED=true`를 설정한 경우에만 `LLMService` 호출과 `tmux_service/usage.py` Claude CLI 실행 시작 전에 차단한다.
 - 사용자에게 API key 원문은 절대 반환하지 않는다.
 - CLI command execution은 allowlist, timeout, working directory, sandbox 정책을 가져야 한다.
 - ledger는 감사 목적이 있으므로 request prompt 원문 저장을 피하고 correlation id와 token/cost metadata 중심으로 저장한다.

--- a/docs/architecture/llm-runtime-usage.md
+++ b/docs/architecture/llm-runtime-usage.md
@@ -37,7 +37,7 @@ User action
 - Settings의 LLM 사용 권한과 External Usage는 같은 내부 사용량 원장(`LLMUsageLedger`)을 본다.
 - provider가 token metadata를 주지 않으면 request/response 길이 기반 추정치를 기록한다.
 - 비용은 실제 billing cost가 아니라 `estimated_cost_usd`로 취급하며 nullable이어야 한다.
-- organization monthly token quota는 기본적으로 호출을 막지 않고 ledger write 이후 counter를 갱신한다. 운영자가 `LLM_USAGE_PREFLIGHT_QUOTA_ENABLED=true`를 설정한 경우에만 `LLMService` 호출과 `tmux_service.py` Claude CLI 실행 전에 strict quota gate를 적용한다.
+- organization monthly token quota는 기본적으로 호출을 막지 않고 ledger write 이후 counter를 갱신한다. 운영자가 `LLM_USAGE_PREFLIGHT_QUOTA_ENABLED=true`를 설정한 경우에만 `LLMService` 호출과 `tmux_service/usage.py` Claude CLI 실행 전에 strict quota gate를 적용한다.
 
 ---
 
@@ -49,7 +49,7 @@ User action
 | Playground 모델 목록 | `api/playground.py` | `LLMService.get_available_models()` -> `LLMModelRegistry` | none | 실행이 아니라 capability 조회 |
 | Task Analyzer 분석 | `api/agents.py` | `LeadOrchestrator.execute()` -> `BaseAgent._invoke_llm()` | `task_analyzer` | 분석 결과는 `TaskAnalysisService`에 저장 |
 | Task Analyzer 이미지 OCR | `api/agents.py` | vision model 후보 -> runtime resolver -> `LLMService._get_llm()` -> `ainvoke()` | `task_analyzer_ocr` | API vision 모델은 explicit fallback entitlement가 있을 때만 실행 |
-| Task Analyzer 터미널 실행 | `api/agents.py` | `services/tmux_service.py` -> `claude -p` | `task_analyzer_execution` | LangChain을 거치지 않는 CLI 실행 경로 |
+| Task Analyzer 터미널 실행 | `api/agents.py` | `services/tmux_service/` -> `claude -p` | `task_analyzer_execution` | LangChain을 거치지 않는 CLI 실행 경로 |
 | Warp Claude launch | `api/warp.py` | `services/warp_service.py` -> Warp launch config -> host `claude` | `warp_launch` | AOS는 launch prompt 입력 추정치만 기록, 후속 Warp 세션 token은 미계상 |
 | Warp AI agent tool | `tools/warp_tools.py` | Warp CLI `agent run` subprocess | `warp_agent` | Warp 자체 AI agent 실행. ExecutorNode 경로는 user/org/project context를 전달 |
 | Git draft commits | `api/git/commits.py` | `LLMService.invoke()` | `git_draft_commit` | 응답의 `total_tokens`를 API response에도 반환 |
@@ -74,7 +74,7 @@ User action
 | `services/llm_service.py` | model config의 provider로 LangChain model 생성 | `RuntimeResolver`가 user/org entitlement와 mode를 먼저 결정 |
 | `orchestrator/engine.py` | 별도 `get_llm()` 구현 | `LLMService` 또는 runtime resolver로 통합 |
 | `api/agents.py` OCR | 사용 가능한 vision model 자동 선택 | CLI vision 가능 여부와 API fallback 정책 반영 |
-| `services/tmux_service.py` | `claude -p` 직접 실행 | CLI runtime execution event로 원장 기록 |
+| `services/tmux_service/usage.py` | `claude -p` 직접 실행 | CLI runtime execution event로 원장 기록 |
 
 ---
 
@@ -130,12 +130,12 @@ Playground는 가장 먼저 원장 계측을 붙일 수 있는 경로다. `LLMSe
 Task Analyzer는 세 종류의 LLM 사용이 있다.
 
 1. 분석: `LeadOrchestrator`가 LLM으로 JSON 실행 계획을 만든다.
-2. 실행: `tmux_service.py`가 `claude -p`를 터미널에서 실행한다.
+2. 실행: `tmux_service/service.py`가 `claude -p`를 터미널에서 실행한다.
 3. OCR: 이미지 텍스트 추출은 vision-capable 후보 모델을 `source=task_analyzer_ocr`로 resolver에 통과시킨 뒤 실행한다.
 
 각 경로는 같은 UI 기능에 속하지만 runtime 경로가 다르므로 source를 분리한다.
 
-`tmux_service.py`는 Claude CLI stdout/stderr를 transcript 파일로 남긴다. 완료 이벤트 기록 시 transcript 안의 JSON usage block 또는 `Input tokens`, `Output tokens`, `Total cost` 형식의 labeled line을 파싱할 수 있으면 `measurement_method=cli_metadata`로 token/cost를 기록한다. 파싱 가능한 metadata가 없으면 기존처럼 token 값을 비워 둔다.
+`tmux_service/service.py`는 Claude CLI stdout/stderr를 transcript 파일로 남긴다. 완료 이벤트 기록 시 transcript 안의 JSON usage block 또는 `Input tokens`, `Output tokens`, `Total cost` 형식의 labeled line을 파싱할 수 있으면 `measurement_method=cli_metadata`로 token/cost를 기록한다. 파싱 가능한 metadata가 없으면 기존처럼 token 값을 비워 둔다.
 
 ### Warp launch
 

--- a/docs/guides/llm-cli-subscription-usage-guide.md
+++ b/docs/guides/llm-cli-subscription-usage-guide.md
@@ -348,7 +348,7 @@ npm run build
 | Runtime resolver | `src/backend/services/llm_runtime_resolver.py` |
 | Usage ledger service | `src/backend/services/llm_usage_ledger_service.py` |
 | Common LLM service | `src/backend/services/llm_service.py` |
-| Task Analyzer tmux | `src/backend/services/tmux_service.py` |
+| Task Analyzer tmux | `src/backend/services/tmux_service/` |
 | External Usage adapter | `src/backend/services/external_usage_service.py` |
 | Settings LLM Access UI | `src/dashboard/src/components/usage/LLMAccessSettings.tsx` |
 | LLM Access UI modules | `src/dashboard/src/components/usage/llm-access/` |

--- a/docs/llm-key-systems.md
+++ b/docs/llm-key-systems.md
@@ -68,7 +68,7 @@ provider billing API에서 org 전체 사용량/비용을 읽는 **admin 키**. 
 
 - Settings의 LLM Access([0])가 현재 기본 실행 권한이다.
 - External Usage의 기본 수치는 provider billing API가 아니라 내부 `llm_usage_ledger`다.
-- 단, **Claude CLI** 카드만은 예외다. `llm_usage_ledger`가 아니라 `claude_session_snapshots`(호스트 전체 `~/.claude/projects/` 스캔, launcher 무관 — cmux/tmux/iterm 포함)에서 온다. ledger의 `claude_cli` 행은 이중집계 방지를 위해 CLAUDE_CLI 집계에서 제외된다(`external_usage_service._collect_internal_ledger_records`). `tmux_service.py`·`api/warp.py`의 claude_cli writer는 유지되나 그 값은 CLAUDE_CLI 카드에 반영되지 않는다.
+- 단, **Claude CLI** 카드만은 예외다. `llm_usage_ledger`가 아니라 `claude_session_snapshots`(호스트 전체 `~/.claude/projects/` 스캔, launcher 무관 — cmux/tmux/iterm 포함)에서 온다. ledger의 `claude_cli` 행은 이중집계 방지를 위해 CLAUDE_CLI 집계에서 제외된다(`external_usage_service._collect_internal_ledger_records`). `tmux_service/usage.py`·`api/warp.py`의 claude_cli writer는 유지되나 그 값은 CLAUDE_CLI 카드에 반영되지 않는다.
 - Settings에 등록하는 fallback/compatibility 키([2])는 **채팅용**이고 `/v1/models`로 검증된다.
 - provider billing API([3])는 **Admin 키**(`sk-admin-`, org 스코프)를 요구한다.
 - 채팅 키로 usage API를 치면 401/403이 발생하므로 [3]은 별도 테이블 + admin 전용 UI + **실제 usage 엔드포인트 verify**로 분리한다.

--- a/scripts/split_audit.py
+++ b/scripts/split_audit.py
@@ -43,6 +43,15 @@ from pathlib import Path
 # then stops covering the barrel at all.
 _BARREL_ONLY = frozenset({"__all__"})
 
+# Names that are *correct* in every module of a package rather than owned by one.
+# `logger = logging.getLogger(__name__)` is the case: the text is identical but
+# `__name__` resolves per module, so a split that gives each module its own is
+# right, and comparing them would abort with "두 모듈에 같은 정의". `split_module.py`
+# already excludes the same name from its assignment table (`tolerate=`); this
+# keeps the two tools' contracts aligned. Losing it everywhere is still caught —
+# by ruff F821, the same backstop that covers dropped imports.
+_PER_MODULE = frozenset({"logger"})
+
 
 def _bound_names(target: ast.expr) -> list[str]:
     """Names an assignment target binds, unpacking tuples and lists."""
@@ -66,7 +75,7 @@ def _definitions(source: str, origin: str) -> dict[str, tuple[str, str]]:
     found: dict[str, tuple[str, str]] = {}
 
     def record(name: str, node: ast.AST, kind: str) -> None:
-        if name in _BARREL_ONLY:
+        if name in _BARREL_ONLY or name in _PER_MODULE:
             return
         # Decorators sit above ``node.lineno``. Comparing from ``def``/``class``
         # would call a definition unchanged after its decorator was removed —

--- a/src/backend/services/tmux_service/__init__.py
+++ b/src/backend/services/tmux_service/__init__.py
@@ -1,0 +1,39 @@
+"""Tmux session management service for Claude Code CLI execution.
+
+Manages tmux sessions that run Claude Code CLI in print mode (-p),
+enabling real-time output capture via `tmux capture-pane`.
+
+Usage:
+- Task Analyzer produces an analysis → build_claude_prompt() converts to instructions
+- execute_analysis() creates a tmux session and runs `claude -p "prompt"`
+- Dashboard polls capture_output() for live terminal output
+
+원래 단일 `services/tmux_service.py`(920줄)를 도메인별로 분할한 결과.
+소비자의 `from services.tmux_service import get_tmux_service` 는 그대로 유효하다.
+
+재노출은 **좁게** 한다 — 여기 있는 것은 실측된 import 사이트가 요구하는
+이름(`get_tmux_service` · `TmuxService` · `TmuxSessionInfo` ·
+`parse_claude_cli_usage_metadata`)과, 공개 메서드 `TmuxService.check_claude_auth`
+의 반환 타입인 `ClaudeAuthStatus` 뿐이다.
+
+**의도적으로 빠진 것**: `record_usage_best_effort` ·
+`enforce_usage_quota_preflight_best_effort`. 원장 심볼이라 이 패키지의 공개
+표면이 아니고, 재노출하면 낡은 패치 경로(`services.tmux_service.<이름>`)가
+성공하되 무효가 된다. 빠져 있으면 `monkeypatch.setattr` 이 그 자리에서
+`AttributeError` 로 죽어 실패가 자기 위치를 가리킨다.
+
+**`_tmux_service` 도 빠져 있다** — 싱글턴은 `global` 로 재바인딩되므로 배럴이
+값을 재노출하면 `None` 스냅샷이 영구히 남는다. 접근자 함수만 내보낸다.
+"""
+
+from .models import ClaudeAuthStatus, TmuxSessionInfo
+from .service import TmuxService, get_tmux_service
+from .usage import parse_claude_cli_usage_metadata
+
+__all__ = [
+    "ClaudeAuthStatus",
+    "TmuxService",
+    "TmuxSessionInfo",
+    "get_tmux_service",
+    "parse_claude_cli_usage_metadata",
+]

--- a/src/backend/services/tmux_service/models.py
+++ b/src/backend/services/tmux_service/models.py
@@ -1,0 +1,30 @@
+"""tmux 세션 정보와 Claude CLI 인증 상태 스키마 (Pydantic)."""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ClaudeAuthStatus(BaseModel):
+    """Claude CLI 인증 상태."""
+
+    authenticated: bool
+    has_credits: bool
+    error: str = ""
+    message: str = ""
+
+
+class TmuxSessionInfo(BaseModel):
+    """tmux 세션 정보."""
+
+    session_name: str
+    analysis_id: str
+    project_path: str
+    active: bool
+    started_at: datetime
+    task_input: str = ""
+    usage_context: dict[str, Any] = Field(default_factory=dict)
+    completion_recorded: bool = False
+    completed_at: datetime | None = None
+    transcript_path: str | None = None

--- a/src/backend/services/tmux_service/service.py
+++ b/src/backend/services/tmux_service/service.py
@@ -1,332 +1,31 @@
-"""Tmux session management service for Claude Code CLI execution.
+"""tmux 세션 기반 Claude Code CLI 실행 관리와 그 싱글턴.
 
-Manages tmux sessions that run Claude Code CLI in print mode (-p),
-enabling real-time output capture via `tmux capture-pane`.
-
-Usage:
-- Task Analyzer produces an analysis → build_claude_prompt() converts to instructions
-- execute_analysis() creates a tmux session and runs `claude -p "prompt"`
-- Dashboard polls capture_output() for live terminal output
+`_tmux_service` 는 `get_tmux_service` 안에서 `global` 로 재바인딩되므로
+반드시 그 접근자와 같은 모듈에 있어야 한다 — 가르면 싱글턴이 분열한다.
 """
 
 import asyncio
-import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 import time
 from datetime import UTC, datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
-
-from models.llm_usage import (
-    LLMRuntimeMode,
-    LLMUsageMeasurementMethod,
-    LLMUsageRecordCreate,
-    LLMUsageSource,
-    LLMUsageStatus,
-)
-from services.llm_usage_ledger_service import (
-    enforce_usage_quota_preflight_best_effort,
-    record_usage_best_effort,
-)
+from models.llm_usage import LLMUsageStatus
 from utils.time import utcnow
 
+from .models import ClaudeAuthStatus, TmuxSessionInfo
+from .usage import (
+    _enforce_tmux_quota_preflight,
+    _record_tmux_cli_usage,
+    _schedule_tmux_cli_usage,
+    parse_claude_cli_usage_metadata,
+)
+
 logger = logging.getLogger(__name__)
-
-
-def _usage_context_value(usage_context: dict[str, Any] | None, key: str) -> Any:
-    if not usage_context:
-        return None
-    value = usage_context.get(key)
-    if isinstance(value, Enum):
-        return value.value
-    return value
-
-
-def _usage_context_metadata(usage_context: dict[str, Any] | None) -> dict[str, Any]:
-    if not usage_context:
-        return {}
-    metadata = usage_context.get("metadata")
-    return metadata if isinstance(metadata, dict) else {}
-
-
-def _estimate_prompt_tokens(prompt: str) -> int:
-    return max(1, len(prompt.split()) * 2)
-
-
-def _compact_text(value: str, *, limit: int = 2000) -> str:
-    return value.strip()[:limit]
-
-
-def _as_int(value: Any) -> int | None:
-    if value is None or isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value if value >= 0 else None
-    if isinstance(value, float):
-        return int(value) if value >= 0 else None
-    if isinstance(value, str):
-        cleaned = value.strip().replace(",", "")
-        if cleaned.isdigit():
-            return int(cleaned)
-    return None
-
-
-def _as_float(value: Any) -> float | None:
-    if value is None or isinstance(value, bool):
-        return None
-    if isinstance(value, int | float):
-        return float(value) if value >= 0 else None
-    if isinstance(value, str):
-        cleaned = value.strip().replace(",", "").removeprefix("$")
-        try:
-            parsed = float(cleaned)
-        except ValueError:
-            return None
-        return parsed if parsed >= 0 else None
-    return None
-
-
-def _first_int(source: dict[str, Any], keys: tuple[str, ...]) -> int | None:
-    for key in keys:
-        value = _as_int(source.get(key))
-        if value is not None:
-            return value
-    return None
-
-
-def _first_float(source: dict[str, Any], keys: tuple[str, ...]) -> float | None:
-    for key in keys:
-        value = _as_float(source.get(key))
-        if value is not None:
-            return value
-    return None
-
-
-def _merge_usage_dict(target: dict[str, Any], source: dict[str, Any]) -> None:
-    input_tokens = _first_int(
-        source,
-        (
-            "input_tokens",
-            "prompt_tokens",
-            "input_token_count",
-            "inputTokenCount",
-        ),
-    )
-    output_tokens = _first_int(
-        source,
-        (
-            "output_tokens",
-            "completion_tokens",
-            "output_token_count",
-            "outputTokenCount",
-        ),
-    )
-    total_tokens = _first_int(
-        source,
-        (
-            "total_tokens",
-            "total_token_count",
-            "totalTokenCount",
-            "tokens",
-        ),
-    )
-    cost_usd = _first_float(
-        source,
-        (
-            "estimated_cost_usd",
-            "total_cost_usd",
-            "cost_usd",
-            "cost",
-        ),
-    )
-
-    if input_tokens is not None and target.get("input_tokens") is None:
-        target["input_tokens"] = input_tokens
-    if output_tokens is not None and target.get("output_tokens") is None:
-        target["output_tokens"] = output_tokens
-    if total_tokens is not None and target.get("total_tokens") is None:
-        target["total_tokens"] = total_tokens
-    if cost_usd is not None and target.get("estimated_cost_usd") is None:
-        target["estimated_cost_usd"] = cost_usd
-
-
-def _iter_usage_dicts(value: Any) -> list[dict[str, Any]]:
-    if not isinstance(value, dict):
-        return []
-    candidates: list[dict[str, Any]] = [value]
-    for key in ("usage", "usage_metadata", "token_usage", "metrics"):
-        nested = value.get(key)
-        if isinstance(nested, dict):
-            candidates.extend(_iter_usage_dicts(nested))
-    return candidates
-
-
-def _extract_labeled_usage(text: str, target: dict[str, Any]) -> None:
-    patterns = {
-        "input_tokens": r"(?:input|prompt)[ _-]?tokens?\s*[:=]\s*([\d,]+)",
-        "output_tokens": r"(?:output|completion)[ _-]?tokens?\s*[:=]\s*([\d,]+)",
-        "total_tokens": r"total[ _-]?tokens?\s*[:=]\s*([\d,]+)",
-        "estimated_cost_usd": r"(?:estimated\s+)?(?:total\s+)?cost(?:\s+usd)?\s*[:=]\s*\$?([\d,.]+)",
-    }
-    for key, pattern in patterns.items():
-        if target.get(key) is not None:
-            continue
-        match = re.search(pattern, text, flags=re.IGNORECASE)
-        if not match:
-            continue
-        value = (
-            _as_float(match.group(1)) if key == "estimated_cost_usd" else _as_int(match.group(1))
-        )
-        if value is not None:
-            target[key] = value
-
-
-def parse_claude_cli_usage_metadata(transcript: str | None) -> dict[str, Any]:
-    """Extract token/cost metadata from Claude CLI transcript text."""
-    if not transcript:
-        return {}
-
-    usage: dict[str, Any] = {
-        "input_tokens": None,
-        "output_tokens": None,
-        "total_tokens": None,
-        "estimated_cost_usd": None,
-    }
-    for line in transcript.splitlines():
-        stripped = line.strip()
-        if not stripped.startswith("{"):
-            continue
-        try:
-            payload = json.loads(stripped)
-        except json.JSONDecodeError:
-            continue
-        for candidate in _iter_usage_dicts(payload):
-            _merge_usage_dict(usage, candidate)
-
-    _extract_labeled_usage(transcript, usage)
-    if usage["total_tokens"] is None and (
-        usage["input_tokens"] is not None or usage["output_tokens"] is not None
-    ):
-        usage["total_tokens"] = (usage["input_tokens"] or 0) + (usage["output_tokens"] or 0)
-
-    return {key: value for key, value in usage.items() if value is not None}
-
-
-async def _enforce_tmux_quota_preflight(
-    usage_context: dict[str, Any] | None,
-    prompt: str,
-) -> None:
-    await enforce_usage_quota_preflight_best_effort(
-        user_id=_usage_context_value(usage_context, "user_id"),
-        organization_id=_usage_context_value(usage_context, "organization_id"),
-        estimated_tokens=_estimate_prompt_tokens(prompt),
-    )
-
-
-async def _record_tmux_cli_usage(
-    *,
-    usage_context: dict[str, Any] | None,
-    analysis_id: str,
-    project_path: str,
-    branch_name: str | None,
-    session_name: str | None,
-    status: LLMUsageStatus,
-    started_at: datetime,
-    event: str = "tmux_execute_analysis_started",
-    prompt_chars: int | None = None,
-    cli_usage_metadata: dict[str, Any] | None = None,
-    error_message: str | None = None,
-) -> None:
-    source = _usage_context_value(usage_context, "source") or (
-        LLMUsageSource.TASK_ANALYZER_EXECUTION.value
-    )
-    metadata = {
-        "event": event,
-        "project_path": project_path,
-        "branch_name": branch_name,
-        "tmux_session": session_name,
-        "prompt_chars": prompt_chars,
-    }
-    if cli_usage_metadata:
-        metadata["cli_usage_metadata"] = cli_usage_metadata
-    metadata.update(_usage_context_metadata(usage_context))
-    metadata = {k: v for k, v in metadata.items() if v is not None}
-    measurement_method = (
-        LLMUsageMeasurementMethod.CLI_METADATA
-        if cli_usage_metadata
-        else LLMUsageMeasurementMethod.UNKNOWN
-    )
-
-    await record_usage_best_effort(
-        LLMUsageRecordCreate(
-            user_id=_usage_context_value(usage_context, "user_id"),
-            organization_id=_usage_context_value(usage_context, "organization_id"),
-            provider="claude_cli",
-            mode=LLMRuntimeMode.CLI,
-            source=source,
-            model="claude-code-cli",
-            input_tokens=cli_usage_metadata.get("input_tokens") if cli_usage_metadata else None,
-            output_tokens=cli_usage_metadata.get("output_tokens") if cli_usage_metadata else None,
-            total_tokens=cli_usage_metadata.get("total_tokens") if cli_usage_metadata else None,
-            measurement_method=measurement_method,
-            estimated_cost_usd=cli_usage_metadata.get("estimated_cost_usd")
-            if cli_usage_metadata
-            else None,
-            status=status,
-            session_id=session_name,
-            analysis_id=analysis_id,
-            project_id=_usage_context_value(usage_context, "project_id"),
-            error_message=error_message,
-            metadata=metadata,
-            started_at=started_at,
-            completed_at=datetime.now(tz=UTC),
-        )
-    )
-
-
-def _schedule_tmux_cli_usage(**kwargs) -> None:
-    """Schedule ledger writes from sync tmux lifecycle methods."""
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        try:
-            asyncio.run(_record_tmux_cli_usage(**kwargs))
-        except Exception:
-            logger.warning("tmux_cli_usage_record_failed", exc_info=True)
-        return
-
-    loop.create_task(_record_tmux_cli_usage(**kwargs))
-
-
-class ClaudeAuthStatus(BaseModel):
-    """Claude CLI 인증 상태."""
-
-    authenticated: bool
-    has_credits: bool
-    error: str = ""
-    message: str = ""
-
-
-class TmuxSessionInfo(BaseModel):
-    """tmux 세션 정보."""
-
-    session_name: str
-    analysis_id: str
-    project_path: str
-    active: bool
-    started_at: datetime
-    task_input: str = ""
-    usage_context: dict[str, Any] = Field(default_factory=dict)
-    completion_recorded: bool = False
-    completed_at: datetime | None = None
-    transcript_path: str | None = None
 
 
 class TmuxService:
@@ -908,7 +607,6 @@ class TmuxService:
         return info
 
 
-# 싱글톤 인스턴스
 _tmux_service: TmuxService | None = None
 
 

--- a/src/backend/services/tmux_service/usage.py
+++ b/src/backend/services/tmux_service/usage.py
@@ -1,0 +1,294 @@
+"""Claude CLI usage 메타데이터 파싱과 LLM 원장 기록 브리지.
+
+`record_usage_best_effort` · `enforce_usage_quota_preflight_best_effort` 를
+읽는 함수가 전부 이 모듈에 있다. 테스트는 그 둘을
+`services.tmux_service.usage.<이름>` 으로 패치한다 — 읽는 쪽을 다른
+모듈로 가르면 패치가 조용히 무효가 된다.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+from models.llm_usage import (
+    LLMRuntimeMode,
+    LLMUsageMeasurementMethod,
+    LLMUsageRecordCreate,
+    LLMUsageSource,
+    LLMUsageStatus,
+)
+from services.llm_usage_ledger_service import (
+    enforce_usage_quota_preflight_best_effort,
+    record_usage_best_effort,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _usage_context_value(usage_context: dict[str, Any] | None, key: str) -> Any:
+    if not usage_context:
+        return None
+    value = usage_context.get(key)
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _usage_context_metadata(usage_context: dict[str, Any] | None) -> dict[str, Any]:
+    if not usage_context:
+        return {}
+    metadata = usage_context.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _estimate_prompt_tokens(prompt: str) -> int:
+    return max(1, len(prompt.split()) * 2)
+
+
+def _compact_text(value: str, *, limit: int = 2000) -> str:
+    return value.strip()[:limit]
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, float):
+        return int(value) if value >= 0 else None
+    if isinstance(value, str):
+        cleaned = value.strip().replace(",", "")
+        if cleaned.isdigit():
+            return int(cleaned)
+    return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value) if value >= 0 else None
+    if isinstance(value, str):
+        cleaned = value.strip().replace(",", "").removeprefix("$")
+        try:
+            parsed = float(cleaned)
+        except ValueError:
+            return None
+        return parsed if parsed >= 0 else None
+    return None
+
+
+def _first_int(source: dict[str, Any], keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        value = _as_int(source.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _first_float(source: dict[str, Any], keys: tuple[str, ...]) -> float | None:
+    for key in keys:
+        value = _as_float(source.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _merge_usage_dict(target: dict[str, Any], source: dict[str, Any]) -> None:
+    input_tokens = _first_int(
+        source,
+        (
+            "input_tokens",
+            "prompt_tokens",
+            "input_token_count",
+            "inputTokenCount",
+        ),
+    )
+    output_tokens = _first_int(
+        source,
+        (
+            "output_tokens",
+            "completion_tokens",
+            "output_token_count",
+            "outputTokenCount",
+        ),
+    )
+    total_tokens = _first_int(
+        source,
+        (
+            "total_tokens",
+            "total_token_count",
+            "totalTokenCount",
+            "tokens",
+        ),
+    )
+    cost_usd = _first_float(
+        source,
+        (
+            "estimated_cost_usd",
+            "total_cost_usd",
+            "cost_usd",
+            "cost",
+        ),
+    )
+
+    if input_tokens is not None and target.get("input_tokens") is None:
+        target["input_tokens"] = input_tokens
+    if output_tokens is not None and target.get("output_tokens") is None:
+        target["output_tokens"] = output_tokens
+    if total_tokens is not None and target.get("total_tokens") is None:
+        target["total_tokens"] = total_tokens
+    if cost_usd is not None and target.get("estimated_cost_usd") is None:
+        target["estimated_cost_usd"] = cost_usd
+
+
+def _iter_usage_dicts(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    candidates: list[dict[str, Any]] = [value]
+    for key in ("usage", "usage_metadata", "token_usage", "metrics"):
+        nested = value.get(key)
+        if isinstance(nested, dict):
+            candidates.extend(_iter_usage_dicts(nested))
+    return candidates
+
+
+def _extract_labeled_usage(text: str, target: dict[str, Any]) -> None:
+    patterns = {
+        "input_tokens": r"(?:input|prompt)[ _-]?tokens?\s*[:=]\s*([\d,]+)",
+        "output_tokens": r"(?:output|completion)[ _-]?tokens?\s*[:=]\s*([\d,]+)",
+        "total_tokens": r"total[ _-]?tokens?\s*[:=]\s*([\d,]+)",
+        "estimated_cost_usd": r"(?:estimated\s+)?(?:total\s+)?cost(?:\s+usd)?\s*[:=]\s*\$?([\d,.]+)",
+    }
+    for key, pattern in patterns.items():
+        if target.get(key) is not None:
+            continue
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if not match:
+            continue
+        value = (
+            _as_float(match.group(1)) if key == "estimated_cost_usd" else _as_int(match.group(1))
+        )
+        if value is not None:
+            target[key] = value
+
+
+def parse_claude_cli_usage_metadata(transcript: str | None) -> dict[str, Any]:
+    """Extract token/cost metadata from Claude CLI transcript text."""
+    if not transcript:
+        return {}
+
+    usage: dict[str, Any] = {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "estimated_cost_usd": None,
+    }
+    for line in transcript.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        for candidate in _iter_usage_dicts(payload):
+            _merge_usage_dict(usage, candidate)
+
+    _extract_labeled_usage(transcript, usage)
+    if usage["total_tokens"] is None and (
+        usage["input_tokens"] is not None or usage["output_tokens"] is not None
+    ):
+        usage["total_tokens"] = (usage["input_tokens"] or 0) + (usage["output_tokens"] or 0)
+
+    return {key: value for key, value in usage.items() if value is not None}
+
+
+async def _enforce_tmux_quota_preflight(
+    usage_context: dict[str, Any] | None,
+    prompt: str,
+) -> None:
+    await enforce_usage_quota_preflight_best_effort(
+        user_id=_usage_context_value(usage_context, "user_id"),
+        organization_id=_usage_context_value(usage_context, "organization_id"),
+        estimated_tokens=_estimate_prompt_tokens(prompt),
+    )
+
+
+async def _record_tmux_cli_usage(
+    *,
+    usage_context: dict[str, Any] | None,
+    analysis_id: str,
+    project_path: str,
+    branch_name: str | None,
+    session_name: str | None,
+    status: LLMUsageStatus,
+    started_at: datetime,
+    event: str = "tmux_execute_analysis_started",
+    prompt_chars: int | None = None,
+    cli_usage_metadata: dict[str, Any] | None = None,
+    error_message: str | None = None,
+) -> None:
+    source = _usage_context_value(usage_context, "source") or (
+        LLMUsageSource.TASK_ANALYZER_EXECUTION.value
+    )
+    metadata = {
+        "event": event,
+        "project_path": project_path,
+        "branch_name": branch_name,
+        "tmux_session": session_name,
+        "prompt_chars": prompt_chars,
+    }
+    if cli_usage_metadata:
+        metadata["cli_usage_metadata"] = cli_usage_metadata
+    metadata.update(_usage_context_metadata(usage_context))
+    metadata = {k: v for k, v in metadata.items() if v is not None}
+    measurement_method = (
+        LLMUsageMeasurementMethod.CLI_METADATA
+        if cli_usage_metadata
+        else LLMUsageMeasurementMethod.UNKNOWN
+    )
+
+    await record_usage_best_effort(
+        LLMUsageRecordCreate(
+            user_id=_usage_context_value(usage_context, "user_id"),
+            organization_id=_usage_context_value(usage_context, "organization_id"),
+            provider="claude_cli",
+            mode=LLMRuntimeMode.CLI,
+            source=source,
+            model="claude-code-cli",
+            input_tokens=cli_usage_metadata.get("input_tokens") if cli_usage_metadata else None,
+            output_tokens=cli_usage_metadata.get("output_tokens") if cli_usage_metadata else None,
+            total_tokens=cli_usage_metadata.get("total_tokens") if cli_usage_metadata else None,
+            measurement_method=measurement_method,
+            estimated_cost_usd=cli_usage_metadata.get("estimated_cost_usd")
+            if cli_usage_metadata
+            else None,
+            status=status,
+            session_id=session_name,
+            analysis_id=analysis_id,
+            project_id=_usage_context_value(usage_context, "project_id"),
+            error_message=error_message,
+            metadata=metadata,
+            started_at=started_at,
+            completed_at=datetime.now(tz=UTC),
+        )
+    )
+
+
+def _schedule_tmux_cli_usage(**kwargs) -> None:
+    """Schedule ledger writes from sync tmux lifecycle methods."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        try:
+            asyncio.run(_record_tmux_cli_usage(**kwargs))
+        except Exception:
+            logger.warning("tmux_cli_usage_record_failed", exc_info=True)
+        return
+
+    loop.create_task(_record_tmux_cli_usage(**kwargs))

--- a/tests/backend/api/split_tmux.py
+++ b/tests/backend/api/split_tmux.py
@@ -1,0 +1,147 @@
+"""services/tmux_service.py(920줄) → 도메인 모듈 3종 분할 배정표. (B5.5 Task 2)
+
+    # CWD = repo 루트. <원본> 은 패키지 승격 **직전** 커밋에서 꺼낸 스냅샷
+    git show <승격직전ref>:src/backend/services/tmux_service.py > /tmp/orig.py
+    src/backend/.venv/bin/python tests/backend/api/split_tmux.py \
+        /tmp/orig.py src/backend/services/tmux_service/
+
+실행 로직은 `split_module.py` 에 있다. 이 파일은 **배정표와 그 근거**만 담는다.
+
+이 파일이 B5.5 의 나머지(`merge_service` · `notification_service` ·
+`playground_service`)와 다른 점은 **모듈 지역 패치 타깃 2 종**이다. 아래 참조.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from split_module import split  # noqa: E402
+
+# ── 배정표: 이름 -> 모듈 ────────────────────────────────────────────────
+#
+# 하중 지지대 규칙: **테스트가 `monkeypatch.setattr` 로 재바인딩하는 이름은,
+# 그것을 읽는 함수 전부와 같은 모듈에 있어야 한다.**
+#
+# 이 파일의 패치 타깃 4 건은 전부 **모듈 지역 심볼 2 종**을 겨냥한다
+# (`tests/backend/test_llm_usage_instrumentation.py:617·675·677·1193):
+#
+#     services.tmux_service.record_usage_best_effort                  (3건)
+#     services.tmux_service.enforce_usage_quota_preflight_best_effort (1건)
+#
+# 둘 다 `services.llm_usage_ledger_service` 에서 tmux_service 네임스페이스로
+# 가져온 이름이고, 읽는 쪽은 `_record_tmux_cli_usage` · `_enforce_tmux_quota_preflight`
+# 뿐이다. 그래서 읽는 함수 둘을 같은 모듈(`usage`)에 두고, **배럴은 그 두 이름을
+# 재노출하지 않는다.** 재노출하면 패치는 성공하되 서브모듈의 전역은 원본을 계속
+# 봐서 조용히 무효가 된다. 재노출하지 않으면 낡은 패치 경로가 `setattr` 줄에서
+# `AttributeError` 로 즉시 죽는다 — 실패가 자기 위치를 가리킨다.
+#
+# 모듈 레벨 상태 실측: `global` 재바인딩은 `get_tmux_service` 의 `_tmux_service`
+# 하나뿐이고 외부 writer 는 0 건이다(`grep -rn '_tmux_service' src/ tests/`).
+# 싱글턴과 그 접근자를 같은 모듈에 두면 분열하지 않는다 — 배럴은 접근자 **함수**만
+# 재노출하고 `_tmux_service` 자체는 재노출하지 않는다(스냅샷 버그 회피).
+ASSIGNMENT: dict[str, str] = {
+    # ── models.py — Pydantic 스키마 2종 (모듈 지역 의존 0) ──
+    "ClaudeAuthStatus": "models",
+    "TmuxSessionInfo": "models",
+    # ── usage.py — CLI usage 메타데이터 파서 + 원장 기록 브리지 ──
+    #    패치 타깃 2 종을 읽는 함수가 전부 여기 있다(위 주석 참조).
+    "_usage_context_value": "usage",
+    "_usage_context_metadata": "usage",
+    "_estimate_prompt_tokens": "usage",
+    "_compact_text": "usage",
+    "_as_int": "usage",
+    "_as_float": "usage",
+    "_first_int": "usage",
+    "_first_float": "usage",
+    "_merge_usage_dict": "usage",
+    "_iter_usage_dicts": "usage",
+    "_extract_labeled_usage": "usage",
+    "parse_claude_cli_usage_metadata": "usage",
+    "_enforce_tmux_quota_preflight": "usage",
+    "_record_tmux_cli_usage": "usage",
+    "_schedule_tmux_cli_usage": "usage",
+    # ── service.py — tmux 세션 수명주기 + 싱글턴 ──
+    "TmuxService": "service",
+    "_tmux_service": "service",
+    "get_tmux_service": "service",
+}
+
+MODULE_ORDER = ["models", "usage", "service"]
+
+DOCSTRINGS = {
+    "models": '"""tmux 세션 정보와 Claude CLI 인증 상태 스키마 (Pydantic)."""',
+    "usage": (
+        '"""Claude CLI usage 메타데이터 파싱과 LLM 원장 기록 브리지.\n\n'
+        "`record_usage_best_effort` · `enforce_usage_quota_preflight_best_effort` 를\n"
+        "읽는 함수가 전부 이 모듈에 있다. 테스트는 그 둘을\n"
+        "`services.tmux_service.usage.<이름>` 으로 패치한다 — 읽는 쪽을 다른\n"
+        '모듈로 가르면 패치가 조용히 무효가 된다.\n"""'
+    ),
+    "service": (
+        '"""tmux 세션 기반 Claude Code CLI 실행 관리와 그 싱글턴.\n\n'
+        "`_tmux_service` 는 `get_tmux_service` 안에서 `global` 로 재바인딩되므로\n"
+        '반드시 그 접근자와 같은 모듈에 있어야 한다 — 가르면 싱글턴이 분열한다.\n"""'
+    ),
+}
+
+BARREL = '''"""Tmux session management service for Claude Code CLI execution.
+
+Manages tmux sessions that run Claude Code CLI in print mode (-p),
+enabling real-time output capture via `tmux capture-pane`.
+
+Usage:
+- Task Analyzer produces an analysis → build_claude_prompt() converts to instructions
+- execute_analysis() creates a tmux session and runs `claude -p "prompt"`
+- Dashboard polls capture_output() for live terminal output
+
+원래 단일 `services/tmux_service.py`(920줄)를 도메인별로 분할한 결과.
+소비자의 `from services.tmux_service import get_tmux_service` 는 그대로 유효하다.
+
+재노출은 **좁게** 한다 — 여기 있는 것은 실측된 import 사이트가 요구하는
+이름(`get_tmux_service` · `TmuxService` · `TmuxSessionInfo` ·
+`parse_claude_cli_usage_metadata`)과, 공개 메서드 `TmuxService.check_claude_auth`
+의 반환 타입인 `ClaudeAuthStatus` 뿐이다.
+
+**의도적으로 빠진 것**: `record_usage_best_effort` ·
+`enforce_usage_quota_preflight_best_effort`. 원장 심볼이라 이 패키지의 공개
+표면이 아니고, 재노출하면 낡은 패치 경로(`services.tmux_service.<이름>`)가
+성공하되 무효가 된다. 빠져 있으면 `monkeypatch.setattr` 이 그 자리에서
+`AttributeError` 로 죽어 실패가 자기 위치를 가리킨다.
+
+**`_tmux_service` 도 빠져 있다** — 싱글턴은 `global` 로 재바인딩되므로 배럴이
+값을 재노출하면 `None` 스냅샷이 영구히 남는다. 접근자 함수만 내보낸다.
+"""
+
+from .models import ClaudeAuthStatus, TmuxSessionInfo
+from .service import TmuxService, get_tmux_service
+from .usage import parse_claude_cli_usage_metadata
+
+__all__ = [
+    "ClaudeAuthStatus",
+    "TmuxService",
+    "TmuxSessionInfo",
+    "get_tmux_service",
+    "parse_claude_cli_usage_metadata",
+]
+'''
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(__doc__)
+        return 2
+    return split(
+        Path(argv[1]),
+        Path(argv[2]),
+        assignment=ASSIGNMENT,
+        docstrings=DOCSTRINGS,
+        module_order=MODULE_ORDER,
+        barrel=BARREL,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/backend/test_llm_usage_instrumentation.py
+++ b/tests/backend/test_llm_usage_instrumentation.py
@@ -614,7 +614,7 @@ async def test_tmux_execute_analysis_records_cli_usage(monkeypatch, tmp_path) ->
         "send_command",
         lambda _name, command: sent_commands.append(command) or True,
     )
-    monkeypatch.setattr("services.tmux_service.record_usage_best_effort", recorder)
+    monkeypatch.setattr("services.tmux_service.usage.record_usage_best_effort", recorder)
 
     info = await service.execute_analysis(
         analysis_id="analysis-1",
@@ -672,9 +672,9 @@ async def test_tmux_execute_analysis_preflight_quota_blocks_session_creation(
     monkeypatch.setattr(service, "is_claude_available", lambda: True)
     monkeypatch.setattr(service, "create_session", create_session)
     monkeypatch.setattr(service, "send_command", send_command)
-    monkeypatch.setattr("services.tmux_service.record_usage_best_effort", recorder)
+    monkeypatch.setattr("services.tmux_service.usage.record_usage_best_effort", recorder)
     monkeypatch.setattr(
-        "services.tmux_service.enforce_usage_quota_preflight_best_effort",
+        "services.tmux_service.usage.enforce_usage_quota_preflight_best_effort",
         preflight,
     )
 
@@ -1190,7 +1190,7 @@ async def test_tmux_get_session_records_completion_when_process_exits(
     )
 
     monkeypatch.setattr(service, "is_session_alive", lambda _name: False)
-    monkeypatch.setattr("services.tmux_service.record_usage_best_effort", recorder)
+    monkeypatch.setattr("services.tmux_service.usage.record_usage_best_effort", recorder)
 
     info = service.get_session("aos-test")
     await asyncio.sleep(0)

--- a/tests/backend/test_tmux_service_package.py
+++ b/tests/backend/test_tmux_service_package.py
@@ -1,0 +1,118 @@
+"""Invariants the ``services.tmux_service`` package split has to keep.
+
+The split is behavior-preserving movement, so most of its risk is invisible to
+the existing suite. Two hazards are specific to this file and neither shows up
+as a failure anywhere else:
+
+1. The barrel must keep every name its measured import sites reach for. Those
+   sites import at startup, so a dropped name fails there, not in a test.
+2. The two ledger symbols the instrumentation tests rebind
+   (``record_usage_best_effort`` · ``enforce_usage_quota_preflight_best_effort``)
+   must stay in the same module as the functions that read them, and the barrel
+   must **not** re-export them. Re-exporting makes a stale patch path succeed
+   while the submodule keeps reading its own global — the patch is silently
+   void. Leaving them off makes it die at the ``setattr`` line instead.
+"""
+
+import asyncio
+
+import pytest
+
+import services.tmux_service as barrel
+import services.tmux_service.service as service_module
+import services.tmux_service.usage as usage_module
+from models.llm_usage import LLMUsageStatus
+from utils.time import utcnow
+
+# Measured from the import sites, not guessed:
+#   src/backend/api/agents/tmux.py               -> get_tmux_service
+#   tests/backend/test_llm_usage_instrumentation -> TmuxService, TmuxSessionInfo,
+#                                                   parse_claude_cli_usage_metadata
+# ``ClaudeAuthStatus`` has no importer today but is the return type of the public
+# ``TmuxService.check_claude_auth``, so it belongs to the package's type surface.
+_PUBLIC_SURFACE = (
+    "ClaudeAuthStatus",
+    "TmuxService",
+    "TmuxSessionInfo",
+    "get_tmux_service",
+    "parse_claude_cli_usage_metadata",
+)
+
+# Names the barrel must NOT carry, and why each one would be a live bug.
+_DELIBERATELY_ABSENT = (
+    "record_usage_best_effort",
+    "enforce_usage_quota_preflight_best_effort",
+    "_tmux_service",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Restore the module singleton so ordering cannot leak an instance."""
+    saved = service_module._tmux_service
+    yield
+    service_module._tmux_service = saved
+
+
+@pytest.mark.parametrize("name", _PUBLIC_SURFACE)
+def test_barrel_still_exposes_every_imported_name(name: str) -> None:
+    """``services.tmux_service`` stays valid verbatim at all of its import sites."""
+    assert hasattr(barrel, name), f"배럴이 {name} 을 잃었다 — import 사이트가 시작 시점에 죽는다"
+
+
+@pytest.mark.parametrize("name", _DELIBERATELY_ABSENT)
+def test_barrel_omits_names_that_would_make_a_patch_silently_void(name: str) -> None:
+    """Re-exporting these turns a loud failure into a silent one.
+
+    ``record_usage_best_effort`` and its preflight sibling are read by
+    ``usage.py``; a patch on the barrel would not reach that global.
+    ``_tmux_service`` is rebound through ``global``, so a barrel copy would
+    freeze ``None`` forever.
+    """
+    assert not hasattr(barrel, name), (
+        f"배럴이 {name} 을 재노출한다 — 낡은 패치 경로가 성공하되 무효가 된다"
+    )
+
+
+def test_ledger_patch_target_reaches_the_reader() -> None:
+    """Patching ``usage.record_usage_best_effort`` reaches ``_record_tmux_cli_usage``.
+
+    This is the load-bearing edge: the instrumentation tests patch that exact
+    path. If the reader ever moves to another module, this fails while those
+    tests could still pass for the wrong reason.
+    """
+    seen: list[str | None] = []
+
+    async def fake_record(record) -> None:
+        seen.append(record.metadata.get("event"))
+
+    original = usage_module.record_usage_best_effort
+    usage_module.record_usage_best_effort = fake_record
+    try:
+        asyncio.run(
+            usage_module._record_tmux_cli_usage(
+                usage_context={"user_id": "u1"},
+                analysis_id="a1",
+                project_path="/p",
+                branch_name=None,
+                session_name="aos-probe",
+                status=LLMUsageStatus.SUCCESS,
+                started_at=utcnow(),
+                event="package_probe",
+            )
+        )
+    finally:
+        usage_module.record_usage_best_effort = original
+
+    assert seen == ["package_probe"]
+
+
+def test_singleton_is_not_split_across_modules() -> None:
+    """The accessor and the global it rebinds stay in one module."""
+    service_module._tmux_service = None
+
+    first = barrel.get_tmux_service()
+    second = barrel.get_tmux_service()
+
+    assert first is second
+    assert service_module._tmux_service is first


### PR DESCRIPTION
## 요약

`services/tmux_service.py` **920 줄 → 패키지 3 모듈, 최대 618 줄**. B5.5 배치 두 번째(#349 `audit_service` 에 이어).

| 모듈 | 줄수 | 내용 |
|---|---:|---|
| `models.py` | 30 | `ClaudeAuthStatus` · `TmuxSessionInfo` |
| `usage.py` | 294 | CLI usage 메타데이터 파서 + 원장 기록 브리지 |
| `service.py` | 618 | `TmuxService` + 싱글턴 |
| `__init__.py` | 39 | 배럴 (실측된 import 사이트 요구분만) |

`from services.tmux_service import get_tmux_service` 가 글자 그대로 유효하게 남아 **프로덕션 호출부(`api/agents/tmux.py` 6 곳)를 한 줄도 고치지 않는다.**

## 이 파일의 고유 위험 — 모듈 지역 패치 타깃 2 종

테스트의 문자열 패치 4 건이 전부 `services.tmux_service` 네임스페이스로 *가져온* 원장 심볼 둘을 겨냥한다:

```
services.tmux_service.record_usage_best_effort                   (3건)
services.tmux_service.enforce_usage_quota_preflight_best_effort  (1건)
```

읽는 함수 둘(`_record_tmux_cli_usage` · `_enforce_tmux_quota_preflight`)을 `usage.py` 에 모으고 **배럴은 그 둘을 재노출하지 않는다.**

- 재노출하면 → 낡은 패치 경로가 *성공하되* 서브모듈 전역은 원본을 계속 봐서 **조용히 무효**
- 빼두면 → `monkeypatch.setattr` 이 그 줄에서 `AttributeError` 로 죽어 **실패가 자기 위치를 가리킨다**

실측으로 확인했다 — 재지정 **전** 3 건이 정확히 그 형태로 실패(RED), 재지정 **후** 30 통과(GREEN).

## 싱글턴

`_tmux_service` 는 `get_tmux_service` 안에서 `global` 로 재바인딩되고 외부 writer 는 0 건(`grep -rn '_tmux_service' src/ tests/`). 접근자와 같은 모듈에 두고 배럴은 **함수만** 내보낸다 — 값을 재노출하면 #349 의 `_audit_logs` 와 같은 스냅샷 버그가 난다.

## 검증 — STATE.md 체크리스트 7 단계 전부

- **정의 보존**: `scripts/split_audit.py` 로 이름 20 종 + 본문 바이트 대조 통과. 프로브로 Red-Green(`_compact_text` 삭제 → FAIL, exit 1)
- **분할 전후 실행 비교**: 싱글턴 멱등·모듈 전역 일치, 파서 3 입력, 원장 도달 경로를 JSON 으로 뽑아 `diff` — 완전 동일. #349 는 이 단계를 건너뛰어 회귀를 만들었다
- **새 계약 테스트** `tests/backend/test_tmux_service_package.py` 10 건 — 배럴 재노출 목록 + **의도적 누락 3 종**을 고정. 배럴에 `record_usage_best_effort` 를 넣어 RED 확인
- **게이트**: `ruff check` · `ruff format --check` · `mypy`(320 파일) · `pytest` **1,698 passed / 0 failed**

## 부수 수정 2 건

1. **`scripts/split_audit.py`** — `logger` 를 per-module 이름으로 tolerate. `split_module.py` 는 이미 `tolerate=` 로 제외하는데 audit 쪽만 빠져 있어 `두 모듈에 같은 정의: logger` 로 중단됐다. #349 의 `audit_service` 는 모듈 레벨 `logger` 가 없어 드러나지 않았을 뿐이고 **남은 3 개(`merge_service`·`notification_service`·`playground_service`)는 전부 같은 곳에서 막힌다.** 유실 자체는 여전히 잡히고(프로브 FAIL) 결손은 ruff F821 이 백스톱(실측: `logger` 줄 삭제 → 3 errors)
2. **`docs/architecture.md`** 트리의 `audit_service.py` — #349 가 패키지로 만들고 갱신하지 않은 잔여 드리프트. 같은 표를 고치는 김에 사실만 정정

## 문서

`mandatory-docs.md` 대로 `docs/architecture.md` 갱신 + 경로가 거짓이 된 살아있는 레퍼런스 4 건(`llm-runtime-usage.md` · `cli-subscription-llm.md` · `llm-key-systems.md` · `llm-cli-subscription-usage-guide.md`). **날짜 박힌 기록(`docs/plans/` · `superpowers/specs/`)은 손대지 않았다** — 당시 사실이므로.

## 알려진 것

엔진의 `_referenced` 가 정규식 과대추정이라 `service.py` 에 불필요한 `import re` 를 얹었다(원본은 메서드 지역 `import re` 를 따로 갖고 있다). `split_audit` 가 import 를 의도적으로 대조하지 않고 ruff 에 맡기는 분업이 그 층을 잡아 `--fix` 로 제거됐다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4dcrPm9QALmLqE2v8pGx1