### PR TITLE
fix(git): DB 모드에서 Git API 가 프로젝트 UUID 를 해석하고 인가를 건다

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -746,6 +746,28 @@ Codex 2 라운드 + 실행 스모크로 지적 4 P1 / 3 P2 중 확인된 것을 
 
   ※ 이 저장소는 public 이므로 재현 절차는 남기지 않는다. 위 사실만으로 수정과 검증에 충분하다.
 
+- **후속 1·2 종료 — 2026-08-28. ID 해석 통일 + 프로젝트 단위 인가를 한 작업으로 반영.**
+  브랜치 `fix/git-db-project-resolution`(`60f5f7a` 기준). 착수 계기는 대시보드 Git 페이지
+  스크린샷이었다: `Project '2bb68d8f-…' not found`.
+
+  - **진짜 결함은 인가 부재가 아니라 그 선행 조건이었다.** DB 모드에서 `/api/projects` 는
+    `ProjectModel.id`(UUID)를 내보내는데 `api/git` 은 `PROJECTS_REGISTRY`(슬러그 키)만
+    조회한다. DB 9 행 중 id 가 우연히 슬러그와 같은 `apfs` 1 건만 동작했다. 회귀 지점은
+    `#318` 이 추가한 `/api/projects` 의 DB 분기다.
+  - **처음 고른 방향은 정반대였고 Codex 가 잡았다.** `/api/projects` 가 슬러그를 내보내게
+    되돌리는 안은 P1 2 건이었다 — `require_project_role`·프로젝트 CRUD 가 UUID 로 조회하므로
+    404 가 되고, `sessions._resolve_project_context` 가 파일시스템을 먼저 보는 탓에 세션
+    생성이 **ACL 검사를 건너뛴다**. DB 가 권위라는 `#318` 의 방향이 옳다.
+  - **채택**: `api/git/_shared.resolve_project` — DB 모드에서 `ProjectModel` 만 본다
+    (파일시스템 폴백 없음). `enforce_git_project_access` 를 라우터에 걸어 GET=viewer /
+    그 외=editor 로 인가한다. `project_id` 를 파라미터로 선언하지 않고 `request.path_params`
+    에서 읽는다 — 선언하면 `{project_id}` 없는 라우트가 422 로 깨진다.
+  - **후속 2 의 원래 우려도 함께 닫혔다**: DB 미등록 슬러그는 이제 404 다. 수정 전에는
+    200 과 실제 저장소 데이터를 반환했다(RED 실측).
+  - **남은 것**: `sessions._resolve_project_context` 의 파일시스템 우선 분기는 그대로다 —
+    같은 우회를 세션 표면에 갖고 있다. `api/git/merge*` 의 `user_role` 은 여전히 클라이언트가
+    쿼리 파라미터로 보낸다(인가 입력이 클라이언트 제어). 둘 다 이 diff 범위 밖.
+
 - **브랜치 정리 (복원 지점)**: `fix/health-badge-and-project-config-db-mode` 를 2026-08-28 에
   로컬·원격 모두 삭제했다. tip 은 **`95dd5b5`**(5 커밋: `f955e7e` · `754edc0` · `7ed7c46` ·
   `22ca9dd` · `95dd5b5`). squash 로 들어갔으므로 개별 커밋 해시는 main 에 없다 — 되살릴 일이

--- a/src/backend/api/git/__init__.py
+++ b/src/backend/api/git/__init__.py
@@ -23,6 +23,7 @@ from . import (
     repositories,
     working_tree,
 )
+from ._shared import enforce_git_project_access
 from .commits import generate_draft_commits, generate_draft_commits_for_project
 
 # 인증은 **라우터 소유 모듈**에서 건다. 하위 8 모듈의 라우트가 전부 이 하나를
@@ -37,14 +38,19 @@ from .commits import generate_draft_commits, generate_draft_commits_for_project
 # 대시보드는 이미 `apiClient` 의 auth interceptor 로 Authorization 헤더를 보내고
 # 있어(그리고 git store 는 전부 apiClient 를 쓴다) 이 변경으로 깨지지 않는다.
 #
-# 이것은 **인증**(누구인지)만 건다. 프로젝트 단위 **인가**(그 프로젝트에 접근할
-# 권한이 있는지)는 아직 없다 — 라우트의 `project_id` 가 path 기반 문자열인 반면
-# `require_project_role` 은 UUID 를 기대해서, ID 해석 통일이 선행 조건이다.
-# `.planning/STATE.md` 의 후속 1·2 에 그 작업으로 묶어 두었다.
+# `get_current_user` 는 **인증**(누구인지)만 건다. 프로젝트 단위 **인가**(그 프로젝트에
+# 접근할 권한이 있는지)는 `enforce_git_project_access` 가 건다. 선행 조건이던 ID 해석
+# 통일(`_shared.resolve_project` — DB 모드에서 `ProjectModel` 이 유일한 권위)을 함께
+# 넣어 `.planning/STATE.md` 의 후속 1·2 를 닫는다.
+#
+# 그 의존성은 `project_id` 를 파라미터로 **선언하지 않고** `request.path_params` 에서
+# 읽는다 — 선언하면 `{project_id}` 없는 라우트(`/repositories`·`/github/...`)에서
+# FastAPI 가 그것을 필수 쿼리 파라미터로 해석해 그 라우트들이 422 로 깨진다.
+# `test_routes_without_project_id_still_work` 가 그 배선 실수를 잡는다.
 router = APIRouter(
     prefix="/git",
     tags=["git"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(get_current_user), Depends(enforce_git_project_access)],
 )
 
 # 등록 순서는 원본 선언 순서를 재현하지 않는다 — 원본은 도메인 그룹이 불연속이라

--- a/src/backend/api/git/_shared.py
+++ b/src/backend/api/git/_shared.py
@@ -5,9 +5,110 @@
 않는다 — 의존은 항상 한 방향(형제 → `_shared`)이다.
 """
 
-from fastapi import HTTPException
+import os
 
-from models.project import get_project
+from fastapi import Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_current_user, get_db_session, require_project_role
+from models.project import Project, get_project
+
+
+def _use_database() -> bool:
+    return os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+# =============================================================================
+# Project Resolution & Authorization
+# =============================================================================
+
+
+async def resolve_project(project_id: str) -> Project:
+    """`project_id` 를 그 모드의 권위 레지스트리로 해석한다.
+
+    DB 모드에서는 `ProjectModel` 이 유일한 권위다 — 파일시스템 폴백을 두지 않는다.
+    폴백을 두면 `projects/` 심링크 이름만 알면 DB 미등록 프로젝트에 git API 가 닿고,
+    `enforce_git_project_access` 가 거는 인가도 그 경로로 우회된다
+    (`api/sessions.py:_resolve_project_context` 가 파일시스템을 먼저 보는 탓에 실제로
+    그 우회를 갖고 있다 — 여기서는 반복하지 않는다).
+
+    DB 행에서 만든 `Project` 는 `Project.from_path` 로 구성한다. `.aos-project.json`
+    의 `git_path`·CLAUDE.md·저장소 유효성을 그대로 얻기 위해서다 — 필드를 손으로
+    옮기면 git-path 설정이 조용히 무시된다.
+    """
+    if not _use_database():
+        project = get_project(project_id)
+        if not project:
+            raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+        return project
+
+    from sqlalchemy import select
+
+    from db.database import async_session_factory
+    from db.models import ProjectModel
+
+    try:
+        async with async_session_factory() as session:
+            row = (
+                await session.execute(
+                    select(ProjectModel).where(
+                        ProjectModel.id == project_id,
+                        ProjectModel.is_active == True,  # noqa: E712
+                    )
+                )
+            ).scalar_one_or_none()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Project lookup is temporarily unavailable",
+        ) from exc
+
+    if row is None or not row.path:
+        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+
+    project = Project.from_path(str(row.id), str(row.path))
+
+    # 이름·설명의 권위는 DB 행이다. `from_path` 는 폴더명·package.json 에서 파생하므로
+    # 그대로 두면 git-path 저장(`set_project_git_path` → `.aos-project.json`)이 그
+    # 파일시스템 기본값을 써 넣어 DB 레코드와 조용히 갈린다.
+    return project.model_copy(update={"name": row.name, "description": row.description or ""})
+
+
+async def enforce_git_project_access(
+    request: Request,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> None:
+    """`{project_id}` 를 가진 git 라우트 전체에 프로젝트 단위 인가를 건다.
+
+    `project_id` 를 파라미터로 **선언하지 않고** `request.path_params` 에서 읽는 것이
+    핵심이다. 선언하면 FastAPI 가 `{project_id}` 없는 라우트(`/repositories`,
+    `/github/...`)에서 그것을 필수 쿼리 파라미터로 해석해 그 라우트들이 깨진다.
+    라우터 소유 모듈에 걸어 두면 새 라우트가 추가돼도 자동으로 덮인다 — 라우트마다
+    붙이는 방식은 한 곳만 빠뜨려도 조용히 열린다.
+
+    메모리 모드에는 프로젝트 ACL 자체가 없으므로(레지스트리가 곧 접근 범위) DB
+    모드에서만 강제한다. 이는 기존 동작 유지이며, 이 변경으로 새로 열리는 표면은 없다.
+    """
+    if not _use_database():
+        return
+
+    project_id = request.path_params.get("project_id")
+    if project_id is None:
+        return
+
+    # 읽기와 쓰기를 나눈다. `models/git/permissions.py` 의 `viewer` 는 READ 전용인데
+    # 전 라우트를 viewer 로 통과시키면 viewer 가 커밋·푸시·브랜치 삭제·브랜치 보호
+    # 변경까지 하게 된다. 기준은 `api/project_configs` 의 filesystem 분기와 같은
+    # 관례(GET=viewer / 그 외=editor)라 두 표면의 쓰기 권한 기준이 일치한다.
+    #
+    # 읽기만 하는 POST(`/merge/preview`·`/draft-commits`)도 editor 를 요구한다 —
+    # 메서드 기준은 라우트 표가 드리프트하지 않고, 엄격한 쪽으로 틀린다.
+    min_role = "viewer" if request.method in {"GET", "HEAD", "OPTIONS"} else "editor"
+
+    # 404(미등록) / 403(거부) / 503(조회 실패) — 전부 fail-closed.
+    await require_project_role(project_id, current_user, db, min_role=min_role)
+
 
 # =============================================================================
 # Service Factories & Path Helpers
@@ -33,8 +134,11 @@ def get_effective_git_path(project) -> str:
     return project.git_path or project.path
 
 
-def get_git_service_for_project(project_id: str, worktree_path: str | None = None):
+async def get_git_service_for_project(project_id: str, worktree_path: str | None = None):
     """Get GitService for a project, optionally targeting a specific worktree.
+
+    인가는 호출자가 아니라 라우터의 `enforce_git_project_access` 가 이미 걸었다 —
+    여기서는 해석만 한다.
 
     Args:
         project_id: Project identifier
@@ -44,9 +148,7 @@ def get_git_service_for_project(project_id: str, worktree_path: str | None = Non
 
     from services.git_service import get_git_service
 
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+    project = await resolve_project(project_id)
 
     git_path = get_effective_git_path(project)
     service = get_git_service(git_path)
@@ -76,13 +178,11 @@ def get_git_service_for_project(project_id: str, worktree_path: str | None = Non
     return service
 
 
-def get_mr_service_for_project(project_id: str, db_session=None):
+async def get_mr_service_for_project(project_id: str, db_session=None):
     """Get MergeRequestService for a project."""
     from services.merge_service import MergeRequestService, get_merge_service
 
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+    project = await resolve_project(project_id)
 
     git_path = get_effective_git_path(project)
     merge_service = get_merge_service(git_path)

--- a/src/backend/api/git/branches.py
+++ b/src/backend/api/git/branches.py
@@ -42,7 +42,7 @@ async def list_branches(
     base_branch: str = Query("main", description="Base branch for ahead/behind calculation"),
 ):
     """List all branches in a project."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     branches = git_service.list_branches(
         include_remote=include_remote,
@@ -64,7 +64,7 @@ async def create_branch(
     """Create a new branch."""
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     try:
         branch = git_service.create_branch(
@@ -84,7 +84,7 @@ async def checkout_branch(
     """Checkout (switch to) a branch."""
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     try:
         branch = git_service.checkout_branch(name=branch_name)
@@ -104,7 +104,7 @@ async def delete_branch(
     """Delete a branch (local and/or remote)."""
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     try:
         success = git_service.delete_branch(
@@ -118,7 +118,7 @@ async def delete_branch(
         closed_mrs = 0
         try:
             db_session = await _get_db_session()
-            mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+            mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
             closed_mrs = await mr_service.close_mrs_by_source_branch_async(
                 branch_name, closed_by="system"
             )
@@ -149,7 +149,7 @@ async def prune_merged_branches(project_id: str, request: PruneRequest):
     """
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
     github_service = get_github_service()  # raises 503 without token
 
     # Pre-fetch active protection patterns (async DB) → pass to sync service
@@ -203,7 +203,7 @@ async def get_branch_diff(
     """Get diff summary between a branch and base."""
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     try:
         diff = git_service.get_branch_diff(branch=branch_name, base=base)

--- a/src/backend/api/git/commits.py
+++ b/src/backend/api/git/commits.py
@@ -96,7 +96,7 @@ async def generate_draft_commits_for_project(
 
     from services.llm_service import LLMService
 
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
 
     # Get diff content
     try:
@@ -308,7 +308,7 @@ async def list_commits(
     skip: int = Query(0, ge=0, description="Number of commits to skip"),
 ):
     """List commits in a branch."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     commits = git_service.get_commits(branch=branch, limit=limit, skip=skip)
     actual_branch = branch or git_service.current_branch
@@ -328,7 +328,7 @@ async def get_commit(
     """Get a specific commit."""
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     try:
         commit = git_service.get_commit(sha)
@@ -345,7 +345,7 @@ async def get_commit_files(
     """Get files changed in a commit."""
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     try:
         files = git_service.get_commit_files(sha)
@@ -363,7 +363,7 @@ async def get_commit_diff(
     """Get diff for a commit."""
     from services.git_service import GitServiceError
 
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     try:
         diff = git_service.get_commit_diff(sha, file_path=file_path)

--- a/src/backend/api/git/merge.py
+++ b/src/backend/api/git/merge.py
@@ -16,20 +16,20 @@ from models.git import (
     # Permission helpers
     can_merge_to_branch,
 )
-from models.project import get_project
 
-from ._shared import get_effective_git_path
+from ._shared import get_effective_git_path, resolve_project
 
 router = APIRouter()
 
 
-def get_merge_service_for_project(project_id: str):
-    """Get MergeService for a project."""
+async def get_merge_service_for_project(project_id: str):
+    """Get MergeService for a project.
+
+    인가는 라우터의 `enforce_git_project_access` 가 이미 걸었다 — 여기서는 해석만 한다.
+    """
     from services.merge_service import get_merge_service
 
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+    project = await resolve_project(project_id)
 
     git_path = get_effective_git_path(project)
     service = get_merge_service(git_path)
@@ -55,7 +55,7 @@ async def preview_merge(
     """Preview merge and check for conflicts (dry-run)."""
     from services.merge_service import MergeServiceError
 
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
 
     try:
         preview = merge_service.check_merge_conflicts(
@@ -74,7 +74,7 @@ async def get_conflicts(
     target_branch: str = Query("main", description="Target branch"),
 ):
     """Get detailed conflict information."""
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
 
     conflicts = merge_service.get_conflict_details(
         source_branch=source_branch,
@@ -91,7 +91,7 @@ async def get_three_way_diff(
     target_branch: str = Query("main", description="Target branch"),
 ):
     """Get three-way diff for a file."""
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
 
     diff = merge_service.get_three_way_diff(
         file_path=file_path,
@@ -120,7 +120,7 @@ async def execute_merge(
             detail=f"Insufficient permissions to merge to '{request.target_branch}'",
         )
 
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
 
     try:
         result = merge_service.merge_branch(
@@ -146,7 +146,7 @@ async def resolve_conflict(
     - theirs: Keep source branch version
     - custom: Provide resolved content manually
     """
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
 
     result = merge_service.resolve_conflict(request)
 
@@ -163,7 +163,7 @@ async def abort_merge(project_id: str):
     Use this endpoint to cancel a merge that has conflicts.
     All changes will be reverted to the pre-merge state.
     """
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
 
     result = merge_service.abort_merge()
 
@@ -181,7 +181,7 @@ async def get_merge_status(project_id: str):
     which files still have unresolved conflicts, and whether
     the merge can be completed.
     """
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
     return merge_service.get_merge_status()
 
 
@@ -194,7 +194,7 @@ async def complete_merge(
 
     Use this endpoint after resolving all conflicts to create the merge commit.
     """
-    merge_service = get_merge_service_for_project(project_id)
+    merge_service = await get_merge_service_for_project(project_id)
 
     result = merge_service.complete_merge(message)
 

--- a/src/backend/api/git/merge_requests.py
+++ b/src/backend/api/git/merge_requests.py
@@ -33,7 +33,7 @@ async def list_merge_requests(
     """List merge requests for a project."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 mrs = await mr_service.list_merge_requests_async(status=status)
@@ -56,7 +56,7 @@ async def get_merge_request(
     """Get a merge request by ID."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 mr = await mr_service.get_merge_request_async(mr_id)
@@ -85,7 +85,7 @@ async def create_merge_request(
     """Create a new merge request."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 mr = await mr_service.create_merge_request_async(
@@ -129,7 +129,7 @@ async def update_merge_request(
     """Update a merge request."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 mr = await mr_service.update_merge_request_async(
@@ -169,7 +169,7 @@ async def approve_merge_request(
     """Approve a merge request. Triggers auto-merge if conditions met."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 mr = await mr_service.approve_merge_request_async(mr_id=mr_id, user_id=user_id)
@@ -197,7 +197,7 @@ async def merge_merge_request(
     """Merge a merge request."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
 
         if db_session:
             async with db_session:
@@ -255,7 +255,7 @@ async def close_merge_request(
     """Close a merge request without merging."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 mr = await mr_service.close_merge_request_async(mr_id=mr_id, closed_by=user_id)
@@ -281,7 +281,7 @@ async def delete_merge_request(
     """Permanently delete a merge request record (metadata only — git refs are untouched)."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 deleted = await mr_service.delete_merge_request_async(mr_id)
@@ -308,7 +308,7 @@ async def refresh_mr_conflicts(
     """Refresh conflict status for a merge request."""
     db_session = await _get_db_session()
     try:
-        mr_service = get_mr_service_for_project(project_id, db_session=db_session)
+        mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
                 mr = await mr_service.refresh_conflict_status_async(mr_id)

--- a/src/backend/api/git/remotes.py
+++ b/src/backend/api/git/remotes.py
@@ -22,7 +22,7 @@ router = APIRouter()
 @router.get("/projects/{project_id}/remotes", response_model=RemoteListResponse)
 async def list_remotes(project_id: str):
     """List all remotes for a project."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
     remotes = git_service.list_remotes()
     return RemoteListResponse(remotes=remotes)
 
@@ -30,7 +30,7 @@ async def list_remotes(project_id: str):
 @router.post("/projects/{project_id}/remotes", response_model=RemoteOperationResult)
 async def add_remote(project_id: str, request: RemoteAddRequest):
     """Add a new remote."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
     result = git_service.add_remote(name=request.name, url=request.url)
     if not result.success:
         raise HTTPException(status_code=400, detail=result.message)
@@ -40,7 +40,7 @@ async def add_remote(project_id: str, request: RemoteAddRequest):
 @router.delete("/projects/{project_id}/remotes/{remote_name}", response_model=RemoteOperationResult)
 async def remove_remote(project_id: str, remote_name: str):
     """Remove a remote."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
     result = git_service.remove_remote(name=remote_name)
     if not result.success:
         raise HTTPException(status_code=400, detail=result.message)
@@ -50,7 +50,7 @@ async def remove_remote(project_id: str, remote_name: str):
 @router.put("/projects/{project_id}/remotes/{remote_name}", response_model=RemoteOperationResult)
 async def update_remote(project_id: str, remote_name: str, request: RemoteUpdateRequest):
     """Update a remote (rename or change URL)."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
 
     # Update URL first if provided
     if request.url:

--- a/src/backend/api/git/working_tree.py
+++ b/src/backend/api/git/working_tree.py
@@ -27,9 +27,8 @@ from models.git import (
     StageHunksRequest,
     UnstageRequest,
 )
-from models.project import get_project
 
-from ._shared import get_effective_git_path, get_git_service_for_project
+from ._shared import get_effective_git_path, get_git_service_for_project, resolve_project
 
 router = APIRouter()
 
@@ -64,9 +63,7 @@ async def get_project_git_status(project_id: str):
     """Get Git status for a project."""
     from services.git_service import get_git_service
 
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+    project = await resolve_project(project_id)
 
     effective_path = get_effective_git_path(project)
     service = get_git_service(effective_path)
@@ -89,12 +86,10 @@ async def update_project_git_path(
     """Update Git path for a project."""
     from pathlib import Path
 
-    from models.project import normalize_path, update_project
+    from models.project import normalize_path, set_project_git_path
     from services.git_service import get_git_service
 
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+    project = await resolve_project(project_id)
 
     # Normalize and validate git_path
     git_path = request.git_path
@@ -107,12 +102,9 @@ async def update_project_git_path(
 
     # Update project
     try:
-        updated_project = update_project(project_id, git_path=git_path)
+        updated_project = set_project_git_path(project, git_path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-
-    if not updated_project:
-        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
     # Get git service for the new path
     effective_path = get_effective_git_path(updated_project)
@@ -137,7 +129,7 @@ async def update_project_git_path(
 @router.get("/projects/{project_id}/worktrees", response_model=GitWorktreeListResponse)
 async def list_worktrees(project_id: str):
     """List all git worktrees for a project."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
     worktrees = git_service.list_worktrees()
     return GitWorktreeListResponse(worktrees=worktrees, total=len(worktrees))
 
@@ -153,7 +145,7 @@ async def get_working_status(
     worktree_path: str | None = Query(None, description="Worktree path to target"),
 ):
     """Get working directory status (staged, unstaged, untracked files)."""
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     return git_service.status()
 
 
@@ -169,7 +161,7 @@ async def stage_files(
     - all=True: stages all changes including deletions (git add -A)
     - Specific paths: stages only those files
     """
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     result = git_service.add(paths=request.paths, all=request.all)
 
     if not result.success:
@@ -188,7 +180,7 @@ async def create_commit(
 
     Requires files to be staged first using the add endpoint.
     """
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     result = git_service.commit(
         message=request.message,
         author_name=request.author_name,
@@ -218,7 +210,7 @@ async def unstage_files(
     - all=True: unstage all files
     - Specific paths: unstage only those files
     """
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     result = git_service.unstage(paths=request.paths or None, all=request.all)
 
     if not result.success:
@@ -235,7 +227,7 @@ async def get_file_diff(
     worktree_path: str | None = Query(None, description="Worktree path to target"),
 ):
     """Get diff for a single file."""
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     try:
         return git_service.get_file_diff(file_path=file_path, staged=staged)
     except Exception as e:
@@ -248,7 +240,7 @@ async def get_staged_diff(
     worktree_path: str | None = Query(None, description="Worktree path to target"),
 ):
     """Get the full staged diff (git diff --staged)."""
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     try:
         diff = git_service.get_working_diff(staged_only=True)
         return {"diff": diff}
@@ -264,7 +256,7 @@ async def get_file_hunks(
     worktree_path: str | None = Query(None, description="Worktree path to target"),
 ):
     """Get diff hunks for a single file."""
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     try:
         return git_service.get_file_hunks(file_path=file_path, staged=staged)
     except Exception as e:
@@ -278,7 +270,7 @@ async def stage_hunks(
     worktree_path: str | None = Query(None, description="Worktree path to target"),
 ):
     """Stage specific hunks of a file."""
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     result = git_service.stage_hunks(
         file_path=request.file_path,
         hunk_indices=request.hunk_indices,
@@ -301,7 +293,7 @@ async def fetch_remote(
     remote: str = Query("origin", description="Remote name"),
 ):
     """Fetch from remote."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
     result = git_service.fetch(remote=remote)
     return result
 
@@ -313,7 +305,7 @@ async def pull_remote(
     branch: str | None = Query(None, description="Branch to pull"),
 ):
     """Pull from remote."""
-    git_service = get_git_service_for_project(project_id)
+    git_service = await get_git_service_for_project(project_id)
     result = git_service.pull(remote=remote, branch=branch)
     return result
 
@@ -327,6 +319,6 @@ async def push_remote(
     worktree_path: str | None = Query(None, description="Worktree path to target"),
 ):
     """Push to remote."""
-    git_service = get_git_service_for_project(project_id, worktree_path=worktree_path)
+    git_service = await get_git_service_for_project(project_id, worktree_path=worktree_path)
     result = git_service.push(remote=remote, branch=branch, set_upstream=set_upstream)
     return result

--- a/src/backend/models/project.py
+++ b/src/backend/models/project.py
@@ -441,6 +441,28 @@ def update_project(
     return project
 
 
+def set_project_git_path(project: Project, git_path: str | None) -> Project:
+    """Set a project's Git repository path and persist it to `.aos-project.json`.
+
+    `update_project` 는 `PROJECTS_REGISTRY` 엔트리에만 동작한다 — DB 모드의 프로젝트는
+    레지스트리에 없으므로 id 가 아니라 `Project` 객체를 직접 받는다. 저장 대상은
+    `update_project` 와 같은 메타데이터 파일이고 읽기도 `Project.from_path` 가 같은
+    파일을 보므로, 두 모드가 같은 위치를 쓴다.
+
+    Raises:
+        ValueError: `git_path` 가 존재하지 않는 경로일 때.
+    """
+    if git_path:
+        git_path = normalize_path(git_path)
+        if not Path(git_path).exists():
+            raise ValueError(f"Git path does not exist: {git_path}")
+
+    project.git_path = git_path or None
+    project.git_enabled = _check_git_repository(project.git_path or project.path)
+    _save_project_metadata(Path(project.path), project.name, project.description, project.git_path)
+    return project
+
+
 def update_project_sort_order(project_id: str, sort_order: int) -> Project | None:
     """Update a project's sort order."""
     project = PROJECTS_REGISTRY.get(project_id)

--- a/tests/backend/api/test_git_db_project_resolution.py
+++ b/tests/backend/api/test_git_db_project_resolution.py
@@ -1,0 +1,272 @@
+"""DB 모드에서 Git API 는 `ProjectModel.id`(UUID)를 해석할 수 있어야 한다.
+
+DB 모드의 프로젝트 권위는 `ProjectModel` 이다 — `/api/projects` 도, 세션 리졸버
+(`api/sessions.py:_resolve_project_context`)도, 인가(`deps.require_project_role`)도
+전부 UUID 를 키로 쓴다. 그런데 `api/git` 은 in-memory `PROJECTS_REGISTRY`(키가
+`projects/<심링크명>` 슬러그)만 조회하는 마지막 표면이라, 대시보드가 방금 목록에서
+받은 id 를 그대로 보내면 404 가 난다:
+
+    {"detail": "Project '2bb68d8f-3e23-4af3-a597-181dea321348' not found"}
+
+라우트 전체(프레임워크 배선 포함)를 지나가게 해서, 핸들러 직접 호출이 건너뛰는
+의존성 해석까지 함께 검증한다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from models.project import PROJECTS_REGISTRY
+
+DB_UUID = "2bb68d8f-3e23-4af3-a597-181dea321348"
+
+
+@pytest.fixture
+def empty_registry():
+    """DB 모드에서 슬러그 엔트리에 기대지 않음을 보장한다."""
+    snapshot = dict(PROJECTS_REGISTRY)
+    PROJECTS_REGISTRY.clear()
+    yield PROJECTS_REGISTRY
+    PROJECTS_REGISTRY.clear()
+    PROJECTS_REGISTRY.update(snapshot)
+
+
+@pytest_asyncio.fixture
+async def db_project_app(authenticated_app, tmp_path, monkeypatch, empty_registry):
+    """DB 에 UUID id 프로젝트 1건만 있는 상태의 앱."""
+    from api.deps import get_db_session
+
+    project_path = tmp_path / "Agent-System"
+    project_path.mkdir()
+
+    row = SimpleNamespace(
+        id=DB_UUID,
+        name="Agent-System",
+        slug="agent-system",
+        description="",
+        path=str(project_path),
+        is_active=True,
+        settings={},
+        organization_id=None,
+    )
+
+    class Result:
+        def scalar_one_or_none(self):
+            return row
+
+        def scalars(self):
+            return SimpleNamespace(all=lambda: [row])
+
+        def all(self):
+            return [(row.id, row.path, row.organization_id)]
+
+    class Database:
+        async def execute(self, *_args, **_kwargs):
+            return Result()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def _override():
+        yield Database()
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    # `resolve_project` 는 주입된 세션이 아니라 자체 세션을 연다(`_shared._get_db_session`
+    # 과 같은 방식). 그래서 dependency override 만으로는 실 DB 에 붙는다 — 실제로 붙어
+    # tmp_path 가 아닌 운영 행을 읽는 것을 이 테스트가 잡았다.
+    monkeypatch.setattr("db.database.async_session_factory", lambda: Database())
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    yield authenticated_app, str(project_path)
+    authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_git_status_resolves_database_project_id(db_project_app):
+    """대시보드가 `/api/projects` 에서 받은 UUID 로 Git 상태를 조회할 수 있어야 한다."""
+    app, project_path = db_project_app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get(f"/api/git/projects/{DB_UUID}/status")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["effective_git_path"] == project_path
+
+
+@pytest.mark.asyncio
+async def test_filesystem_slug_is_not_reachable_in_database_mode(
+    authenticated_app, tmp_path, monkeypatch, empty_registry
+):
+    """DB 모드에서 `projects/` 슬러그는 git API 에 닿지 못한다.
+
+    파일시스템 폴백을 두면 심링크 이름만 알면 DB 미등록 프로젝트의 저장소 내용에
+    닿을 수 있고, 라우터의 프로젝트 인가도 그 경로로 통째로 우회된다.
+    (`.planning/STATE.md` 후속 2 가 제기한 우려가 정확히 이것이다.)
+    """
+    from api.deps import get_db_session
+    from models.project import register_project
+
+    project_path = tmp_path / "not-in-db"
+    project_path.mkdir()
+    register_project("leaked-slug", str(project_path))
+
+    class EmptyResult:
+        def scalar_one_or_none(self):
+            return None
+
+        def scalars(self):
+            return SimpleNamespace(all=lambda: [])
+
+        def all(self):
+            return []
+
+    class EmptyDatabase:
+        async def execute(self, *_args, **_kwargs):
+            return EmptyResult()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def _override():
+        yield EmptyDatabase()
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    monkeypatch.setattr("db.database.async_session_factory", lambda: EmptyDatabase())
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    try:
+        transport = ASGITransport(app=authenticated_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/git/projects/leaked-slug/status")
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_routes_without_project_id_still_work(db_project_app):
+    """`enforce_git_project_access` 가 `{project_id}` 없는 라우트를 깨뜨리지 않는다.
+
+    의존성이 `project_id` 를 파라미터로 선언하면 FastAPI 가 이런 라우트에서 그것을
+    필수 쿼리 파라미터로 해석해 422 가 된다 — 그 배선 실수를 잡는 대조군이다.
+    """
+    app, _ = db_project_app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/git/repositories")
+
+    assert response.status_code != 422, response.text
+
+
+@pytest.mark.asyncio
+async def test_viewer_can_read_but_not_mutate(db_project_app, monkeypatch):
+    """viewer 역할은 읽기만 — `models/git/permissions.py` 의 viewer 는 READ 전용이다.
+
+    전 라우트를 `min_role="viewer"` 로 통과시키면 viewer 가 커밋·푸시·브랜치 삭제까지
+    하게 된다. 시스템 admin 우회를 타지 않도록 일반 사용자로 갈아끼운 뒤 판정한다.
+    """
+    from api.deps import get_current_user
+    from services.project_access_service import ProjectAccessService
+
+    app, _ = db_project_app
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="viewer-user", role="member", is_admin=False, is_active=True
+    )
+
+    async def _has_acl(*_args, **_kwargs):
+        return True
+
+    async def _check_access(*_args, **_kwargs):
+        return "viewer"
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", _has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", _check_access)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        read = await ac.get(f"/api/git/projects/{DB_UUID}/status")
+        write = await ac.post(
+            f"/api/git/projects/{DB_UUID}/branches", json={"name": "feature/x"}
+        )
+
+    assert read.status_code == 200, read.text
+    assert write.status_code == 403, write.text
+
+
+@pytest.mark.asyncio
+async def test_git_path_save_does_not_overwrite_db_name(
+    authenticated_app, tmp_path, monkeypatch, empty_registry
+):
+    """git-path 저장이 DB 의 이름·설명을 파일시스템 기본값으로 덮지 않는다.
+
+    `Project.from_path` 는 이름을 폴더명에서 파생한다. 그대로 `set_project_git_path`
+    에 넘기면 `.aos-project.json` 에 폴더명이 기록돼 DB 레코드와 갈린다.
+    """
+    import json
+
+    from api.deps import get_db_session
+
+    project_path = tmp_path / "folder-name-differs"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+
+    row = SimpleNamespace(
+        id=DB_UUID,
+        name="관리자가 정한 이름",
+        slug="db-named",
+        description="DB 설명",
+        path=str(project_path),
+        is_active=True,
+        settings={},
+        organization_id=None,
+    )
+
+    class Result:
+        def scalar_one_or_none(self):
+            return row
+
+        def scalars(self):
+            return SimpleNamespace(all=lambda: [row])
+
+        def all(self):
+            return [(row.id, row.path, row.organization_id)]
+
+    class Database:
+        async def execute(self, *_args, **_kwargs):
+            return Result()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def _override():
+        yield Database()
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    monkeypatch.setattr("db.database.async_session_factory", lambda: Database())
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    try:
+        transport = ASGITransport(app=authenticated_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.put(
+                f"/api/git/projects/{DB_UUID}/git-path",
+                json={"git_path": str(project_path)},
+            )
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+    assert response.status_code == 200, response.text
+    metadata = json.loads((project_path / ".aos-project.json").read_text(encoding="utf-8"))
+    assert metadata["name"] == "관리자가 정한 이름"
+    assert metadata["description"] == "DB 설명"

--- a/tests/backend/test_llm_usage_instrumentation.py
+++ b/tests/backend/test_llm_usage_instrumentation.py
@@ -301,7 +301,11 @@ async def test_git_draft_commits_passes_usage_context(monkeypatch) -> None:
             provider="codex_cli",
         )
 
-    monkeypatch.setattr("api.git.commits.get_git_service_for_project", MagicMock(return_value=git_service))
+    # `get_git_service_for_project` 는 DB 리졸버를 쓰면서 async 가 됐다 — MagicMock 은
+    # await 할 수 없다.
+    monkeypatch.setattr(
+        "api.git.commits.get_git_service_for_project", AsyncMock(return_value=git_service)
+    )
     monkeypatch.setattr(LLMService, "invoke", fake_invoke)
 
     result = await generate_draft_commits(
@@ -337,7 +341,11 @@ async def test_git_draft_commits_passes_llm_access_context(monkeypatch) -> None:
             provider="codex_cli",
         )
 
-    monkeypatch.setattr("api.git.commits.get_git_service_for_project", MagicMock(return_value=git_service))
+    # `get_git_service_for_project` 는 DB 리졸버를 쓰면서 async 가 됐다 — MagicMock 은
+    # await 할 수 없다.
+    monkeypatch.setattr(
+        "api.git.commits.get_git_service_for_project", AsyncMock(return_value=git_service)
+    )
     monkeypatch.setattr(LLMService, "invoke", fake_invoke)
 
     result = await generate_draft_commits_for_project(


### PR DESCRIPTION
## 문제

대시보드 Git 페이지가 거의 모든 프로젝트에서 실패했다.

```
작업 실패 — Project '2bb68d8f-3e23-4af3-a597-181dea321348' not found
```

**프로젝트 ID 네임스페이스가 둘이다.**

| | 발행처 | 형태 |
|---|---|---|
| DB 권위 | `ProjectModel.id` (`scripts/seed_projects_to_db.py` 가 발급) | UUID |
| 메모리 레지스트리 | `PROJECTS_REGISTRY` 키 = `projects/<심링크명>` | 슬러그 |

`USE_DATABASE=true` 에서 `/api/projects` 는 UUID 를 내보내는데 `api/git` 은 슬러그
레지스트리만 조회하는 마지막 표면이었다. DB 9 행 중 id 가 우연히 슬러그와 같은
`apfs` 1 건만 동작했다. 회귀 지점은 `#318` 이 추가한 `/api/projects` 의 DB 분기다
(`git log -S 'registry_projects'` 로 특정).

**부수로 드러난 것**: 수정 전에는 DB 미등록 슬러그가 `/status` 에 **200 과 실제
저장소 데이터**를 반환했다. `.planning/STATE.md` 후속 2 가 제기한 우려가 사실이었다.

## 수정

- **`api/git/_shared.resolve_project`** — DB 모드에서 `ProjectModel` 이 유일한 권위.
  **파일시스템 폴백 없음**. 폴백을 두면 심링크 이름만으로 DB 미등록 프로젝트에 닿고
  아래 인가도 통째로 우회된다.
- **`enforce_git_project_access`** — 라우터 레벨 프로젝트 단위 인가.
  `project_id` 를 파라미터로 **선언하지 않고** `request.path_params` 에서 읽는다.
  선언하면 `{project_id}` 없는 라우트(`/repositories`·`/github/...`)가 422 로 깨진다.
- **읽기·쓰기 분리** (GET=viewer / 그 외=editor). `models/git/permissions.py` 의
  viewer 는 READ 전용인데 전 라우트를 viewer 로 통과시키면 viewer 가 커밋·푸시·
  브랜치 삭제까지 하게 된다. 기준은 `api/project_configs` 의 filesystem 분기와 같다.
- **이름·설명은 DB 행이 권위** — `Project.from_path` 는 폴더명에서 파생하므로 그대로
  두면 git-path 저장이 파일시스템 기본값을 `.aos-project.json` 에 써서 DB 와 갈린다.
- **`models.project.set_project_git_path`** — `update_project` 는 레지스트리 엔트리에만
  동작해 DB 프로젝트의 git-path 저장이 404 였다.

`get_git_service_for_project` · `get_mr_service_for_project` ·
`get_merge_service_for_project` 가 async 가 되어 호출부 45 곳에 await 를 전파했다.

이 변경으로 `.planning/STATE.md` 의 **후속 1·2 를 닫는다** (ID 해석 통일이 프로젝트
단위 인가의 선행 조건이었고, 그 문서가 둘을 한 작업으로 묶어 두었다).

## 검증

**RED 를 세 트리에서 각각 실측한 뒤 GREEN 확인** (손으로 세운 상태가 아니라 실제 신호로):

| 트리 | 증상 |
|---|---|
| `60f5f7a` | UUID → 404 (스크린샷과 동일 문자열) · DB 미등록 슬러그 → **200 + 저장소 데이터** |
| `851c68b` | viewer 의 `POST /branches` → 400 (인가를 통과해 핸들러 도달) |
| `0b1a30f` | git-path 저장이 `.aos-project.json` 에 `folder-name-differs` 를 기록 |

- 게이트: ruff · ruff format · mypy(320 files) · **pytest 1704 passed / 32 skipped**
- 라이브(실 DB · 실 백엔드): 스크린샷의 UUID → 200 (`branch=main`),
  `/branches`·`/working-status`·`/remotes`·`/commits` 200,
  `{project_id}` 없는 `/repositories` 200(422 아님), DB 미등록 슬러그 404
- 기존 데이터 영향 없음: `merge_requests`·`branch_protection_rules` 모두 0 행
  (슬러그 키로 박힌 행이 없어 감춰지는 데이터가 없다)

**Codex 리뷰 3 라운드.** 1 라운드 P1 2 건이 타당해 **첫 수정안을 통째로 되돌렸다**
(`/api/projects` 가 슬러그를 내보내게 하는 안 → `require_project_role` 이 UUID 로
조회해 404, 그리고 `sessions._resolve_project_context` 가 파일시스템을 먼저 봐서
세션 생성이 ACL 을 건너뜀). 3 라운드 P2(메타데이터 덮어쓰기)는 재현 후 반영했다.
반복 지적된 "prune 테스트가 깨진다"는 **실측 반증**했다 — `unittest.mock.patch` 가
async 대상을 자동으로 `AsyncMock` 으로 만들어 7 건 전부 통과한다.

## 범위 밖 (후속 후보)

1. `api/sessions.py:_resolve_project_context` 가 파일시스템을 먼저 조회한다 —
   슬러그를 알면 세션 생성에서 `require_project_role` 을 건너뛰는 같은 우회가 남아 있다.
2. `api/git/merge*` 의 `user_role` 을 클라이언트가 쿼리 파라미터로 보낸다
   (인가 입력을 클라이언트가 제어).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgKSCX95X9fde37R1hV8rN
