### PR TITLE
refactor(services): notification_service 를 패키지로 승격해 한도 안에 넣는다 (B5.5 Task 4)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -282,7 +282,7 @@ src/backend/
 │   ├── mcp_manager.py             # MCP 서버 생명주기 관리
 │   ├── mcp_service.py             # MCP 서버 관리
 │   ├── merge_service/             # Git 머지/충돌 해결 (패키지: errors·service·requests)
-│   ├── notification_service.py    # 알림 서비스 (Slack, Discord, Email, Webhook)
+│   ├── notification_service/      # 알림 서비스 (패키지: config·adapters·service)
 │   ├── organization_service.py    # 조직/멀티테넌트 서비스
 │   ├── playground_service.py      # 에이전트 플레이그라운드
 │   ├── playground_tools.py        # 플레이그라운드 도구 정의

--- a/src/backend/services/notification_service/__init__.py
+++ b/src/backend/services/notification_service/__init__.py
@@ -1,0 +1,67 @@
+"""Notification service for sending alerts across multiple channels.
+
+원래 단일 `services/notification_service.py`(1,017줄)를 도메인별로 분할한 결과.
+소비자의 `from services.notification_service import NotificationService` 는
+그대로 유효하다.
+
+재노출은 실측된 import 사이트가 요구하는 것만 담는다:
+
+    api/organizations.py -> NotificationService · ADAPTERS
+    api/notifications.py -> NotificationService · USE_DATABASE
+    tests/…test_notification_service.py -> SlackAdapter · DiscordAdapter ·
+        WebhookAdapter · NotificationService · _rules · _notification_history ·
+        notify_task_completed · notify_task_failed
+
+`NotificationAdapter`(추상 베이스) · `EmailAdapter` · `notify_approval_required`
+는 현재 가져가는 곳이 없지만 위 이름들의 형제이고 재바인딩 대상이 아니라
+같이 내보낸다.
+
+`_rules` · `_notification_history` 를 재노출하는 것은 안전하다 — 재바인딩이
+없어(모듈에 `global` 문 없음, 테스트도 `.clear()` 만 한다) 배럴이 가리키는
+객체가 서브모듈의 그것과 계속 같다.
+
+**의도적으로 빠진 것**
+
+- `httpx` — 테스트가 `httpx.AsyncClient` 를 패치한다. 배럴에 두면 낡은 경로
+  (`services.notification_service.httpx.AsyncClient`)가 성공해 버려 어댑터가
+  실제로 어느 모듈에서 읽는지와 무관해진다. 빠져 있으면 `patch` 가 그 자리에서
+  `AttributeError` 로 죽어 실패가 자기 위치를 가리킨다.
+- `_channel_configs` — `global` 로 재바인딩된다. 값을 재노출하면 재바인딩
+  이후 배럴이 낡은 dict 를 영구히 노출한다(`audit_service` 의 `_audit_logs` 와
+  같은 형태).
+- `DATA_DIR` · `CHANNEL_CONFIGS_FILE` — 가져가는 곳이 없다.
+"""
+
+from .adapters import (
+    DiscordAdapter,
+    EmailAdapter,
+    NotificationAdapter,
+    SlackAdapter,
+    WebhookAdapter,
+)
+from .config import USE_DATABASE
+from .service import (
+    ADAPTERS,
+    NotificationService,
+    _notification_history,
+    _rules,
+    notify_approval_required,
+    notify_task_completed,
+    notify_task_failed,
+)
+
+__all__ = [
+    "ADAPTERS",
+    "USE_DATABASE",
+    "DiscordAdapter",
+    "EmailAdapter",
+    "NotificationAdapter",
+    "NotificationService",
+    "SlackAdapter",
+    "WebhookAdapter",
+    "_notification_history",
+    "_rules",
+    "notify_approval_required",
+    "notify_task_completed",
+    "notify_task_failed",
+]

--- a/src/backend/services/notification_service/adapters.py
+++ b/src/backend/services/notification_service/adapters.py
@@ -1,0 +1,229 @@
+"""채널별 전송 어댑터.
+
+`httpx` 를 읽는 곳이 전부 여기다. 테스트는
+`services.notification_service.adapters.httpx.AsyncClient` 를 패치한다 —
+읽는 쪽을 다른 모듈로 가르면 패치가 조용히 무효가 된다.
+"""
+
+import re
+import ssl
+from abc import ABC, abstractmethod
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import aiosmtplib
+import httpx
+
+from models.notification import ChannelConfig, NotificationMessage, NotificationPriority
+from utils.time import utcnow
+
+
+class NotificationAdapter(ABC):
+    """Base class for notification channel adapters."""
+
+    @abstractmethod
+    async def send(
+        self, message: NotificationMessage, config: ChannelConfig
+    ) -> tuple[bool, str | None]:
+        """Send a notification. Returns (success, error_message)."""
+        pass
+
+
+class SlackAdapter(NotificationAdapter):
+    """Slack webhook notification adapter."""
+
+    async def send(
+        self, message: NotificationMessage, config: ChannelConfig
+    ) -> tuple[bool, str | None]:
+        if not config.webhook_url:
+            return False, "Slack webhook URL not configured"
+
+        # Format message for Slack
+        priority_emoji = {
+            NotificationPriority.LOW: ":information_source:",
+            NotificationPriority.MEDIUM: ":bell:",
+            NotificationPriority.HIGH: ":warning:",
+            NotificationPriority.URGENT: ":rotating_light:",
+        }
+
+        payload = {
+            "text": f"{priority_emoji.get(message.priority, '')} {message.title}",
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {"type": "plain_text", "text": message.title},
+                },
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": message.body},
+                },
+            ],
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    config.webhook_url,
+                    json=payload,
+                    timeout=10.0,
+                )
+                if response.status_code == 200:
+                    return True, None
+                return False, f"Slack API error: {response.status_code}"
+        except Exception as e:
+            return False, str(e)
+
+
+class DiscordAdapter(NotificationAdapter):
+    """Discord webhook notification adapter."""
+
+    async def send(
+        self, message: NotificationMessage, config: ChannelConfig
+    ) -> tuple[bool, str | None]:
+        if not config.webhook_url:
+            return False, "Discord webhook URL not configured"
+
+        # Format message for Discord
+        color_map = {
+            NotificationPriority.LOW: 0x3498DB,  # Blue
+            NotificationPriority.MEDIUM: 0xF39C12,  # Orange
+            NotificationPriority.HIGH: 0xE74C3C,  # Red
+            NotificationPriority.URGENT: 0x9B59B6,  # Purple
+        }
+
+        payload = {
+            "embeds": [
+                {
+                    "title": message.title,
+                    "description": message.body,
+                    "color": color_map.get(message.priority, 0x95A5A6),
+                    "timestamp": utcnow().isoformat(),
+                }
+            ]
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    config.webhook_url,
+                    json=payload,
+                    timeout=10.0,
+                )
+                if response.status_code in (200, 204):
+                    return True, None
+                return False, f"Discord API error: {response.status_code}"
+        except Exception as e:
+            return False, str(e)
+
+
+class EmailAdapter(NotificationAdapter):
+    """Email notification adapter using SMTP."""
+
+    async def send(
+        self, message: NotificationMessage, config: ChannelConfig
+    ) -> tuple[bool, str | None]:
+        if not config.email_address:
+            return False, "Email address not configured"
+
+        if not config.smtp_host or not config.smtp_username or not config.smtp_password:
+            return False, "SMTP settings not configured"
+
+        # Build email message
+        email_msg = MIMEMultipart("alternative")
+        email_msg["Subject"] = f"[AOS] {message.title}"
+        email_msg["From"] = config.smtp_username
+        email_msg["To"] = config.email_address
+
+        # Priority header
+        priority_map = {
+            NotificationPriority.LOW: "5",
+            NotificationPriority.MEDIUM: "3",
+            NotificationPriority.HIGH: "2",
+            NotificationPriority.URGENT: "1",
+        }
+        email_msg["X-Priority"] = priority_map.get(message.priority, "3")
+
+        # Plain text and HTML versions
+        text_content = f"{message.title}\n\n{message.body}"
+
+        # Convert URLs in body to clickable <a> tags for HTML version
+        html_body = re.sub(
+            r'(https?://[^\s<>"]+)',
+            r'<a href="\1" style="color: #2563eb;">\1</a>',
+            message.body,
+        )
+        # Preserve line breaks in HTML
+        html_body = html_body.replace("\n", "<br>")
+
+        html_content = f"""
+        <html>
+        <body style="font-family: Arial, sans-serif; padding: 20px;">
+            <h2 style="color: #333;">{message.title}</h2>
+            <p style="color: #666; line-height: 1.6;">{html_body}</p>
+            <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">
+            <p style="color: #999; font-size: 12px;">
+                Sent by Agent Orchestration Service
+            </p>
+        </body>
+        </html>
+        """
+
+        email_msg.attach(MIMEText(text_content, "plain"))
+        email_msg.attach(MIMEText(html_content, "html"))
+
+        try:
+            # Create SSL context for TLS
+            if config.smtp_use_tls:
+                tls_context = ssl.create_default_context()
+            else:
+                tls_context = None
+
+            # Send email via SMTP
+            await aiosmtplib.send(
+                email_msg,
+                hostname=config.smtp_host,
+                port=config.smtp_port,
+                username=config.smtp_username,
+                password=config.smtp_password,
+                start_tls=config.smtp_use_tls,
+                tls_context=tls_context,
+            )
+            return True, None
+        except aiosmtplib.SMTPAuthenticationError:
+            return False, "SMTP authentication failed. Check username/app password"
+        except aiosmtplib.SMTPConnectError:
+            return False, f"Cannot connect to SMTP server {config.smtp_host}:{config.smtp_port}"
+        except Exception as e:
+            return False, f"Email send failed: {str(e)}"
+
+
+class WebhookAdapter(NotificationAdapter):
+    """Generic webhook notification adapter."""
+
+    async def send(
+        self, message: NotificationMessage, config: ChannelConfig
+    ) -> tuple[bool, str | None]:
+        if not config.webhook_url:
+            return False, "Webhook URL not configured"
+
+        payload = {
+            "event": message.event_type.value,
+            "priority": message.priority.value,
+            "title": message.title,
+            "body": message.body,
+            "data": message.data,
+            "timestamp": utcnow().isoformat(),
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    config.webhook_url,
+                    json=payload,
+                    timeout=10.0,
+                )
+                if response.status_code in (200, 201, 202, 204):
+                    return True, None
+                return False, f"Webhook error: {response.status_code}"
+        except Exception as e:
+            return False, str(e)

--- a/src/backend/services/notification_service/config.py
+++ b/src/backend/services/notification_service/config.py
@@ -1,0 +1,77 @@
+"""알림 설정 — 저장 모드 플래그와 채널 설정 파일 I/O.
+
+`DATA_DIR` 은 패키지 승격으로 이 파일의 깊이가 한 단계 늘어난 만큼
+`.parent` 를 하나 더 탄다. 원본(`services/notification_service.py`)이
+가리키던 `src/backend/data` 를 그대로 가리켜야 한다 — 기존 설정 파일이
+거기 있다.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from models.notification import ChannelConfig, NotificationChannel
+
+USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+# 패키지 승격으로 이 파일이 한 단계 깊어졌다 — 원본
+# `services/notification_service.py` 에서 `.parent.parent` 가 가리키던
+# `src/backend/` 를 계속 가리키려면 `.parent` 를 하나 더 타야 한다.
+# 기존 `notification_channel_configs.json` 이 거기 있으므로 경로가 바뀌면
+# 설정이 통째로 사라진 것처럼 보인다.
+DATA_DIR = Path(__file__).parent.parent.parent / "data"
+
+
+CHANNEL_CONFIGS_FILE = DATA_DIR / "notification_channel_configs.json"
+
+
+def _load_channel_configs() -> dict[NotificationChannel, ChannelConfig]:
+    """Load channel configs from JSON file."""
+    if not CHANNEL_CONFIGS_FILE.exists():
+        return {}
+    try:
+        with open(CHANNEL_CONFIGS_FILE) as f:
+            data = json.load(f)
+        configs = {}
+        for channel_str, config_data in data.items():
+            channel = NotificationChannel(channel_str)
+            configs[channel] = ChannelConfig(
+                channel=channel,
+                enabled=config_data.get("enabled", True),
+                webhook_url=config_data.get("webhook_url"),
+                api_key=config_data.get("api_key"),
+                bot_token=config_data.get("bot_token"),
+                email_address=config_data.get("email_address"),
+                smtp_host=config_data.get("smtp_host"),
+                smtp_port=config_data.get("smtp_port", 587),
+                smtp_username=config_data.get("smtp_username"),
+                smtp_password=config_data.get("smtp_password"),
+                smtp_use_tls=config_data.get("smtp_use_tls", True),
+                rate_limit_per_hour=config_data.get("rate_limit_per_hour", 60),
+            )
+        return configs
+    except Exception:
+        return {}
+
+
+def _save_channel_configs(configs: dict[NotificationChannel, ChannelConfig]) -> None:
+    """Save channel configs to JSON file."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    data = {}
+    for channel, config in configs.items():
+        data[channel.value] = {
+            "enabled": config.enabled,
+            "webhook_url": config.webhook_url,
+            "api_key": config.api_key,
+            "bot_token": config.bot_token,
+            "email_address": config.email_address,
+            "smtp_host": config.smtp_host,
+            "smtp_port": config.smtp_port,
+            "smtp_username": config.smtp_username,
+            "smtp_password": config.smtp_password,
+            "smtp_use_tls": config.smtp_use_tls,
+            "rate_limit_per_hour": config.rate_limit_per_hour,
+        }
+    with open(CHANNEL_CONFIGS_FILE, "w") as f:
+        json.dump(data, f, indent=2)

--- a/src/backend/services/notification_service/service.py
+++ b/src/backend/services/notification_service/service.py
@@ -1,19 +1,14 @@
-"""Notification service for sending alerts across multiple channels."""
+"""알림 규칙·발송·이력과 그 인메모리 상태.
 
-import json
-import os
-import re
-import ssl
+`_channel_configs` 는 `get_channel_config` 안에서 `global` 로 재바인딩된다.
+그것을 읽는 곳 전부가 이 모듈에 있어야 하고, 배럴은 이 이름을 재노출하면
+안 된다 — 재바인딩 이후 낡은 dict 를 영구히 노출한다.
+"""
+
 import uuid
-from abc import ABC, abstractmethod
 from datetime import timedelta
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-from pathlib import Path
 from typing import Any
 
-import aiosmtplib
-import httpx
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,276 +26,15 @@ from models.notification import (
 )
 from utils.time import utcnow
 
-USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
+from .adapters import (
+    DiscordAdapter,
+    EmailAdapter,
+    NotificationAdapter,
+    SlackAdapter,
+    WebhookAdapter,
+)
+from .config import USE_DATABASE, _load_channel_configs, _save_channel_configs
 
-# Data directory for persistent storage
-DATA_DIR = Path(__file__).parent.parent / "data"
-CHANNEL_CONFIGS_FILE = DATA_DIR / "notification_channel_configs.json"
-
-
-def _load_channel_configs() -> dict[NotificationChannel, ChannelConfig]:
-    """Load channel configs from JSON file."""
-    if not CHANNEL_CONFIGS_FILE.exists():
-        return {}
-    try:
-        with open(CHANNEL_CONFIGS_FILE) as f:
-            data = json.load(f)
-        configs = {}
-        for channel_str, config_data in data.items():
-            channel = NotificationChannel(channel_str)
-            configs[channel] = ChannelConfig(
-                channel=channel,
-                enabled=config_data.get("enabled", True),
-                webhook_url=config_data.get("webhook_url"),
-                api_key=config_data.get("api_key"),
-                bot_token=config_data.get("bot_token"),
-                email_address=config_data.get("email_address"),
-                smtp_host=config_data.get("smtp_host"),
-                smtp_port=config_data.get("smtp_port", 587),
-                smtp_username=config_data.get("smtp_username"),
-                smtp_password=config_data.get("smtp_password"),
-                smtp_use_tls=config_data.get("smtp_use_tls", True),
-                rate_limit_per_hour=config_data.get("rate_limit_per_hour", 60),
-            )
-        return configs
-    except Exception:
-        return {}
-
-
-def _save_channel_configs(configs: dict[NotificationChannel, ChannelConfig]) -> None:
-    """Save channel configs to JSON file."""
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    data = {}
-    for channel, config in configs.items():
-        data[channel.value] = {
-            "enabled": config.enabled,
-            "webhook_url": config.webhook_url,
-            "api_key": config.api_key,
-            "bot_token": config.bot_token,
-            "email_address": config.email_address,
-            "smtp_host": config.smtp_host,
-            "smtp_port": config.smtp_port,
-            "smtp_username": config.smtp_username,
-            "smtp_password": config.smtp_password,
-            "smtp_use_tls": config.smtp_use_tls,
-            "rate_limit_per_hour": config.rate_limit_per_hour,
-        }
-    with open(CHANNEL_CONFIGS_FILE, "w") as f:
-        json.dump(data, f, indent=2)
-
-
-class NotificationAdapter(ABC):
-    """Base class for notification channel adapters."""
-
-    @abstractmethod
-    async def send(
-        self, message: NotificationMessage, config: ChannelConfig
-    ) -> tuple[bool, str | None]:
-        """Send a notification. Returns (success, error_message)."""
-        pass
-
-
-class SlackAdapter(NotificationAdapter):
-    """Slack webhook notification adapter."""
-
-    async def send(
-        self, message: NotificationMessage, config: ChannelConfig
-    ) -> tuple[bool, str | None]:
-        if not config.webhook_url:
-            return False, "Slack webhook URL not configured"
-
-        # Format message for Slack
-        priority_emoji = {
-            NotificationPriority.LOW: ":information_source:",
-            NotificationPriority.MEDIUM: ":bell:",
-            NotificationPriority.HIGH: ":warning:",
-            NotificationPriority.URGENT: ":rotating_light:",
-        }
-
-        payload = {
-            "text": f"{priority_emoji.get(message.priority, '')} {message.title}",
-            "blocks": [
-                {
-                    "type": "header",
-                    "text": {"type": "plain_text", "text": message.title},
-                },
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": message.body},
-                },
-            ],
-        }
-
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    config.webhook_url,
-                    json=payload,
-                    timeout=10.0,
-                )
-                if response.status_code == 200:
-                    return True, None
-                return False, f"Slack API error: {response.status_code}"
-        except Exception as e:
-            return False, str(e)
-
-
-class DiscordAdapter(NotificationAdapter):
-    """Discord webhook notification adapter."""
-
-    async def send(
-        self, message: NotificationMessage, config: ChannelConfig
-    ) -> tuple[bool, str | None]:
-        if not config.webhook_url:
-            return False, "Discord webhook URL not configured"
-
-        # Format message for Discord
-        color_map = {
-            NotificationPriority.LOW: 0x3498DB,  # Blue
-            NotificationPriority.MEDIUM: 0xF39C12,  # Orange
-            NotificationPriority.HIGH: 0xE74C3C,  # Red
-            NotificationPriority.URGENT: 0x9B59B6,  # Purple
-        }
-
-        payload = {
-            "embeds": [
-                {
-                    "title": message.title,
-                    "description": message.body,
-                    "color": color_map.get(message.priority, 0x95A5A6),
-                    "timestamp": utcnow().isoformat(),
-                }
-            ]
-        }
-
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    config.webhook_url,
-                    json=payload,
-                    timeout=10.0,
-                )
-                if response.status_code in (200, 204):
-                    return True, None
-                return False, f"Discord API error: {response.status_code}"
-        except Exception as e:
-            return False, str(e)
-
-
-class EmailAdapter(NotificationAdapter):
-    """Email notification adapter using SMTP."""
-
-    async def send(
-        self, message: NotificationMessage, config: ChannelConfig
-    ) -> tuple[bool, str | None]:
-        if not config.email_address:
-            return False, "Email address not configured"
-
-        if not config.smtp_host or not config.smtp_username or not config.smtp_password:
-            return False, "SMTP settings not configured"
-
-        # Build email message
-        email_msg = MIMEMultipart("alternative")
-        email_msg["Subject"] = f"[AOS] {message.title}"
-        email_msg["From"] = config.smtp_username
-        email_msg["To"] = config.email_address
-
-        # Priority header
-        priority_map = {
-            NotificationPriority.LOW: "5",
-            NotificationPriority.MEDIUM: "3",
-            NotificationPriority.HIGH: "2",
-            NotificationPriority.URGENT: "1",
-        }
-        email_msg["X-Priority"] = priority_map.get(message.priority, "3")
-
-        # Plain text and HTML versions
-        text_content = f"{message.title}\n\n{message.body}"
-
-        # Convert URLs in body to clickable <a> tags for HTML version
-        html_body = re.sub(
-            r'(https?://[^\s<>"]+)',
-            r'<a href="\1" style="color: #2563eb;">\1</a>',
-            message.body,
-        )
-        # Preserve line breaks in HTML
-        html_body = html_body.replace("\n", "<br>")
-
-        html_content = f"""
-        <html>
-        <body style="font-family: Arial, sans-serif; padding: 20px;">
-            <h2 style="color: #333;">{message.title}</h2>
-            <p style="color: #666; line-height: 1.6;">{html_body}</p>
-            <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">
-            <p style="color: #999; font-size: 12px;">
-                Sent by Agent Orchestration Service
-            </p>
-        </body>
-        </html>
-        """
-
-        email_msg.attach(MIMEText(text_content, "plain"))
-        email_msg.attach(MIMEText(html_content, "html"))
-
-        try:
-            # Create SSL context for TLS
-            if config.smtp_use_tls:
-                tls_context = ssl.create_default_context()
-            else:
-                tls_context = None
-
-            # Send email via SMTP
-            await aiosmtplib.send(
-                email_msg,
-                hostname=config.smtp_host,
-                port=config.smtp_port,
-                username=config.smtp_username,
-                password=config.smtp_password,
-                start_tls=config.smtp_use_tls,
-                tls_context=tls_context,
-            )
-            return True, None
-        except aiosmtplib.SMTPAuthenticationError:
-            return False, "SMTP authentication failed. Check username/app password"
-        except aiosmtplib.SMTPConnectError:
-            return False, f"Cannot connect to SMTP server {config.smtp_host}:{config.smtp_port}"
-        except Exception as e:
-            return False, f"Email send failed: {str(e)}"
-
-
-class WebhookAdapter(NotificationAdapter):
-    """Generic webhook notification adapter."""
-
-    async def send(
-        self, message: NotificationMessage, config: ChannelConfig
-    ) -> tuple[bool, str | None]:
-        if not config.webhook_url:
-            return False, "Webhook URL not configured"
-
-        payload = {
-            "event": message.event_type.value,
-            "priority": message.priority.value,
-            "title": message.title,
-            "body": message.body,
-            "data": message.data,
-            "timestamp": utcnow().isoformat(),
-        }
-
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    config.webhook_url,
-                    json=payload,
-                    timeout=10.0,
-                )
-                if response.status_code in (200, 201, 202, 204):
-                    return True, None
-                return False, f"Webhook error: {response.status_code}"
-        except Exception as e:
-            return False, str(e)
-
-
-# Adapter registry
 ADAPTERS: dict[NotificationChannel, NotificationAdapter] = {
     NotificationChannel.SLACK: SlackAdapter(),
     NotificationChannel.DISCORD: DiscordAdapter(),
@@ -309,9 +43,12 @@ ADAPTERS: dict[NotificationChannel, NotificationAdapter] = {
 }
 
 
-# In-memory storage (fallback when USE_DATABASE=false)
 _rules: dict[str, NotificationRule] = {}
+
+
 _channel_configs: dict[NotificationChannel, ChannelConfig] = _load_channel_configs()
+
+
 _notification_history: list[NotificationMessage] = []
 
 
@@ -983,7 +720,6 @@ class NotificationService:
         return result.rowcount
 
 
-# Convenience functions
 async def notify_task_completed(session_id: str, task_id: str, task_title: str) -> None:
     """Send task completed notification."""
     await NotificationService.send_notification(

--- a/tests/backend/api/split_notification.py
+++ b/tests/backend/api/split_notification.py
@@ -1,0 +1,183 @@
+"""services/notification_service.py(1,017줄) → 도메인 모듈 3종 분할 배정표. (B5.5 Task 4)
+
+    # CWD = repo 루트. <원본> 은 패키지 승격 **직전** 커밋에서 꺼낸 스냅샷
+    git show <승격직전ref>:src/backend/services/notification_service.py > /tmp/orig.py
+    src/backend/.venv/bin/python tests/backend/api/split_notification.py \
+        /tmp/orig.py src/backend/services/notification_service/
+
+실행 로직은 `split_module.py` 에 있다. 이 파일은 **배정표와 그 근거**만 담는다.
+
+**이 분할에는 엔진이 만들 수 없는 후속 수정이 하나 있다 — `DATA_DIR`.**
+아래 config 절의 주석을 반드시 읽을 것. 본문 바이트가 같으면 오히려 깨진다.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from split_module import split  # noqa: E402
+
+# ── 배정표: 이름 -> 모듈 ────────────────────────────────────────────────
+#
+# 하중 지지대 규칙: **재바인딩되는 이름은 그것을 읽는 함수 전부와 같은 모듈에.**
+#
+# 실측 (계획서 숫자를 물려받지 않았다):
+#
+# - 문자열 패치 **7 건**(계획서는 13 이라 적었다)이고 전부 한 형태다:
+#   `patch("services.notification_service.httpx.AsyncClient")`.
+#   `httpx` 를 읽는 세 곳(L135 Slack · L177 Discord · L290 Webhook)이 전부
+#   어댑터라 `adapters.py` 로 재지정한다. 배럴에 `httpx` 를 두지 않으므로 낡은
+#   경로는 `AttributeError` 로 즉시 죽는다.
+# - `global` 재바인딩은 **`_channel_configs` 하나**(L549). 읽는 곳이 전부
+#   `NotificationService` 안이라 같은 모듈에 둔다. 외부 소비자 0 건이므로
+#   배럴에서도 뺀다 — 재노출하면 재바인딩 후 낡은 dict 를 영구히 노출한다.
+# - `_rules` · `_notification_history` 는 재바인딩이 **없다**. 테스트가
+#   `.clear()` 로 내용만 건드리므로(L81·82·196·197·600·601) 배럴 재노출이
+#   같은 객체를 가리켜 안전하다 — 그래서 넣는다(테스트가 실제로 가져간다).
+ASSIGNMENT: dict[str, str] = {
+    # ── config.py — 환경 플래그와 채널 설정 파일 I/O ──
+    #
+    #   ⚠️ `DATA_DIR` 은 `Path(__file__).parent.parent / "data"` 다.
+    #   원본은 `services/notification_service.py` 라 `.parent.parent` 가
+    #   `src/backend/` 였지만, 패키지 안에서는 한 단계 깊어져 `services/` 를
+    #   가리킨다 — 데이터 디렉토리가 조용히 이동한다. 패키지 안 어느 위치에
+    #   두어도 `.parent.parent` 로는 맞출 수 없으므로 **본문을 고쳐야 한다**
+    #   (`.parent.parent.parent`). 이것이 이 분할의 유일한 의도적 본문 변경이고
+    #   `split_audit.py` 가 그 한 건을 정직하게 FAIL 로 보고한다 — 억누르지 말고
+    #   전후 실행 비교로 절대 경로가 같은지 확인할 것.
+    #   같은 형태가 `playground_service.STORAGE_DIR`(Task 5)에도 있다.
+    "USE_DATABASE": "config",
+    "DATA_DIR": "config",
+    "CHANNEL_CONFIGS_FILE": "config",
+    "_load_channel_configs": "config",
+    "_save_channel_configs": "config",
+    # ── adapters.py — 채널별 전송 어댑터 5종 ──
+    #    `httpx` 를 읽는 곳이 전부 여기다(패치 타깃 7 건의 목적지).
+    "NotificationAdapter": "adapters",
+    "SlackAdapter": "adapters",
+    "DiscordAdapter": "adapters",
+    "EmailAdapter": "adapters",
+    "WebhookAdapter": "adapters",
+    # ── service.py — 규칙·발송·이력 + 모듈 상태 4종 + 편의 함수 3종 ──
+    #    `_channel_configs` 의 `global` 재바인딩과 그 reader 가 전부 여기 있다.
+    "ADAPTERS": "service",
+    "_rules": "service",
+    "_channel_configs": "service",
+    "_notification_history": "service",
+    "NotificationService": "service",
+    "notify_task_completed": "service",
+    "notify_task_failed": "service",
+    "notify_approval_required": "service",
+}
+
+MODULE_ORDER = ["config", "adapters", "service"]
+
+DOCSTRINGS = {
+    "config": (
+        '"""알림 설정 — 저장 모드 플래그와 채널 설정 파일 I/O.\n\n'
+        "`DATA_DIR` 은 패키지 승격으로 이 파일의 깊이가 한 단계 늘어난 만큼\n"
+        "`.parent` 를 하나 더 탄다. 원본(`services/notification_service.py`)이\n"
+        "가리키던 `src/backend/data` 를 그대로 가리켜야 한다 — 기존 설정 파일이\n"
+        '거기 있다.\n"""'
+    ),
+    "adapters": (
+        '"""채널별 전송 어댑터.\n\n'
+        "`httpx` 를 읽는 곳이 전부 여기다. 테스트는\n"
+        "`services.notification_service.adapters.httpx.AsyncClient` 를 패치한다 —\n"
+        '읽는 쪽을 다른 모듈로 가르면 패치가 조용히 무효가 된다.\n"""'
+    ),
+    "service": (
+        '"""알림 규칙·발송·이력과 그 인메모리 상태.\n\n'
+        "`_channel_configs` 는 `get_channel_config` 안에서 `global` 로 재바인딩된다.\n"
+        "그것을 읽는 곳 전부가 이 모듈에 있어야 하고, 배럴은 이 이름을 재노출하면\n"
+        '안 된다 — 재바인딩 이후 낡은 dict 를 영구히 노출한다.\n"""'
+    ),
+}
+
+BARREL = '''"""Notification service for sending alerts across multiple channels.
+
+원래 단일 `services/notification_service.py`(1,017줄)를 도메인별로 분할한 결과.
+소비자의 `from services.notification_service import NotificationService` 는
+그대로 유효하다.
+
+재노출은 실측된 import 사이트가 요구하는 것만 담는다:
+
+    api/organizations.py -> NotificationService · ADAPTERS
+    api/notifications.py -> NotificationService · USE_DATABASE
+    tests/…test_notification_service.py -> SlackAdapter · DiscordAdapter ·
+        WebhookAdapter · NotificationService · _rules · _notification_history ·
+        notify_task_completed · notify_task_failed
+
+`NotificationAdapter`(추상 베이스) · `EmailAdapter` · `notify_approval_required`
+는 현재 가져가는 곳이 없지만 위 이름들의 형제이고 재바인딩 대상이 아니라
+같이 내보낸다.
+
+`_rules` · `_notification_history` 를 재노출하는 것은 안전하다 — 재바인딩이
+없어(모듈에 `global` 문 없음, 테스트도 `.clear()` 만 한다) 배럴이 가리키는
+객체가 서브모듈의 그것과 계속 같다.
+
+**의도적으로 빠진 것**
+
+- `httpx` — 테스트가 `httpx.AsyncClient` 를 패치한다. 배럴에 두면 낡은 경로
+  (`services.notification_service.httpx.AsyncClient`)가 성공해 버려 어댑터가
+  실제로 어느 모듈에서 읽는지와 무관해진다. 빠져 있으면 `patch` 가 그 자리에서
+  `AttributeError` 로 죽어 실패가 자기 위치를 가리킨다.
+- `_channel_configs` — `global` 로 재바인딩된다. 값을 재노출하면 재바인딩
+  이후 배럴이 낡은 dict 를 영구히 노출한다(`audit_service` 의 `_audit_logs` 와
+  같은 형태).
+- `DATA_DIR` · `CHANNEL_CONFIGS_FILE` — 가져가는 곳이 없다.
+"""
+
+from .adapters import (
+    DiscordAdapter,
+    EmailAdapter,
+    NotificationAdapter,
+    SlackAdapter,
+    WebhookAdapter,
+)
+from .config import USE_DATABASE
+from .service import (
+    ADAPTERS,
+    NotificationService,
+    _notification_history,
+    _rules,
+    notify_approval_required,
+    notify_task_completed,
+    notify_task_failed,
+)
+
+__all__ = [
+    "ADAPTERS",
+    "USE_DATABASE",
+    "DiscordAdapter",
+    "EmailAdapter",
+    "NotificationAdapter",
+    "NotificationService",
+    "SlackAdapter",
+    "WebhookAdapter",
+    "notify_approval_required",
+    "notify_task_completed",
+    "notify_task_failed",
+]
+'''
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(__doc__)
+        return 2
+    return split(
+        Path(argv[1]),
+        Path(argv[2]),
+        assignment=ASSIGNMENT,
+        docstrings=DOCSTRINGS,
+        module_order=MODULE_ORDER,
+        barrel=BARREL,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/backend/test_notification_service.py
+++ b/tests/backend/test_notification_service.py
@@ -404,7 +404,7 @@ class TestSlackAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.httpx.AsyncClient", return_value=mock_client):
+        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
             success, error = await adapter.send(message, config)
 
         assert success is True
@@ -430,7 +430,7 @@ class TestSlackAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.httpx.AsyncClient", return_value=mock_client):
+        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
             success, error = await adapter.send(message, config)
 
         assert success is False
@@ -453,7 +453,7 @@ class TestSlackAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.httpx.AsyncClient", return_value=mock_client):
+        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
             success, error = await adapter.send(message, config)
 
         assert success is False
@@ -503,7 +503,7 @@ class TestDiscordAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.httpx.AsyncClient", return_value=mock_client):
+        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
             success, error = await adapter.send(message, config)
 
         assert success is True
@@ -532,7 +532,7 @@ class TestDiscordAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.httpx.AsyncClient", return_value=mock_client):
+        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
             success, error = await adapter.send(message, config)
 
         assert success is False
@@ -582,7 +582,7 @@ class TestWebhookAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.httpx.AsyncClient", return_value=mock_client):
+        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
             success, error = await adapter.send(message, config)
 
         assert success is True
@@ -630,7 +630,7 @@ class TestSendNotification:
         with patch(
             "services.notification_service.NotificationService.get_channel_config",
             return_value=slack_config,
-        ), patch("services.notification_service.httpx.AsyncClient", return_value=mock_client):
+        ), patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
             msg = await NotificationService.send_notification(
                 NotificationEventType.TASK_COMPLETED,
                 {"task_title": "My Task"},

--- a/tests/backend/test_notification_service_package.py
+++ b/tests/backend/test_notification_service_package.py
@@ -1,0 +1,120 @@
+"""Invariants the ``services.notification_service`` package split has to keep.
+
+Three hazards, none of which shows up as a failure anywhere else:
+
+1. ``DATA_DIR`` is ``Path(__file__).parent…`` — a **depth-coupled** path. The
+   package promotion put the file one level deeper, so keeping the expression
+   byte-identical would silently move the data directory from ``src/backend/data``
+   to ``src/backend/services/data``, and the existing channel config would read
+   as empty. This is the split's one intentional body change; the assertion below
+   is what makes it verified rather than assumed.
+2. ``_channel_configs`` is rebound through ``global``. Its readers must stay in
+   the module that rebinds it, and the barrel must not carry the value.
+3. ``httpx`` must not be on the barrel. Seven ``patch`` sites name the module
+   that actually reads it; a barrel copy would let a stale path succeed.
+"""
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+import services.notification_service as barrel
+import services.notification_service.adapters as adapters_module
+import services.notification_service.config as config_module
+import services.notification_service.service as service_module
+
+# Measured from the import sites, not guessed:
+#   api/organizations.py -> NotificationService · ADAPTERS
+#   api/notifications.py -> NotificationService · USE_DATABASE
+#   tests/…test_notification_service.py -> SlackAdapter · DiscordAdapter ·
+#       WebhookAdapter · NotificationService · _rules · _notification_history ·
+#       notify_task_completed · notify_task_failed
+_PUBLIC_SURFACE = (
+    "ADAPTERS",
+    "DiscordAdapter",
+    "EmailAdapter",
+    "NotificationAdapter",
+    "NotificationService",
+    "SlackAdapter",
+    "USE_DATABASE",
+    "WebhookAdapter",
+    "_notification_history",
+    "_rules",
+    "notify_approval_required",
+    "notify_task_completed",
+    "notify_task_failed",
+)
+
+# Names the barrel must NOT carry, and why each one would be a live bug.
+_DELIBERATELY_ABSENT = ("httpx", "_channel_configs")
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    service_module._rules.clear()
+    service_module._notification_history.clear()
+    yield
+    service_module._rules.clear()
+    service_module._notification_history.clear()
+
+
+@pytest.mark.parametrize("name", _PUBLIC_SURFACE)
+def test_barrel_still_exposes_every_imported_name(name: str) -> None:
+    """``services.notification_service`` stays valid verbatim at its import sites."""
+    assert hasattr(barrel, name), f"배럴이 {name} 을 잃었다 — import 사이트가 시작 시점에 죽는다"
+
+
+@pytest.mark.parametrize("name", _DELIBERATELY_ABSENT)
+def test_barrel_omits_names_that_would_make_a_patch_silently_void(name: str) -> None:
+    """Re-exporting these turns a loud failure into a silent one."""
+    assert not hasattr(barrel, name), (
+        f"배럴이 {name} 을 재노출한다 — 낡은 패치 경로가 성공하되 무효가 된다"
+    )
+
+
+def test_data_dir_survived_the_extra_package_level() -> None:
+    """``DATA_DIR`` still points at ``src/backend/data``, not one level shallower.
+
+    ``split_audit.py`` compares bodies byte for byte, so it reports this file's
+    one changed line — and would have reported *nothing* had the line been left
+    alone, which is exactly the failure: same bytes, different directory.
+    """
+    # `services` 패키지 위치에서 독립적으로 유도한다 — config 모듈 자신의 깊이로
+    # 계산하면 구현을 그대로 되풀이하는 동어반복이 되어 아무것도 잡지 못한다.
+    import services
+
+    backend_root = Path(services.__file__).parent.parent
+
+    assert config_module.DATA_DIR.resolve() == (backend_root / "data").resolve()
+    assert config_module.DATA_DIR.parent.name == "backend"
+    assert config_module.CHANNEL_CONFIGS_FILE.parent == config_module.DATA_DIR
+
+
+def test_channel_config_rebinding_is_visible_to_its_readers() -> None:
+    """``get_channel_config`` rebinds ``_channel_configs``; readers must follow.
+
+    The reader and the ``global`` statement are in one module, so the rebound
+    dict is what the next read sees. If they were ever split, this returns a
+    config drawn from the stale copy.
+    """
+    from models.notification import NotificationChannel
+
+    config = service_module.NotificationService.get_channel_config(NotificationChannel.SLACK)
+
+    assert config is not None
+    assert service_module._channel_configs[NotificationChannel.SLACK] is config
+
+
+def test_adapters_read_the_process_wide_httpx_module() -> None:
+    """The patch path ``adapters.httpx.AsyncClient`` reaches the adapters.
+
+    Seven sites in ``test_notification_service.py`` name that exact path.
+    """
+    assert adapters_module.httpx is httpx
+
+
+def test_state_objects_are_shared_not_copied() -> None:
+    """The barrel forwards the same list/dict objects the service mutates."""
+    assert barrel._rules is service_module._rules
+    assert barrel._notification_history is service_module._notification_history


### PR DESCRIPTION
## 요약

`services/notification_service.py` **1,017 줄 → 패키지 3 모듈, 최대 753 줄**. B5.5 네 번째(#349 · #354 · #356 에 이어).

| 모듈 | 줄수 | 내용 |
|---|---:|---|
| `config.py` | 77 | `USE_DATABASE` · `DATA_DIR` · 채널 설정 파일 I/O |
| `adapters.py` | 229 | Slack · Discord · Email · Webhook 어댑터 |
| `service.py` | 753 | `NotificationService` + 모듈 상태 4종 + 편의 함수 3종 |
| `__init__.py` | 65 | 배럴 |

## 이 배치에서 처음 나온 형태 — 깊이 결합 경로

```python
DATA_DIR = Path(__file__).parent.parent / "data"
```

원본(`services/notification_service.py`)에서는 `src/backend/` 를 가리켰다. 패키지 안에서는 한 단계 깊어져 **`services/` 를 가리킨다** — 데이터 디렉토리가 조용히 이동하고 기존 `notification_channel_configs.json` 이 사라진 것처럼 읽힌다. 패키지 안 **어느 위치에 두어도** `.parent.parent` 로는 맞출 수 없어 본문을 고쳤다(`.parent` 하나 추가).

**이것이 이 분할의 유일한 의도적 본문 변경이다.** `split_audit.py` 가 그 한 건만 FAIL 로 보고한다(나머지 17종 통과) — 억누르지 않고 근거를 남겼다.

> **본문을 그대로 뒀다면 audit 은 OK 를 냈을 것이다.** 같은 바이트, 다른 디렉토리. 정의 보존 도구가 구조적으로 못 보는 층이다.

그 층은 `test_data_dir_survived_the_extra_package_level` 만 덮고 Red-Green 으로 확인했다 — 원래 깊이로 되돌리니 **그 단언 하나만** 실패했다. 단언의 앵커는 `services` 패키지 위치에서 독립적으로 유도한다(config 모듈 자신의 깊이로 계산하면 구현을 되풀이하는 동어반복이라 아무것도 못 잡는다).

**확산 판정**: 같은 형태가 `playground_service.STORAGE_DIR`(Task 5)에 있다. 이미 머지된 `audit_service` · `tmux_service` · `merge_service` 에는 `__file__` 이 없어 무영향이다.

## 패치 타깃 7 건 — 계획서의 13 이 아니다

전부 `patch("services.notification_service.httpx.AsyncClient")` 한 형태다. `httpx` 를 읽는 세 곳(L135 Slack · L177 Discord · L290 Webhook)이 전부 어댑터라 `adapters.py` 로 재지정했다. 배럴에 `httpx` 를 두지 않으므로 낡은 경로는 `AttributeError` 로 죽는다 — RED 7 건 확인 후 52 통과.

## 모듈 상태 — 재바인딩 여부로 갈린다

| 이름 | 재바인딩 | 배럴 |
|---|---|---|
| `_channel_configs` | `global` (L549) | **뺀다** — 재바인딩 후 낡은 dict 를 영구 노출 |
| `_rules` · `_notification_history` | 없음 (테스트도 `.clear()` 만) | **넣는다** — 테스트가 실제로 가져가고 같은 객체를 가리킨다 |

`__all__` 에 두 private 이름을 넣는 것은 `audit_service` 배럴 선례를 따랐다.

## 검증

- **정의 보존**: 18종 중 17종 본문 바이트 일치, `DATA_DIR` 1건은 위 근거대로 의도적 변경
- **분할 전후 실행 비교**: DATA_DIR 절대 경로 · 어댑터 매핑 · httpx 모듈 동일성 · 재바인딩 가시성 · 상태 공유 · 배럴 표면을 JSON 으로 뽑아 `diff` — 완전 일치
- **계약 테스트** `tests/backend/test_notification_service_package.py` **19 건** + Red-Green 2 종
- **게이트**: `ruff check` · `ruff format --check` · `mypy`(326) · `pytest` **1,730 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4dcrPm9QALmLqE2v8pGx1