### PR TITLE
fix: 프로젝트 인가 우회 2건 — 세션 슬러그 폴백과 클라이언트 제어 머지 역할

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -852,9 +852,27 @@ Codex 2 라운드 + 실행 스모크로 지적 4 P1 / 3 P2 중 확인된 것을 
     에서 읽는다 — 선언하면 `{project_id}` 없는 라우트가 422 로 깨진다.
   - **후속 2 의 원래 우려도 함께 닫혔다**: DB 미등록 슬러그는 이제 404 다. 수정 전에는
     200 과 실제 저장소 데이터를 반환했다(RED 실측).
-  - **남은 것**: `sessions._resolve_project_context` 의 파일시스템 우선 분기는 그대로다 —
-    같은 우회를 세션 표면에 갖고 있다. `api/git/merge*` 의 `user_role` 은 여전히 클라이언트가
-    쿼리 파라미터로 보낸다(인가 입력이 클라이언트 제어). 둘 다 이 diff 범위 밖.
+  - ~~**남은 것**: `sessions._resolve_project_context` 의 파일시스템 우선 분기,
+    `api/git/merge*` 의 클라이언트 제어 `user_role`~~ → **2026-08-28 둘 다 종료**
+    (PR `#363`, 브랜치 `fix/project-authz-followups`).
+    - 세션: DB 모드에서 파일시스템 폴백을 없앴다. 실측으로 확인된 우회였다 — 일반
+      사용자가 DB 미등록 슬러그로 `POST /api/sessions` 에 **200** 을 받았다.
+      `test_session_prefers_the_filesystem_registry`(#318 이 만든 **성능** 계약)를
+      교체했다. 그 계약의 순서가 곧 우회로였다.
+    - 머지: `user_role`·`user_id` 쿼리 파라미터를 서버 판정값으로 대체했다.
+      `user_id` 는 attribution 위조가 아니라 **승인 우회**다 —
+      `merge_service/requests.py:_try_auto_merge` 가 승인 수를 실제로 게이트한다.
+    - **다음 세션이 다시 만들 판단 2 가지**:
+      1) 어휘가 셋이라(`require_project_role`=owner/editor/viewer,
+         `GIT_ROLE_PERMISSIONS`=owner/admin/manager/member/viewer, org 멤버십)
+         `editor` 를 그대로 넘기면 키 부재로 **에러 없이 전면 거부**가 된다.
+         `_PROJECT_ROLE_TO_GIT_ROLE` 매핑 표가 그래서 명시적이다.
+      2) org 역할은 대안이 못 된다 — 등록 프로젝트의 `organization_id` 가
+         **전부 NULL**(실측 9/9)이다. 채워진 권위는 `project_access`(8 행).
+    - **아직 남은 것**: 대시보드 `GitPage.tsx:501` 의 `canMerge` 는 여전히 org 역할로
+      판정해 서버(프로젝트 ACL 역할)와 기준이 다르다 — 보안 문제는 아니나 버튼 노출이
+      어긋날 수 있다. `create_merge_request` 의 `author_*` 도 클라이언트 입력이다
+      (인가 미사용, attribution 전용).
 
 - **브랜치 정리 (복원 지점)**: `fix/health-badge-and-project-config-db-mode` 를 2026-08-28 에
   로컬·원격 모두 삭제했다. tip 은 **`95dd5b5`**(5 커밋: `f955e7e` · `754edc0` · `7ed7c46` ·

--- a/src/backend/api/git/_shared.py
+++ b/src/backend/api/git/_shared.py
@@ -18,6 +18,20 @@ def _use_database() -> bool:
     return os.getenv("USE_DATABASE", "false").lower() == "true"
 
 
+# 프로젝트 ACL 역할(owner/editor/viewer) → git 권한 역할.
+# 어휘가 셋이라 그냥 넘기면 조용히 틀린다: `require_project_role` 이 돌려주는
+# `editor` 는 `models/git/permissions.py` 의 `GIT_ROLE_PERMISSIONS` 에 없어서
+# `has_git_permission` 이 빈 리스트를 받고 **전면 거부**가 된다(에러 없음).
+# 대시보드가 보내던 org 역할은 대안이 못 된다 — 등록된 프로젝트의
+# `organization_id` 가 전부 NULL 이라 조회할 조직이 없다(실측 9/9).
+# `editor` → `member`: 쓰기는 되지만 보호 브랜치 머지(MERGE_MAIN)는 안 된다.
+_PROJECT_ROLE_TO_GIT_ROLE: dict[str, str] = {
+    "owner": "owner",
+    "editor": "member",
+    "viewer": "viewer",
+}
+
+
 # =============================================================================
 # Project Resolution & Authorization
 # =============================================================================
@@ -91,6 +105,9 @@ async def enforce_git_project_access(
     모드에서만 강제한다. 이는 기존 동작 유지이며, 이 변경으로 새로 열리는 표면은 없다.
     """
     if not _use_database():
+        # 메모리 모드에는 프로젝트 ACL 이 없어 인증된 사용자가 이미 모든 git 쓰기를
+        # 할 수 있다. 머지만 따로 막으면 기능 제거가 되므로 기존 동작을 유지한다.
+        request.state.git_role = "admin"
         return
 
     project_id = request.path_params.get("project_id")
@@ -107,7 +124,21 @@ async def enforce_git_project_access(
     min_role = "viewer" if request.method in {"GET", "HEAD", "OPTIONS"} else "editor"
 
     # 404(미등록) / 403(거부) / 503(조회 실패) — 전부 fail-closed.
-    await require_project_role(project_id, current_user, db, min_role=min_role)
+    project_role = await require_project_role(project_id, current_user, db, min_role=min_role)
+
+    # 머지 권한(`can_merge_to_branch`)이 쓸 역할을 여기서 확정해 둔다. 이전에는
+    # 핸들러가 `user_role` 을 **쿼리 파라미터로** 받아 `?user_role=owner` 한 줄이면
+    # 보호 브랜치 제한이 사라졌다.
+    request.state.git_role = _PROJECT_ROLE_TO_GIT_ROLE.get(project_role, "viewer")
+
+
+async def get_git_role(request: Request) -> str:
+    """`enforce_git_project_access` 가 확정한 git 권한 역할.
+
+    그 의존성은 라우터 소유라 엔드포인트 파라미터보다 먼저 해석되므로 값이 항상 있다.
+    없으면(배선이 끊긴 경우) 가장 낮은 역할로 떨어진다 — fail-closed.
+    """
+    return getattr(request.state, "git_role", "viewer")
 
 
 # =============================================================================

--- a/src/backend/api/git/merge.py
+++ b/src/backend/api/git/merge.py
@@ -1,6 +1,6 @@
 """merge 관련 Git API 라우트."""
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from models.git import (
     ConflictFile,
@@ -17,7 +17,7 @@ from models.git import (
     can_merge_to_branch,
 )
 
-from ._shared import get_effective_git_path, resolve_project
+from ._shared import get_effective_git_path, get_git_role, resolve_project
 
 router = APIRouter()
 
@@ -105,7 +105,7 @@ async def get_three_way_diff(
 async def execute_merge(
     project_id: str,
     request: MergeExecuteRequest,
-    user_role: str = Query("member", description="User role for permission check"),
+    user_role: str = Depends(get_git_role),
 ):
     """Execute merge operation.
 

--- a/src/backend/api/git/merge_requests.py
+++ b/src/backend/api/git/merge_requests.py
@@ -2,8 +2,9 @@
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from api.deps import get_current_user
 from models.git import (
     MergeRequest,
     MergeRequestCreate,
@@ -13,7 +14,7 @@ from models.git import (
     can_merge_to_branch,
 )
 
-from ._shared import _get_db_session, get_mr_service_for_project
+from ._shared import _get_db_session, get_git_role, get_mr_service_for_project
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +165,7 @@ async def update_merge_request(
 async def approve_merge_request(
     project_id: str,
     mr_id: str,
-    user_id: str = Query(..., description="Approving user ID"),
+    current_user=Depends(get_current_user),
 ):
     """Approve a merge request. Triggers auto-merge if conditions met."""
     db_session = await _get_db_session()
@@ -172,10 +173,12 @@ async def approve_merge_request(
         mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
-                mr = await mr_service.approve_merge_request_async(mr_id=mr_id, user_id=user_id)
+                mr = await mr_service.approve_merge_request_async(
+                    mr_id=mr_id, user_id=str(current_user.id)
+                )
                 await db_session.commit()
         else:
-            mr = mr_service.approve_merge_request(mr_id=mr_id, user_id=user_id)
+            mr = mr_service.approve_merge_request(mr_id=mr_id, user_id=str(current_user.id))
 
         if not mr:
             raise HTTPException(status_code=404, detail="Merge request not found")
@@ -191,8 +194,8 @@ async def approve_merge_request(
 async def merge_merge_request(
     project_id: str,
     mr_id: str,
-    user_id: str = Query(..., description="User ID performing the merge"),
-    user_role: str = Query("member", description="User role for permission check"),
+    current_user=Depends(get_current_user),
+    user_role: str = Depends(get_git_role),
 ):
     """Merge a merge request."""
     db_session = await _get_db_session()
@@ -212,7 +215,7 @@ async def merge_merge_request(
                     )
 
                 mr, result = await mr_service.merge_merge_request_async(
-                    mr_id=mr_id, merged_by=user_id
+                    mr_id=mr_id, merged_by=str(current_user.id)
                 )
                 await db_session.commit()
 
@@ -230,7 +233,7 @@ async def merge_merge_request(
                     detail=f"Insufficient permissions to merge to '{mr.target_branch}'",
                 )
 
-            mr, result = mr_service.merge_merge_request(mr_id=mr_id, merged_by=user_id)
+            mr, result = mr_service.merge_merge_request(mr_id=mr_id, merged_by=str(current_user.id))
 
         if not mr:
             raise HTTPException(status_code=404, detail="Merge request not found")
@@ -250,7 +253,7 @@ async def merge_merge_request(
 async def close_merge_request(
     project_id: str,
     mr_id: str,
-    user_id: str = Query(..., description="User ID closing the MR"),
+    current_user=Depends(get_current_user),
 ):
     """Close a merge request without merging."""
     db_session = await _get_db_session()
@@ -258,10 +261,12 @@ async def close_merge_request(
         mr_service = await get_mr_service_for_project(project_id, db_session=db_session)
         if db_session:
             async with db_session:
-                mr = await mr_service.close_merge_request_async(mr_id=mr_id, closed_by=user_id)
+                mr = await mr_service.close_merge_request_async(
+                    mr_id=mr_id, closed_by=str(current_user.id)
+                )
                 await db_session.commit()
         else:
-            mr = mr_service.close_merge_request(mr_id=mr_id, closed_by=user_id)
+            mr = mr_service.close_merge_request(mr_id=mr_id, closed_by=str(current_user.id))
 
         if not mr:
             raise HTTPException(status_code=404, detail="Merge request not found")

--- a/src/backend/api/sessions.py
+++ b/src/backend/api/sessions.py
@@ -117,23 +117,19 @@ async def _resolve_project_context(
 ):
     """Resolve a project id against whichever registry is authoritative.
 
-    In database mode startup no longer populates PROJECTS_REGISTRY while
-    ``/api/projects`` serves ProjectModel ids - so the filesystem lookup misses
-    every id the dashboard is able to send, and session creation 404s on the
-    projects it just listed. Fall back to the DB registry there.
+    DB 모드에서는 `ProjectModel` 이 유일한 권위다 — 파일시스템 레지스트리를 먼저
+    보지 않는다. 이전에는 `get_project()` 가 히트하면 아래 `require_project_role`
+    **전에** return 했는데, `app.py` 가 DB 모드에서도 `projects/` 심링크 스캔을
+    돌리므로(`7ed7c46`) 그 레지스트리는 비어 있지 않다. 즉 심링크 이름만 알면 DB
+    미등록 프로젝트를 세션에 붙일 수 있었다(실측: 일반 사용자가 200 을 받았다).
 
-    The DB branch authorizes the project the same way every other
-    project-scoped route does: a session must not be able to attach a project
-    the caller could not otherwise reach.
+    `api/git/_shared.resolve_project` 와 같은 규칙이다 — 두 표면이 갈리면 한쪽만
+    닫히고 다른 쪽이 우회로로 남는다.
     """
     from models.project import Project, get_project
 
-    project = get_project(project_id)
-    if project is not None:
-        return project
-
     if os.getenv("USE_DATABASE", "false").lower() != "true":
-        return None
+        return get_project(project_id)
 
     from sqlalchemy import select
 

--- a/tests/backend/api/test_git_merge_role_authority.py
+++ b/tests/backend/api/test_git_merge_role_authority.py
@@ -1,0 +1,163 @@
+"""머지 권한은 클라이언트가 보낸 값이 아니라 서버가 판정한 역할로 정한다.
+
+`execute_merge` · `merge_merge_request` 는 `user_role` 을 **쿼리 파라미터**로 받아
+`can_merge_to_branch` 에 그대로 넘겼다. 즉 `?user_role=owner` 한 줄이면 보호 브랜치
+머지 제한이 사라진다. `user_id` 도 같은 방식이라 임의 사용자 명의로 승인할 수 있고,
+승인 수는 `merge_service/requests.py:_try_auto_merge` 가 실제로 게이트한다.
+
+라우트 전체를 지나가게 한다 — 핸들러 직접 호출은 의존성 해석을 건너뛴다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from models.project import PROJECTS_REGISTRY
+
+DB_UUID = "2bb68d8f-3e23-4af3-a597-181dea321348"
+
+
+@pytest.fixture
+def empty_registry():
+    snapshot = dict(PROJECTS_REGISTRY)
+    PROJECTS_REGISTRY.clear()
+    yield PROJECTS_REGISTRY
+    PROJECTS_REGISTRY.clear()
+    PROJECTS_REGISTRY.update(snapshot)
+
+
+@pytest_asyncio.fixture
+async def editor_app(app, tmp_path, monkeypatch, empty_registry):
+    """프로젝트 ACL 상 `editor` 인 일반 사용자."""
+    from api.deps import get_current_user, get_db_session
+    from services.project_access_service import ProjectAccessService
+
+    project_path = tmp_path / "repo"
+    project_path.mkdir()
+
+    row = SimpleNamespace(
+        id=DB_UUID,
+        name="Repo",
+        slug="repo",
+        description="",
+        path=str(project_path),
+        is_active=True,
+        settings={},
+        organization_id=None,
+    )
+
+    class Result:
+        def scalar_one_or_none(self):
+            return row
+
+        def scalars(self):
+            return SimpleNamespace(all=lambda: [row])
+
+        def all(self):
+            return [(row.id, row.path, row.organization_id)]
+
+    class Database:
+        async def execute(self, *_args, **_kwargs):
+            return Result()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def _db():
+        yield Database()
+
+    async def _has_acl(*_a, **_k):
+        return True
+
+    async def _check_access(*_a, **_k):
+        return "editor"
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    monkeypatch.setattr("db.database.async_session_factory", lambda: Database())
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", _has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", _check_access)
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="editor-user", role="member", is_admin=False, is_active=True
+    )
+    app.dependency_overrides[get_db_session] = _db
+    yield app
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_client_supplied_role_cannot_unlock_protected_branch_merge(editor_app):
+    """`?user_role=owner` 로는 보호 브랜치(main) 머지를 열 수 없다."""
+    transport = ASGITransport(app=editor_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            f"/api/git/projects/{DB_UUID}/merge?user_role=owner",
+            json={"source_branch": "feature/x", "target_branch": "main"},
+        )
+
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_approval_is_recorded_for_the_authenticated_user(editor_app, monkeypatch):
+    """`?user_id=<남의 id>` 로 타인 명의 승인을 만들 수 없다.
+
+    승인 수는 `merge_service/requests.py:_try_auto_merge` 가 실제로 게이트하므로
+    (`len(mr.approved_by) < required_approvals`), 이는 attribution 위조가 아니라
+    승인 우회다.
+    """
+    from api.git import merge_requests as mr_module
+
+    recorded: dict = {}
+
+    class FakeMRService:
+        def approve_merge_request(self, mr_id, user_id):
+            recorded["user_id"] = user_id
+            return SimpleNamespace(id=mr_id)
+
+    async def fake_service(*_a, **_k):
+        return FakeMRService()
+
+    async def no_db():
+        return None
+
+    monkeypatch.setattr(mr_module, "get_mr_service_for_project", fake_service)
+    monkeypatch.setattr(mr_module, "_get_db_session", no_db)
+
+    transport = ASGITransport(app=editor_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # 응답 직렬화는 이 테스트의 관심사가 아니다 — 승인에 **누가** 기록되는지만 본다.
+        try:
+            await ac.post(
+                f"/api/git/projects/{DB_UUID}/merge-requests/mr-1/approve?user_id=someone-else"
+            )
+        except Exception:
+            pass
+
+    assert recorded.get("user_id") == "editor-user", recorded
+
+
+@pytest.mark.asyncio
+async def test_read_routes_still_work_for_viewer(app, tmp_path, monkeypatch, empty_registry):
+    """메모리 모드는 기존 동작을 유지한다 — 머지만 따로 막지 않는다.
+
+    ACL 이 없는 모드에서 인증 사용자는 이미 모든 git 쓰기를 할 수 있으므로,
+    머지 역할을 `admin` 으로 두는 것이 기능 제거를 피하는 선택이다.
+    """
+    from api.git._shared import get_git_role
+
+    class _Req:
+        state = SimpleNamespace(git_role="admin")
+
+    assert await get_git_role(_Req()) == "admin"
+
+    class _Unwired:
+        state = SimpleNamespace()
+
+    # 배선이 끊기면 가장 낮은 역할로 떨어진다 — fail-closed.
+    assert await get_git_role(_Unwired()) == "viewer"

--- a/tests/backend/api/test_session_project_authz.py
+++ b/tests/backend/api/test_session_project_authz.py
@@ -1,0 +1,87 @@
+"""DB 모드에서 세션 생성은 파일시스템 슬러그로 프로젝트 인가를 우회할 수 없다.
+
+`_resolve_project_context` 는 `get_project()`(in-memory `PROJECTS_REGISTRY`)를 먼저
+조회하고 히트하면 `require_project_role` 전에 return 했다. `app.py` 가 DB 모드에서도
+`projects/` 심링크 스캔을 돌리므로(`7ed7c46`) 그 레지스트리는 비어 있지 않고,
+심링크 이름만 알면 DB 미등록 프로젝트를 세션에 붙일 수 있었다.
+
+라우트 전체(프레임워크 배선 포함)를 지나가게 한다 — 핸들러 직접 호출은 의존성
+해석을 건너뛰어 이 경로를 검증하지 못한다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from models.project import PROJECTS_REGISTRY
+
+FS_SLUG = "leaked-slug"
+
+
+@pytest.fixture
+def empty_registry():
+    snapshot = dict(PROJECTS_REGISTRY)
+    PROJECTS_REGISTRY.clear()
+    yield PROJECTS_REGISTRY
+    PROJECTS_REGISTRY.clear()
+    PROJECTS_REGISTRY.update(snapshot)
+
+
+class _EmptyResult:
+    def scalar_one_or_none(self):
+        return None
+
+    def scalars(self):
+        return SimpleNamespace(all=lambda: [])
+
+    def all(self):
+        return []
+
+
+class _EmptyDatabase:
+    """DB 에 그 프로젝트가 없는 상태."""
+
+    async def execute(self, *_args, **_kwargs):
+        return _EmptyResult()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+@pytest_asyncio.fixture
+async def db_mode_app(app, tmp_path, monkeypatch, empty_registry):
+    from api.deps import get_current_user, get_db_session
+    from models.project import register_project
+
+    project_dir = tmp_path / "not-in-db"
+    project_dir.mkdir()
+    register_project(FS_SLUG, str(project_dir))
+
+    async def _db():
+        yield _EmptyDatabase()
+
+    # 시스템 admin 은 인가를 우회하므로 일반 사용자로 판정한다.
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="member-user", role="member", is_admin=False, is_active=True
+    )
+    app.dependency_overrides[get_db_session] = _db
+    monkeypatch.setenv("USE_DATABASE", "true")
+    monkeypatch.setattr("db.database.async_session_factory", lambda: _EmptyDatabase())
+    yield app
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_session_creation_rejects_filesystem_slug_in_database_mode(db_mode_app):
+    """DB 에 없는 프로젝트는 레지스트리에 있어도 세션에 붙일 수 없다."""
+    transport = ASGITransport(app=db_mode_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post("/api/sessions", json={"project_id": FS_SLUG})
+
+    assert response.status_code in (403, 404), response.text

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -1378,21 +1378,39 @@ async def test_session_filesystem_mode_does_not_query_the_database(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_session_prefers_the_filesystem_registry(monkeypatch):
-    """A registry hit short-circuits before any DB work."""
+async def test_session_ignores_the_filesystem_registry_in_database_mode(monkeypatch):
+    """DB 모드에서 레지스트리 히트가 인가를 건너뛰던 우회로를 막는다.
+
+    이전 계약은 "레지스트리 히트 시 DB 작업 생략"(성능)이었다. 그러나 `app.py` 는
+    DB 모드에서도 `projects/` 심링크를 스캔하므로(`7ed7c46`) 그 레지스트리는 비어
+    있지 않고, 심링크 이름만 알면 DB 미등록 프로젝트를 세션에 붙일 수 있었다.
+    DB 모드에서는 `ProjectModel` 이 유일한 권위다 —
+    `api/git/_shared.resolve_project` 와 같은 규칙.
+    """
     from api import sessions as sessions_module
 
     monkeypatch.setenv("USE_DATABASE", "true")
     registry_project = SimpleNamespace(id="obsidian", name="Obsidian")
     monkeypatch.setattr("models.project.get_project", lambda pid: registry_project)
 
+    authorized = {}
+
+    async def fake_require(project_id, _user, _db, min_role="viewer"):
+        authorized["project_id"] = project_id
+        return "viewer"
+
+    monkeypatch.setattr(sessions_module, "require_project_role", fake_require)
+
     db = _FakeDb(_db_project_row())
     project = await sessions_module._resolve_project_context(
         "obsidian", SimpleNamespace(id="u1", role="user", is_admin=False, is_active=True), db
     )
 
-    assert project is registry_project
-    assert db.executed == 0
+    # 레지스트리를 지나치고 인가를 실제로 거쳤다.
+    assert authorized["project_id"] == "obsidian"
+    assert project is not registry_project
+    assert project.id == "05c4302d-9602-4b70-8267-65964f5bed4d"
+    assert db.executed == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`#357` 이 git 표면에 프로젝트 단위 인가를 걸면서 후속으로 남겨 둔 2 건이다.
둘 다 **인가 판정의 입력을 신뢰할 수 없는 곳에서 받던** 문제다.

## 1. 세션 생성이 파일시스템 슬러그로 프로젝트 인가를 우회한다

`api/sessions.py:_resolve_project_context` 는 `get_project()`(in-memory
`PROJECTS_REGISTRY`)를 먼저 조회하고 히트하면 `require_project_role` **전에**
return 했다. 레지스트리가 비어 있던 시절에는 안전해 보였으나, `7ed7c46` 이 DB
모드에서도 `projects/` 심링크 스캔을 켜면서 조용히 열렸다.

**실측(라우트 전체 통과)**: 일반 사용자(`is_admin=False`)가 DB 에 없는 슬러그로
`POST /api/sessions` → **200**. 수정 후 404.

DB 모드에서는 `ProjectModel` 이 유일한 권위로, 파일시스템 폴백을 두지 않는다 —
`api/git/_shared.resolve_project` 와 같은 규칙이다. 두 리졸버가 갈리면 한쪽만
닫히고 다른 쪽이 우회로로 남는다(이번이 같은 결함의 두 번째 사본이었다).

`test_session_prefers_the_filesystem_registry` 는 계약이 뒤집혔으므로 교체했다.
원래 단언("레지스트리 히트 시 DB 작업 생략")은 **성능** 계약이었고, 그 순서가 곧
우회로였다.

## 2. 머지 권한과 승인 주체를 클라이언트가 보낸다

`execute_merge` · `merge_merge_request` 가 `user_role` 을 **쿼리 파라미터**로 받아
`can_merge_to_branch` 에 그대로 넘겼다. `?user_role=owner` 한 줄이면 보호 브랜치
머지 제한이 사라진다.

`approve` · `merge` · `close` 의 `user_id` 도 같다. 이건 attribution 위조에
그치지 않는다 — 승인 수를 `merge_service/requests.py:_try_auto_merge` 가 실제로
게이트하므로(`len(mr.approved_by) < required_approvals`) **승인 우회**다.

**실측**: ACL 상 `editor` 인 사용자가 `?user_role=owner` 로 `main` 머지 검사를
통과했고, `?user_id=someone-else` 로 타인 명의 승인이 기록됐다.

`enforce_git_project_access` 가 이미 판정한 역할을 `request.state.git_role` 로
넘기고 핸들러는 `Depends(get_git_role)` 로 받는다. `user_id` 는 `current_user.id`.

### 어휘가 셋이라 매핑 표를 명시했다

| 출처 | 값 |
|---|---|
| `require_project_role` 반환 | `owner` / `editor` / `viewer` |
| `GIT_ROLE_PERMISSIONS` | `owner` / `admin` / `manager` / `member` / `viewer` |
| org 멤버십 | `owner` / `admin` / `member` / `viewer` |

`editor` 를 그대로 넘기면 `GIT_ROLE_PERMISSIONS` 에 그 키가 없어
`has_git_permission` 이 빈 리스트를 받고 **에러 없이 전면 거부**가 된다.
→ `owner→owner` / `editor→member`(쓰기 O, MERGE_MAIN X) / `viewer→viewer`.

대시보드가 보내던 **org 역할은 대안이 못 된다** — 등록된 프로젝트의
`organization_id` 가 전부 NULL 이다(실측 9/9). 채워진 권위는 `project_access`(8 행).

**메모리 모드는 `admin` 으로 둔다.** ACL 이 없는 모드에서 인증 사용자는 이미 모든
git 쓰기를 할 수 있어, 머지만 따로 막으면 새 보호가 아니라 기능 제거다
(`enforce_git_project_access` 가 그 모드에서 조기 return 하는 것과 같은 결정).
배선이 끊기면 `get_git_role` 은 `viewer` 로 떨어진다 — fail-closed.

## 검증

RED 를 각각 수정 전 트리에서 실측한 뒤 GREEN 확인:

| 단언 | 수정 전 |
|---|---|
| 슬러그로 세션 생성 거부 | **200** (생성됨) |
| `?user_role=owner` 로 main 머지 차단 | **400** (권한검사 통과 후 git 서비스 도달) |
| 승인이 인증 주체로 기록 | `someone-else` 로 기록 |

- 게이트: ruff · ruff format · mypy(326 files) · **pytest 1740 passed / 32 skipped**
- Codex 리뷰: **지적 0 건**

## 범위 밖 (후속 후보)

1. **대시보드 UI 게이트가 서버와 기준이 다르다.** `GitPage.tsx:501` 의
   `canMerge` 는 여전히 org 역할로 판정하는데 서버는 프로젝트 ACL 역할로 판정한다.
   보안 문제는 아니지만(서버가 권위이고 더 엄격) 버튼 노출이 어긋날 수 있다.
   대시보드가 계속 보내는 `user_role`·`user_id` 쿼리 파라미터는 서버가 무시하므로
   깨지지 않으나, 정리하면 계약이 정직해진다.
2. `create_merge_request` 의 `author_id`·`author_name`·`author_email` 도 클라이언트
   입력이다. 인가에는 쓰이지 않아(attribution 전용) 이번 범위에서 제외했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgKSCX95X9fde37R1hV8rN
