### PR TITLE
fix: restore database-mode project monitoring

### DIFF
--- a/docs/plans/2026-08-28-aos-security-regression-remediation.md
+++ b/docs/plans/2026-08-28-aos-security-regression-remediation.md
@@ -1,0 +1,249 @@
+# AOS Security Regression Remediation Implementation Plan
+
+> **For Hermes:** Execute task-by-task with the subagent-driven-development workflow. Use a fresh isolated worktree and require independent Security review before any live restart.
+
+**Goal:** Restore authenticated AOS SSE and DB-mode monitoring behavior without weakening the fail-closed authorization introduced by #318/#328/#351.
+
+**Architecture:** Keep backend authentication and RBAC authoritative. Replace URL-only browser `EventSource` calls on protected streams with one authenticated streaming transport that can attach the existing Bearer access token and participate in the existing refresh/re-auth policy. Keep DB mode fail-closed: either provide a DB-backed monitoring read/execute path or explicitly suppress legacy filesystem calls in the Dashboard; never re-enable an unauthorized filesystem fallback.
+
+**Tech Stack:** FastAPI/Starlette, SQLAlchemy async dependencies, React/TypeScript, Zustand, Vitest, pytest, Vite proxy.
+
+**Workspace:** `/Users/younghwankang/orca/workspaces/Agent-System/aos-security-fix`
+
+**Baseline:** `main@4dcd179` (detached isolated worktree). The previous live worktree was removed externally and the running uvicorn process still points into `.orca-worktree-trash`; do not edit or restart that process from this plan.
+
+---
+
+## Scope and acceptance criteria
+
+### In scope
+
+1. Protected SSE transport for the incident routes:
+   - `/api/project-configs/stream`
+   - `/api/claude-sessions/{session_id}/activity/stream`
+   - `/api/claude-sessions/{session_id}/stream` if the same transport contract applies
+2. Audit and classify the other protected Dashboard SSE consumers before changing them:
+   - project checks
+   - workflow logs
+   - agent monitor
+3. DB-mode monitoring compatibility for `health-config`, `health`, and check execution.
+4. Role and error behavior: `401/403` must not create an infinite reconnect loop; authorized access must remain authorized.
+5. Regression tests, static checks, full test gates, and post-restart probes.
+
+### Out of scope
+
+- Removing or weakening `get_current_user`, project ACL, or admin/manager authorization.
+- Putting access tokens into query strings or loggable URLs.
+- Database migrations, credential changes, infrastructure volume changes, or public deployment.
+- Restarting the currently running service before the user approves the verified build.
+
+### Done means
+
+- Authenticated protected SSE connections receive `200` and expected events.
+- Unauthenticated requests still receive `401`; unauthorized roles still receive `403`.
+- No repeated `Config stream error` or `SSE connection error` for valid authenticated sessions.
+- DB-mode Monitor either returns DB-backed results or is visibly/behaviorally disabled without calling legacy filesystem handlers.
+- Backend security suite, Dashboard tests, type-check, lint/build, and targeted integration tests pass.
+- A fresh service instance from this worktree passes readiness, auth, SSE, and Monitor probes.
+
+---
+
+## Task 0: Freeze baseline and create a red reproduction
+
+**Objective:** Capture the current source/runtime boundary and encode the incident symptoms before implementation.
+
+**Files:**
+- Test: `tests/backend/test_security_hardening.py` or a focused new backend route test
+- Test: `src/dashboard/src/stores/__tests__/projectConfigs.test.ts`
+- Test: `src/dashboard/src/stores/__tests__/claudeCodeActivity.test.ts`
+- Test: `src/dashboard/src/stores/__tests__/monitoring.test.ts`
+
+**Steps:**
+
+1. Record `git status`, `git rev-parse HEAD`, and the existing live process cwd. Treat the deleted worktree as external state, not as an implementation target.
+2. Run the existing focused security suite and Dashboard tests to establish the clean baseline.
+3. Add the smallest test that demonstrates the missing authenticated SSE transport contract. The test must fail before the implementation for the expected reason, not because of a fixture typo.
+4. Run the new test alone and preserve the RED output.
+5. Do not call mutating API endpoints. Use dependency overrides, fixture tokens, or a local ASGI test client for route behavior.
+
+**Verification:** Baseline command output and the intentional RED test are recorded in the task session.
+
+---
+
+## Task 1: Design one authenticated SSE client
+
+**Objective:** Provide a single Dashboard transport that can send the existing access token without exposing it in the URL.
+
+**Files:**
+- Create or modify: `src/dashboard/src/services/` authenticated SSE client module
+- Modify: `src/dashboard/src/services/apiClient.ts` only if shared token-refresh behavior is extracted safely
+- Test: `src/dashboard/src/services/__tests__/` authenticated SSE transport tests
+
+**Steps:**
+
+1. Re-read the existing auth store, token refresh behavior, API error types, and cancellation conventions.
+2. Define the smallest API needed by stores: URL, event handlers, abort/close, and terminal status callback.
+3. Attach `Authorization: Bearer <access token>` to the request using the same auth source as `apiClient`.
+4. On `401`, perform at most one existing token-refresh attempt; on refresh failure, emit an authentication terminal state instead of retrying forever.
+5. On `403`, emit a permission terminal state and do not reconnect automatically.
+6. Parse SSE framing (`event`, `data`, blank-line dispatch) and preserve the existing event names/payloads.
+7. Add tests for header presence, refresh retry, `401`, `403`, cancellation, malformed event data, and clean close.
+8. Run the focused tests and confirm GREEN.
+
+**Security constraints:** No token query parameter, no token logging, no raw exception payload sent to the user.
+
+---
+
+## Task 2: Migrate the incident SSE consumers
+
+**Objective:** Remove the URL-only `EventSource` contract from the two failing streams while preserving store behavior.
+
+**Files:**
+- Modify: `src/dashboard/src/stores/projectConfigs/projects.ts:108-150`
+- Modify: `src/dashboard/src/stores/claudeCodeActivity.ts:165-223`
+- Review: `src/dashboard/src/stores/claudeSessions/index.ts:497-569`
+- Tests: corresponding store test files
+
+**Steps:**
+
+1. Replace project-config stream construction with the authenticated SSE client.
+2. Replace Claude activity stream construction with the authenticated SSE client.
+3. Preserve initial batches, incremental events, completion events, cleanup, and selected-session state updates.
+4. Make `401/403` terminal for the affected store and clear only the relevant stream state.
+5. Add store tests that assert the authenticated client receives the URL and auth context, and that no reconnect occurs after `401/403`.
+6. Run the affected store tests and the new transport tests.
+
+**Verification:** The tests must prove both sides of the contract: valid auth is sent and invalid/insufficient auth remains fail-closed.
+
+---
+
+## Task 3: Audit remaining Dashboard SSE surfaces
+
+**Objective:** Prevent the same security regression from remaining in other protected streams.
+
+**Files:**
+- Review/modify only when the route is protected: `src/dashboard/src/stores/monitoring.ts`
+- Review/modify only when protected: `src/dashboard/src/stores/workflows.ts`
+- Review/modify only when protected: `src/dashboard/src/stores/agentMonitor.ts`
+- Review: matching backend route modules under `src/backend/api/`
+- Tests: matching store tests
+
+**Steps:**
+
+1. Enumerate each `new EventSource(...)` call and map it to its backend route dependency.
+2. Classify each route as public, Bearer-protected, role-protected, or WebSocket-only.
+3. Migrate every protected route to the authenticated client; leave explicitly public health streams unchanged.
+4. Add a test for every migrated protected consumer and document any intentionally public consumer.
+5. Run the affected tests.
+
+**Stop condition:** If a route’s intended user/role policy is unclear, stop implementation for that route and record the policy decision required from the owner.
+
+---
+
+## Task 4: Resolve DB-mode Monitor compatibility without weakening security
+
+**Objective:** Eliminate the user-visible `503`/warning caused by Dashboard calls into legacy filesystem monitoring routes.
+
+**Files:**
+- Backend: `src/backend/api/deps.py:44-50`
+- Backend: `src/backend/api/monitoring.py:72-293`
+- Dashboard: `src/dashboard/src/stores/monitoring.ts:125-198` and check execution paths
+- Tests: `tests/backend/` monitoring route tests
+- Tests: `src/dashboard/src/stores/__tests__/monitoring.test.ts`
+
+**Steps:**
+
+1. Confirm the DB-mode authority and current project/ACL data shape without reading secrets or changing data.
+2. Choose exactly one implementation path in the plan review:
+   - implement DB-backed health-config/health/check handlers, or
+   - explicitly disable/hide legacy Monitor operations in DB mode and return a typed capability state.
+3. Keep authorization before any filesystem operation.
+4. Preserve `503` for genuinely unavailable DB-backed dependencies and preserve `403` for denied access.
+5. Add route tests for authorized, denied, unavailable, and DB-mode cases.
+6. Add Dashboard tests proving it does not repeatedly call an unsupported legacy route.
+7. Run focused backend and Dashboard tests.
+
+**Stop condition:** Do not replace the fail-closed guard with filesystem fallback merely to make the UI green.
+
+---
+
+## Task 5: Independent Security and quality review
+
+**Objective:** Verify the final diff independently before any service restart.
+
+**Steps:**
+
+1. Capture `git diff`, `git status`, and changed-file scope.
+2. Run added-line secret/injection scans without reading `.env` values.
+3. Run backend security tests, affected backend tests, Dashboard tests, type-check, lint, and build using repository commands.
+4. Dispatch an independent Security reviewer with the final diff and require structured JSON:
+
+```json
+{
+  "passed": true,
+  "security_concerns": [],
+  "logic_errors": [],
+  "suggestions": [],
+  "summary": "..."
+}
+```
+
+5. Treat any security concern or logic error as a blocking failure. Re-review after every fix.
+6. Run the complete suite once after focused gates pass.
+
+**Verification:** No merge/push and no live restart until Security returns `passed: true` and all required test gates are green.
+
+---
+
+## Task 6: Apply only after explicit restart approval
+
+**Objective:** Verify that the tested code is the code serving AOS.
+
+**Preconditions:**
+
+- Fresh worktree diff is reviewed and committed only if the owner authorizes commit.
+- Existing deleted-worktree process ownership is understood.
+- User explicitly approves stopping/restarting the affected AOS backend and Dashboard processes.
+- Shared-infra volumes remain untouched.
+
+**Steps:**
+
+1. Stop/restart only the affected AOS services using the repository-defined commands.
+2. Verify `/health` and `/api/health` readiness.
+3. Verify unauthenticated `GET` requests remain `401/403` where expected.
+4. Verify authenticated SSE connections and event delivery with validation-only fixture credentials.
+5. Verify DB-mode Monitor behavior.
+6. Observe backend/dashboard logs over a bounded window for recurrence.
+7. Report code commit, process cwd, probes, status codes, remaining warnings, and rollback point.
+
+**Rollback:** Stop the new instance and restore the prior known-good service process only if the user approves; never delete shared volumes.
+
+---
+
+## Verification command set
+
+Run from the new worktree after implementation:
+
+```bash
+cd src/backend && uv run pytest ../../tests/backend/test_security_hardening.py -q --tb=short
+cd src/backend && uv run pytest ../../tests/backend -q --tb=short
+cd src/dashboard && npm run type-check
+cd src/dashboard && npm run test:run
+cd src/dashboard && npm run lint
+cd src/dashboard && npm run build
+```
+
+Use the exact repository command names. Do not add Jest-only flags to Vitest. Separate invocation errors, environment failures, test failures, and warnings in the final report.
+
+---
+
+## Estimated execution
+
+- Baseline/worktree re-establishment: 1–2 hours
+- Authenticated SSE client and incident consumers: 4–6 hours
+- Remaining SSE audit: 1–3 hours
+- DB-mode Monitor compatibility: 4–8 hours
+- Tests, Security review, and release verification: 5–8 hours
+- **Total:** 15–27 engineering hours before restart; add 1–2 hours for live re-baseline/restart verification when approved.
+
+No code, restart, merge, push, credential change, or external message is authorized by this document alone.

--- a/src/backend/api/artifacts.py
+++ b/src/backend/api/artifacts.py
@@ -1,16 +1,43 @@
 """Workflow artifacts API router."""
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.deps import get_current_user, get_db_session
+from api.workflow_authz import authorize_run
+from db.models import UserModel
 from services.artifact_service import get_artifact_service
 
-router = APIRouter(tags=["artifacts"])
+router = APIRouter(tags=["artifacts"], dependencies=[Depends(get_current_user)])
+
+
+async def _authorize_artifact(
+    artifact_id: str,
+    current_user: UserModel,
+    db: AsyncSession,
+    min_role: str = "viewer",
+) -> dict:
+    """Load an artifact and authorize it through its run's owning project."""
+    service = get_artifact_service()
+    artifact = service.get_artifact(artifact_id)
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    run_id = artifact.get("run_id")
+    if not isinstance(run_id, str):
+        raise HTTPException(status_code=404, detail="Run not found")
+    await authorize_run(run_id, current_user, db, min_role=min_role)
+    return artifact
 
 
 @router.get("/workflows/runs/{run_id}/artifacts")
-async def list_artifacts(run_id: str):
+async def list_artifacts(
+    run_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
+):
     """List artifacts for a workflow run."""
+    await authorize_run(run_id, current_user, db)
     service = get_artifact_service()
     artifacts = service.list_artifacts(run_id)
     return {
@@ -42,8 +69,11 @@ async def upload_artifact(
     job_id: str = Form(None),
     step_id: str = Form(None),
     retention_days: int = Form(30),
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
 ):
     """Upload an artifact for a workflow run."""
+    await authorize_run(run_id, current_user, db, min_role="editor")
     service = get_artifact_service()
     data = await file.read()
     artifact_name = name or file.filename or "artifact"
@@ -67,12 +97,13 @@ async def upload_artifact(
 
 
 @router.get("/workflows/artifacts/{artifact_id}")
-async def get_artifact(artifact_id: str):
+async def get_artifact(
+    artifact_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Get artifact metadata."""
-    service = get_artifact_service()
-    artifact = service.get_artifact(artifact_id)
-    if not artifact:
-        raise HTTPException(status_code=404, detail="Artifact not found")
+    artifact = await _authorize_artifact(artifact_id, current_user, db)
     return {
         "id": artifact["id"],
         "run_id": artifact["run_id"],
@@ -89,13 +120,15 @@ async def get_artifact(artifact_id: str):
 
 
 @router.get("/workflows/artifacts/{artifact_id}/download")
-async def download_artifact(artifact_id: str):
+async def download_artifact(
+    artifact_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Download artifact file."""
-    service = get_artifact_service()
-    artifact = service.get_artifact(artifact_id)
-    if not artifact:
-        raise HTTPException(status_code=404, detail="Artifact not found")
+    artifact = await _authorize_artifact(artifact_id, current_user, db)
 
+    service = get_artifact_service()
     data = service.get_artifact_data(artifact_id)
     if data is None:
         raise HTTPException(status_code=404, detail="Artifact file not found")
@@ -108,8 +141,13 @@ async def download_artifact(artifact_id: str):
 
 
 @router.delete("/workflows/artifacts/{artifact_id}", status_code=204)
-async def delete_artifact(artifact_id: str):
+async def delete_artifact(
+    artifact_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Delete an artifact."""
+    await _authorize_artifact(artifact_id, current_user, db, min_role="editor")
     service = get_artifact_service()
     if not service.delete_artifact(artifact_id):
         raise HTTPException(status_code=404, detail="Artifact not found")

--- a/src/backend/api/deps.py
+++ b/src/backend/api/deps.py
@@ -361,6 +361,21 @@ _PROJECT_ROLE_HIERARCHY: dict[str, int] = {
 }
 
 
+def normalize_project_id(project_id: object) -> str:
+    """Return a usable project identifier or fail closed.
+
+    An empty or whitespace-only identifier is not "no project" — downstream
+    filters treat it as falsy and silently widen to every project, so it is
+    rejected here instead of being normalized away.
+    """
+    if not isinstance(project_id, str):
+        raise HTTPException(status_code=400, detail="Invalid project identifier")
+    normalized = project_id.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="Invalid project identifier")
+    return normalized
+
+
 async def require_project_role(
     project_id: str,
     current_user: UserModel,
@@ -372,11 +387,22 @@ async def require_project_role(
     Returns the user's role string.
 
     Rules:
-    - System admins (role=="admin" or is_admin==True) bypass all checks.
+    - Malformed project identifiers and unknown roles are rejected (fail closed).
+    - System admins (role=="admin" or is_admin==True) bypass the ACL checks.
     - Projects with no access control records are open to all authenticated users.
     - Otherwise, the user must have at least `min_role` level.
     """
     from services.project_access_service import ProjectAccessService
+
+    # Shape checks run before the admin bypass: an admin must not be able to
+    # smuggle a blank identifier through, and an unknown ``min_role`` must fail
+    # the same way for every caller instead of only for non-admins.
+    project_id = normalize_project_id(project_id)
+    if min_role not in _PROJECT_ROLE_HIERARCHY:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unknown project role requirement",
+        )
 
     # Database mode is authoritative. Do this check before ACL handling so a
     # known filesystem-only project ID cannot reach legacy project handlers.
@@ -429,8 +455,14 @@ async def require_project_role(
             detail="No access to this project",
         )
 
-    user_level = _PROJECT_ROLE_HIERARCHY.get(user_role, 0)
-    required_level = _PROJECT_ROLE_HIERARCHY.get(min_role, 0)
+    if not isinstance(user_role, str) or user_role not in _PROJECT_ROLE_HIERARCHY:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unrecognized project role",
+        )
+
+    user_level = _PROJECT_ROLE_HIERARCHY[user_role]
+    required_level = _PROJECT_ROLE_HIERARCHY[min_role]
 
     if user_level < required_level:
         raise HTTPException(

--- a/src/backend/api/monitoring.py
+++ b/src/backend/api/monitoring.py
@@ -5,7 +5,8 @@ Obsidian vault health checks: links, frontmatter, orphans, images via SSE stream
 
 import json
 import os
-from typing import Literal
+from pathlib import Path
+from typing import Literal, NamedTuple
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -32,6 +33,87 @@ router = APIRouter(tags=["orchestration"])
 
 # In-memory storage for project health (could be replaced with DB)
 _project_health: dict[str, ProjectHealth] = {}
+
+# Returned when an authorized database-mode project carries no inspectable
+# directory. Kept distinct from the generic dependency-failure detail so the
+# two 503 causes stay separable by callers and by tests.
+NO_MONITORED_PATH_DETAIL = "Project has no registered filesystem path for health monitoring"
+
+
+class MonitoredProject(NamedTuple):
+    """The one project this request may inspect, and the identity to report.
+
+    ``project_id`` is the public identity echoed back to the client;
+    ``path`` is the only filesystem location the request is allowed to touch.
+    Both come from the same authoritative record, so a path-derived or
+    client-supplied identifier can never widen the inspected location.
+    """
+
+    project_id: str
+    name: str
+    path: str
+
+
+def _use_database() -> bool:
+    return os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+async def _resolve_database_project(project_id: str, db) -> MonitoredProject | None:
+    """Resolve the canonical DB project row into an inspectable target.
+
+    Only ``ProjectModel.id`` is matched — the path-derived identifiers used by
+    the legacy filesystem registry and by ProjectConfigMonitor are deliberately
+    not accepted here, so they cannot reach the filesystem through monitoring.
+
+    Returns ``None`` when the registration has no usable directory. The caller
+    keeps that fail-closed instead of guessing a path.
+    """
+    from sqlalchemy import select
+
+    from db.models import ProjectModel
+
+    try:
+        result = await db.execute(
+            select(ProjectModel).where(
+                ProjectModel.id == project_id,
+                ProjectModel.is_active == True,  # noqa: E712
+            )
+        )
+        row = result.scalar_one_or_none()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Project monitoring is temporarily unavailable",
+        ) from exc
+
+    if row is None:
+        return None
+    path = str(row.path or "").strip()
+    if not path or not Path(path).is_dir():
+        return None
+    return MonitoredProject(project_id=str(row.id), name=str(row.name or ""), path=path)
+
+
+async def _monitored_project(project_id: str, db) -> MonitoredProject:
+    """Resolve the inspection target *after* the caller has authorized access.
+
+    Database mode reads the DB registry, which is authoritative for both
+    identity and path. Filesystem mode keeps the legacy registry lookup behind
+    ``reject_legacy_project_operation_in_database_mode`` — that guard is
+    unreachable from here in database mode by construction, and is kept as a
+    standing assertion that the legacy branch never runs in that mode.
+    """
+    if _use_database():
+        project = await _resolve_database_project(project_id, db)
+        if project is None:
+            raise HTTPException(status_code=503, detail=NO_MONITORED_PATH_DETAIL)
+        return project
+
+    reject_legacy_project_operation_in_database_mode()
+    legacy = get_project(project_id)
+    if not legacy:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return MonitoredProject(project_id=project_id, name=legacy.name, path=legacy.path)
 
 
 class CheckResponse(BaseModel):
@@ -89,27 +171,37 @@ class MonitoringCapabilitiesResponse(BaseModel):
 async def get_monitoring_capabilities(
     project_id: str, current_user=Depends(get_current_user), db=Depends(get_db_session)
 ):
-    """Report whether legacy filesystem monitoring is available for a project.
+    """Report which monitoring operations this project supports.
 
-    Database mode deliberately advertises the legacy health/check operations as
-    disabled. It does not fall back to filesystem handlers, so this endpoint
-    cannot weaken the database-mode authorization boundary.
+    Database mode is served by the DB-backed handlers below, which inspect only
+    the path registered on the project row. A project whose registration has no
+    usable directory stays disabled — the endpoint never falls back to the
+    legacy filesystem registry, so it cannot weaken the authorization boundary.
     """
     await require_project_role(project_id, current_user, db, min_role="viewer")
-    use_database = os.getenv("USE_DATABASE", "false").lower() == "true"
-    if use_database:
+    if not _use_database():
+        return MonitoringCapabilitiesResponse(
+            project_id=project_id,
+            mode="filesystem",
+            health_config="available",
+            health="available",
+            checks="available",
+        )
+
+    project = await _resolve_database_project(project_id, db)
+    if project is None:
         return MonitoringCapabilitiesResponse(
             project_id=project_id,
             mode="database",
             health_config="disabled",
             health="disabled",
             checks="disabled",
-            reason="Database-backed project monitoring is not available",
+            reason=NO_MONITORED_PATH_DETAIL,
         )
 
     return MonitoringCapabilitiesResponse(
-        project_id=project_id,
-        mode="filesystem",
+        project_id=project.project_id,
+        mode="database",
         health_config="available",
         health="available",
         checks="available",
@@ -122,14 +214,11 @@ async def get_health_config(
 ):
     """Get the health check configuration (labels & commands) for a project."""
     await require_project_role(project_id, current_user, db, min_role="viewer")
-    reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = await _monitored_project(project_id, db)
 
     config = get_check_config(project.path)
     return CheckConfigResponse(
-        project_id=project_id,
+        project_id=project.project_id,
         checks={k: CheckConfigEntry(**v) for k, v in config.items()},
         check_types=list(config.keys()),
     )
@@ -141,10 +230,8 @@ async def get_project_health(
 ):
     """Get the health status of a project."""
     await require_project_role(project_id, current_user, db, min_role="viewer")
-    reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = await _monitored_project(project_id, db)
+    project_id = project.project_id
 
     # Initialize health if not exists
     if project_id not in _project_health:
@@ -189,10 +276,8 @@ async def run_all_checks(
     Returns a streaming response with SSE events for all checks.
     """
     await require_project_role(project_id, current_user, db, min_role="editor")
-    reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = await _monitored_project(project_id, db)
+    project_id = project.project_id
 
     # Initialize health if not exists
     if project_id not in _project_health:
@@ -270,10 +355,8 @@ async def run_check(
     - check_completed: Check has finished
     """
     await require_project_role(project_id, current_user, db, min_role="editor")
-    reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = await _monitored_project(project_id, db)
+    project_id = project.project_id
 
     config = get_check_config(project.path)
     if check_type not in config:

--- a/src/backend/api/monitoring.py
+++ b/src/backend/api/monitoring.py
@@ -4,6 +4,8 @@ Obsidian vault health checks: links, frontmatter, orphans, images via SSE stream
 """
 
 import json
+import os
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -67,6 +69,51 @@ class CheckConfigResponse(BaseModel):
     project_id: str
     checks: dict[str, CheckConfigEntry]
     check_types: list[str] = []
+
+
+class MonitoringCapabilitiesResponse(BaseModel):
+    """Capabilities exposed by the active project-monitoring backend."""
+
+    project_id: str
+    mode: Literal["filesystem", "database"]
+    health_config: Literal["available", "disabled"]
+    health: Literal["available", "disabled"]
+    checks: Literal["available", "disabled"]
+    reason: str | None = None
+
+
+@router.get(
+    "/projects/{project_id}/monitoring-capabilities",
+    response_model=MonitoringCapabilitiesResponse,
+)
+async def get_monitoring_capabilities(
+    project_id: str, current_user=Depends(get_current_user), db=Depends(get_db_session)
+):
+    """Report whether legacy filesystem monitoring is available for a project.
+
+    Database mode deliberately advertises the legacy health/check operations as
+    disabled. It does not fall back to filesystem handlers, so this endpoint
+    cannot weaken the database-mode authorization boundary.
+    """
+    await require_project_role(project_id, current_user, db, min_role="viewer")
+    use_database = os.getenv("USE_DATABASE", "false").lower() == "true"
+    if use_database:
+        return MonitoringCapabilitiesResponse(
+            project_id=project_id,
+            mode="database",
+            health_config="disabled",
+            health="disabled",
+            checks="disabled",
+            reason="Database-backed project monitoring is not available",
+        )
+
+    return MonitoringCapabilitiesResponse(
+        project_id=project_id,
+        mode="filesystem",
+        health_config="available",
+        health="available",
+        checks="available",
+    )
 
 
 @router.get("/projects/{project_id}/health-config", response_model=CheckConfigResponse)

--- a/src/backend/api/project_configs/access.py
+++ b/src/backend/api/project_configs/access.py
@@ -5,7 +5,7 @@ import os
 from fastapi import Depends, HTTPException, Request, status
 
 from api.deps import get_current_user, get_db_session, require_project_role
-from db.models import ProjectAccessModel, ProjectModel, UserModel
+from db.models import ProjectModel, UserModel
 
 
 async def require_project_config_access(
@@ -79,19 +79,12 @@ async def require_project_config_access(
         from api.projects import _get_admin_org_ids
 
         admin_org_ids = await _get_admin_org_ids(current_user)
-        access_result = await db.execute(
-            select(ProjectAccessModel.project_id).where(
-                ProjectAccessModel.project_id == project.id,
-                ProjectAccessModel.user_id == current_user.id,
-            )
-        )
-        has_direct_access = access_result.scalar_one_or_none() is not None
-        if project.organization_id in admin_org_ids or has_direct_access:
+        if project.organization_id in admin_org_ids:
             return current_user
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Project access denied",
-        )
+
+        min_role = "viewer" if request.method in {"GET", "HEAD", "OPTIONS"} else "editor"
+        await require_project_role(str(project.id), current_user, db, min_role=min_role)
+        return current_user
     except HTTPException:
         raise
     except Exception as exc:
@@ -143,20 +136,11 @@ async def require_project_config_target_access(
         from api.projects import _get_admin_org_ids
 
         admin_org_ids = await _get_admin_org_ids(current_user)
-        access_result = await db.execute(
-            select(ProjectAccessModel.project_id).where(
-                ProjectAccessModel.project_id == project.id,
-                ProjectAccessModel.user_id == current_user.id,
-            )
-        )
-        if (
-            project.organization_id in admin_org_ids
-            or access_result.scalar_one_or_none() is not None
-        ):
+        if project.organization_id in admin_org_ids:
             return
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Target project access denied"
-        )
+
+        await require_project_role(str(project.id), current_user, db, min_role="editor")
+        return
     except HTTPException:
         raise
     except Exception as exc:

--- a/src/backend/api/project_configs/access.py
+++ b/src/backend/api/project_configs/access.py
@@ -5,7 +5,32 @@ import os
 from fastapi import Depends, HTTPException, Request, status
 
 from api.deps import get_current_user, get_db_session, require_project_role
+from api.project_configs.identity import (
+    CANONICAL_ID_SLOT,
+)
 from db.models import ProjectModel, UserModel
+from services import project_config_monitor
+
+
+def _bind_canonical_identity(request: Request, project: ProjectModel) -> None:
+    """정규 DB id 를 요청 스코프에 남기고 `{project_id}` 를 모니터 키로 바꾼다.
+
+    DB 모드에서 이 라우터로 들어오는 id 는 정규 UUID 인데, `.claude/` 자산을
+    실제로 읽는 `ProjectConfigMonitor` 는 경로 파생 키밖에 모른다. 번역을 여기
+    한 곳에서만 하고 핸들러는 평소대로 `{project_id}` 를 쓴다 — FastAPI 는
+    라우터 의존성을 전부 푼 **뒤에** 핸들러의 path 파라미터를 뽑으므로 이
+    제자리 변경이 핸들러까지 전달된다.
+
+    호출은 **인가를 통과한 뒤에만** 한다. `monitor_id_for_registered_path` 가
+    경로를 모니터에 등록하므로, 권한 없는 요청이 감시 대상을 늘리지 않게 한다.
+
+    경로 없는 DB 프로젝트는 번역할 대상이 없다. 정규 id 만 남기고
+    `{project_id}` 는 그대로 둬서 핸들러가 평소대로 404 를 내게 한다.
+    """
+    request.path_params[CANONICAL_ID_SLOT] = str(project.id)
+    # Keep the handler's project_id canonical. ProjectConfigMonitor resolves
+    # this public ID through the alias registered by the access guard; mutating
+    # Starlette path_params here would make responses leak the internal path key.
 
 
 async def require_project_config_access(
@@ -40,9 +65,7 @@ async def require_project_config_access(
 
     use_database = os.getenv("USE_DATABASE", "false").lower() == "true"
     if not use_database:
-        from services.project_config_monitor import get_project_config_monitor
-
-        if get_project_config_monitor().get_project_summary(project_id) is None:
+        if project_config_monitor.get_project_config_monitor().get_project_summary(project_id) is None:
             raise HTTPException(status_code=404, detail="Project not found")
 
         # Existence was the only check here, which made this the one
@@ -67,23 +90,31 @@ async def require_project_config_access(
         def route_ids(project: ProjectModel) -> set[str]:
             ids = {str(project.id), f"db-{project.id}"}
             if project.path:
-                ids.add(str(project.path).replace("/", "-").replace("\\", "-"))
+                monitor = project_config_monitor.get_project_config_monitor()
+                ids.add(monitor.encode_project_path(str(project.path)))
             return ids
 
         project = next((item for item in projects if project_id in route_ids(item)), None)
         if project is None:
             raise HTTPException(status_code=404, detail="Project not found")
+        if project.path:
+            monitor = project_config_monitor.get_project_config_monitor()
+            monitor.add_external_project(str(project.path))
+            monitor.register_project_id_alias(str(project.id), str(project.path))
         if is_privileged:
+            _bind_canonical_identity(request, project)
             return current_user
 
         from api.projects import _get_admin_org_ids
 
         admin_org_ids = await _get_admin_org_ids(current_user)
         if project.organization_id in admin_org_ids:
+            _bind_canonical_identity(request, project)
             return current_user
 
         min_role = "viewer" if request.method in {"GET", "HEAD", "OPTIONS"} else "editor"
         await require_project_role(str(project.id), current_user, db, min_role=min_role)
+        _bind_canonical_identity(request, project)
         return current_user
     except HTTPException:
         raise
@@ -101,9 +132,7 @@ async def require_project_config_target_access(
 ) -> None:
     """Authorize the destination of a project-config copy operation."""
     if os.getenv("USE_DATABASE", "false").lower() != "true":
-        from services.project_config_monitor import get_project_config_monitor
-
-        if get_project_config_monitor().get_project_summary(target_project_id) is None:
+        if project_config_monitor.get_project_config_monitor().get_project_summary(target_project_id) is None:
             raise HTTPException(status_code=404, detail="Target project not found")
 
         # The route dependency authorizes the *source* project only, and a copy
@@ -122,12 +151,16 @@ async def require_project_config_target_access(
         def route_ids(project: ProjectModel) -> set[str]:
             ids = {str(project.id), f"db-{project.id}"}
             if project.path:
-                ids.add(str(project.path).replace("/", "-").replace("\\", "-"))
+                ids.add(project_config_monitor.get_project_config_monitor().encode_project_path(str(project.path)))
             return ids
 
         project = next((item for item in projects if target_project_id in route_ids(item)), None)
         if project is None:
             raise HTTPException(status_code=404, detail="Target project not found")
+        if project.path:
+            monitor = project_config_monitor.get_project_config_monitor()
+            monitor.add_external_project(str(project.path))
+            monitor.register_project_id_alias(str(project.id), str(project.path))
 
         is_privileged = current_user.role in {"admin", "manager"} or current_user.is_admin
         if is_privileged:

--- a/src/backend/api/project_configs/access.py
+++ b/src/backend/api/project_configs/access.py
@@ -65,7 +65,10 @@ async def require_project_config_access(
 
     use_database = os.getenv("USE_DATABASE", "false").lower() == "true"
     if not use_database:
-        if project_config_monitor.get_project_config_monitor().get_project_summary(project_id) is None:
+        if (
+            project_config_monitor.get_project_config_monitor().get_project_summary(project_id)
+            is None
+        ):
             raise HTTPException(status_code=404, detail="Project not found")
 
         # Existence was the only check here, which made this the one
@@ -132,7 +135,12 @@ async def require_project_config_target_access(
 ) -> None:
     """Authorize the destination of a project-config copy operation."""
     if os.getenv("USE_DATABASE", "false").lower() != "true":
-        if project_config_monitor.get_project_config_monitor().get_project_summary(target_project_id) is None:
+        if (
+            project_config_monitor.get_project_config_monitor().get_project_summary(
+                target_project_id
+            )
+            is None
+        ):
             raise HTTPException(status_code=404, detail="Target project not found")
 
         # The route dependency authorizes the *source* project only, and a copy
@@ -151,7 +159,11 @@ async def require_project_config_target_access(
         def route_ids(project: ProjectModel) -> set[str]:
             ids = {str(project.id), f"db-{project.id}"}
             if project.path:
-                ids.add(project_config_monitor.get_project_config_monitor().encode_project_path(str(project.path)))
+                ids.add(
+                    project_config_monitor.get_project_config_monitor().encode_project_path(
+                        str(project.path)
+                    )
+                )
             return ids
 
         project = next((item for item in projects if target_project_id in route_ids(item)), None)

--- a/src/backend/api/project_configs/core.py
+++ b/src/backend/api/project_configs/core.py
@@ -87,6 +87,7 @@ async def _get_db_filtered_projects(monitor, current_user=None) -> list:
 
     from sqlalchemy import or_, select
 
+    from api.project_configs.identity import stamp_project_info
     from db.database import async_session_factory
     from db.models import ProjectAccessModel, ProjectModel
     from models.project_config import ProjectInfo
@@ -181,17 +182,26 @@ async def _get_db_filtered_projects(monitor, current_user=None) -> list:
             path = PathLib(db_proj.path)
             if path.exists() and path.is_dir():
                 monitor.add_external_project(str(path))
-                # Re-scan this specific project
-                project_id = str(path).replace("/", "-").replace("\\", "-")
+                # Re-scan this specific project. The monitor key must come from
+                # the monitor's own normalization -- encoding the raw string
+                # misses this project whenever the registered path is a symlink
+                # (every `projects/` entry in this repo is one).
+                project_id = monitor.encode_project_path(str(path))
                 summary = monitor.get_project_summary(project_id)
                 if summary and summary.project:
-                    filtered.append(summary.project)
+                    # The public identity is the DB id, not the monitor's
+                    # path-derived key. The dashboard reuses whatever id this
+                    # list hands out for every child request, so leaking the
+                    # monitor key here is what split the two vocabularies.
+                    filtered.append(stamp_project_info(summary.project, str(db_proj.id)))
                     seen_paths.add(summary.project.project_path)
                     continue
 
         # Fallback: DB project has no path or path scan failed
-        # Include it as a basic ProjectInfo so it appears in the list
-        project_id = f"db-{db_proj.id}"
+        # Include it as a basic ProjectInfo so it appears in the list.
+        # Same canonical identity as the scanned branch above -- the guard
+        # still accepts the legacy `db-` spelling on the way in.
+        project_id = str(db_proj.id)
         filtered.append(
             ProjectInfo(
                 project_id=project_id,

--- a/src/backend/api/project_configs/identity.py
+++ b/src/backend/api/project_configs/identity.py
@@ -1,0 +1,145 @@
+"""정규 프로젝트 신원(`ProjectModel.id`) ↔ 모니터 식별자 번역.
+
+DB 모드에서 프로젝트의 권위는 `ProjectModel` 이다 — `/api/projects`, 세션
+리졸버, `deps.require_project_role`, `api/git/_shared.resolve_project` 가 전부
+UUID 를 키로 쓴다. 반면 `.claude/` 자산을 실제로 읽는 `ProjectConfigMonitor`
+는 경로 파생 키(`-Users-me-Work-Proj`)밖에 모른다.
+
+두 어휘를 섞지 않기 위해 방향을 하나로 고정한다:
+
+  - **바깥으로 나가는 신원은 정규 DB id** (`stamp_*`). 경로 파생 id 를 공개
+    식별자로 내보내지 않는다. 대시보드는 목록·요약에서 받은 `project_id` 를
+    그대로 다음 요청에 쓰므로(`stores/projectConfigs/`), 여기서 새는 id 는
+    곧 화면마다 다른 키가 된다.
+  - **안으로 들어온 정규 id 는 모니터 식별자로 해석**
+    (`monitor_id_for_registered_path`). 해석은 **DB 에 등록된 경로**에 대해서만
+    한다 — 파일시스템을 훑어 후보를 찾지 않는다. 등록되지 않은 프로젝트는
+    해석되지 않고, 호출자는 평소대로 404 를 낸다(fail-closed).
+
+파일시스템 모드는 이 모듈을 쓰지 않는다. 그 모드에서는 경로 파생 id 가 곧
+정규 id 이므로 번역할 것이 없다.
+"""
+
+import logging
+import os
+from typing import TypeVar
+
+from fastapi import Request
+from pydantic import BaseModel
+
+from models.project_config import ProjectConfigSummary, ProjectInfo
+from services.project_config_monitor import get_project_config_monitor
+
+logger = logging.getLogger(__name__)
+
+# `require_project_config_access` 가 `{project_id}` 를 모니터 식별자로 바꿔치기
+# 하면서 원래의 정규 id 를 남겨 두는 요청 스코프 슬롯. 라우트가 선언하지 않은
+# 키라 FastAPI 의 파라미터 해석에는 잡히지 않는다.
+CANONICAL_ID_SLOT = "_aos_canonical_project_id"
+
+# `ProjectConfigSummary` 안에서 `project_id` 를 들고 다니는 자식 자산 필드.
+_SUMMARY_CHILD_FIELDS = (
+    "skills",
+    "agents",
+    "mcp_servers",
+    "user_mcp_servers",
+    "hooks",
+    "commands",
+    "rules",
+    "memories",
+)
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+
+def use_database() -> bool:
+    return os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+def canonical_project_id(request: Request) -> str | None:
+    """이 요청의 정규 프로젝트 id. 번역이 없었으면 None."""
+    return request.path_params.get(CANONICAL_ID_SLOT)
+
+
+def canonical_or(request: Request, fallback: str) -> str:
+    """이 요청의 공개 프로젝트 id — 번역이 없었으면 들어온 값 그대로.
+
+    파일시스템 모드에서는 들어온 경로 파생 id 가 곧 공개 id 이므로 이 함수의
+    결과로 찍는 것이 항등이다. 덕분에 호출부는 모드 분기 없이 무조건 찍으면
+    된다 — 분기를 40여 곳에 복제하면 그중 하나를 빠뜨리는 쪽이 진짜 위험이다.
+    """
+    return canonical_project_id(request) or fallback
+
+
+def monitor_id_for_registered_path(path: str) -> str | None:
+    """DB 에 등록된 경로를 모니터에 붙이고 그 모니터 식별자를 돌려준다.
+
+    `add_external_project` 는 이미 감시 중이면 False 를 돌려주지만 그것은
+    실패가 아니다 — 필요한 것은 등록 여부가 아니라 키다. 키는 모니터 자신의
+    정규화(`encode_project_path`)로만 만든다.
+
+    호출자가 넘기는 경로는 **DB 행의 경로**뿐이다. 이 함수는 파일시스템을
+    탐색하지 않으므로 미등록 프로젝트가 이 경로로 감시 대상이 되지 않는다.
+    """
+    if not path:
+        return None
+    monitor = get_project_config_monitor()
+    monitor.add_external_project(path)
+    return monitor.encode_project_path(path)
+
+
+def stamp(model: _ModelT, canonical_id: str) -> _ModelT:
+    """`project_id` 를 정규 id 로 바꾼 사본 (입력은 그대로 둔다)."""
+    return model.model_copy(update={"project_id": canonical_id})
+
+
+def stamp_summary(summary: ProjectConfigSummary, canonical_id: str) -> ProjectConfigSummary:
+    """요약의 프로젝트와 **자식 자산 전부**에 정규 id 를 찍는다.
+
+    자식까지 찍는 이유: 대시보드가 다음 요청을 만들 때 쓰는 것이
+    `skill.project_id` · `agent.project_id` 다(`stores/projectConfigs/skills.ts`
+    등). 최상위만 바꾸면 한 응답 안에 두 어휘가 섞인다.
+    """
+    updates: dict[str, object] = {"project": stamp(summary.project, canonical_id)}
+    for field in _SUMMARY_CHILD_FIELDS:
+        updates[field] = [stamp(item, canonical_id) for item in getattr(summary, field)]
+    return summary.model_copy(update=updates)
+
+
+def stamp_project_info(project: ProjectInfo, canonical_id: str) -> ProjectInfo:
+    return stamp(project, canonical_id)
+
+
+async def canonical_id_for_path(path: str) -> str | None:
+    """이 파일시스템 경로로 등록된 DB 프로젝트의 정규 id (없으면 None).
+
+    경로로 들어오는 표면(`/by-path`)의 응답 신원을 맞추기 위한 최선 노력
+    조회다. 인가 판단에는 쓰이지 않으므로 조회 실패는 번역 없음으로 떨어진다
+    — 지금 DB 를 전혀 보지 않는 라우트에 새 실패 모드를 만들지 않기 위해서다.
+    """
+    if not use_database() or not path:
+        return None
+
+    try:
+        from sqlalchemy import select
+
+        from db.database import async_session_factory
+        from db.models import ProjectModel
+
+        target = get_project_config_monitor().encode_project_path(path)
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(ProjectModel).where(ProjectModel.is_active == True)  # noqa: E712
+            )
+            for row in result.scalars().all():
+                if not row.path:
+                    continue
+                if target == _encode(str(row.path)):
+                    return str(row.id)
+    except Exception:
+        logger.warning("Canonical project id lookup by path failed", exc_info=True)
+    return None
+
+
+def _encode(path: str) -> str:
+    return get_project_config_monitor().encode_project_path(path)

--- a/src/backend/api/templates.py
+++ b/src/backend/api/templates.py
@@ -1,11 +1,20 @@
 """Workflow templates API router."""
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.deps import (
+    get_current_admin_or_manager_user,
+    get_current_user,
+    get_db_session,
+    normalize_project_id,
+)
+from api.workflow_authz import authorize_workflow_project
+from db.models import UserModel
 from models.template import TemplateCategory, TemplateCreate, TemplateListResponse
 from services.template_service import get_template_service
 
-router = APIRouter(tags=["templates"])
+router = APIRouter(tags=["templates"], dependencies=[Depends(get_current_user)])
 
 
 @router.get("/workflows/templates", response_model=TemplateListResponse)
@@ -20,8 +29,15 @@ async def list_templates(
 
 
 @router.post("/workflows/templates", status_code=201)
-async def create_template(data: TemplateCreate):
-    """Create a new workflow template."""
+async def create_template(
+    data: TemplateCreate,
+    _current_user: UserModel = Depends(get_current_admin_or_manager_user),
+):
+    """Create a new workflow template.
+
+    Templates are deployment-global (they carry no project scope), so writing
+    one is an operator action rather than a project-member action.
+    """
     try:
         service = get_template_service()
         return service.create_template(data)
@@ -40,8 +56,11 @@ async def get_template(template_id: str):
 
 
 @router.delete("/workflows/templates/{template_id}", status_code=204)
-async def delete_template(template_id: str):
-    """Delete a workflow template."""
+async def delete_template(
+    template_id: str,
+    _current_user: UserModel = Depends(get_current_admin_or_manager_user),
+):
+    """Delete a workflow template (deployment-global, operator only)."""
     service = get_template_service()
     if not service.delete_template(template_id):
         raise HTTPException(status_code=404, detail="Template not found")
@@ -52,8 +71,17 @@ async def create_from_template(
     template_id: str,
     name: str | None = Query(None),
     project_id: str | None = Query(None),
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
 ):
-    """Create a new workflow from a template."""
+    """Create a new workflow from a template.
+
+    This writes a workflow into ``project_id``, so it needs the same editor
+    authorization as ``POST /workflows`` — a template is not a bypass.
+    """
+    if project_id is not None:
+        project_id = normalize_project_id(project_id)
+    await authorize_workflow_project(project_id, current_user, db, min_role="editor")
     service = get_template_service()
     result = service.create_workflow_from_template(template_id, name=name, project_id=project_id)
     if not result:

--- a/src/backend/api/webhooks.py
+++ b/src/backend/api/webhooks.py
@@ -1,7 +1,11 @@
 """Webhook API router."""
 
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.deps import get_current_user, get_db_session
+from api.workflow_authz import authorize_workflow
+from db.models import UserModel
 from services.webhook_service import get_webhook_service
 
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
@@ -14,20 +18,31 @@ async def receive_webhook(
     x_github_event: str | None = Header(None, alias="X-GitHub-Event"),
     x_hub_signature_256: str | None = Header(None, alias="X-Hub-Signature-256"),
 ):
-    """Receive and process an incoming webhook."""
+    """Receive and process an incoming webhook.
+
+    This endpoint is unauthenticated by design, so the HMAC signature is the
+    only credential. It is therefore mandatory: an unsigned request is rejected
+    before the body is parsed and before any workflow can be triggered.
+    """
+    if not x_hub_signature_256:
+        raise HTTPException(status_code=401, detail="Missing webhook signature")
+
     service = get_webhook_service()
     webhook = service.get_webhook(webhook_id)
     if not webhook:
         raise HTTPException(status_code=404, detail="Webhook not found")
 
     body = await request.body()
+    if not service.verify_signature(webhook_id, body, x_hub_signature_256):
+        raise HTTPException(status_code=401, detail="Invalid signature")
 
-    # Verify signature if provided
-    if x_hub_signature_256:
-        if not service.verify_signature(webhook_id, body, x_hub_signature_256):
-            raise HTTPException(status_code=401, detail="Invalid signature")
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid webhook payload")
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Invalid webhook payload")
 
-    payload = await request.json()
     event_type = x_github_event or payload.get("event", "push")
 
     result = await service.handle_webhook(webhook_id, event_type, payload)
@@ -38,12 +53,20 @@ async def receive_webhook(
 
 
 # Workflow-scoped webhook management
-workflow_webhook_router = APIRouter(tags=["webhooks"])
+workflow_webhook_router = APIRouter(
+    tags=["webhooks"],
+    dependencies=[Depends(get_current_user)],
+)
 
 
 @workflow_webhook_router.post("/workflows/{workflow_id}/webhooks", status_code=201)
-async def create_webhook(workflow_id: str):
+async def create_webhook(
+    workflow_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Create a webhook for a workflow."""
+    await authorize_workflow(workflow_id, current_user, db, min_role="editor")
     service = get_webhook_service()
     webhook = service.create_webhook(workflow_id)
     return {
@@ -58,8 +81,13 @@ async def create_webhook(workflow_id: str):
 
 
 @workflow_webhook_router.get("/workflows/{workflow_id}/webhooks")
-async def list_webhooks(workflow_id: str):
+async def list_webhooks(
+    workflow_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
+):
     """List webhooks for a workflow."""
+    await authorize_workflow(workflow_id, current_user, db)
     service = get_webhook_service()
     webhooks = service.get_webhooks_for_workflow(workflow_id)
     return {
@@ -79,8 +107,19 @@ async def list_webhooks(workflow_id: str):
 
 
 @workflow_webhook_router.delete("/workflows/{workflow_id}/webhooks/{webhook_id}", status_code=204)
-async def delete_webhook(workflow_id: str, webhook_id: str):
-    """Delete a webhook."""
+async def delete_webhook(
+    workflow_id: str,
+    webhook_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Delete a webhook belonging to the given workflow."""
+    await authorize_workflow(workflow_id, current_user, db, min_role="editor")
     service = get_webhook_service()
+    webhook = service.get_webhook(webhook_id)
+    # The authorization above covers ``workflow_id`` only, so a webhook owned by
+    # a different workflow must not be deletable through this path.
+    if not webhook or webhook.get("workflow_id") != workflow_id:
+        raise HTTPException(status_code=404, detail="Webhook not found")
     if not service.delete_webhook(webhook_id):
         raise HTTPException(status_code=404, detail="Webhook not found")

--- a/src/backend/api/workflow_authz.py
+++ b/src/backend/api/workflow_authz.py
@@ -1,0 +1,86 @@
+"""Shared authorization helpers for workflow-scoped routers.
+
+Workflows, runs, artifacts, templates and webhooks are all reachable from
+several routers. Centralising the "resolve the owning project, then apply
+project RBAC" walk keeps those routers from drifting apart, and keeps the
+global (``project_id is None``) case privileged in exactly one place.
+"""
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import is_privileged_user, require_project_role
+from db.models import UserModel
+from services.workflow_service import USE_DATABASE, WorkflowService, get_workflow_service
+
+
+async def authorize_workflow_project(
+    project_id: str | None,
+    current_user: UserModel,
+    db: AsyncSession,
+    min_role: str = "viewer",
+) -> None:
+    """Authorize a workflow's project, keeping global workflows operator-only."""
+    if project_id is None:
+        if not is_privileged_user(current_user):
+            raise HTTPException(status_code=403, detail="Global workflow access denied")
+        return
+    await require_project_role(project_id, current_user, db, min_role=min_role)
+
+
+def workflow_project_id(workflow: dict) -> str | None:
+    """Read the owning project of a workflow record."""
+    project_id = workflow.get("project_id")
+    return project_id if isinstance(project_id, str) else None
+
+
+async def load_workflow(workflow_id: str, db: AsyncSession) -> dict:
+    """Load a workflow by ID or raise 404."""
+    service = get_workflow_service()
+    if USE_DATABASE:
+        workflow = await WorkflowService.get_workflow_async(db, workflow_id)
+    else:
+        workflow = service.get_workflow(workflow_id)
+    if not workflow:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    return workflow
+
+
+async def authorize_workflow(
+    workflow_id: str,
+    current_user: UserModel,
+    db: AsyncSession,
+    min_role: str = "viewer",
+) -> dict:
+    """Load a workflow and authorize the caller against its project."""
+    workflow = await load_workflow(workflow_id, db)
+    await authorize_workflow_project(
+        workflow_project_id(workflow), current_user, db, min_role=min_role
+    )
+    return workflow
+
+
+async def load_run(run_id: str, db: AsyncSession) -> dict:
+    """Load a run by ID or raise 404 (in-memory first, then database)."""
+    service = get_workflow_service()
+    run = service.get_run(run_id)
+    if not run and USE_DATABASE:
+        run = await WorkflowService.get_run_async(db, run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return run
+
+
+async def authorize_run(
+    run_id: str,
+    current_user: UserModel,
+    db: AsyncSession,
+    min_role: str = "viewer",
+) -> dict:
+    """Load a run and authorize the caller against its workflow's project."""
+    run = await load_run(run_id, db)
+    workflow_id = run.get("workflow_id")
+    if not isinstance(workflow_id, str):
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    await authorize_workflow(workflow_id, current_user, db, min_role=min_role)
+    return run

--- a/src/backend/api/workflows.py
+++ b/src/backend/api/workflows.py
@@ -7,7 +7,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.deps import get_current_user, normalize_project_id
+from api.workflow_authz import (
+    authorize_run,
+    authorize_workflow,
+    authorize_workflow_project,
+    workflow_project_id,
+)
 from db.database import get_db
+from db.models import UserModel
 from models.workflow import (
     WorkflowCreate,
     WorkflowListResponse,
@@ -18,7 +26,11 @@ from services.workflow_engine import get_workflow_engine
 from services.workflow_service import USE_DATABASE, WorkflowService, get_workflow_service
 from services.workflow_yaml_parser import workflow_to_yaml
 
-router = APIRouter(prefix="/workflows", tags=["workflows"])
+router = APIRouter(
+    prefix="/workflows",
+    tags=["workflows"],
+    dependencies=[Depends(get_current_user)],
+)
 
 
 def _to_workflow_response(w: dict) -> dict:
@@ -65,13 +77,24 @@ def _to_run_response(r: dict) -> dict:
 async def list_workflows(
     project_id: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ):
-    """List all workflow definitions."""
+    """List workflows visible to the authenticated project member."""
+    if project_id is not None:
+        # A blank identifier is rejected rather than normalized: both listing
+        # backends treat a falsy project_id as "no filter" and would return
+        # every workflow in the deployment.
+        project_id = normalize_project_id(project_id)
+    await authorize_workflow_project(project_id, current_user, db)
     service = get_workflow_service()
     if USE_DATABASE:
         workflows = await WorkflowService.list_workflows_async(db, project_id=project_id)
     else:
         workflows = service.list_workflows(project_id=project_id)
+    if project_id is not None:
+        # Defensive: the authorized scope is exactly one project, so the
+        # response must never carry a global or foreign workflow.
+        workflows = [w for w in workflows if w.get("project_id") == project_id]
     return {
         "workflows": [_to_workflow_response(w) for w in workflows],
         "total": len(workflows),
@@ -79,21 +102,26 @@ async def list_workflows(
 
 
 @router.get("/{workflow_id}")
-async def get_workflow(workflow_id: str, db: AsyncSession = Depends(get_db)):
+async def get_workflow(
+    workflow_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Get a workflow definition by ID."""
-    service = get_workflow_service()
-    if USE_DATABASE:
-        workflow = await WorkflowService.get_workflow_async(db, workflow_id)
-    else:
-        workflow = service.get_workflow(workflow_id)
-    if not workflow:
-        raise HTTPException(status_code=404, detail="Workflow not found")
+    workflow = await authorize_workflow(workflow_id, current_user, db)
     return _to_workflow_response(workflow)
 
 
 @router.post("", status_code=201)
-async def create_workflow(data: WorkflowCreate, db: AsyncSession = Depends(get_db)):
+async def create_workflow(
+    data: WorkflowCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Create a new workflow definition."""
+    if data.project_id is not None:
+        data = data.model_copy(update={"project_id": normalize_project_id(data.project_id)})
+    await authorize_workflow_project(data.project_id, current_user, db, min_role="editor")
     try:
         service = get_workflow_service()
         if USE_DATABASE:
@@ -110,10 +138,25 @@ async def update_workflow(
     workflow_id: str,
     data: WorkflowUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ):
     """Update a workflow definition."""
+    service = get_workflow_service()
+    # Authorize the source project before anything else, then — when the update
+    # relocates the workflow — the destination project independently. Checking
+    # only one side lets an editor of project A move a workflow into project B
+    # (or into the privileged global scope) that they cannot write to.
+    existing = await authorize_workflow(workflow_id, current_user, db, min_role="editor")
+    if "project_id" in data.model_fields_set:
+        target_project_id = data.project_id
+        if target_project_id is not None:
+            target_project_id = normalize_project_id(target_project_id)
+            data = data.model_copy(update={"project_id": target_project_id})
+        if target_project_id != workflow_project_id(existing):
+            # ``require_project_role`` also validates that the target project is
+            # registered and active (database mode is authoritative).
+            await authorize_workflow_project(target_project_id, current_user, db, min_role="editor")
     try:
-        service = get_workflow_service()
         if USE_DATABASE:
             workflow = await WorkflowService.update_workflow_async(db, workflow_id, data)
         else:
@@ -126,9 +169,14 @@ async def update_workflow(
 
 
 @router.delete("/{workflow_id}", status_code=204)
-async def delete_workflow(workflow_id: str, db: AsyncSession = Depends(get_db)):
+async def delete_workflow(
+    workflow_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Delete a workflow definition."""
     service = get_workflow_service()
+    await authorize_workflow(workflow_id, current_user, db, min_role="editor")
     if USE_DATABASE:
         success = await WorkflowService.delete_workflow_async(db, workflow_id)
     else:
@@ -145,9 +193,11 @@ async def list_runs(
     workflow_id: str,
     limit: int = Query(50, le=200),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ):
-    """List runs for a workflow."""
+    """List runs for an authorized workflow."""
     service = get_workflow_service()
+    await authorize_workflow(workflow_id, current_user, db)
     if USE_DATABASE:
         runs = await WorkflowService.list_runs_async(db, workflow_id=workflow_id, limit=limit)
     else:
@@ -163,10 +213,12 @@ async def trigger_run(
     workflow_id: str,
     data: WorkflowRunTrigger | None = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ):
-    """Trigger a new workflow run."""
+    """Trigger a new workflow run for an authorized workflow."""
+    service = get_workflow_service()
+    await authorize_workflow(workflow_id, current_user, db, min_role="editor")
     try:
-        service = get_workflow_service()
         trigger = data or WorkflowRunTrigger()
         if USE_DATABASE:
             run = await service.trigger_run_async(db, workflow_id, trigger)
@@ -178,25 +230,25 @@ async def trigger_run(
 
 
 @router.get("/runs/{run_id}")
-async def get_run(run_id: str, db: AsyncSession = Depends(get_db)):
+async def get_run(
+    run_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Get a workflow run by ID."""
-    service = get_workflow_service()
-    if USE_DATABASE:
-        # Check in-memory first (active runs for SSE)
-        run = service.get_run(run_id)
-        if not run:
-            run = await WorkflowService.get_run_async(db, run_id)
-    else:
-        run = service.get_run(run_id)
-    if not run:
-        raise HTTPException(status_code=404, detail="Run not found")
+    run = await authorize_run(run_id, current_user, db)
     return _to_run_response(run)
 
 
 @router.post("/runs/{run_id}/cancel")
-async def cancel_run(run_id: str, db: AsyncSession = Depends(get_db)):
+async def cancel_run(
+    run_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Cancel a running workflow."""
     service = get_workflow_service()
+    await authorize_run(run_id, current_user, db, min_role="editor")
     if USE_DATABASE:
         run = await service.cancel_run_async(db, run_id)
     else:
@@ -207,9 +259,14 @@ async def cancel_run(run_id: str, db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/runs/{run_id}/retry", status_code=201)
-async def retry_run(run_id: str, db: AsyncSession = Depends(get_db)):
+async def retry_run(
+    run_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Retry a failed workflow run."""
     service = get_workflow_service()
+    await authorize_run(run_id, current_user, db, min_role="editor")
     if USE_DATABASE:
         workflow_id = await WorkflowService.retry_run_async(db, run_id)
     else:
@@ -229,16 +286,14 @@ async def retry_run(run_id: str, db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/runs/{run_id}/stream")
-async def stream_run_logs(run_id: str, db: AsyncSession = Depends(get_db)):
-    """Stream real-time logs for a workflow run via SSE."""
+async def stream_run_logs(
+    run_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Stream real-time logs for an authorized workflow run via SSE."""
     service = get_workflow_service()
-    # Check in-memory first (active runs); fallback to DB for completed
-    run = service.get_run(run_id)
-    if not run and USE_DATABASE:
-        run = await WorkflowService.get_run_async(db, run_id)
-    if not run:
-        raise HTTPException(status_code=404, detail="Run not found")
-
+    await authorize_run(run_id, current_user, db)
     engine = get_workflow_engine()
 
     async def event_stream():
@@ -250,8 +305,13 @@ async def stream_run_logs(run_id: str, db: AsyncSession = Depends(get_db)):
                 yield f"event: log\ndata: {json.dumps(log)}\n\n"
                 log_index += 1
 
-            # Check run status (in-memory is authoritative for active runs)
+            # Check the active in-memory run first. In database mode a run may
+            # outlive the process-local cache, so fall back to the authoritative
+            # DB snapshot; otherwise a terminal run would leave this stream open
+            # forever without a final snapshot/EOF.
             current_run = service.get_run(run_id)
+            if current_run is None and USE_DATABASE:
+                current_run = await WorkflowService.get_run_async(db, run_id)
             if current_run:
                 status = current_run["status"]
                 if isinstance(status, str):
@@ -283,15 +343,13 @@ async def stream_run_logs(run_id: str, db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/{workflow_id}/yaml")
-async def export_yaml(workflow_id: str, db: AsyncSession = Depends(get_db)):
+async def export_yaml(
+    workflow_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Export workflow definition as YAML."""
-    service = get_workflow_service()
-    if USE_DATABASE:
-        workflow = await WorkflowService.get_workflow_async(db, workflow_id)
-    else:
-        workflow = service.get_workflow(workflow_id)
-    if not workflow:
-        raise HTTPException(status_code=404, detail="Workflow not found")
+    workflow = await authorize_workflow(workflow_id, current_user, db)
 
     if workflow.get("yaml_content"):
         return {"yaml": workflow["yaml_content"]}

--- a/src/backend/services/project_config_monitor.py
+++ b/src/backend/services/project_config_monitor.py
@@ -88,6 +88,14 @@ class ProjectConfigMonitor:
     def add_external_project(self, path: str) -> bool:
         return self._discovery.add_external_project(path)
 
+    def encode_project_path(self, path: str) -> str:
+        """Monitor key for a filesystem path, normalized as monitored paths are."""
+        return self._discovery.encode_project_path(path)
+
+    def register_project_id_alias(self, public_project_id: str, project_path: str) -> None:
+        """Register a DB public ID for the already-registered filesystem path."""
+        self._discovery.register_project_id_alias(public_project_id, project_path)
+
     def remove_external_project(self, path: str) -> bool:
         result = self._discovery.remove_external_project(path)
         if result:
@@ -970,7 +978,7 @@ class ProjectConfigMonitor:
             return None
 
         return ProjectConfigSummary(
-            project=project_info,
+            project=project_info.model_copy(update={"project_id": project_id}),
             skills=self.get_project_skills(project_id),
             agents=self.get_project_agents(project_id),
             mcp_servers=self.get_project_mcp_config(project_id),

--- a/src/backend/services/project_discovery.py
+++ b/src/backend/services/project_discovery.py
@@ -35,6 +35,10 @@ class ProjectDiscovery:
         self._project_paths: list[Path] = []
         self._external_paths: list[str] = []
         self._auto_discovered: set[Path] = set()
+        # DB-backed project IDs are public identities; managers still need the
+        # path-derived key used by the filesystem monitor.  Aliases are
+        # registered only by the DB-aware API guard for active registered paths.
+        self._project_id_aliases: dict[str, str] = {}
         self._is_docker = bool(os.getenv("CLAUDE_HOME"))
         self._allow_auto_discovery = allow_auto_discovery
         # Add current directory (even without .claude/)
@@ -75,6 +79,21 @@ class ProjectDiscovery:
         """Whether running in Docker environment."""
         return self._is_docker
 
+    def normalize_path(self, path: str) -> Path:
+        """Normalize a filesystem path the way monitored paths are stored.
+
+        Symlinks are resolved outside Docker (host paths are unreachable inside
+        it), which is what makes `encode_path` agree with `find_project_path`.
+        Callers that need a monitor key for a path must go through this instead
+        of encoding the raw string — `projects/` entries are symlinks, so the
+        two spellings disagree for exactly the projects this repo registers.
+        """
+        return Path(path) if self._is_docker else Path(path).resolve()
+
+    def encode_project_path(self, path: str) -> str:
+        """Monitor key for a filesystem path (normalize + encode)."""
+        return self.encode_path(self.normalize_path(path))
+
     def add_external_project(self, path: str) -> bool:
         """Add an external project path at runtime.
 
@@ -84,7 +103,7 @@ class ProjectDiscovery:
         Returns:
             True if added, False if invalid or already exists
         """
-        p = Path(path) if self._is_docker else Path(path).resolve()
+        p = self.normalize_path(path)
 
         # In Docker, host paths aren't accessible - skip validation
         if not self._is_docker:
@@ -170,6 +189,14 @@ class ProjectDiscovery:
     def get_monitored_paths(self) -> list[str]:
         """Get all monitored project paths."""
         return [str(p) for p in self._project_paths]
+
+    def register_project_id_alias(self, public_project_id: str, project_path: str) -> None:
+        """Bind a DB public ID to an already registered monitor path key."""
+        self._project_id_aliases[public_project_id] = self.encode_project_path(project_path)
+
+    def resolve_project_id(self, project_id: str) -> str:
+        """Resolve a public ID to the monitor's path-derived key."""
+        return self._project_id_aliases.get(project_id, project_id)
 
     def encode_path(self, path: Path) -> str:
         """Encode path to project ID.
@@ -414,15 +441,9 @@ class ProjectDiscovery:
         )
 
     def find_project_path(self, project_id: str) -> Path | None:
-        """Find project path by ID.
-
-        Args:
-            project_id: Project identifier
-
-        Returns:
-            Path to project or None
-        """
+        """Find project path by public or path-derived ID."""
+        monitor_id = self.resolve_project_id(project_id)
         for project_path in self._project_paths:
-            if self.encode_path(project_path) == project_id:
+            if self.encode_path(project_path) == monitor_id:
                 return project_path
         return None

--- a/src/backend/services/webhook_service.py
+++ b/src/backend/services/webhook_service.py
@@ -50,6 +50,8 @@ class WebhookService:
         webhook = self._webhooks.get(webhook_id)
         if not webhook:
             return False
+        if not isinstance(signature, str) or not signature:
+            return False
 
         expected = (
             "sha256="
@@ -60,7 +62,12 @@ class WebhookService:
             ).hexdigest()
         )
 
-        return hmac.compare_digest(expected, signature)
+        try:
+            return hmac.compare_digest(expected, signature)
+        except TypeError:
+            # ``compare_digest`` rejects non-ASCII str operands; a hostile
+            # header must fail verification, not raise a 500.
+            return False
 
     async def handle_webhook(
         self,

--- a/src/dashboard/src/components/monitor/ContextPanel.tsx
+++ b/src/dashboard/src/components/monitor/ContextPanel.tsx
@@ -20,6 +20,8 @@ export function ContextPanel({ projectId }: ContextPanelProps) {
   const {
     projectContext,
     isLoadingContext,
+    contextUnavailableReason,
+    contextUnavailableProjectId,
     activeContextTab,
     fetchProjectContext,
     setActiveContextTab,
@@ -30,6 +32,11 @@ export function ContextPanel({ projectId }: ContextPanelProps) {
       fetchProjectContext(projectId)
     }
   }, [projectId, fetchProjectContext])
+
+  const visibleProjectContext = projectContext?.project_id === projectId ? projectContext : null
+  const contextUnavailable = contextUnavailableProjectId === projectId
+    ? contextUnavailableReason
+    : null
 
   const tabs = [
     { id: 'claude-md' as const, label: 'CLAUDE.md', icon: FileText },
@@ -46,7 +53,16 @@ export function ContextPanel({ projectId }: ContextPanelProps) {
       )
     }
 
-    if (!projectContext) {
+    if (contextUnavailable) {
+      return (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+          <p className="font-medium">Project context is unavailable in database mode.</p>
+          <p className="mt-1">{contextUnavailable}</p>
+        </div>
+      )
+    }
+
+    if (!visibleProjectContext) {
       return (
         <div className="text-center text-gray-500 py-8">
           No context available
@@ -56,11 +72,11 @@ export function ContextPanel({ projectId }: ContextPanelProps) {
 
     switch (activeContextTab) {
       case 'claude-md':
-        return <ClaudeMdView content={projectContext.claude_md} />
+        return <ClaudeMdView content={visibleProjectContext.claude_md} />
       case 'dev-docs':
-        return <DevDocsView docs={projectContext.dev_docs} />
+        return <DevDocsView docs={visibleProjectContext.dev_docs} />
       case 'session':
-        return <SessionView sessionInfo={projectContext.session_info} />
+        return <SessionView sessionInfo={visibleProjectContext.session_info} />
       default:
         return null
     }
@@ -95,7 +111,11 @@ export function ContextPanel({ projectId }: ContextPanelProps) {
 
           <button
             onClick={() => fetchProjectContext(projectId)}
-            className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            disabled={Boolean(contextUnavailable) || isLoadingContext}
+            className={cn(
+              'p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
+              (contextUnavailable || isLoadingContext) && 'opacity-50 cursor-not-allowed'
+            )}
             title="Refresh context"
           >
             <RefreshCw

--- a/src/dashboard/src/components/monitor/HealthOverview.tsx
+++ b/src/dashboard/src/components/monitor/HealthOverview.tsx
@@ -18,11 +18,13 @@ export function HealthOverview({ health, projectId }: HealthOverviewProps) {
     activeLogView,
     setActiveLogView,
     workflowChecks,
+    workflowProjectId,
     runningWorkflowIds,
     runWorkflowCheck,
   } = useMonitoringStore()
   const runningChecks = getRunningChecks(projectId)
   const checkTypes = getCheckTypes(projectId)
+  const visibleWorkflowChecks = workflowProjectId === projectId ? workflowChecks : []
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-3">
@@ -53,18 +55,18 @@ export function HealthOverview({ health, projectId }: HealthOverviewProps) {
       </div>
 
       {/* Workflow Checks Section */}
-      {workflowChecks.length > 0 ? (
+      {visibleWorkflowChecks.length > 0 ? (
         <div className="mt-3">
           <div className="flex items-center gap-1.5 mb-2">
             <Workflow className="w-3.5 h-3.5 text-gray-500" />
             <h3 className="text-xs font-semibold text-gray-700 dark:text-gray-300">
               Workflow Checks
             </h3>
-            <span className="text-xs text-gray-400">({workflowChecks.length})</span>
+            <span className="text-xs text-gray-400">({visibleWorkflowChecks.length})</span>
           </div>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-            {workflowChecks.map((wc) => (
+            {visibleWorkflowChecks.map((wc) => (
               <WorkflowCheckCard
                 key={wc.id}
                 workflow={wc}

--- a/src/dashboard/src/components/monitor/OutputLog.tsx
+++ b/src/dashboard/src/components/monitor/OutputLog.tsx
@@ -26,12 +26,25 @@ export function OutputLog({ projectId }: OutputLogProps) {
     setActiveLogView,
     clearLogs,
     workflowChecks,
+    workflowProjectId,
     workflowLogs,
     clearWorkflowLogs,
     getCheckTypes,
   } = useMonitoringStore()
   const checkLabels = useCheckLabels(projectId)
   const checkTypes = getCheckTypes(projectId)
+  const visibleWorkflowChecks = workflowProjectId === projectId ? workflowChecks : []
+  const visibleWorkflowIds = new Set(visibleWorkflowChecks.map((workflow) => workflow.id))
+  const visibleWorkflowLogs = workflowProjectId === projectId
+    ? Object.fromEntries(
+        Object.entries(workflowLogs)
+          .filter(([workflowId]) => visibleWorkflowIds.has(workflowId))
+          .map(([workflowId, logs]) => [
+            workflowId,
+            logs.filter((log) => log.projectId === projectId),
+          ]),
+      )
+    : {}
   const logContainerRef = useRef<HTMLDivElement>(null)
 
   // Check if current view is a known check type
@@ -49,8 +62,8 @@ export function OutputLog({ projectId }: OutputLogProps) {
           .filter((log) => log.projectId === projectId)
           .map((log) => ({ ...log, label: checkLabels[ct] || ct }))
       )
-      const allWfLogs = Object.entries(workflowLogs).flatMap(([wfId, logs]) => {
-        const wf = workflowChecks.find((w) => w.id === wfId)
+      const allWfLogs = Object.entries(visibleWorkflowLogs).flatMap(([wfId, logs]) => {
+        const wf = visibleWorkflowChecks.find((w) => w.id === wfId)
         return logs.map((log) => ({ ...log, label: wf?.name || wfId }))
       })
       return [...allCheckLogs, ...allWfLogs].sort(
@@ -60,8 +73,8 @@ export function OutputLog({ projectId }: OutputLogProps) {
 
     if (isWorkflowView) {
       // Workflow logs
-      return (workflowLogs[activeLogView] || []).map((log) => {
-        const wf = workflowChecks.find((w) => w.id === activeLogView)
+      return (visibleWorkflowLogs[activeLogView] || []).map((log) => {
+        const wf = visibleWorkflowChecks.find((w) => w.id === activeLogView)
         return { ...log, label: wf?.name || activeLogView }
       })
     }
@@ -145,10 +158,10 @@ export function OutputLog({ projectId }: OutputLogProps) {
             ))}
 
             {/* Workflow tabs (with divider) */}
-            {workflowChecks.length > 0 && (
+            {visibleWorkflowChecks.length > 0 && (
               <>
                 <div className="w-px h-5 bg-gray-300 dark:bg-gray-600 mx-1 shrink-0" />
-                {workflowChecks.map((wc) => (
+                {visibleWorkflowChecks.map((wc) => (
                   <button
                     key={wc.id}
                     onClick={() => setActiveLogView(wc.id)}

--- a/src/dashboard/src/components/monitor/__tests__/ContextPanel.test.tsx
+++ b/src/dashboard/src/components/monitor/__tests__/ContextPanel.test.tsx
@@ -21,12 +21,16 @@ const mockSetActiveContextTab = vi.fn()
 
 let mockProjectContext: ProjectContext | null = null
 let mockIsLoadingContext = false
+let mockContextUnavailableReason: string | null = null
+let mockContextUnavailableProjectId: string | null = null
 let mockActiveContextTab: 'claude-md' | 'dev-docs' | 'session' = 'claude-md'
 
 vi.mock('../../../stores/monitoring', () => ({
   useMonitoringStore: () => ({
     projectContext: mockProjectContext,
     isLoadingContext: mockIsLoadingContext,
+    contextUnavailableReason: mockContextUnavailableReason,
+    contextUnavailableProjectId: mockContextUnavailableProjectId,
     activeContextTab: mockActiveContextTab,
     fetchProjectContext: mockFetchProjectContext,
     setActiveContextTab: mockSetActiveContextTab,
@@ -48,6 +52,8 @@ describe('ContextPanel', () => {
     vi.clearAllMocks()
     mockProjectContext = null
     mockIsLoadingContext = false
+    mockContextUnavailableReason = null
+    mockContextUnavailableProjectId = null
     mockActiveContextTab = 'claude-md'
   })
 
@@ -73,6 +79,21 @@ describe('ContextPanel', () => {
     mockIsLoadingContext = false
     render(<ContextPanel projectId="proj-1" />)
     expect(screen.getByText('No context available')).toBeInTheDocument()
+  })
+
+  it('does not render context from another project', () => {
+    mockProjectContext = makeContext({ project_id: 'other-project', claude_md: '# Other' })
+    render(<ContextPanel projectId="proj-1" />)
+    expect(screen.getByText('No context available')).toBeInTheDocument()
+    expect(screen.queryByText('# Other')).not.toBeInTheDocument()
+  })
+
+  it('shows a non-error unavailable state when project context is disabled', () => {
+    mockContextUnavailableReason = 'Database-backed project monitoring is not available'
+    mockContextUnavailableProjectId = 'proj-1'
+    render(<ContextPanel projectId="proj-1" />)
+    expect(screen.getByText('Project context is unavailable in database mode.')).toBeInTheDocument()
+    expect(screen.getByText('Database-backed project monitoring is not available')).toBeInTheDocument()
   })
 
   it('shows CLAUDE.md content when on claude-md tab', () => {

--- a/src/dashboard/src/components/monitor/__tests__/HealthOverview.test.tsx
+++ b/src/dashboard/src/components/monitor/__tests__/HealthOverview.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../../stores/monitoring', () => ({
     activeLogView: mockActiveLogView,
     setActiveLogView: mockSetActiveLogView,
     workflowChecks: mockWorkflowChecks,
+    workflowProjectId: 'proj-1',
     runningWorkflowIds: mockRunningWorkflowIds,
     runWorkflowCheck: mockRunWorkflowCheck,
   }),

--- a/src/dashboard/src/components/monitor/__tests__/OutputLog.test.tsx
+++ b/src/dashboard/src/components/monitor/__tests__/OutputLog.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../../../stores/monitoring', () => ({
     setActiveLogView: mockSetActiveLogView,
     clearLogs: mockClearLogs,
     workflowChecks: mockWorkflowChecks,
+    workflowProjectId: 'proj-1',
     workflowLogs: mockWorkflowLogs,
     clearWorkflowLogs: mockClearWorkflowLogs,
     getCheckLabel: (_projectId: string, checkType: string) => {

--- a/src/dashboard/src/pages/MonitorPage.test.tsx
+++ b/src/dashboard/src/pages/MonitorPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MonitorPage } from './MonitorPage'
 
@@ -32,6 +32,7 @@ vi.mock('../components/monitor', () => ({
 const mockFetchProjects = vi.fn()
 const mockFetchCheckConfig = vi.fn()
 const mockFetchProjectHealth = vi.fn()
+const mockFetchMonitoringCapabilities = vi.fn()
 const mockFetchWorkflowChecks = vi.fn()
 const mockRunAllChecks = vi.fn()
 const mockClearError = vi.fn()
@@ -41,6 +42,7 @@ let mockProjects: Array<{ id: string; name: string; path: string }> = []
 let mockError: string | null = null
 let mockIsLoadingHealth = false
 let mockProjectHealthMap: Record<string, unknown> = {}
+let mockCapabilities: Record<string, unknown> = {}
 
 vi.mock('../stores/orchestration', () => ({
   useOrchestrationStore: (selector: (s: Record<string, unknown>) => unknown) => {
@@ -60,8 +62,10 @@ vi.mock('../stores/monitoring', () => ({
       getRunningChecks: () => new Set(),
       isLoadingHealth: mockIsLoadingHealth,
       error: mockError,
+      getMonitoringCapabilities: (id: string) => mockCapabilities[id] || null,
       fetchCheckConfig: mockFetchCheckConfig,
       fetchProjectHealth: mockFetchProjectHealth,
+      fetchMonitoringCapabilities: mockFetchMonitoringCapabilities,
       fetchWorkflowChecks: mockFetchWorkflowChecks,
       runAllChecks: mockRunAllChecks,
       clearError: mockClearError,
@@ -82,6 +86,16 @@ describe('MonitorPage', () => {
     mockError = null
     mockIsLoadingHealth = false
     mockProjectHealthMap = {}
+    mockCapabilities = {
+      'proj-1': {
+        project_id: 'proj-1', mode: 'filesystem', health_config: 'available',
+        health: 'available', checks: 'available', reason: null,
+      },
+    }
+    mockFetchMonitoringCapabilities.mockResolvedValue({
+      project_id: 'proj-1', mode: 'filesystem', health_config: 'available',
+      health: 'available', checks: 'available', reason: null,
+    })
   })
 
   it('shows select project prompt when no project selected', () => {
@@ -134,14 +148,14 @@ describe('MonitorPage', () => {
     expect(mockClearError).toHaveBeenCalledTimes(1)
   })
 
-  it('calls refresh when Refresh button clicked', () => {
+  it('calls refresh when Refresh button clicked', async () => {
     mockSelectedProjectId = 'proj-1'
     mockProjects = [{ id: 'proj-1', name: 'Test', path: '/test' }]
     mockProjectHealthMap = { 'proj-1': { status: 'healthy' } }
 
     render(<MonitorPage />)
     fireEvent.click(screen.getByText('Refresh'))
-    expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1')
+    await waitFor(() => expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1'))
   })
 
   it('calls runAllChecks when Run All button clicked', () => {
@@ -154,12 +168,15 @@ describe('MonitorPage', () => {
     expect(mockRunAllChecks).toHaveBeenCalledWith('proj-1')
   })
 
-  it('fetches health and checks when project changes', () => {
+  it('fetches capabilities before health and checks when project changes', async () => {
     mockSelectedProjectId = 'proj-1'
     mockProjects = [{ id: 'proj-1', name: 'Test', path: '/test' }]
 
     render(<MonitorPage />)
-    expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1')
-    expect(mockFetchWorkflowChecks).toHaveBeenCalledWith('proj-1')
+    await waitFor(() => {
+      expect(mockFetchMonitoringCapabilities).toHaveBeenCalledWith('proj-1')
+      expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1')
+      expect(mockFetchWorkflowChecks).toHaveBeenCalledWith('proj-1')
+    })
   })
 })

--- a/src/dashboard/src/pages/MonitorPage.test.tsx
+++ b/src/dashboard/src/pages/MonitorPage.test.tsx
@@ -67,6 +67,7 @@ vi.mock('../stores/monitoring', () => ({
       fetchProjectHealth: mockFetchProjectHealth,
       fetchMonitoringCapabilities: mockFetchMonitoringCapabilities,
       fetchWorkflowChecks: mockFetchWorkflowChecks,
+      resetMonitoringSelection: vi.fn(),
       runAllChecks: mockRunAllChecks,
       clearError: mockClearError,
     }
@@ -155,7 +156,7 @@ describe('MonitorPage', () => {
 
     render(<MonitorPage />)
     fireEvent.click(screen.getByText('Refresh'))
-    await waitFor(() => expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1'))
+    await waitFor(() => expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1', expect.any(Function)))
   })
 
   it('calls runAllChecks when Run All button clicked', () => {
@@ -174,9 +175,61 @@ describe('MonitorPage', () => {
 
     render(<MonitorPage />)
     await waitFor(() => {
-      expect(mockFetchMonitoringCapabilities).toHaveBeenCalledWith('proj-1')
-      expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1')
-      expect(mockFetchWorkflowChecks).toHaveBeenCalledWith('proj-1')
+      expect(mockFetchMonitoringCapabilities).toHaveBeenCalledWith('proj-1', expect.any(Function))
+      expect(mockFetchProjectHealth).toHaveBeenCalledWith('proj-1', expect.any(Function))
+      expect(mockFetchWorkflowChecks).toHaveBeenCalledWith('proj-1', expect.any(Function))
+    })
+  })
+  // Database mode is no longer a blanket "monitoring off" state: the backend
+  // now serves health from the DB-registered project path, so the page must
+  // key off the capability flags rather than the mode string. A project whose
+  // DB row has no inspectable path stays fail-closed and keeps the banner.
+  describe('database-backed monitoring', () => {
+    const dbProjectId = '3f9c1b74-6d20-4a8e-9c31-5b7e0d2a8f61'
+
+    it('renders health without the unavailable banner when database mode reports available', async () => {
+      const capabilities = {
+        project_id: dbProjectId, mode: 'database', health_config: 'available',
+        health: 'available', checks: 'available', reason: null,
+      }
+      mockSelectedProjectId = dbProjectId
+      mockProjects = [{ id: dbProjectId, name: 'Test', path: '/test' }]
+      mockProjectHealthMap = { [dbProjectId]: { status: 'healthy' } }
+      mockCapabilities = { [dbProjectId]: capabilities }
+      mockFetchMonitoringCapabilities.mockResolvedValue(capabilities)
+
+      render(<MonitorPage />)
+
+      await waitFor(() => {
+        expect(mockFetchCheckConfig).toHaveBeenCalledWith(dbProjectId, expect.any(Function))
+        expect(mockFetchProjectHealth).toHaveBeenCalledWith(dbProjectId, expect.any(Function))
+      })
+      expect(screen.queryByText(/unavailable in database mode/)).not.toBeInTheDocument()
+      expect(screen.getByTestId('health-overview')).toBeInTheDocument()
+      expect(screen.getByText('Run All')).not.toBeDisabled()
+    })
+
+    it('keeps the fail-closed banner when database mode reports every operation disabled', async () => {
+      const capabilities = {
+        project_id: dbProjectId, mode: 'database', health_config: 'disabled',
+        health: 'disabled', checks: 'disabled',
+        reason: 'Project has no registered filesystem path for health monitoring',
+      }
+      mockSelectedProjectId = dbProjectId
+      mockProjects = [{ id: dbProjectId, name: 'Test', path: '/test' }]
+      mockCapabilities = { [dbProjectId]: capabilities }
+      mockFetchMonitoringCapabilities.mockResolvedValue(capabilities)
+
+      render(<MonitorPage />)
+
+      expect(screen.getByText(/unavailable in database mode/)).toBeInTheDocument()
+      expect(
+        screen.getByText(/no registered filesystem path for health monitoring/),
+      ).toBeInTheDocument()
+      expect(screen.getByText('Run All')).toBeDisabled()
+      await waitFor(() => expect(mockFetchMonitoringCapabilities).toHaveBeenCalled())
+      expect(mockFetchCheckConfig).not.toHaveBeenCalled()
+      expect(mockFetchProjectHealth).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/dashboard/src/pages/MonitorPage.tsx
+++ b/src/dashboard/src/pages/MonitorPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { RefreshCw, Play, AlertCircle, PanelLeftClose, PanelLeft, FolderKanban, Network, ChevronDown, ChevronRight } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { HealthOverview, OutputLog, ContextPanel, ResizablePanel, ProjectsPanel, DiagnosticsPanel, TopologyMap, VaultHealthDetail } from '../components/monitor'
@@ -18,6 +18,7 @@ export function MonitorPage() {
     fetchMonitoringCapabilities,
     getMonitoringCapabilities,
     fetchWorkflowChecks,
+    resetMonitoringSelection,
     runAllChecks,
     clearError,
   } = useMonitoringStore()
@@ -26,6 +27,8 @@ export function MonitorPage() {
   const [showProjects, setShowProjects] = useState(true)
   const [showTopology, setShowTopology] = useState(false)
   const selectedProject = projects.find((p) => p.id === selectedProjectId)
+  const selectedProjectRef = useRef(selectedProjectId)
+  selectedProjectRef.current = selectedProjectId
 
   // 현재 선택된 프로젝트의 health와 runningChecks
   const projectHealth = selectedProjectId ? getProjectHealth(selectedProjectId) : null
@@ -50,19 +53,30 @@ export function MonitorPage() {
   // Resolve capabilities first. Legacy filesystem monitoring is fail-closed
   // until the backend explicitly says each operation is available.
   useEffect(() => {
+    resetMonitoringSelection()
+    let active = true
     if (selectedProjectId) {
       void (async () => {
-        const capabilities = await fetchMonitoringCapabilities(selectedProjectId)
+        const capabilities = await fetchMonitoringCapabilities(
+          selectedProjectId,
+          () => active,
+        )
+        if (!active) return
         if (capabilities?.health_config === 'available') {
-          await fetchCheckConfig(selectedProjectId)
+          await fetchCheckConfig(selectedProjectId, () => active)
         }
+        if (!active) return
         if (capabilities?.health === 'available') {
-          await fetchProjectHealth(selectedProjectId)
+          await fetchProjectHealth(selectedProjectId, () => active)
         }
-        await fetchWorkflowChecks(selectedProjectId)
+        if (!active) return
+        await fetchWorkflowChecks(selectedProjectId, () => active)
       })()
     }
-  }, [selectedProjectId, fetchMonitoringCapabilities, fetchCheckConfig, fetchProjectHealth, fetchWorkflowChecks])
+    return () => {
+      active = false
+    }
+  }, [selectedProjectId, fetchMonitoringCapabilities, fetchCheckConfig, fetchProjectHealth, fetchWorkflowChecks, resetMonitoringSelection])
 
   // No project selected - show projects panel for selection
   if (!selectedProjectId || !selectedProject) {
@@ -145,7 +159,7 @@ export function MonitorPage() {
 
             {/* Refresh button */}
             <button
-              onClick={() => fetchProjectHealth(selectedProjectId)}
+              onClick={() => fetchProjectHealth(selectedProjectId, () => selectedProjectRef.current === selectedProjectId)}
               disabled={isLoadingHealth || !healthAvailable}
               className={cn(
                 'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
@@ -208,7 +222,7 @@ export function MonitorPage() {
         )}
 
         {/* Health overview and logs */}
-        {!monitoringDisabled && projectHealth && (
+        {healthAvailable && projectHealth && (
           <>
             <HealthOverview health={projectHealth} projectId={selectedProjectId} />
             <DiagnosticsPanel projectId={selectedProjectId} />

--- a/src/dashboard/src/pages/MonitorPage.tsx
+++ b/src/dashboard/src/pages/MonitorPage.tsx
@@ -15,6 +15,8 @@ export function MonitorPage() {
     activeLogView,
     fetchCheckConfig,
     fetchProjectHealth,
+    fetchMonitoringCapabilities,
+    getMonitoringCapabilities,
     fetchWorkflowChecks,
     runAllChecks,
     clearError,
@@ -28,20 +30,39 @@ export function MonitorPage() {
   // 현재 선택된 프로젝트의 health와 runningChecks
   const projectHealth = selectedProjectId ? getProjectHealth(selectedProjectId) : null
   const runningChecks = selectedProjectId ? getRunningChecks(selectedProjectId) : new Set()
+  const monitoringCapabilities = selectedProjectId
+    ? getMonitoringCapabilities(selectedProjectId)
+    : null
+  const capabilitiesLoaded = monitoringCapabilities !== null
+  const healthAvailable = monitoringCapabilities?.health === 'available'
+  const checksAvailable = monitoringCapabilities?.checks === 'available'
+  const monitoringDisabled = capabilitiesLoaded &&
+    monitoringCapabilities?.mode === 'database' &&
+    monitoringCapabilities.health_config === 'disabled' &&
+    monitoringCapabilities.health === 'disabled' &&
+    monitoringCapabilities.checks === 'disabled'
 
   // Fetch projects on mount
   useEffect(() => {
     fetchProjects()
   }, [fetchProjects])
 
-  // Fetch health config, health, and workflow checks when project changes
+  // Resolve capabilities first. Legacy filesystem monitoring is fail-closed
+  // until the backend explicitly says each operation is available.
   useEffect(() => {
     if (selectedProjectId) {
-      fetchCheckConfig(selectedProjectId)
-      fetchProjectHealth(selectedProjectId)
-      fetchWorkflowChecks(selectedProjectId)
+      void (async () => {
+        const capabilities = await fetchMonitoringCapabilities(selectedProjectId)
+        if (capabilities?.health_config === 'available') {
+          await fetchCheckConfig(selectedProjectId)
+        }
+        if (capabilities?.health === 'available') {
+          await fetchProjectHealth(selectedProjectId)
+        }
+        await fetchWorkflowChecks(selectedProjectId)
+      })()
     }
-  }, [selectedProjectId, fetchCheckConfig, fetchProjectHealth, fetchWorkflowChecks])
+  }, [selectedProjectId, fetchMonitoringCapabilities, fetchCheckConfig, fetchProjectHealth, fetchWorkflowChecks])
 
   // No project selected - show projects panel for selection
   if (!selectedProjectId || !selectedProject) {
@@ -125,7 +146,7 @@ export function MonitorPage() {
             {/* Refresh button */}
             <button
               onClick={() => fetchProjectHealth(selectedProjectId)}
-              disabled={isLoadingHealth}
+              disabled={isLoadingHealth || !healthAvailable}
               className={cn(
                 'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
                 'border border-gray-300 dark:border-gray-600',
@@ -143,7 +164,7 @@ export function MonitorPage() {
             {/* Run All button */}
             <button
               onClick={() => runAllChecks(selectedProjectId)}
-              disabled={isAnyRunning}
+              disabled={isAnyRunning || !checksAvailable}
               className={cn(
                 'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap',
                 'bg-primary-600 hover:bg-primary-700 text-white',
@@ -155,6 +176,13 @@ export function MonitorPage() {
             </button>
           </div>
         </div>
+
+        {monitoringDisabled && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+            Project health checks are unavailable in database mode.
+            {monitoringCapabilities.reason ? ` ${monitoringCapabilities.reason}` : ''}
+          </div>
+        )}
 
         {/* Error banner */}
         {error && (
@@ -180,7 +208,7 @@ export function MonitorPage() {
         )}
 
         {/* Health overview and logs */}
-        {projectHealth && (
+        {!monitoringDisabled && projectHealth && (
           <>
             <HealthOverview health={projectHealth} projectId={selectedProjectId} />
             <DiagnosticsPanel projectId={selectedProjectId} />

--- a/src/dashboard/src/services/__tests__/authenticatedSse.test.ts
+++ b/src/dashboard/src/services/__tests__/authenticatedSse.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthenticatedSseClient } from '../authenticatedSse'
+import { useAuthStore } from '../../stores/auth'
+
+function streamResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+describe('authenticated SSE client', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    useAuthStore.setState({
+      accessToken: 'access-token',
+      refreshToken: null,
+    })
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('sends the access token in the Authorization header, never the URL', async () => {
+    globalThis.fetch = vi.fn(async () => streamResponse('')) as typeof fetch
+
+    createAuthenticatedSseClient('/api/protected/stream')
+
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]
+
+    expect(url).toBe('/api/protected/stream')
+    expect(init?.headers).toEqual({ Authorization: 'Bearer access-token' })
+    expect(url).not.toContain('access-token')
+  })
+
+  it('terminates with permission-denied on 403 without reconnecting', async () => {
+    const onStatus = vi.fn()
+    globalThis.fetch = vi.fn(async () => streamResponse('', 403)) as typeof fetch
+
+    createAuthenticatedSseClient('/api/protected/stream', { onStatus })
+
+    await vi.waitFor(() => expect(onStatus).toHaveBeenCalledWith('permission-denied'))
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes once after 401 and retries with the new access token', async () => {
+    useAuthStore.setState({ accessToken: 'expired-token', refreshToken: 'refresh-token' })
+    let streamAttempts = 0
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/auth/refresh')) {
+        return new Response(JSON.stringify({
+          access_token: 'new-token',
+          refresh_token: 'new-refresh-token',
+          expires_in: 3600,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      streamAttempts += 1
+      return streamResponse(streamAttempts === 1 ? '' : 'event: connected\\ndata: {}\\n\\n', streamAttempts === 1 ? 401 : 200)
+    }) as typeof fetch
+
+    const onStatus = vi.fn()
+    const client = createAuthenticatedSseClient('/api/protected/stream', { onStatus })
+    client.addEventListener('connected', vi.fn())
+
+    await vi.waitFor(() => expect(streamAttempts).toBe(2))
+    const calls = vi.mocked(globalThis.fetch).mock.calls
+    expect((calls[0][1]?.headers as Record<string, string>).Authorization).toBe('Bearer expired-token')
+    expect((calls[2][1]?.headers as Record<string, string>).Authorization).toBe('Bearer new-token')
+    expect(onStatus).not.toHaveBeenCalledWith('authentication-failed')
+  })
+
+  it('terminates with authentication-failed when refresh cannot recover a 401', async () => {
+    useAuthStore.setState({ accessToken: 'expired-token', refreshToken: null })
+    const onStatus = vi.fn()
+    globalThis.fetch = vi.fn(async () => streamResponse('', 401)) as typeof fetch
+
+    createAuthenticatedSseClient('/api/protected/stream', { onStatus })
+
+    await vi.waitFor(() => expect(onStatus).toHaveBeenCalledWith('authentication-failed'))
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('parses SSE event names and preserves malformed payloads for the consumer', async () => {
+    globalThis.fetch = vi.fn(async () => streamResponse(
+      'event: config_change\r\ndata: not-json{{{\r\n\r\n',
+    )) as typeof fetch
+    const onEvent = vi.fn()
+
+    const client = createAuthenticatedSseClient('/api/project-configs/stream')
+    client.addEventListener('config_change', onEvent)
+
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1))
+    expect(onEvent.mock.calls[0][0].data).toBe('not-json{{{')
+  })
+
+  it('closes an active stream without reporting a reconnectable error', async () => {
+    let aborted = false
+    globalThis.fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          aborted = true
+          reject(new DOMException('Aborted', 'AbortError'))
+        })
+      }),
+    ) as typeof fetch
+    const onStatus = vi.fn()
+
+    const client = createAuthenticatedSseClient('/api/protected/stream', { onStatus })
+    client.close()
+    await vi.waitFor(() => expect(aborted).toBe(true))
+
+    expect(onStatus).not.toHaveBeenCalled()
+  })
+})

--- a/src/dashboard/src/services/authenticatedSse.ts
+++ b/src/dashboard/src/services/authenticatedSse.ts
@@ -1,0 +1,180 @@
+/**
+ * Fetch-based SSE transport for endpoints protected by Bearer authentication.
+ *
+ * Native EventSource cannot send an Authorization header. This transport keeps
+ * the token out of URLs and logs, while retaining the EventSource listener
+ * surface used by the stores.
+ */
+import { useAuthStore } from '../stores/auth'
+
+export type AuthenticatedSseStatus =
+  | 'authentication-failed'
+  | 'permission-denied'
+  | 'error'
+  | 'closed'
+
+export interface AuthenticatedSseOptions {
+  onStatus?: (status: AuthenticatedSseStatus) => void
+}
+
+export interface AuthenticatedSseClient {
+  addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void
+  close(): void
+}
+
+type EventListener = (event: MessageEvent<string>) => void
+
+class SseParser {
+  private buffer = ''
+  private eventName = 'message'
+  private dataLines: string[] = []
+
+  feed(chunk: string, dispatch: (event: MessageEvent<string>) => void): void {
+    this.buffer += chunk
+
+    while (true) {
+      const lineBreak = this.buffer.match(/\r\n|\n|\r/)
+      if (!lineBreak || lineBreak.index === undefined) return
+
+      const line = this.buffer.slice(0, lineBreak.index)
+      this.buffer = this.buffer.slice(lineBreak.index + lineBreak[0].length)
+      this.consumeLine(line, dispatch)
+    }
+  }
+
+  private consumeLine(line: string, dispatch: (event: MessageEvent<string>) => void): void {
+    if (line === '') {
+      if (this.dataLines.length === 0) return
+      dispatch(new MessageEvent(this.eventName, { data: this.dataLines.join('\n') }))
+      this.eventName = 'message'
+      this.dataLines = []
+      return
+    }
+
+    if (line.startsWith(':')) return
+
+    const separator = line.indexOf(':')
+    const field = separator === -1 ? line : line.slice(0, separator)
+    let value = separator === -1 ? '' : line.slice(separator + 1)
+    if (value.startsWith(' ')) value = value.slice(1)
+
+    if (field === 'event') this.eventName = value || 'message'
+    if (field === 'data') this.dataLines.push(value)
+  }
+}
+
+/** Open an authenticated SSE stream without placing credentials in the URL. */
+export function createAuthenticatedSseClient(
+  url: string,
+  options: AuthenticatedSseOptions = {},
+): AuthenticatedSseClient {
+  const listeners = new Map<string, EventListener[]>()
+  const controller = new AbortController()
+  const parser = new SseParser()
+  let closed = false
+  let refreshAttempted = false
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+
+  const emitStatus = (status: AuthenticatedSseStatus) => {
+    options.onStatus?.(status)
+  }
+
+  const terminate = (status: Exclude<AuthenticatedSseStatus, 'closed'>) => {
+    if (closed) return
+    closed = true
+    controller.abort()
+    emitStatus(status)
+  }
+
+  const dispatch = (event: MessageEvent<string>) => {
+    for (const listener of listeners.get(event.type) ?? []) listener(event)
+  }
+
+  const connect = async (): Promise<void> => {
+    if (closed) return
+
+    let response: Response
+    try {
+      const { accessToken } = useAuthStore.getState()
+      const headers: Record<string, string> = {}
+      if (accessToken) headers.Authorization = `Bearer ${accessToken}`
+      response = await fetch(url, { headers, signal: controller.signal })
+    } catch {
+      if (!closed) terminate('error')
+      return
+    }
+
+    // A mocked or otherwise malformed fetch implementation must not leave an
+    // unhandled rejection in consumers. Treat it as a transport failure.
+    if (!response) {
+      terminate('error')
+      return
+    }
+
+    if (response.status === 401) {
+      if (refreshAttempted) {
+        terminate('authentication-failed')
+        return
+      }
+      refreshAttempted = true
+      let refreshed: boolean
+      try {
+        refreshed = await useAuthStore.getState().refreshAccessToken()
+      } catch {
+        refreshed = false
+      }
+      if (!refreshed) {
+        terminate('authentication-failed')
+        return
+      }
+      await connect()
+      return
+    }
+
+    if (response.status === 403) {
+      terminate('permission-denied')
+      return
+    }
+
+    if (!response.ok || !response.body) {
+      terminate('error')
+      return
+    }
+
+    reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    try {
+      while (!closed) {
+        const result = await reader.read()
+        if (result.done) break
+        parser.feed(decoder.decode(result.value, { stream: true }), dispatch)
+      }
+      if (!closed) {
+        parser.feed(decoder.decode(), dispatch)
+        closed = true
+        emitStatus('closed')
+      }
+    } catch {
+      if (!closed) terminate('error')
+    } finally {
+      reader = undefined
+    }
+  }
+
+  const client: AuthenticatedSseClient = {
+    addEventListener(type, listener) {
+      const current = listeners.get(type) ?? []
+      current.push(listener)
+      listeners.set(type, current)
+    },
+    close() {
+      if (closed) return
+      closed = true
+      controller.abort()
+      void reader?.cancel().catch(() => undefined)
+    },
+  }
+
+  void connect()
+  return client
+}

--- a/src/dashboard/src/stores/__tests__/claudeCodeActivity.test.ts
+++ b/src/dashboard/src/stores/__tests__/claudeCodeActivity.test.ts
@@ -11,24 +11,47 @@ vi.mock('../../services/apiClient', () => ({
   },
 }))
 
+const { authenticatedSseInstances, mockCreateAuthenticatedSseClient } = vi.hoisted(() => {
+  type StatusHandler = (status: string) => void
+  type Client = {
+    url: string
+    listeners: Record<string, ((e: MessageEvent) => void)[]>
+    close: ReturnType<typeof vi.fn>
+    addEventListener: (event: string, handler: (e: MessageEvent) => void) => void
+    emit: (event: string, data?: unknown) => void
+    emitStatus: (status: string) => void
+  }
+  const instances: Client[] = []
+  const create = vi.fn((url: string, options?: { onStatus?: StatusHandler }) => {
+    const client = {
+      url,
+      listeners: {} as Record<string, ((e: MessageEvent) => void)[]>,
+      close: vi.fn(),
+      addEventListener(event: string, handler: (e: MessageEvent) => void) {
+        ;(this.listeners[event] ??= []).push(handler)
+      },
+      emit(event: string, data?: unknown) {
+        for (const handler of this.listeners[event] ?? []) handler(data as MessageEvent)
+      },
+      emitStatus(status: string) {
+        options?.onStatus?.(status)
+      },
+    } satisfies Client
+    instances.push(client)
+    return client
+  })
+  return { authenticatedSseInstances: instances, mockCreateAuthenticatedSseClient: create }
+})
+
+vi.mock('../../services/authenticatedSse', () => ({
+  createAuthenticatedSseClient: mockCreateAuthenticatedSseClient,
+}))
+
 import { useClaudeCodeActivityStore } from '../claudeCodeActivity'
 import { apiClient } from '../../services/apiClient'
+import { useAuthStore } from '../auth'
 
 const mockApiClient = vi.mocked(apiClient)
-
-// Mock EventSource
-class MockEventSource {
-  url: string
-  listeners: Record<string, ((e: MessageEvent) => void)[]> = {}
-  close = vi.fn()
-  constructor(url: string) { this.url = url }
-  addEventListener(event: string, handler: (e: MessageEvent) => void) {
-    if (!this.listeners[event]) this.listeners[event] = []
-    this.listeners[event].push(handler)
-  }
-}
-// @ts-expect-error - Mock
-global.EventSource = MockEventSource
 
 function resetStore() {
   useClaudeCodeActivityStore.setState({
@@ -45,11 +68,18 @@ function resetStore() {
     eventSource: null,
     error: null,
   })
+  authenticatedSseInstances.length = 0
 }
 
 describe('claudeCodeActivity store', () => {
   beforeEach(() => {
     resetStore()
+    useAuthStore.setState({
+      _hasHydrated: false,
+      accessToken: null,
+      refreshToken: null,
+      expiresAt: null,
+    })
     vi.clearAllMocks()
   })
 
@@ -238,7 +268,7 @@ describe('claudeCodeActivity store', () => {
     it('creates EventSource with correct URL', () => {
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
 
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
       expect(es).not.toBeNull()
       expect(es.url).toContain('/api/claude-sessions/s-1/activity/stream')
     })
@@ -250,6 +280,22 @@ describe('claudeCodeActivity store', () => {
       useClaudeCodeActivityStore.getState().startStreaming('s-2')
 
       expect(oldES.close).toHaveBeenCalled()
+    })
+
+    it('resumes a persisted session when auth hydrates after the activity store', async () => {
+      useClaudeCodeActivityStore.setState({ activeSessionId: 's-hydrated' })
+      useAuthStore.setState({
+        _hasHydrated: true,
+        accessToken: 'hydrated-token',
+        refreshToken: null,
+        expiresAt: Date.now() + 60_000,
+      })
+
+      await vi.waitFor(() => expect(authenticatedSseInstances).toHaveLength(1))
+
+      expect(authenticatedSseInstances[0].url).toContain(
+        '/api/claude-sessions/s-hydrated/activity/stream',
+      )
     })
   })
 
@@ -331,7 +377,7 @@ describe('claudeCodeActivity store', () => {
       expect(state.rootTaskIds).toEqual(['t1'])
       expect(state.eventSource).not.toBeNull()
 
-      const es = state.eventSource as unknown as MockEventSource
+      const es = state.eventSource as unknown as (typeof authenticatedSseInstances)[number]
       expect(es.url).toContain('/api/claude-sessions/s-1/activity/stream')
     })
 
@@ -368,7 +414,7 @@ describe('claudeCodeActivity store', () => {
   describe('SSE activity_batch event handler', () => {
     it('sets activities from parsed JSON batch', () => {
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const batch = [
         { id: 'ev-1', type: 'user', session_id: 's-1', timestamp: '2024-01-01T00:00:00Z' },
@@ -384,7 +430,7 @@ describe('claudeCodeActivity store', () => {
     it('logs error and does not update state when JSON is invalid', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       useClaudeCodeActivityStore.setState({ activities: [{ id: 'existing' } as any] })
 
@@ -410,7 +456,7 @@ describe('claudeCodeActivity store', () => {
       })
 
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const newActivity = {
         id: 'ev-2',
@@ -435,7 +481,7 @@ describe('claudeCodeActivity store', () => {
       })
 
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const taskCreateActivity = {
         id: 'ev-3',
@@ -467,7 +513,7 @@ describe('claudeCodeActivity store', () => {
       })
 
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const taskUpdateActivity = {
         id: 'ev-4',
@@ -491,7 +537,7 @@ describe('claudeCodeActivity store', () => {
 
     it('does not refetch tasks for other tool_use types', () => {
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const otherActivity = {
         id: 'ev-5',
@@ -509,7 +555,7 @@ describe('claudeCodeActivity store', () => {
 
     it('does not refetch tasks for non-tool_use activity types', () => {
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const assistantActivity = {
         id: 'ev-6',
@@ -529,7 +575,7 @@ describe('claudeCodeActivity store', () => {
       useClaudeCodeActivityStore.setState({ activities: [], activityTotalCount: 0 })
 
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const handler = es.listeners['activity'][0]
       handler(new MessageEvent('activity', { data: 'bad-json}}' }))
@@ -553,7 +599,7 @@ describe('claudeCodeActivity store', () => {
       })
 
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       // Verify the handler exists
       expect(es.listeners['session_completed']).toBeDefined()
@@ -569,114 +615,58 @@ describe('claudeCodeActivity store', () => {
     })
   })
 
-  describe('SSE error event handler', () => {
-    it('logs a warning on error', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  describe('SSE transport status handling', () => {
+    it('reconnects after a transport error, but only while the session is active', () => {
       vi.useFakeTimers()
-
-      useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
-
-      const handler = es.listeners['error'][0]
-      handler(new MessageEvent('error', { data: 'connection refused' }))
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('SSE connection error:'),
-        expect.anything()
-      )
-
-      vi.useRealTimers()
-      warnSpy.mockRestore()
-    })
-
-    it('reconnects after 5s when activeSessionId is set and dataSource is claude-code', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      vi.useFakeTimers()
-
       useClaudeCodeActivityStore.setState({
         activeSessionId: 's-1',
         dataSource: 'claude-code',
       })
 
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
+      es.emitStatus('error')
 
-      const handler = es.listeners['error'][0]
-      handler(new MessageEvent('error', { data: '' }))
-
-      // Before timeout, eventSource is still the old one
-      const esBeforeTimeout = useClaudeCodeActivityStore.getState().eventSource
-      expect(esBeforeTimeout).toBe(es)
-
-      // Advance timers by 5000ms to trigger reconnect
+      expect(useClaudeCodeActivityStore.getState().eventSource).toBe(es)
       vi.advanceTimersByTime(5000)
 
-      // After timeout, a new EventSource should have been created
-      const newEs = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
-      expect(newEs).not.toBeNull()
+      const newEs = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
+      expect(newEs).not.toBe(es)
       expect(newEs.url).toContain('/api/claude-sessions/s-1/activity/stream')
-
       vi.useRealTimers()
-      warnSpy.mockRestore()
     })
 
-    it('does not reconnect after 5s when activeSessionId is null', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('does not reconnect after a terminal authentication failure', () => {
       vi.useFakeTimers()
-
       useClaudeCodeActivityStore.setState({
-        activeSessionId: null,
+        activeSessionId: 's-1',
         dataSource: 'claude-code',
       })
 
-      useClaudeCodeActivityStore.getState().startStreaming('s-temp')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
-
-      // Manually set activeSessionId to null to simulate session cleared during error
-      useClaudeCodeActivityStore.setState({ activeSessionId: null })
-
-      const handler = es.listeners['error'][0]
-      handler(new MessageEvent('error', { data: '' }))
-
+      useClaudeCodeActivityStore.getState().startStreaming('s-1')
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
+      es.emitStatus('authentication-failed')
       vi.advanceTimersByTime(5000)
 
-      // eventSource should not have been replaced with a new one
-      // (the old mock es was replaced during startStreaming setup, but no new one created after timeout)
-      const currentEs = useClaudeCodeActivityStore.getState().eventSource
-      // It won't be the new MockEventSource created by reconnect since condition failed
-      if (currentEs !== null) {
-        const currentMockEs = currentEs as unknown as MockEventSource
-        // If there is an eventSource, it must be the same one (no reconnect occurred)
-        expect(currentMockEs).toBe(es)
-      }
-
+      expect(useClaudeCodeActivityStore.getState().eventSource).toBeNull()
+      expect(useClaudeCodeActivityStore.getState().error).toContain('Authentication required')
+      expect(authenticatedSseInstances).toHaveLength(1)
       vi.useRealTimers()
-      warnSpy.mockRestore()
     })
 
-    it('does not reconnect when dataSource is not claude-code', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('does not reconnect when the active session or data source changes', () => {
       vi.useFakeTimers()
-
       useClaudeCodeActivityStore.setState({
         activeSessionId: 's-1',
-        dataSource: 'aos',
+        dataSource: 'claude-code',
       })
-
       useClaudeCodeActivityStore.getState().startStreaming('s-1')
-      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
-
-      const handler = es.listeners['error'][0]
-      handler(new MessageEvent('error', { data: '' }))
-
+      const es = useClaudeCodeActivityStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
+      es.emitStatus('error')
+      useClaudeCodeActivityStore.setState({ activeSessionId: null })
       vi.advanceTimersByTime(5000)
-
-      // eventSource should still be the same one from before (no reconnect)
-      const currentEs = useClaudeCodeActivityStore.getState().eventSource as unknown as MockEventSource
-      expect(currentEs).toBe(es)
-
+      expect(authenticatedSseInstances).toHaveLength(1)
       vi.useRealTimers()
-      warnSpy.mockRestore()
     })
   })
 

--- a/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
+++ b/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
@@ -11,29 +11,45 @@ vi.mock('../../services/apiClient', () => ({
   },
 }))
 
+const { authenticatedSseInstances, mockCreateAuthenticatedSseClient } = vi.hoisted(() => {
+  type Client = {
+    url: string
+    listeners: Record<string, ((e: MessageEvent) => void)[]>
+    close: ReturnType<typeof vi.fn>
+    addEventListener: (event: string, handler: (e: MessageEvent) => void) => void
+    emit: (event: string, data?: unknown) => void
+    emitStatus: (status: string) => void
+  }
+  const instances: Client[] = []
+  const create = vi.fn((url: string, options?: { onStatus?: (status: string) => void }) => {
+    const client = {
+      url,
+      listeners: {} as Record<string, ((e: MessageEvent) => void)[]>,
+      close: vi.fn(),
+      addEventListener(event: string, handler: (e: MessageEvent) => void) {
+        ;(this.listeners[event] ??= []).push(handler)
+      },
+      emit(event: string, data?: unknown) {
+        for (const handler of this.listeners[event] ?? []) handler(data as MessageEvent)
+      },
+      emitStatus(status: string) {
+        options?.onStatus?.(status)
+      },
+    } satisfies Client
+    instances.push(client)
+    return client
+  })
+  return { authenticatedSseInstances: instances, mockCreateAuthenticatedSseClient: create }
+})
+
+vi.mock('../../services/authenticatedSse', () => ({
+  createAuthenticatedSseClient: mockCreateAuthenticatedSseClient,
+}))
+
 import { useClaudeSessionsStore } from '../claudeSessions'
 import { apiClient } from '../../services/apiClient'
 
 const mockApiClient = vi.mocked(apiClient)
-
-// Mock EventSource
-class MockEventSource {
-  url: string
-  listeners: Record<string, ((e: MessageEvent) => void)[]> = {}
-  close = vi.fn()
-  constructor(url: string) { this.url = url }
-  addEventListener(event: string, handler: (e: MessageEvent) => void) {
-    if (!this.listeners[event]) this.listeners[event] = []
-    this.listeners[event].push(handler)
-  }
-  // Helper: fire a registered event
-  emit(event: string, data?: any) {
-    const handlers = this.listeners[event] || []
-    handlers.forEach((h) => h(data as MessageEvent))
-  }
-}
-// @ts-expect-error - Mock
-global.EventSource = MockEventSource
 
 const emptyResponse = {
   sessions: [],
@@ -82,6 +98,7 @@ function resetStore() {
     batchProgress: { total: 0, processed: 0, success: 0, failed: 0 },
     pendingSummaryCount: 0,
   })
+  authenticatedSseInstances.length = 0
 }
 
 describe('claudeSessions store', () => {
@@ -1434,7 +1451,7 @@ describe('claudeSessions store', () => {
     it('startStreaming creates EventSource', () => {
       useClaudeSessionsStore.getState().startStreaming('s-1')
 
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
       expect(es).not.toBeNull()
       expect(es.url).toContain('/api/claude-sessions/s-1/stream')
     })
@@ -1456,7 +1473,7 @@ describe('claudeSessions store', () => {
       useClaudeSessionsStore.getState().startStreaming('s-2')
 
       expect(oldES.close).toHaveBeenCalled()
-      const newES = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const newES = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
       expect(newES).not.toBeNull()
       expect(newES.url).toContain('s-2')
     })
@@ -1468,7 +1485,7 @@ describe('claudeSessions store', () => {
       })
 
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       const updateData = {
         session_id: 's-1',
@@ -1496,7 +1513,7 @@ describe('claudeSessions store', () => {
       })
 
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('session_update', {
         data: JSON.stringify({
@@ -1517,7 +1534,7 @@ describe('claudeSessions store', () => {
     it('session_update handles invalid JSON gracefully', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       // Should not throw
       es.emit('session_update', { data: 'invalid json' })
@@ -1532,7 +1549,7 @@ describe('claudeSessions store', () => {
       })
 
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('session_completed', {
         data: JSON.stringify({
@@ -1552,7 +1569,7 @@ describe('claudeSessions store', () => {
       })
 
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('session_completed', {
         data: JSON.stringify({
@@ -1568,7 +1585,7 @@ describe('claudeSessions store', () => {
     it('session_completed handles invalid JSON gracefully', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('session_completed', { data: 'bad json' })
 
@@ -1578,7 +1595,7 @@ describe('claudeSessions store', () => {
 
     it('session_ended event stops streaming', () => {
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('session_ended', {})
 
@@ -1592,7 +1609,7 @@ describe('claudeSessions store', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('error', {})
 
@@ -1614,7 +1631,7 @@ describe('claudeSessions store', () => {
       useClaudeSessionsStore.setState({
         selectedSession: { status: 'completed' } as any,
       })
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('error', {})
 
@@ -1627,7 +1644,7 @@ describe('claudeSessions store', () => {
       useClaudeSessionsStore.setState({ selectedSession: null })
 
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('error', {})
 
@@ -1645,7 +1662,7 @@ describe('claudeSessions store', () => {
       })
 
       useClaudeSessionsStore.getState().startStreaming('s-1')
-      const es = useClaudeSessionsStore.getState().eventSource as unknown as MockEventSource
+      const es = useClaudeSessionsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
 
       es.emit('session_update', {
         data: JSON.stringify({

--- a/src/dashboard/src/stores/__tests__/monitoring.test.ts
+++ b/src/dashboard/src/stores/__tests__/monitoring.test.ts
@@ -56,10 +56,14 @@ function resetStore() {
     activeLogView: 'all',
     activeContextTab: 'claude-md',
     workflowChecks: [],
+    workflowProjectId: null,
     isLoadingWorkflows: false,
     runningWorkflowIds: new Set(),
     workflowLogs: {},
     error: null,
+    contextUnavailableReason: null,
+    contextUnavailableProjectId: null,
+    monitoringCapabilitiesErrorMap: {},
     monitoringCapabilitiesMap: {
       p1: {
         project_id: 'p1',
@@ -120,6 +124,41 @@ describe('monitoring store', () => {
       expect(useMonitoringStore.getState().monitoringCapabilitiesMap.p1).toEqual(capabilities)
     })
 
+    it('shares an in-flight capability request for the same project', async () => {
+      let resolveCapabilities!: (value: unknown) => void
+      const pendingCapabilities = new Promise((resolve) => {
+        resolveCapabilities = resolve
+      })
+      useMonitoringStore.setState({ monitoringCapabilitiesMap: {} })
+      mockApiClient.get.mockReturnValueOnce(pendingCapabilities as any)
+
+      const firstRequest = useMonitoringStore.getState().fetchMonitoringCapabilities('p1')
+      const secondRequest = useMonitoringStore.getState().fetchMonitoringCapabilities('p1')
+      expect(mockApiClient.get).toHaveBeenCalledTimes(1)
+
+      resolveCapabilities({
+        project_id: 'p1',
+        mode: 'database',
+        health_config: 'disabled',
+        health: 'disabled',
+        checks: 'disabled',
+        reason: 'Database-backed project monitoring is not available',
+      })
+
+      await expect(firstRequest).resolves.toMatchObject({ project_id: 'p1' })
+      await expect(secondRequest).resolves.toMatchObject({ project_id: 'p1' })
+    })
+
+    it('propagates capability failures for direct consumers', async () => {
+      useMonitoringStore.setState({ monitoringCapabilitiesMap: {} })
+      mockApiClient.get.mockRejectedValueOnce(new Error('capability authentication failed'))
+
+      await useMonitoringStore.getState().fetchMonitoringCapabilities('p1')
+
+      expect(useMonitoringStore.getState().error).toContain('capability authentication failed')
+      expect(useMonitoringStore.getState().monitoringCapabilitiesErrorMap.p1).toContain('capability authentication failed')
+    })
+
     it('blocks legacy health and check operations when the backend disables them', async () => {
       const capabilities = {
         project_id: 'p1' as string,
@@ -140,6 +179,177 @@ describe('monitoring store', () => {
       expect(mockApiClient.get).not.toHaveBeenCalledWith(expect.stringContaining('/health'))
       expect(eventSourceInstances).toHaveLength(0)
       expect(useMonitoringStore.getState().error).toContain('Database-backed')
+    })
+    it('does not call the legacy context endpoint in database mode', async () => {
+      const capabilities = {
+        project_id: 'p1' as string,
+        mode: 'database' as const,
+        health_config: 'disabled' as const,
+        health: 'disabled' as const,
+        checks: 'disabled' as const,
+        reason: 'Database-backed project monitoring is not available',
+      }
+      useMonitoringStore.setState({ monitoringCapabilitiesMap: {} })
+      mockApiClient.get.mockResolvedValueOnce(capabilities)
+
+      await useMonitoringStore.getState().fetchProjectContext('p1')
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects/p1/monitoring-capabilities')
+      expect(mockApiClient.get).not.toHaveBeenCalledWith('/api/projects/p1/context')
+      expect(useMonitoringStore.getState().contextUnavailableReason).toContain('Database-backed')
+      expect(useMonitoringStore.getState().error).toBeNull()
+    })
+    it('clears stale context when capability loading fails', async () => {
+      useMonitoringStore.setState({
+        projectContext: {
+          project_id: 'p1',
+          project_name: 'Previous project',
+          project_path: '/previous',
+          claude_md: '# stale',
+          dev_docs: [],
+          session_info: null,
+        },
+      })
+      useMonitoringStore.setState({ monitoringCapabilitiesMap: {} })
+      mockApiClient.get.mockRejectedValueOnce(new Error('capability request failed'))
+
+      await useMonitoringStore.getState().fetchProjectContext('p2')
+
+      expect(useMonitoringStore.getState().projectContext).toBeNull()
+      expect(useMonitoringStore.getState().isLoadingContext).toBe(false)
+    })
+
+    it('ignores a late response from a previously selected project', async () => {
+      let resolveP1!: (value: unknown) => void
+      const p1Context = new Promise((resolve) => {
+        resolveP1 = resolve
+      })
+      mockApiClient.get.mockReturnValueOnce(p1Context as any)
+
+      const p1Request = useMonitoringStore.getState().fetchProjectContext('p1')
+      useMonitoringStore.setState({
+        monitoringCapabilitiesMap: {
+          p1: useMonitoringStore.getState().monitoringCapabilitiesMap.p1,
+          p2: {
+            project_id: 'p2',
+            mode: 'database',
+            health_config: 'disabled',
+            health: 'disabled',
+            checks: 'disabled',
+            reason: 'Database-backed project monitoring is not available',
+          },
+        },
+      })
+      const p2Request = useMonitoringStore.getState().fetchProjectContext('p2')
+      await p2Request
+
+      resolveP1({
+        project_id: 'p1',
+        project_name: 'Previous project',
+        project_path: '/previous',
+        claude_md: '# stale',
+        dev_docs: [],
+        session_info: null,
+      })
+      await p1Request
+
+      expect(useMonitoringStore.getState().projectContext).toBeNull()
+      expect(useMonitoringStore.getState().contextUnavailableReason).toContain('Database-backed')
+    })
+
+    it('re-fetches capabilities when the cached project identity is inconsistent', async () => {
+      useMonitoringStore.setState({
+        monitoringCapabilitiesMap: {
+          p1: {
+            project_id: 'different-project',
+            mode: 'filesystem',
+            health_config: 'available',
+            health: 'available',
+            checks: 'available',
+            reason: null,
+          },
+        },
+      })
+      mockApiClient.get
+        .mockResolvedValueOnce({
+          project_id: 'p1',
+          mode: 'filesystem',
+          health_config: 'available',
+          health: 'available',
+          checks: 'available',
+          reason: null,
+        })
+        .mockResolvedValueOnce({ project_id: 'p1', claude_md: '# Current', dev_docs: [], session_info: null })
+
+      await useMonitoringStore.getState().fetchProjectContext('p1')
+
+      expect(mockApiClient.get).toHaveBeenNthCalledWith(1, '/api/projects/p1/monitoring-capabilities')
+      expect(mockApiClient.get).toHaveBeenNthCalledWith(2, '/api/projects/p1/context')
+      expect(useMonitoringStore.getState().projectContext?.project_id).toBe('p1')
+    })
+
+    it('ignores a late capability failure from a previously selected project', async () => {
+      let rejectP1!: (reason?: unknown) => void
+      const p1Capabilities = new Promise((_resolve, reject) => {
+        rejectP1 = reject
+      })
+      mockApiClient.get.mockReturnValueOnce(p1Capabilities as any)
+
+      const p1Request = useMonitoringStore.getState().fetchProjectContext('p1')
+      useMonitoringStore.setState({
+        monitoringCapabilitiesMap: {
+          p2: {
+            project_id: 'p2',
+            mode: 'database',
+            health_config: 'disabled',
+            health: 'disabled',
+            checks: 'disabled',
+            reason: 'Database-backed project monitoring is not available',
+          },
+        },
+      })
+      await useMonitoringStore.getState().fetchProjectContext('p2')
+
+      rejectP1(new Error('previous project capability request failed'))
+      await p1Request
+
+      expect(useMonitoringStore.getState().error).toBeNull()
+      expect(useMonitoringStore.getState().contextUnavailableReason).toContain('Database-backed')
+    })
+
+    it('rejects capability responses for a different project', async () => {
+      useMonitoringStore.setState({ monitoringCapabilitiesMap: {} })
+      mockApiClient.get.mockResolvedValueOnce({
+        project_id: 'p2',
+        mode: 'database',
+        health_config: 'disabled',
+        health: 'disabled',
+        checks: 'disabled',
+        reason: 'Database-backed project monitoring is not available',
+      })
+
+      await useMonitoringStore.getState().fetchProjectContext('p1')
+
+      expect(useMonitoringStore.getState().projectContext).toBeNull()
+      expect(useMonitoringStore.getState().contextUnavailableReason).toBeNull()
+      expect(useMonitoringStore.getState().error).toContain('did not match')
+      expect(mockApiClient.get).not.toHaveBeenCalledWith('/api/projects/p1/context')
+    })
+
+    it('ignores context responses for a different project', async () => {
+      mockApiClient.get.mockResolvedValueOnce({
+        project_id: 'p2',
+        project_name: 'Wrong project',
+        project_path: '/wrong',
+        claude_md: '# wrong',
+        dev_docs: [],
+        session_info: null,
+      })
+
+      await useMonitoringStore.getState().fetchProjectContext('p1')
+
+      expect(useMonitoringStore.getState().projectContext).toBeNull()
+      expect(useMonitoringStore.getState().isLoadingContext).toBe(false)
     })
   })
 
@@ -336,7 +546,7 @@ describe('monitoring store', () => {
 
   describe('fetchProjectContext', () => {
     it('fetches and stores context', async () => {
-      const contextData = { claude_md: '# Test', dev_docs: null }
+      const contextData = { project_id: 'p1', claude_md: '# Test', dev_docs: null }
       mockApiClient.get.mockResolvedValueOnce(contextData)
 
       await useMonitoringStore.getState().fetchProjectContext('p1')
@@ -357,12 +567,42 @@ describe('monitoring store', () => {
   // ── fetchWorkflowChecks ────────────────────────────────
 
   describe('fetchWorkflowChecks', () => {
+    it('rejects workflows from a different project', async () => {
+      mockApiClient.get.mockResolvedValueOnce({
+        workflows: [{ id: 'wf-other', project_id: 'p2', name: 'Other', description: '' }],
+      })
+
+      await useMonitoringStore.getState().fetchWorkflowChecks('p1')
+
+      expect(useMonitoringStore.getState().workflowChecks).toEqual([])
+      expect(useMonitoringStore.getState().error).toContain('different project')
+    })
+
+    it('rejects a global (null project) workflow in a project-scoped response', async () => {
+      mockApiClient.get.mockResolvedValueOnce({
+        workflows: [{ id: 'wf-global', project_id: null, name: 'Global', description: '' }],
+      })
+
+      await useMonitoringStore.getState().fetchWorkflowChecks('p1')
+
+      expect(useMonitoringStore.getState().workflowChecks).toEqual([])
+      expect(useMonitoringStore.getState().error).toContain('different project')
+    })
+
+    it('encodes the project id in the request URL', async () => {
+      mockApiClient.get.mockResolvedValueOnce({ workflows: [] })
+
+      await useMonitoringStore.getState().fetchWorkflowChecks('p 1&x=2')
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/api/workflows?project_id=p%201%26x%3D2')
+    })
+
     it('fetches workflows and maps to checks', async () => {
       mockApiClient.get.mockResolvedValueOnce({
         workflows: [
-          { id: 'wf-1', name: 'CI', description: 'CI Pipeline', last_run_status: 'completed', last_run_at: '2025-01-01' },
-          { id: 'wf-2', name: 'Deploy', description: '', last_run_status: 'failed', last_run_at: null },
-          { id: 'wf-3', name: 'Test', description: '', last_run_status: null, last_run_at: null },
+          { id: 'wf-1', project_id: 'p1', name: 'CI', description: 'CI Pipeline', last_run_status: 'completed', last_run_at: '2025-01-01' },
+          { id: 'wf-2', project_id: 'p1', name: 'Deploy', description: '', last_run_status: 'failed', last_run_at: null },
+          { id: 'wf-3', project_id: 'p1', name: 'Test', description: '', last_run_status: null, last_run_at: null },
         ],
       })
 
@@ -615,7 +855,7 @@ describe('monitoring store', () => {
     }
 
     beforeEach(() => {
-      useMonitoringStore.setState({ workflowChecks: [mockWorkflow] })
+      useMonitoringStore.setState({ workflowChecks: [mockWorkflow], workflowProjectId: 'p1' })
     })
 
     it('marks workflow as running and adds start log', async () => {

--- a/src/dashboard/src/stores/__tests__/monitoring.test.ts
+++ b/src/dashboard/src/stores/__tests__/monitoring.test.ts
@@ -40,6 +40,10 @@ class MockEventSource {
 // @ts-expect-error - Mock
 global.EventSource = MockEventSource
 
+vi.mock('../../services/authenticatedSse', () => ({
+  createAuthenticatedSseClient: (url: string) => new MockEventSource(url),
+}))
+
 function resetStore() {
   useMonitoringStore.setState({
     projectHealthMap: {},
@@ -56,6 +60,16 @@ function resetStore() {
     runningWorkflowIds: new Set(),
     workflowLogs: {},
     error: null,
+    monitoringCapabilitiesMap: {
+      p1: {
+        project_id: 'p1',
+        mode: 'filesystem',
+        health_config: 'available',
+        health: 'available',
+        checks: 'available',
+        reason: null,
+      },
+    },
   })
   eventSourceInstances.length = 0
 }
@@ -87,8 +101,49 @@ describe('monitoring store', () => {
     })
   })
 
-  // ── UI Actions ─────────────────────────────────────────
+  describe('monitoring capabilities', () => {
+    it('fetches and stores the backend capability before legacy operations', async () => {
+      useMonitoringStore.setState({ monitoringCapabilitiesMap: {} })
+      const capabilities = {
+        project_id: 'p1',
+        mode: 'database',
+        health_config: 'disabled',
+        health: 'disabled',
+        checks: 'disabled',
+        reason: 'Database-backed project monitoring is not available',
+      }
+      mockApiClient.get.mockResolvedValueOnce(capabilities)
 
+      await useMonitoringStore.getState().fetchMonitoringCapabilities('p1')
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects/p1/monitoring-capabilities')
+      expect(useMonitoringStore.getState().monitoringCapabilitiesMap.p1).toEqual(capabilities)
+    })
+
+    it('blocks legacy health and check operations when the backend disables them', async () => {
+      const capabilities = {
+        project_id: 'p1' as string,
+        mode: 'database' as const,
+        health_config: 'disabled' as const,
+        health: 'disabled' as const,
+        checks: 'disabled' as const,
+        reason: 'Database-backed project monitoring is not available',
+      }
+      useMonitoringStore.setState({ monitoringCapabilitiesMap: { p1: capabilities } })
+
+      await useMonitoringStore.getState().fetchCheckConfig('p1')
+      await useMonitoringStore.getState().fetchProjectHealth('p1')
+      useMonitoringStore.getState().runCheck('p1', 'test')
+      useMonitoringStore.getState().runAllChecks('p1')
+
+      expect(mockApiClient.get).not.toHaveBeenCalledWith(expect.stringContaining('/health-config'))
+      expect(mockApiClient.get).not.toHaveBeenCalledWith(expect.stringContaining('/health'))
+      expect(eventSourceInstances).toHaveLength(0)
+      expect(useMonitoringStore.getState().error).toContain('Database-backed')
+    })
+  })
+
+  // ── UI Actions ──────────────────────────────────────────
   describe('UI actions', () => {
     it('setActiveLogView updates view', () => {
       useMonitoringStore.getState().setActiveLogView('test')

--- a/src/dashboard/src/stores/__tests__/projectConfigs.test.ts
+++ b/src/dashboard/src/stores/__tests__/projectConfigs.test.ts
@@ -11,24 +11,45 @@ vi.mock('../../services/apiClient', () => ({
   },
 }))
 
+const { authenticatedSseInstances, mockCreateAuthenticatedSseClient } = vi.hoisted(() => {
+  type Client = {
+    url: string
+    listeners: Record<string, ((e: MessageEvent) => void)[]>
+    close: ReturnType<typeof vi.fn>
+    addEventListener: (event: string, handler: (e: MessageEvent) => void) => void
+    emit: (event: string, data?: unknown) => void
+    emitStatus: (status: string) => void
+  }
+  const instances: Client[] = []
+  const create = vi.fn((url: string, options?: { onStatus?: (status: string) => void }) => {
+    const client = {
+      url,
+      listeners: {} as Record<string, ((e: MessageEvent) => void)[]>,
+      close: vi.fn(),
+      addEventListener(event: string, handler: (e: MessageEvent) => void) {
+        ;(this.listeners[event] ??= []).push(handler)
+      },
+      emit(event: string, data?: unknown) {
+        for (const handler of this.listeners[event] ?? []) handler(data as MessageEvent)
+      },
+      emitStatus(status: string) {
+        options?.onStatus?.(status)
+      },
+    } satisfies Client
+    instances.push(client)
+    return client
+  })
+  return { authenticatedSseInstances: instances, mockCreateAuthenticatedSseClient: create }
+})
+
+vi.mock('../../services/authenticatedSse', () => ({
+  createAuthenticatedSseClient: mockCreateAuthenticatedSseClient,
+}))
+
 import { useProjectConfigsStore } from '../projectConfigs'
 import { apiClient } from '../../services/apiClient'
 
 const mockApiClient = vi.mocked(apiClient)
-
-// Mock EventSource
-class MockEventSource {
-  url: string
-  listeners: Record<string, ((e: MessageEvent) => void)[]> = {}
-  close = vi.fn()
-  constructor(url: string) { this.url = url }
-  addEventListener(event: string, handler: (e: MessageEvent) => void) {
-    if (!this.listeners[event]) this.listeners[event] = []
-    this.listeners[event].push(handler)
-  }
-}
-// @ts-expect-error - Mock
-global.EventSource = MockEventSource
 
 function resetStore() {
   useProjectConfigsStore.setState({
@@ -63,6 +84,7 @@ function resetStore() {
     savingAgent: false,
     deletingAgents: new Set(),
   })
+  authenticatedSseInstances.length = 0
 }
 
 describe('projectConfigs store', () => {
@@ -276,12 +298,44 @@ describe('projectConfigs store', () => {
       expect(useProjectConfigsStore.getState().eventSource).toBeNull()
     })
 
-    it('startStreaming creates EventSource', () => {
+    it('startStreaming creates an authenticated SSE client with the stream URL', () => {
       useProjectConfigsStore.getState().startStreaming()
 
-      const es = useProjectConfigsStore.getState().eventSource as unknown as MockEventSource
+      const es = useProjectConfigsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
       expect(es).not.toBeNull()
       expect(es.url).toContain('/api/project-configs/stream')
+      expect(mockCreateAuthenticatedSseClient).toHaveBeenCalledWith(
+        expect.stringContaining('/api/project-configs/stream'),
+        expect.objectContaining({ onStatus: expect.any(Function) }),
+      )
+    })
+
+    it('reconnects once for a transport error through status, not an error event listener', () => {
+      vi.useFakeTimers()
+      useProjectConfigsStore.getState().startStreaming()
+      const es = useProjectConfigsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
+
+      expect(es.listeners.error).toBeUndefined()
+      es.emitStatus('error')
+      es.emitStatus('error')
+      vi.advanceTimersByTime(5000)
+
+      expect(authenticatedSseInstances).toHaveLength(2)
+      expect(authenticatedSseInstances[0].close).toHaveBeenCalled()
+      vi.useRealTimers()
+    })
+
+    it('does not reconnect after authentication or permission failure', () => {
+      vi.useFakeTimers()
+      useProjectConfigsStore.getState().startStreaming()
+      const es = useProjectConfigsStore.getState().eventSource as unknown as (typeof authenticatedSseInstances)[number]
+      es.emitStatus('permission-denied')
+      vi.advanceTimersByTime(5000)
+
+      expect(authenticatedSseInstances).toHaveLength(1)
+      expect(useProjectConfigsStore.getState().eventSource).toBeNull()
+      expect(useProjectConfigsStore.getState().error).toContain('permission')
+      vi.useRealTimers()
     })
   })
 

--- a/src/dashboard/src/stores/__tests__/workflows.test.ts
+++ b/src/dashboard/src/stores/__tests__/workflows.test.ts
@@ -11,6 +11,14 @@ vi.mock('../../services/apiClient', () => ({
   },
 }))
 
+const { mockCreateAuthenticatedSseClient } = vi.hoisted(() => ({
+  mockCreateAuthenticatedSseClient: vi.fn(),
+}))
+
+vi.mock('../../services/authenticatedSse', () => ({
+  createAuthenticatedSseClient: mockCreateAuthenticatedSseClient,
+}))
+
 import { useWorkflowStore } from '../workflows'
 import { apiClient } from '../../services/apiClient'
 
@@ -62,6 +70,7 @@ describe('workflow store', () => {
   beforeEach(() => {
     resetStore()
     vi.clearAllMocks()
+    mockCreateAuthenticatedSseClient.mockImplementation((url: string) => new MockEventSource(url) as any)
   })
 
   // ── Initial State ──────────────────────────────────────
@@ -532,6 +541,17 @@ describe('workflow store', () => {
   })
 
   // ── stopLogStream ──────────────────────────────────────
+
+  describe('authenticated log stream', () => {
+    it('uses the authenticated SSE client for the protected stream', () => {
+      useWorkflowStore.getState().streamRunLogs('run 1')
+
+      expect(mockCreateAuthenticatedSseClient).toHaveBeenCalledWith(
+        expect.stringContaining('/api/workflows/runs/run%201/stream'),
+        expect.objectContaining({ onStatus: expect.any(Function) }),
+      )
+    })
+  })
 
   describe('stopLogStream', () => {
     it('stops existing log stream', () => {

--- a/src/dashboard/src/stores/claudeCodeActivity.ts
+++ b/src/dashboard/src/stores/claudeCodeActivity.ts
@@ -8,7 +8,10 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { apiClient } from '../services/apiClient'
+import { useAuthStore } from './auth'
 import { getApiUrl } from '../config/api'
+import { createAuthenticatedSseClient } from '../services/authenticatedSse'
+import type { AuthenticatedSseClient } from '../services/authenticatedSse'
 import {
   ActivityEvent,
   ActivityResponse,
@@ -37,7 +40,7 @@ interface ClaudeCodeActivityState {
   isLoadingTasks: boolean
 
   // SSE connection
-  eventSource: EventSource | null
+  eventSource: AuthenticatedSseClient | null
 
   // Error state
   error: string | null
@@ -170,8 +173,33 @@ export const useClaudeCodeActivityStore = create<ClaudeCodeActivityState>()(
       stopStreaming()
     }
 
-    const eventSource = new EventSource(
-      getApiUrl(`/api/claude-sessions/${sessionId}/activity/stream`)
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    const scheduleReconnect = () => {
+      if (reconnectTimer !== null) return
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null
+        const { activeSessionId, dataSource, eventSource: current } = get()
+        if (current === eventSource && activeSessionId && dataSource === 'claude-code') {
+          get().startStreaming(activeSessionId)
+        }
+      }, 5000)
+    }
+
+    const eventSource: AuthenticatedSseClient = createAuthenticatedSseClient(
+      getApiUrl(`/api/claude-sessions/${sessionId}/activity/stream`),
+      {
+        onStatus: (status) => {
+          if (status === 'authentication-failed') {
+            set({ eventSource: null, error: 'Authentication required for activity stream' })
+          } else if (status === 'permission-denied') {
+            set({ eventSource: null, error: 'You do not have permission to view activity' })
+          } else if (status === 'error') {
+            // Only a transport error is reconnectable. Authentication and
+            // permission failures above are terminal for this stream.
+            scheduleReconnect()
+          }
+        },
+      },
     )
 
     // Handle initial batch of activity
@@ -207,17 +235,6 @@ export const useClaudeCodeActivityStore = create<ClaudeCodeActivityState>()(
     eventSource.addEventListener('session_completed', () => {
       // Session completed, but keep the data
       // Claude Code session completed
-    })
-
-    eventSource.addEventListener('error', (event) => {
-      console.warn('SSE connection error:', event)
-      // Attempt to reconnect after a short delay
-      setTimeout(() => {
-        const { activeSessionId, dataSource } = get()
-        if (activeSessionId && dataSource === 'claude-code') {
-          get().startStreaming(activeSessionId)
-        }
-      }, 5000)
     })
 
     set({ eventSource })
@@ -265,7 +282,10 @@ export const useClaudeCodeActivityStore = create<ClaudeCodeActivityState>()(
         rootTaskIds: state.rootTaskIds,
       }),
       onRehydrateStorage: () => (state) => {
-        if (state?.activeSessionId) {
+        const auth = useAuthStore.getState()
+        const canOpenProtectedStream =
+          auth._hasHydrated && auth.isAuthenticated() && !auth.isTokenExpired()
+        if (state?.activeSessionId && canOpenProtectedStream) {
           // Defer SSE reconnection to next tick to ensure store is fully initialized
           setTimeout(() => {
             state.startStreaming(state.activeSessionId!)
@@ -275,3 +295,25 @@ export const useClaudeCodeActivityStore = create<ClaudeCodeActivityState>()(
     },
   ),
 )
+
+// Auth and activity stores hydrate independently. If the activity store wins
+// the race, retry exactly when auth hydration completes instead of opening a
+// protected stream without validated credentials or leaving it permanently
+// disconnected.
+useAuthStore.subscribe((auth, previousAuth) => {
+  if (!previousAuth._hasHydrated && auth._hasHydrated) {
+    setTimeout(() => {
+      const activity = useClaudeCodeActivityStore.getState()
+      const currentAuth = useAuthStore.getState()
+      if (
+        activity.activeSessionId &&
+        !activity.eventSource &&
+        currentAuth._hasHydrated &&
+        currentAuth.isAuthenticated() &&
+        !currentAuth.isTokenExpired()
+      ) {
+        activity.startStreaming(activity.activeSessionId)
+      }
+    }, 0)
+  }
+})

--- a/src/dashboard/src/stores/claudeSessions/index.ts
+++ b/src/dashboard/src/stores/claudeSessions/index.ts
@@ -7,6 +7,7 @@ import {
   TranscriptResponse,
 } from '../../types/claudeSession'
 import { apiClient } from '../../services/apiClient'
+import { createAuthenticatedSseClient } from '../../services/authenticatedSse'
 import { isApiError } from '../../services/errors'
 import { getApiUrl } from '../../config/api'
 import type { ClaudeSessionsState, ProviderFilter, SortField, SortOrder } from './types'
@@ -507,8 +508,17 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
       return
     }
 
-    const eventSource = new EventSource(
+    const eventSource = createAuthenticatedSseClient(
       getApiUrl(`/api/claude-sessions/${sessionId}/stream`),
+      {
+        onStatus: (status) => {
+          if (status === 'authentication-failed') {
+            set({ eventSource: null, error: 'Authentication required for session stream' })
+          } else if (status === 'permission-denied') {
+            set({ eventSource: null, permissionDenied: true, error: 'Session access denied' })
+          }
+        },
+      },
     )
 
     eventSource.addEventListener('session_update', (event) => {

--- a/src/dashboard/src/stores/claudeSessions/types.ts
+++ b/src/dashboard/src/stores/claudeSessions/types.ts
@@ -3,6 +3,7 @@
  * `ClaudeSessionsState` 는 패키지 내부 전용이지만, 액션을 모듈로 승격할 때
  * `SetFn`/`GetFn` 타입이 이것을 참조하므로 export 한다.
  */
+import type { AuthenticatedSseClient } from '../../services/authenticatedSse'
 import type {
   ClaudeSessionDetail,
   ClaudeSessionInfo,
@@ -122,7 +123,7 @@ export interface ClaudeSessionsState {
   generateBatchSummaries: (limit?: number) => Promise<void>
 
   // SSE connection
-  eventSource: EventSource | null
+  eventSource: AuthenticatedSseClient | null
   startStreaming: (sessionId: string) => void
   stopStreaming: () => void
 }

--- a/src/dashboard/src/stores/monitoring.ts
+++ b/src/dashboard/src/stores/monitoring.ts
@@ -50,6 +50,7 @@ interface MonitoringState {
 
   // Workflow checks
   workflowChecks: WorkflowCheck[]
+  workflowProjectId: string | null
   isLoadingWorkflows: boolean
   runningWorkflowIds: Set<string>
   workflowLogs: Record<string, LogLine[]>
@@ -59,9 +60,12 @@ interface MonitoringState {
 
   // Capabilities of the active monitoring backend (filesystem or database)
   monitoringCapabilitiesMap: Record<string, MonitoringCapabilities>
+  monitoringCapabilitiesErrorMap: Record<string, string>
 
   // Error state
   error: string | null
+  contextUnavailableReason: string | null
+  contextUnavailableProjectId: string | null
 
   // Actions
   getProjectHealth: (projectId: string) => ProjectHealth | null
@@ -69,8 +73,8 @@ interface MonitoringState {
   getCheckLabel: (projectId: string, checkType: CheckType) => string
   getCheckConfig: (projectId: string) => Record<string, CheckConfigEntry> | null
   getCheckTypes: (projectId: string) => string[]
-  fetchCheckConfig: (projectId: string) => Promise<void>
-  fetchProjectHealth: (projectId: string) => Promise<void>
+  fetchCheckConfig: (projectId: string, isRequestCurrent?: () => boolean) => Promise<void>
+  fetchProjectHealth: (projectId: string, isRequestCurrent?: () => boolean) => Promise<void>
   fetchProjectContext: (projectId: string) => Promise<void>
   runCheck: (projectId: string, checkType: CheckType) => void
   runAllChecks: (projectId: string) => void
@@ -78,18 +82,52 @@ interface MonitoringState {
   setActiveContextTab: (tab: 'claude-md' | 'dev-docs' | 'session') => void
   clearLogs: (checkType?: CheckType) => void
   clearError: () => void
+  resetMonitoringSelection: () => void
   getMonitoringCapabilities: (projectId: string) => MonitoringCapabilities | null
-  fetchMonitoringCapabilities: (projectId: string) => Promise<MonitoringCapabilities | null>
+  fetchMonitoringCapabilities: (projectId: string, isRequestCurrent?: () => boolean, propagateError?: boolean) => Promise<MonitoringCapabilities | null>
 
   // Vault health actions
   getVaultHealth: (projectId: string) => VaultHealthResult | null
   parseVaultHealth: (projectId: string, stdout: string) => void
 
   // Workflow actions
-  fetchWorkflowChecks: (projectId: string) => Promise<void>
+  fetchWorkflowChecks: (projectId: string, isRequestCurrent?: () => boolean) => Promise<void>
   runWorkflowCheck: (workflowId: string) => Promise<void>
   clearWorkflowLogs: (workflowId?: string) => void
 }
+
+const invalidateProjectMonitoringState = (
+  state: MonitoringState,
+  projectId: string,
+  error: string,
+): Partial<MonitoringState> => {
+  const { [projectId]: _capabilities, ...monitoringCapabilitiesMap } = state.monitoringCapabilitiesMap
+  const { [projectId]: _health, ...projectHealthMap } = state.projectHealthMap
+  const { [projectId]: _config, ...checkConfigMap } = state.checkConfigMap
+  const { [projectId]: _running, ...runningChecksMap } = state.runningChecksMap
+  const checkLogs = Object.fromEntries(
+    Object.entries(state.checkLogs).map(([checkType, logs]) => [
+      checkType,
+      logs.filter((log) => log.projectId !== projectId),
+    ]),
+  )
+  return {
+    monitoringCapabilitiesMap,
+    projectHealthMap,
+    checkConfigMap,
+    runningChecksMap,
+    checkLogs,
+    monitoringCapabilitiesErrorMap: {
+      ...state.monitoringCapabilitiesErrorMap,
+      [projectId]: error,
+    },
+  }
+}
+
+let projectContextRequestId = 0
+const monitoringCapabilityRequests: Record<string, Promise<MonitoringCapabilities | null> | undefined> = {}
+const workflowEventSources: Record<string, ReturnType<typeof createAuthenticatedSseClient> | undefined> = {}
+let workflowRequestId = 0
 
 export const useMonitoringStore = create<MonitoringState>((set, get) => ({
   projectHealthMap: {},
@@ -102,12 +140,16 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
   activeLogView: 'all',
   activeContextTab: 'claude-md',
   workflowChecks: [],
+  workflowProjectId: null,
   isLoadingWorkflows: false,
   runningWorkflowIds: new Set(),
   workflowLogs: {},
   vaultHealthMap: {},
   monitoringCapabilitiesMap: {},
+  monitoringCapabilitiesErrorMap: {},
   error: null,
+  contextUnavailableReason: null,
+  contextUnavailableProjectId: null,
 
   getProjectHealth: (projectId: string) => {
     return get().projectHealthMap[projectId] || null
@@ -130,41 +172,120 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
     return get().checkConfigMap[projectId]?.check_types ?? []
   },
 
+  resetMonitoringSelection: () => {
+    Object.values(workflowEventSources).forEach((eventSource) => eventSource?.close())
+    for (const workflowId of Object.keys(workflowEventSources)) {
+      delete workflowEventSources[workflowId]
+    }
+    workflowRequestId += 1
+    set({
+      error: null,
+      isLoadingHealth: false,
+      workflowChecks: [],
+      workflowProjectId: null,
+      isLoadingWorkflows: false,
+      runningWorkflowIds: new Set<string>(),
+      workflowLogs: {},
+    })
+  },
+
   getMonitoringCapabilities: (projectId: string) => {
-    return get().monitoringCapabilitiesMap[projectId] ?? null
+    const capabilities = get().monitoringCapabilitiesMap[projectId]
+    return capabilities?.project_id === projectId ? capabilities : null
   },
 
-  fetchMonitoringCapabilities: async (projectId: string) => {
-    try {
-      const data = await apiClient.get<MonitoringCapabilities>(
-        `/api/projects/${projectId}/monitoring-capabilities`,
-      )
-      set((state) => ({
-        monitoringCapabilitiesMap: {
-          ...state.monitoringCapabilitiesMap,
-          [projectId]: data,
-        },
-      }))
+  fetchMonitoringCapabilities: async (projectId: string, isRequestCurrent?: () => boolean, propagateError = true) => {
+    const publishConsumerError = (data: MonitoringCapabilities | null) => {
+      if (propagateError && !data) {
+        const capabilityError = get().monitoringCapabilitiesErrorMap[projectId]
+        if (capabilityError) set({ error: capabilityError })
+      }
       return data
-    } catch (e) {
-      const errorMessage = e instanceof Error ? e.message : 'Unknown error'
-      set({ error: errorMessage })
-      return null
+    }
+
+    const existingRequest = monitoringCapabilityRequests[projectId]
+    if (existingRequest) {
+      const data = await existingRequest
+      if (isRequestCurrent && !isRequestCurrent()) return null
+      return publishConsumerError(data)
+    }
+
+    const request = (async () => {
+      try {
+        const data = await apiClient.get<MonitoringCapabilities>(
+          `/api/projects/${projectId}/monitoring-capabilities`,
+        )
+        const rawData = data as Partial<MonitoringCapabilities>
+        const validCapability = rawData.project_id === projectId &&
+          (rawData.mode === 'filesystem' || rawData.mode === 'database') &&
+          (rawData.health_config === 'available' || rawData.health_config === 'disabled') &&
+          (rawData.health === 'available' || rawData.health === 'disabled') &&
+          (rawData.checks === 'available' || rawData.checks === 'disabled')
+        if (!validCapability) {
+          const errorMessage = rawData.project_id !== projectId
+            ? 'Monitoring capabilities response did not match the requested project'
+            : 'Monitoring capabilities response was invalid'
+          set((state) => invalidateProjectMonitoringState(state, projectId, errorMessage))
+          return null
+        }
+        set((state) => {
+          const { [projectId]: _ignored, ...remainingErrors } = state.monitoringCapabilitiesErrorMap
+          return {
+            monitoringCapabilitiesMap: {
+              ...state.monitoringCapabilitiesMap,
+              [projectId]: data,
+            },
+            monitoringCapabilitiesErrorMap: remainingErrors,
+          }
+        })
+        return data
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : 'Unknown error'
+        set((state) => invalidateProjectMonitoringState(state, projectId, errorMessage))
+        return null
+      }
+    })()
+    monitoringCapabilityRequests[projectId] = request
+
+    try {
+      const data = await request
+      if (isRequestCurrent && !isRequestCurrent()) return null
+      return publishConsumerError(data)
+    } finally {
+      if (monitoringCapabilityRequests[projectId] === request) {
+        delete monitoringCapabilityRequests[projectId]
+      }
     }
   },
 
-  fetchCheckConfig: async (projectId: string) => {
-    let capabilities: MonitoringCapabilities | undefined = get().monitoringCapabilitiesMap[projectId]
+  fetchCheckConfig: async (projectId: string, isRequestCurrent?: () => boolean) => {
+    let capabilities: MonitoringCapabilities | undefined = get().getMonitoringCapabilities(projectId) ?? undefined
     if (!capabilities) {
-      capabilities = (await get().fetchMonitoringCapabilities(projectId)) ?? undefined
+      capabilities = (await get().fetchMonitoringCapabilities(projectId, isRequestCurrent)) ?? undefined
     }
+    if (isRequestCurrent && !isRequestCurrent()) return
     if (!capabilities || capabilities.health_config === 'disabled') {
-      set({ error: capabilities?.reason ?? 'Project monitoring configuration is unavailable' })
+      const errorMessage = get().monitoringCapabilitiesErrorMap[projectId] ?? capabilities?.reason ?? 'Project monitoring configuration is unavailable'
+      set((state) => {
+        const { [projectId]: _staleConfig, ...checkConfigMap } = state.checkConfigMap
+        return { checkConfigMap, error: errorMessage }
+      })
       return
     }
 
     try {
       const data = await apiClient.get<CheckConfig>(`/api/projects/${projectId}/health-config`)
+      if (isRequestCurrent && !isRequestCurrent()) return
+      if (data.project_id !== projectId) {
+        set((state) => {
+          const { [projectId]: _staleConfig, ...checkConfigMap } = state.checkConfigMap
+          return {
+            checkConfigMap,
+            error: 'Project monitoring configuration response did not match the requested project',
+          }
+        })
+        return
+      }
       set((state) => {
         // Initialize checkLogs for new check types
         const newLogs = { ...state.checkLogs }
@@ -179,24 +300,46 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
         }
       })
     } catch (e) {
-      console.warn('Failed to fetch check config:', e)
+      if (isRequestCurrent && !isRequestCurrent()) return
+      const errorMessage = e instanceof Error ? e.message : 'Unknown error'
+      set((state) => {
+        const { [projectId]: _staleConfig, ...checkConfigMap } = state.checkConfigMap
+        return { checkConfigMap, error: errorMessage }
+      })
     }
   },
 
-  fetchProjectHealth: async (projectId: string) => {
-    let capabilities: MonitoringCapabilities | undefined = get().monitoringCapabilitiesMap[projectId]
+  fetchProjectHealth: async (projectId: string, isRequestCurrent?: () => boolean) => {
+    let capabilities: MonitoringCapabilities | undefined = get().getMonitoringCapabilities(projectId) ?? undefined
     if (!capabilities) {
-      capabilities = (await get().fetchMonitoringCapabilities(projectId)) ?? undefined
+      capabilities = (await get().fetchMonitoringCapabilities(projectId, isRequestCurrent)) ?? undefined
     }
+    if (isRequestCurrent && !isRequestCurrent()) return
     if (!capabilities || capabilities.health === 'disabled') {
-      set({ isLoadingHealth: false, error: capabilities?.reason ?? 'Project health monitoring is unavailable' })
+      const errorMessage = get().monitoringCapabilitiesErrorMap[projectId] ?? capabilities?.reason ?? 'Project health monitoring is unavailable'
+      set((state) => {
+        const { [projectId]: _staleHealth, ...projectHealthMap } = state.projectHealthMap
+        return { projectHealthMap, isLoadingHealth: false, error: errorMessage }
+      })
       return
     }
 
-    set({ isLoadingHealth: true, error: null })
+    set({ isLoadingHealth: true })
 
     try {
       const data = await apiClient.get<ProjectHealth>(`/api/projects/${projectId}/health`)
+      if (isRequestCurrent && !isRequestCurrent()) return
+      if (data.project_id !== projectId) {
+        set((state) => {
+          const { [projectId]: _staleHealth, ...projectHealthMap } = state.projectHealthMap
+          return {
+            projectHealthMap,
+            error: 'Project health response did not match the requested project',
+            isLoadingHealth: false,
+          }
+        })
+        return
+      }
       set((state) => ({
         projectHealthMap: {
           ...state.projectHealthMap,
@@ -205,25 +348,73 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
         isLoadingHealth: false,
       }))
     } catch (e) {
+      if (isRequestCurrent && !isRequestCurrent()) return
       const errorMessage = e instanceof Error ? e.message : 'Unknown error'
-      set({ error: errorMessage, isLoadingHealth: false })
+      set((state) => {
+        const { [projectId]: _staleHealth, ...projectHealthMap } = state.projectHealthMap
+        return { projectHealthMap, error: errorMessage, isLoadingHealth: false }
+      })
     }
   },
 
   fetchProjectContext: async (projectId: string) => {
-    set({ isLoadingContext: true, error: null })
+    const requestId = ++projectContextRequestId
+    set({
+      projectContext: null,
+      isLoadingContext: true,
+      error: null,
+      contextUnavailableReason: null,
+      contextUnavailableProjectId: null,
+    })
+
+    let capabilities: MonitoringCapabilities | undefined = get().getMonitoringCapabilities(projectId) ?? undefined
+    if (capabilities?.project_id !== projectId) {
+      capabilities = undefined
+    }
+    if (!capabilities) {
+      capabilities = (await get().fetchMonitoringCapabilities(
+        projectId,
+        () => requestId === projectContextRequestId,
+        false,
+      )) ?? undefined
+    }
+    if (requestId !== projectContextRequestId) return
+    if (!capabilities) {
+      const capabilityError = get().monitoringCapabilitiesErrorMap[projectId]
+      set({ isLoadingContext: false, error: capabilityError ?? null })
+      return
+    }
+    if (capabilities.mode === 'database') {
+      set({
+        projectContext: null,
+        isLoadingContext: false,
+        contextUnavailableReason: capabilities.reason ?? 'Project context is unavailable in database mode',
+        contextUnavailableProjectId: projectId,
+      })
+      return
+    }
 
     try {
       const data = await apiClient.get<ProjectContext>(`/api/projects/${projectId}/context`)
-      set({ projectContext: data, isLoadingContext: false })
+      if (requestId !== projectContextRequestId) return
+      if (data.project_id !== projectId) {
+        set({
+          projectContext: null,
+          isLoadingContext: false,
+          error: 'Project context response did not match the requested project',
+        })
+        return
+      }
+      set({ projectContext: data, isLoadingContext: false, contextUnavailableReason: null, contextUnavailableProjectId: null })
     } catch (e) {
+      if (requestId !== projectContextRequestId) return
       const errorMessage = e instanceof Error ? e.message : 'Unknown error'
       set({ error: errorMessage, isLoadingContext: false })
     }
   },
 
   runCheck: (projectId: string, checkType: CheckType) => {
-    const capabilities = get().monitoringCapabilitiesMap[projectId]
+    const capabilities = get().getMonitoringCapabilities(projectId)
     if (!capabilities) {
       void get().fetchMonitoringCapabilities(projectId).then((loaded) => {
         if (loaded?.checks === 'available') get().runCheck(projectId, checkType)
@@ -435,7 +626,7 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
   },
 
   runAllChecks: (projectId: string) => {
-    const capabilities = get().monitoringCapabilitiesMap[projectId]
+    const capabilities = get().getMonitoringCapabilities(projectId)
     if (!capabilities) {
       void get().fetchMonitoringCapabilities(projectId).then((loaded) => {
         if (loaded?.checks === 'available') get().runAllChecks(projectId)
@@ -696,12 +887,39 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
 
   // ── Workflow Actions ──────────────────────────────────────
 
-  fetchWorkflowChecks: async (projectId: string) => {
-    set({ isLoadingWorkflows: true })
+  fetchWorkflowChecks: async (projectId: string, isRequestCurrent?: () => boolean) => {
+    const previousProjectId = get().workflowProjectId
+    if (previousProjectId !== null && previousProjectId !== projectId) {
+      Object.values(workflowEventSources).forEach((eventSource) => eventSource?.close())
+      for (const workflowId of Object.keys(workflowEventSources)) {
+        delete workflowEventSources[workflowId]
+      }
+    }
+    const requestId = ++workflowRequestId
+    set({
+      workflowChecks: [],
+      workflowProjectId: projectId,
+      workflowLogs: {},
+      ...(previousProjectId !== null && previousProjectId !== projectId
+        ? { runningWorkflowIds: new Set<string>() }
+        : {}),
+      isLoadingWorkflows: true,
+    })
 
     try {
-      const data = await apiClient.get<{ workflows: Record<string, unknown>[] }>(`/api/workflows?project_id=${projectId}`)
+      const data = await apiClient.get<{ workflows: Record<string, unknown>[] }>(`/api/workflows?project_id=${encodeURIComponent(projectId)}`)
+      if (requestId !== workflowRequestId || (isRequestCurrent && !isRequestCurrent())) return
       const workflows = data.workflows || []
+      // The request is project-scoped, so every workflow must carry exactly the
+      // requested id. A null project_id is a global workflow, not a match.
+      if (workflows.some((workflow) => workflow.project_id !== projectId)) {
+        set({
+          workflowChecks: [],
+          error: 'Workflow response contained a workflow from a different project',
+          isLoadingWorkflows: false,
+        })
+        return
+      }
 
       const checks: WorkflowCheck[] = workflows.map((w: Record<string, unknown>) => {
         let status: WorkflowCheckStatus = 'idle'
@@ -719,16 +937,25 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
         }
       })
 
-      set({ workflowChecks: checks, isLoadingWorkflows: false })
+      set({ workflowChecks: checks, workflowProjectId: projectId, isLoadingWorkflows: false })
     } catch (e) {
+      if (requestId !== workflowRequestId || (isRequestCurrent && !isRequestCurrent())) return
       const errorMessage = e instanceof Error ? e.message : 'Unknown error'
       set({ error: errorMessage, isLoadingWorkflows: false })
     }
   },
 
   runWorkflowCheck: async (workflowId: string) => {
-    const { runningWorkflowIds } = get()
+    const { runningWorkflowIds, workflowProjectId, workflowChecks } = get()
+    const projectId = workflowProjectId
+    const workflowGeneration = workflowRequestId
+    if (!projectId || !workflowChecks.some((workflow) => workflow.id === workflowId)) return
     if (runningWorkflowIds.has(workflowId)) return
+
+    const isCurrentWorkflow = () => {
+      const state = get()
+      return state.workflowProjectId === projectId && workflowRequestId === workflowGeneration && state.workflowChecks.some((workflow) => workflow.id === workflowId)
+    }
 
     // Mark as running
     const newRunning = new Set(runningWorkflowIds)
@@ -752,7 +979,7 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
               timestamp: new Date().toISOString(),
               text: `>>> Starting workflow: ${wc?.name || workflowId}...`,
               isStderr: false,
-              projectId: '',
+              projectId: projectId,
             },
           ],
         },
@@ -762,12 +989,42 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
     try {
       // Trigger the run
       const runData = await apiClient.post<{ id: string }>(`/api/workflows/${workflowId}/runs`, {})
+      if (!isCurrentWorkflow()) return
       const runId = runData.id
 
       // Stream logs via SSE
-      const eventSource = new EventSource(getApiUrl(`/api/workflows/runs/${runId}/stream`))
+      const finishWorkflowStream = (message: string) => {
+        if (!isCurrentWorkflow()) return
+        delete workflowEventSources[workflowId]
+        const { runningWorkflowIds: currentRunning } = get()
+        const updated = new Set(currentRunning)
+        updated.delete(workflowId)
+        set((state) => ({
+          runningWorkflowIds: updated,
+          workflowChecks: state.workflowChecks.map((wc) =>
+            wc.id === workflowId ? { ...wc, status: 'failure' as WorkflowCheckStatus } : wc
+          ),
+          error: message,
+        }))
+      }
+      const eventSource = createAuthenticatedSseClient(
+        getApiUrl(`/api/workflows/runs/${runId}/stream`),
+        {
+          onStatus: (status) => {
+            if (status === 'authentication-failed') finishWorkflowStream('Workflow stream authentication failed')
+            else if (status === 'permission-denied') finishWorkflowStream('Workflow stream permission denied')
+            else if (status === 'error') finishWorkflowStream('Workflow stream error')
+            else if (status === 'closed') finishWorkflowStream('Workflow stream ended before completion')
+          },
+        },
+      )
+      workflowEventSources[workflowId] = eventSource
 
       eventSource.addEventListener('log', (event) => {
+        if (!isCurrentWorkflow()) {
+          eventSource.close()
+          return
+        }
         const logData = JSON.parse(event.data)
         set((state) => ({
           workflowLogs: {
@@ -778,7 +1035,7 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
                 timestamp: logData.timestamp || new Date().toISOString(),
                 text: logData.message || logData.output || JSON.stringify(logData),
                 isStderr: logData.level === 'error' || logData.is_stderr === true,
-                projectId: '',
+                projectId: projectId,
               },
             ],
           },
@@ -786,6 +1043,10 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
       })
 
       eventSource.addEventListener('status', (event) => {
+        if (!isCurrentWorkflow()) {
+          eventSource.close()
+          return
+        }
         const statusData = JSON.parse(event.data)
         const statusValue = statusData.status
 
@@ -801,6 +1062,10 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
       })
 
       eventSource.addEventListener('done', (event) => {
+        if (!isCurrentWorkflow()) {
+          eventSource.close()
+          return
+        }
         const doneData = JSON.parse(event.data)
         const finalStatus: WorkflowCheckStatus =
           doneData.status === 'completed' ? 'success' : doneData.status === 'failed' ? 'failure' : 'idle'
@@ -830,16 +1095,21 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
                 timestamp: new Date().toISOString(),
                 text: `>>> Workflow ${finalStatus === 'success' ? 'completed' : 'failed'}${doneData.duration_seconds ? ` (${doneData.duration_seconds.toFixed(1)}s)` : ''}`,
                 isStderr: finalStatus === 'failure',
-                projectId: '',
+                projectId: projectId,
               },
             ],
           },
         }))
 
+        delete workflowEventSources[workflowId]
         eventSource.close()
       })
 
       eventSource.addEventListener('error', () => {
+        if (!isCurrentWorkflow()) {
+          eventSource.close()
+          return
+        }
         const { runningWorkflowIds: currentRunning } = get()
         const updated = new Set(currentRunning)
         updated.delete(workflowId)
@@ -851,9 +1121,11 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
           ),
           error: `Workflow stream error`,
         }))
+        delete workflowEventSources[workflowId]
         eventSource.close()
       })
     } catch (e) {
+      if (!isCurrentWorkflow()) return
       const { runningWorkflowIds: currentRunning } = get()
       const updated = new Set(currentRunning)
       updated.delete(workflowId)
@@ -873,7 +1145,7 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
               timestamp: new Date().toISOString(),
               text: `>>> Error: ${errorMessage}`,
               isStderr: true,
-              projectId: '',
+              projectId: projectId,
             },
           ],
         },

--- a/src/dashboard/src/stores/monitoring.ts
+++ b/src/dashboard/src/stores/monitoring.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { apiClient } from '../services/apiClient'
+import { createAuthenticatedSseClient } from '../services/authenticatedSse'
 import { getApiUrl } from '../config/api'
 import {
   CheckType,
@@ -13,6 +14,7 @@ import {
   WorkflowCheck,
   WorkflowCheckStatus,
   VaultHealthResult,
+  MonitoringCapabilities,
 } from '../types/monitoring'
 
 export interface LogLine {
@@ -55,6 +57,9 @@ interface MonitoringState {
   // Vault health (parsed from vault-health check stdout)
   vaultHealthMap: Record<string, VaultHealthResult>
 
+  // Capabilities of the active monitoring backend (filesystem or database)
+  monitoringCapabilitiesMap: Record<string, MonitoringCapabilities>
+
   // Error state
   error: string | null
 
@@ -73,6 +78,8 @@ interface MonitoringState {
   setActiveContextTab: (tab: 'claude-md' | 'dev-docs' | 'session') => void
   clearLogs: (checkType?: CheckType) => void
   clearError: () => void
+  getMonitoringCapabilities: (projectId: string) => MonitoringCapabilities | null
+  fetchMonitoringCapabilities: (projectId: string) => Promise<MonitoringCapabilities | null>
 
   // Vault health actions
   getVaultHealth: (projectId: string) => VaultHealthResult | null
@@ -99,6 +106,7 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
   runningWorkflowIds: new Set(),
   workflowLogs: {},
   vaultHealthMap: {},
+  monitoringCapabilitiesMap: {},
   error: null,
 
   getProjectHealth: (projectId: string) => {
@@ -122,7 +130,39 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
     return get().checkConfigMap[projectId]?.check_types ?? []
   },
 
+  getMonitoringCapabilities: (projectId: string) => {
+    return get().monitoringCapabilitiesMap[projectId] ?? null
+  },
+
+  fetchMonitoringCapabilities: async (projectId: string) => {
+    try {
+      const data = await apiClient.get<MonitoringCapabilities>(
+        `/api/projects/${projectId}/monitoring-capabilities`,
+      )
+      set((state) => ({
+        monitoringCapabilitiesMap: {
+          ...state.monitoringCapabilitiesMap,
+          [projectId]: data,
+        },
+      }))
+      return data
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : 'Unknown error'
+      set({ error: errorMessage })
+      return null
+    }
+  },
+
   fetchCheckConfig: async (projectId: string) => {
+    let capabilities: MonitoringCapabilities | undefined = get().monitoringCapabilitiesMap[projectId]
+    if (!capabilities) {
+      capabilities = (await get().fetchMonitoringCapabilities(projectId)) ?? undefined
+    }
+    if (!capabilities || capabilities.health_config === 'disabled') {
+      set({ error: capabilities?.reason ?? 'Project monitoring configuration is unavailable' })
+      return
+    }
+
     try {
       const data = await apiClient.get<CheckConfig>(`/api/projects/${projectId}/health-config`)
       set((state) => {
@@ -144,6 +184,15 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
   },
 
   fetchProjectHealth: async (projectId: string) => {
+    let capabilities: MonitoringCapabilities | undefined = get().monitoringCapabilitiesMap[projectId]
+    if (!capabilities) {
+      capabilities = (await get().fetchMonitoringCapabilities(projectId)) ?? undefined
+    }
+    if (!capabilities || capabilities.health === 'disabled') {
+      set({ isLoadingHealth: false, error: capabilities?.reason ?? 'Project health monitoring is unavailable' })
+      return
+    }
+
     set({ isLoadingHealth: true, error: null })
 
     try {
@@ -174,6 +223,18 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
   },
 
   runCheck: (projectId: string, checkType: CheckType) => {
+    const capabilities = get().monitoringCapabilitiesMap[projectId]
+    if (!capabilities) {
+      void get().fetchMonitoringCapabilities(projectId).then((loaded) => {
+        if (loaded?.checks === 'available') get().runCheck(projectId, checkType)
+      })
+      return
+    }
+    if (capabilities.checks === 'disabled') {
+      set({ error: capabilities.reason ?? 'Project checks are unavailable' })
+      return
+    }
+
     const { runningChecksMap } = get()
     const runningChecks = runningChecksMap[projectId] || new Set()
 
@@ -193,8 +254,27 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
     }))
 
     // Start SSE connection
-    const eventSource = new EventSource(
+    const eventSource = createAuthenticatedSseClient(
       `${getApiUrl('/api')}/projects/${projectId}/checks/${checkType}`,
+      {
+        onStatus: (status) => {
+          if (status === 'authentication-failed') {
+            set({ error: 'Authentication required for project checks' })
+          } else if (status === 'permission-denied') {
+            set({ error: 'You do not have permission to run project checks' })
+          } else if (status === 'error') {
+            set({ error: `Check ${checkType} failed` })
+          }
+          if (status !== 'closed') {
+            const currentRunning = get().runningChecksMap[projectId] || new Set()
+            const newRunning = new Set(currentRunning)
+            newRunning.delete(checkType)
+            set((state) => ({
+              runningChecksMap: { ...state.runningChecksMap, [projectId]: newRunning },
+            }))
+          }
+        },
+      },
     )
 
     eventSource.addEventListener('check_started', (event) => {
@@ -355,6 +435,18 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
   },
 
   runAllChecks: (projectId: string) => {
+    const capabilities = get().monitoringCapabilitiesMap[projectId]
+    if (!capabilities) {
+      void get().fetchMonitoringCapabilities(projectId).then((loaded) => {
+        if (loaded?.checks === 'available') get().runAllChecks(projectId)
+      })
+      return
+    }
+    if (capabilities.checks === 'disabled') {
+      set({ error: capabilities.reason ?? 'Project checks are unavailable' })
+      return
+    }
+
     const { runningChecksMap } = get()
     const runningChecks = runningChecksMap[projectId] || new Set()
 
@@ -364,8 +456,27 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
     }
 
     // Start SSE connection for all checks
-    const eventSource = new EventSource(
+    const eventSource = createAuthenticatedSseClient(
       `${getApiUrl('/api')}/projects/${projectId}/checks/run-all`,
+      {
+        onStatus: (status) => {
+          if (status === 'authentication-failed') {
+            set({ error: 'Authentication required for project checks' })
+          } else if (status === 'permission-denied') {
+            set({ error: 'You do not have permission to run project checks' })
+          } else if (status === 'error') {
+            set({ error: 'Failed to run checks' })
+          }
+          if (status !== 'closed') {
+            set((state) => ({
+              runningChecksMap: {
+                ...state.runningChecksMap,
+                [projectId]: new Set(),
+              },
+            }))
+          }
+        },
+      },
     )
 
     eventSource.addEventListener('check_started', (event) => {

--- a/src/dashboard/src/stores/projectConfigs/projects.ts
+++ b/src/dashboard/src/stores/projectConfigs/projects.ts
@@ -1,6 +1,7 @@
 /** 프로젝트 목록·선택·전역 설정·SSE 스트리밍·탭/에러 등 스토어 전반의 액션. */
 import { apiClient } from '../../services/apiClient'
 import { getApiUrl } from '../../config/api'
+import { createAuthenticatedSseClient } from '../../services/authenticatedSse'
 import type { ConfigChangeEvent, GlobalConfigSummary, ProjectConfigSummary, ProjectConfigsState, ProjectInfo, TabType } from './types'
 
 /** `git/` 도메인 모듈과 같은 형태. set/get 을 명시 인자로 받는다. */
@@ -112,7 +113,30 @@ export function startStreaming(set: SetFn, get: GetFn) {
     stopStreaming()
   }
 
-  const eventSource = new EventSource(getApiUrl('/api/project-configs/stream'))
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  const scheduleReconnect = () => {
+    if (reconnectTimer !== null) return
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      if (get().eventSource === eventSource) {
+        get().startStreaming()
+      }
+    }, 5000)
+  }
+
+  const eventSource = createAuthenticatedSseClient(getApiUrl('/api/project-configs/stream'), {
+    onStatus: (status) => {
+      if (status === 'authentication-failed') {
+        set({ eventSource: null, error: 'Authentication required for config stream' })
+      } else if (status === 'permission-denied') {
+        set({ eventSource: null, error: 'You do not have permission to view config changes' })
+      } else if (status === 'error') {
+        // The authenticated client owns transport status. Do not also use a
+        // legacy EventSource error listener, which would schedule duplicates.
+        scheduleReconnect()
+      }
+    },
+  })
 
   eventSource.addEventListener('config_change', (event) => {
     try {
@@ -135,15 +159,6 @@ export function startStreaming(set: SetFn, get: GetFn) {
 
   eventSource.addEventListener('connected', () => {
     // Connected to config stream
-  })
-
-  eventSource.addEventListener('error', () => {
-    console.warn('Config stream error, will reconnect...')
-    stopStreaming()
-    // Auto-reconnect after 5 seconds
-    setTimeout(() => {
-      get().startStreaming()
-    }, 5000)
   })
 
   set({ eventSource })

--- a/src/dashboard/src/stores/projectConfigs/projects.ts
+++ b/src/dashboard/src/stores/projectConfigs/projects.ts
@@ -36,16 +36,23 @@ export function selectProject(set: SetFn, get: GetFn, projectId: string | null) 
   }
 }
 
-export async function fetchProjectSummary(set: SetFn, _get: GetFn, projectId: string) {
+export async function fetchProjectSummary(set: SetFn, get: GetFn, projectId: string) {
+  const initialSelection = get().selectedProjectId
+  if (initialSelection && initialSelection !== projectId) return
   set({ isLoadingProject: true, error: null })
 
   try {
     const data = await apiClient.get<ProjectConfigSummary>(`/api/project-configs/${projectId}`)
+    const currentSelection = get().selectedProjectId
+    if (currentSelection && currentSelection !== projectId) return
+    if (data.project?.project_id && data.project.project_id !== projectId) return
     set({
       selectedProject: data,
       isLoadingProject: false,
     })
   } catch (e) {
+    const currentSelection = get().selectedProjectId
+    if (currentSelection && currentSelection !== projectId) return
     const errorMessage = e instanceof Error ? e.message : 'Unknown error'
     set({ error: errorMessage, isLoadingProject: false })
   }

--- a/src/dashboard/src/stores/projectConfigs/types.ts
+++ b/src/dashboard/src/stores/projectConfigs/types.ts
@@ -3,6 +3,8 @@
  * `ProjectConfigsState` 는 패키지 내부 전용이지만, 액션을 모듈로 승격할 때(Task 8)
  * 각 도메인 모듈이 `SetFn`/`GetFn` 대신 이것을 직접 참조하므로 export 한다.
  */
+import type { AuthenticatedSseClient } from '../../services/authenticatedSse'
+
 export interface ProjectInfo {
   project_id: string
   project_name: string
@@ -191,7 +193,7 @@ export interface ProjectConfigsState {
   externalPaths: string[]
 
   // Real-time updates
-  eventSource: EventSource | null
+  eventSource: AuthenticatedSseClient | null
   recentChanges: ConfigChangeEvent[]
 
   // Skill content

--- a/src/dashboard/src/stores/workflows.ts
+++ b/src/dashboard/src/stores/workflows.ts
@@ -13,6 +13,8 @@ import type {
 
 import { apiClient } from '../services/apiClient'
 import { getApiUrl } from '../config/api'
+import { createAuthenticatedSseClient } from '../services/authenticatedSse'
+import type { AuthenticatedSseClient } from '../services/authenticatedSse'
 
 interface WorkflowState {
   // Data
@@ -75,7 +77,12 @@ interface WorkflowState {
   setShowTemplateGallery: (show: boolean) => void
 }
 
-let currentEventSource: EventSource | null = null
+let currentSseClient: AuthenticatedSseClient | null = null
+/**
+ * Monotonic id for the active log stream. Every handler checks it before
+ * touching the store so a superseded stream can never revive stale state.
+ */
+let streamGeneration = 0
 
 export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   workflows: [],
@@ -99,7 +106,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   fetchWorkflows: async (projectId?: string) => {
     set({ isLoading: true, error: null })
     try {
-      const params = projectId ? `?project_id=${projectId}` : ''
+      const params = projectId ? `?project_id=${encodeURIComponent(projectId)}` : ''
       const data = await apiClient.get<{ workflows: Workflow[] }>(`/api/workflows${params}`)
       set({ workflows: data.workflows, isLoading: false })
     } catch (e) {
@@ -207,52 +214,104 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   },
 
   streamRunLogs: (runId: string) => {
-    // Close existing stream
-    if (currentEventSource) {
-      currentEventSource.close()
-      currentEventSource = null
+    // Close any existing stream and invalidate its in-flight handlers.
+    if (currentSseClient) {
+      currentSseClient.close()
+      currentSseClient = null
     }
 
-    const eventSource = new EventSource(getApiUrl(`/api/workflows/runs/${runId}/stream`))
-    currentEventSource = eventSource
+    const generation = ++streamGeneration
+    const isCurrent = () => streamGeneration === generation
 
-    eventSource.addEventListener('log', (event) => {
-      const log = JSON.parse(event.data)
+    // Drop logs from a previous attempt at this run so a re-stream cannot
+    // append onto stale output.
+    set(state => ({ runLogs: { ...state.runLogs, [runId]: [] }, error: null }))
+
+    const detach = () => {
+      if (!isCurrent()) return
+      currentSseClient = null
+    }
+
+    /** Terminal, non-success end of the stream. */
+    const failStream = (message: string) => {
+      if (!isCurrent()) return
+      detach()
+      set({ error: message, isRunning: false })
+    }
+
+    const parse = (event: MessageEvent<string>): Record<string, unknown> | null => {
+      try {
+        return JSON.parse(event.data)
+      } catch {
+        return null
+      }
+    }
+
+    const client = createAuthenticatedSseClient(
+      getApiUrl(`/api/workflows/runs/${encodeURIComponent(runId)}/stream`),
+      {
+        onStatus: (status) => {
+          if (status === 'authentication-failed') failStream('Workflow log stream authentication failed')
+          else if (status === 'permission-denied') failStream('Workflow log stream permission denied')
+          else if (status === 'error') failStream('Workflow log stream error')
+          // A clean EOF after `done` is suppressed by close() below, so a
+          // surviving 'closed' means the stream ended before completing.
+          else if (status === 'closed') failStream('Workflow log stream ended before completion')
+        },
+      },
+    )
+    currentSseClient = client
+
+    client.addEventListener('log', (event) => {
+      if (!isCurrent()) {
+        client.close()
+        return
+      }
+      const log = parse(event)
+      if (!log) return
       set(state => ({
         runLogs: {
           ...state.runLogs,
-          [runId]: [...(state.runLogs[runId] || []), log],
+          [runId]: [...(state.runLogs[runId] || []), log as unknown as WorkflowLog],
         },
       }))
     })
 
-    eventSource.addEventListener('status', (event) => {
-      const { status } = JSON.parse(event.data)
+    client.addEventListener('status', (event) => {
+      if (!isCurrent()) {
+        client.close()
+        return
+      }
+      const data = parse(event)
+      if (!data) return
+      const status = data.status
       set(state => {
         if (state.activeRun && state.activeRun.id === runId) {
-          return { activeRun: { ...state.activeRun, status } }
+          return { activeRun: { ...state.activeRun, status: status as WorkflowRun['status'] } }
         }
         return {}
       })
     })
 
-    eventSource.addEventListener('done', (event) => {
-      const run = JSON.parse(event.data)
-      set({ activeRun: run })
-      eventSource.close()
-      currentEventSource = null
+    client.addEventListener('done', (event) => {
+      if (!isCurrent()) {
+        client.close()
+        return
+      }
+      const run = parse(event)
+      // close() before the transport reaches EOF, so the terminal 'closed'
+      // status is suppressed and a completed run reports no error.
+      client.close()
+      detach()
+      if (run) set({ activeRun: run as unknown as WorkflowRun, isRunning: false })
     })
-
-    eventSource.onerror = () => {
-      eventSource.close()
-      currentEventSource = null
-    }
   },
 
   stopLogStream: () => {
-    if (currentEventSource) {
-      currentEventSource.close()
-      currentEventSource = null
+    streamGeneration += 1
+    if (currentSseClient) {
+      currentSseClient.close()
+      currentSseClient = null
     }
   },
 

--- a/src/dashboard/src/types/monitoring.ts
+++ b/src/dashboard/src/types/monitoring.ts
@@ -61,6 +61,18 @@ export interface CheckConfig {
   checks: Record<string, CheckConfigEntry>
 }
 
+export type MonitoringBackendMode = 'filesystem' | 'database'
+export type MonitoringCapability = 'available' | 'disabled'
+
+export interface MonitoringCapabilities {
+  project_id: string
+  mode: MonitoringBackendMode
+  health_config: MonitoringCapability
+  health: MonitoringCapability
+  checks: MonitoringCapability
+  reason: string | null
+}
+
 // Workflow check types for monitor integration
 export type WorkflowCheckStatus = 'idle' | 'running' | 'success' | 'failure'
 

--- a/tests/backend/api/test_monitoring_capabilities.py
+++ b/tests/backend/api/test_monitoring_capabilities.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+@pytest.mark.anyio
+async def test_monitoring_capability_is_disabled_in_database_mode(monkeypatch):
+    monkeypatch.setenv("USE_DATABASE", "true")
+
+    from api.monitoring import get_monitoring_capabilities
+
+    monkeypatch.setattr("api.monitoring.require_project_role", _allow_project_role)
+
+    result = await get_monitoring_capabilities("project-1", current_user=object(), db=object())
+
+    assert result.mode == "database"
+    assert result.health_config == "disabled"
+    assert result.health == "disabled"
+    assert result.checks == "disabled"
+
+
+async def _allow_project_role(*_args, **_kwargs):
+    return "viewer"

--- a/tests/backend/api/test_monitoring_capabilities.py
+++ b/tests/backend/api/test_monitoring_capabilities.py
@@ -1,21 +1,56 @@
+"""`monitoring-capabilities` 는 DB 장애를 조용히 'disabled' 로 덮지 않는다.
+
+DB 모드의 capability 는 이제 `ProjectModel` 조회 결과로 결정된다
+(`test_monitoring_db_health.py` 가 라우트 전체의 available/disabled 계약을 고정).
+그래서 이 파일은 남은 한 가지 위험만 본다: **조회가 실패했을 때**.
+
+조회 실패를 `disabled` 로 보고하면 화면에는 "이 프로젝트는 헬스 기능이 없다"
+라는 영구 상태처럼 보인다 — 실제로는 일시 장애다. 진단이 엉뚱한 곳을 향하게
+되므로 503 으로 드러내야 한다.
+"""
+
 import pytest
-
-
-@pytest.mark.anyio
-async def test_monitoring_capability_is_disabled_in_database_mode(monkeypatch):
-    monkeypatch.setenv("USE_DATABASE", "true")
-
-    from api.monitoring import get_monitoring_capabilities
-
-    monkeypatch.setattr("api.monitoring.require_project_role", _allow_project_role)
-
-    result = await get_monitoring_capabilities("project-1", current_user=object(), db=object())
-
-    assert result.mode == "database"
-    assert result.health_config == "disabled"
-    assert result.health == "disabled"
-    assert result.checks == "disabled"
+from fastapi import HTTPException
 
 
 async def _allow_project_role(*_args, **_kwargs):
     return "viewer"
+
+
+class _BrokenDatabase:
+    async def execute(self, *_args, **_kwargs):
+        raise RuntimeError("database connection lost")
+
+
+@pytest.mark.asyncio
+async def test_capabilities_surface_database_failure_as_unavailable(monkeypatch):
+    monkeypatch.setenv("USE_DATABASE", "true")
+    monkeypatch.setattr("api.monitoring.require_project_role", _allow_project_role)
+
+    from api.monitoring import get_monitoring_capabilities
+
+    with pytest.raises(HTTPException) as excinfo:
+        await get_monitoring_capabilities(
+            "3f9c1b74-6d20-4a8e-9c31-5b7e0d2a8f61",
+            current_user=object(),
+            db=_BrokenDatabase(),
+        )
+
+    assert excinfo.value.status_code == 503
+    assert "temporarily unavailable" in excinfo.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_filesystem_mode_capabilities_do_not_touch_the_database(monkeypatch):
+    """파일시스템 모드는 DB 를 보지 않는다 — 새 실패 모드를 만들지 않았다."""
+    monkeypatch.setenv("USE_DATABASE", "false")
+    monkeypatch.setattr("api.monitoring.require_project_role", _allow_project_role)
+
+    from api.monitoring import get_monitoring_capabilities
+
+    result = await get_monitoring_capabilities(
+        "fs-project", current_user=object(), db=_BrokenDatabase()
+    )
+
+    assert result.mode == "filesystem"
+    assert result.health == "available"

--- a/tests/backend/api/test_monitoring_db_health.py
+++ b/tests/backend/api/test_monitoring_db_health.py
@@ -1,0 +1,422 @@
+"""DB 모드에서 프로젝트 헬스 모니터링이 실제로 동작해야 한다.
+
+`#328` 이후 DB 모드의 `/health-config`·`/health`·`/checks/*` 는
+`reject_legacy_project_operation_in_database_mode()` 로 통째로 503 이었다.
+그 게이트는 레거시 파일시스템 레지스트리(`models.project.get_project`)가
+DB 모드의 인가 경계 밖에 있기 때문에 옳았지만, 대신 Monitor 화면 전체가
+"Project health checks are unavailable in database mode" 로 죽었다.
+
+여기서 고정하는 계약:
+
+  1. **공개 신원은 `ProjectModel.id`** — 응답의 `project_id` 는 요청한 정규
+     id 와 같아야 한다. 대시보드가 그 값으로 다음 요청을 만든다.
+  2. **검사 대상 경로는 DB 행의 `path` 하나뿐** — 경로 파생 id 나 임의 경로가
+     권위가 되지 않는다. 레거시 레지스트리(`get_project`)는 DB 모드에서 절대
+     호출되지 않는다.
+  3. **인가가 파일시스템 접근보다 먼저** — 401/403/404 는 그대로, 503 은 진짜
+     사용 불가한 DB 의존성에만.
+
+라우트 전체(프레임워크 배선 포함)를 지나가게 한다 — 핸들러 직접 호출은
+`Depends(get_current_user)` 와 경로 파라미터 추출을 건너뛰어 이 계약을 검증하지
+못한다.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+DB_UUID = "3f9c1b74-6d20-4a8e-9c31-5b7e0d2a8f61"
+UNREGISTERED_UUID = "00000000-0000-4000-8000-000000000000"
+
+
+def _make_project_tree(root):
+    """`.aos-project.json` 으로 커스텀 체크 1개를 선언한 최소 프로젝트.
+
+    기본 프리셋(test/lint/typecheck/build)과 다른 체크 id 를 쓰는 것이 핵심이다
+    — 응답에 `probe` 가 있으면 **이 경로를 실제로 읽었다**는 증거가 된다.
+    """
+    root.mkdir(parents=True)
+    (root / ".aos-project.json").write_text(
+        json.dumps({"health_checks": {"probe": {"label": "Probe", "command": ["echo", "ok"]}}}),
+        encoding="utf-8",
+    )
+    return root
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return SimpleNamespace(all=lambda: list(self._rows))
+
+    def all(self):
+        return [(r.id, r.path, r.organization_id) for r in self._rows]
+
+
+class _IdAwareDatabase:
+    """등록된 행의 id 가 쿼리에 바인딩됐을 때만 그 행을 돌려주는 세션 스텁.
+
+    id 를 무시하고 항상 행을 돌려주는 스텁이면 "미등록 id → 404" 테스트가
+    스텁의 고장으로도 통과한다(거짓 초록). 반대로 항상 빈 결과를 돌려주는
+    스텁이면 성공 케이스가 깨진다 — 두 케이스를 같은 스텁으로 짝지어 두면
+    스텁 자체가 검증된다.
+    """
+
+    def __init__(self, row):
+        self.row = row
+
+    async def execute(self, statement, *_args, **_kwargs):
+        try:
+            bound = {str(value) for value in statement.compile().params.values()}
+        except Exception:  # pragma: no cover - 방어적
+            bound = set()
+        if str(self.row.id) in bound:
+            return _Result([self.row])
+        return _Result([])
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+def _row(path):
+    return SimpleNamespace(
+        id=DB_UUID,
+        name="Agent-System",
+        slug="agent-system",
+        description="",
+        path=path,
+        is_active=True,
+        settings={},
+        organization_id=None,
+        created_by=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+
+def _install_db(app, monkeypatch, row):
+    from api.deps import get_db_session
+
+    database = _IdAwareDatabase(row)
+
+    async def _override():
+        yield database
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    app.dependency_overrides[get_db_session] = _override
+    return database
+
+
+@pytest_asyncio.fixture
+async def db_mode_app(authenticated_app, tmp_path, monkeypatch):
+    """DB 에 경로를 가진 프로젝트 1건만 등록된 DB 모드 앱 (관리자 신원)."""
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+
+    # 레거시 레지스트리는 DB 모드에서 호출되면 안 된다 — 호출되면 즉시 터진다.
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("legacy filesystem project registry must not be used in DB mode")
+
+    monkeypatch.setattr("api.monitoring.get_project", _forbidden)
+
+    from api.deps import get_db_session
+
+    yield authenticated_app, str(project_path)
+    authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+async def _get(app, url):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get(url)
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. 인가된 DB 모드 성공 경로
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_capabilities_are_available_for_registered_db_project(db_mode_app):
+    """등록된 DB 프로젝트는 DB 모드에서도 헬스 기능을 쓸 수 있다고 보고한다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/monitoring-capabilities")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["project_id"] == DB_UUID
+    assert body["mode"] == "database"
+    assert body["health_config"] == "available"
+    assert body["health"] == "available"
+    assert body["checks"] == "available"
+
+
+@pytest.mark.asyncio
+async def test_health_config_reads_the_registered_db_path(db_mode_app):
+    """설정은 **DB 행의 경로**에서 읽는다 — `probe` 는 그 경로의 파일에만 있다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/health-config")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["project_id"] == DB_UUID
+    assert body["check_types"] == ["probe"]
+    assert body["checks"]["probe"]["label"] == "Probe"
+
+
+@pytest.mark.asyncio
+async def test_health_reports_canonical_identity_and_registered_path(db_mode_app):
+    app, project_path = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/health")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["project_id"] == DB_UUID
+    assert body["project_name"] == "Agent-System"
+    assert body["project_path"] == project_path
+    assert set(body["checks"]) == {"probe"}
+    assert body["checks"]["probe"]["project_id"] == DB_UUID
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. 인증·인가
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_request_is_rejected(app, tmp_path, monkeypatch):
+    """토큰 없는 요청은 401 — DB 모드에서도 그대로다."""
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+    from api.deps import get_db_session
+
+    try:
+        for url in (
+            f"/api/projects/{DB_UUID}/monitoring-capabilities",
+            f"/api/projects/{DB_UUID}/health-config",
+            f"/api/projects/{DB_UUID}/health",
+        ):
+            response = await _get(app, url)
+            assert response.status_code == 401, f"{url} -> {response.status_code}"
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_denied_project_access_is_forbidden(app, tmp_path, monkeypatch):
+    """프로젝트 권한이 없는 인증 사용자는 403 — 파일시스템에 닿기 전에 막힌다."""
+    from api.deps import get_current_user, get_db_session
+    from services.project_access_service import ProjectAccessService
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="outsider", role="user", is_admin=False, is_active=True
+    )
+
+    async def _has_acl(*_args, **_kwargs):
+        return True
+
+    async def _no_access(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", _has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", _no_access)
+
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("filesystem inspection must not run before authorization")
+
+    monkeypatch.setattr("api.monitoring.get_check_config", _forbidden)
+
+    try:
+        response = await _get(app, f"/api/projects/{DB_UUID}/health-config")
+        assert response.status_code == 403, response.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_viewer_cannot_execute_checks(app, tmp_path, monkeypatch):
+    """읽기는 viewer, 실행은 editor — DB 모드에서도 등급이 유지된다."""
+    from api.deps import get_current_user, get_db_session
+    from services.project_access_service import ProjectAccessService
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="reader", role="user", is_admin=False, is_active=True
+    )
+
+    async def _has_acl(*_args, **_kwargs):
+        return True
+
+    async def _viewer(*_args, **_kwargs):
+        return "viewer"
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", _has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", _viewer)
+
+    try:
+        readable = await _get(app, f"/api/projects/{DB_UUID}/health-config")
+        assert readable.status_code == 200, readable.text
+
+        response = await _get(app, f"/api/projects/{DB_UUID}/checks/probe")
+        assert response.status_code == 403, response.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. 신원 — 미등록·오형식·레거시 폴백 금지
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unregistered_canonical_id_is_not_found(db_mode_app):
+    """DB 에 없는 UUID 는 404 (같은 스텁이 위 테스트에서 200 을 낸다)."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/projects/{UNREGISTERED_UUID}/health-config")
+
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_path_derived_id_is_not_authority_in_database_mode(db_mode_app):
+    """경로 파생 id 로는 닿지 못한다 — 레거시 파일시스템 폴백이 없다."""
+    app, project_path = db_mode_app
+    leaked_id = project_path.replace("/", "-")
+
+    response = await _get(app, f"/api/projects/{leaked_id}/health")
+
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_blank_identity_is_rejected(db_mode_app):
+    """공백 식별자는 400 — 빈 문자열이 필터를 넓히지 못하게 한다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, "/api/projects/%20/health-config")
+
+    assert response.status_code == 400, response.text
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. 503 은 진짜 사용 불가한 의존성에만 — 두 원인을 분리해 검증
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_db_project_without_path_stays_fail_closed(authenticated_app, monkeypatch):
+    """경로 없는 DB 프로젝트는 disabled 로 보고되고 읽기는 503 이다."""
+    from api.deps import get_db_session
+
+    _install_db(authenticated_app, monkeypatch, _row(None))
+    try:
+        capabilities = await _get(
+            authenticated_app, f"/api/projects/{DB_UUID}/monitoring-capabilities"
+        )
+        assert capabilities.status_code == 200, capabilities.text
+        body = capabilities.json()
+        assert body["mode"] == "database"
+        assert body["health_config"] == "disabled"
+        assert body["health"] == "disabled"
+        assert body["checks"] == "disabled"
+        assert body["reason"]
+
+        config = await _get(authenticated_app, f"/api/projects/{DB_UUID}/health-config")
+        assert config.status_code == 503, config.text
+        assert "path" in config.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_database_failure_is_reported_as_unavailable(authenticated_app, tmp_path, monkeypatch):
+    """DB 조회 자체가 실패하면 503 — 위의 '경로 없음' 503 과 detail 이 다르다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    database = _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+
+    calls = {"n": 0}
+    original = database.execute
+
+    async def _fail_after_authorization(statement, *args, **kwargs):
+        calls["n"] += 1
+        # 1번째는 `require_project_role` 의 등록 확인 — 통과시킨다.
+        if calls["n"] == 1:
+            return await original(statement, *args, **kwargs)
+        raise RuntimeError("database connection lost")
+
+    monkeypatch.setattr(database, "execute", _fail_after_authorization)
+
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/health-config")
+        assert response.status_code == 503, response.text
+        assert "temporarily unavailable" in response.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 5. 파일시스템 모드는 그대로
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filesystem_mode_still_uses_the_legacy_registry(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """파일시스템 모드는 레거시 레지스트리와 경로 파생 id 를 그대로 쓴다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "fs-project")
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+    monkeypatch.setattr(
+        "api.monitoring.get_project",
+        lambda pid: SimpleNamespace(name="fs-project", path=str(project_path))
+        if pid == "fs-project"
+        else None,
+    )
+
+    async def _override():
+        yield SimpleNamespace()
+
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    try:
+        capabilities = await _get(
+            authenticated_app, "/api/projects/fs-project/monitoring-capabilities"
+        )
+        assert capabilities.status_code == 200, capabilities.text
+        assert capabilities.json()["mode"] == "filesystem"
+        assert capabilities.json()["health"] == "available"
+
+        config = await _get(authenticated_app, "/api/projects/fs-project/health-config")
+        assert config.status_code == 200, config.text
+        assert config.json()["check_types"] == ["probe"]
+
+        missing = await _get(authenticated_app, "/api/projects/nope/health-config")
+        assert missing.status_code == 404, missing.text
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)

--- a/tests/backend/api/test_project_config_db_identity.py
+++ b/tests/backend/api/test_project_config_db_identity.py
@@ -1,0 +1,221 @@
+"""DB 모드에서 project-config 표면의 공개 id 는 `ProjectModel.id` 여야 한다.
+
+DB 모드의 프로젝트 권위는 `ProjectModel` 이다 — `/api/projects`·세션 리졸버·
+`deps.require_project_role`·`api/git/_shared.resolve_project` 가 전부 UUID 를
+키로 쓴다. 그런데 `/api/project-configs` 만 `ProjectConfigMonitor` 의 경로 파생
+id(`-Users-me-Work-Proj`)를 그대로 내보냈다. 대시보드는 목록에서 받은
+`project_id` 를 그대로 자식 라우트에 보내므로(`stores/projectConfigs/projects.ts`)
+두 표면의 id 어휘가 갈리면 같은 프로젝트가 화면마다 다른 키를 갖는다.
+
+여기서 고정하는 계약은 둘이다:
+
+  1. **바깥으로 나가는 id 는 정규 DB id** — 목록·요약 모두. 경로 파생 id 를
+     공개 신원으로 내보내지 않는다.
+  2. **안에서는 해석한다** — 정규 id 로 들어온 자식 라우트가 등록된 경로의
+     모니터 식별자로 해석돼야 한다. 해석이 없으면 대시보드가 방금 받은 id 로
+     보낸 첫 요청이 404 가 된다.
+
+파일시스템 모드의 경로 파생 id 는 그대로 유지된다(같은 파일 마지막 테스트).
+
+라우트 전체(프레임워크 배선 포함)를 지나가게 한다 — 핸들러 직접 호출은
+라우터 소유 의존성(`require_project_config_access`)을 건너뛰어 이 계약을
+전혀 검증하지 못한다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+DB_UUID = "7f2a1c30-9b4e-4d51-8a17-2c6f0e3b9d44"
+
+
+def _make_project_tree(root):
+    """`.claude/skills/demo/SKILL.md` 하나를 가진 최소 프로젝트."""
+    skill_dir = root / ".claude" / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: demo skill\n---\n\n# Demo\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture
+def isolated_monitor(monkeypatch, tmp_path):
+    """자동 탐색이 꺼진 전용 모니터를 전역 싱글턴 자리에 꽂는다.
+
+    `get_project_config_monitor` 는 여러 모듈이 `from ... import` 로 복사해 갔다.
+    정의 모듈의 싱글턴(`_monitor`)을 갈아끼우면 복사본 전부가 이 인스턴스를
+    돌려준다 — 임포트한 모듈마다 patch 할 필요가 없다.
+    """
+    from services.project_config_monitor import ProjectConfigMonitor
+
+    monitor = ProjectConfigMonitor(
+        project_paths=[],
+        include_current=False,
+        include_env_paths=False,
+        allow_auto_discovery=False,
+    )
+    monkeypatch.setattr("services.project_config_monitor._monitor", monitor)
+    return monitor
+
+
+def _database_stub(row):
+    """`ProjectModel` 행 하나만 돌려주는 세션 스텁."""
+
+    class Result:
+        def scalar_one_or_none(self):
+            return row
+
+        def scalars(self):
+            return SimpleNamespace(all=lambda: [row])
+
+        def all(self):
+            return [(row.id, row.path, row.organization_id)]
+
+    class Database:
+        async def execute(self, *_args, **_kwargs):
+            return Result()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    return Database
+
+
+@pytest_asyncio.fixture
+async def db_mode_app(authenticated_app, tmp_path, monkeypatch, isolated_monitor):
+    """DB 에 UUID id 프로젝트 1건만 등록된 상태의 앱.
+
+    `tmp_path` 는 macOS 에서 `/var/folders/...`(→ `/private/var/...`) 심링크다.
+    모니터는 해석된 경로를 키로 쓰므로, 미해석 경로로 만든 id 는 매칭되지 않는다
+    — 이 픽스처가 그 실제 조건을 그대로 재현한다.
+    """
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+
+    row = SimpleNamespace(
+        id=DB_UUID,
+        name="Agent-System",
+        slug="agent-system",
+        description="",
+        path=str(project_path),
+        is_active=True,
+        settings={},
+        organization_id=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+    Database = _database_stub(row)
+
+    async def _override():
+        yield Database()
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    # 목록 필터(`_get_db_filtered_projects`)는 주입된 세션이 아니라 자체
+    # `async_session_factory()` 를 연다. override 만으로는 실 DB 에 붙는다.
+    monkeypatch.setattr("db.database.async_session_factory", lambda: Database())
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    yield authenticated_app, str(project_path)
+    authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+async def _get(app, url):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get(url)
+
+
+@pytest.mark.asyncio
+async def test_list_exposes_canonical_database_project_id(db_mode_app):
+    """목록의 `project_id` 는 DB id 다 — 경로 파생 id 가 아니다."""
+    app, project_path = db_mode_app
+
+    response = await _get(app, "/api/project-configs")
+
+    assert response.status_code == 200, response.text
+    projects = response.json()["projects"]
+    assert len(projects) == 1
+    assert projects[0]["project_id"] == DB_UUID
+    assert projects[0]["project_path"] == project_path
+
+
+@pytest.mark.asyncio
+async def test_summary_resolves_and_returns_canonical_project_id(db_mode_app):
+    """목록에서 받은 id 로 요약을 조회할 수 있고, 요약도 같은 id 를 돌려준다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/project-configs/{DB_UUID}")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["project"]["project_id"] == DB_UUID
+    # 요약 안의 자식 자산도 같은 어휘를 써야 한다 — 대시보드는
+    # `skill.project_id` 로 다음 요청을 만든다(`stores/projectConfigs/skills.ts`).
+    assert [skill["project_id"] for skill in body["skills"]] == [DB_UUID]
+
+
+@pytest.mark.asyncio
+async def test_child_config_route_resolves_canonical_project_id(db_mode_app):
+    """자식 설정 라우트도 정규 id 로 닿아야 한다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/project-configs/{DB_UUID}/skills")
+
+    assert response.status_code == 200, response.text
+    assert [skill["skill_id"] for skill in response.json()] == ["demo"]
+
+
+@pytest.mark.asyncio
+async def test_unregistered_path_id_is_not_reachable_in_database_mode(
+    db_mode_app, tmp_path, monkeypatch, isolated_monitor
+):
+    """DB 미등록 경로는 경로 파생 id 로도 닿지 못한다(파일시스템 폴백 금지)."""
+    app, _ = db_mode_app
+
+    outsider = _make_project_tree(tmp_path / "not-in-db")
+    isolated_monitor.add_external_project(str(outsider))
+    leaked_id = str(outsider.resolve()).replace("/", "-")
+
+    response = await _get(app, f"/api/project-configs/{leaked_id}/skills")
+
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_filesystem_mode_keeps_path_derived_ids(
+    authenticated_app, tmp_path, monkeypatch, isolated_monitor
+):
+    """파일시스템 모드의 경로 파생 id 와 동작은 그대로다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "fs-project")
+    isolated_monitor.add_external_project(str(project_path))
+    expected_id = str(project_path.resolve()).replace("/", "-")
+
+    async def _override():
+        yield SimpleNamespace()
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    try:
+        listed = await _get(authenticated_app, "/api/project-configs")
+        assert listed.status_code == 200, listed.text
+        assert [p["project_id"] for p in listed.json()["projects"]] == [expected_id]
+
+        summary = await _get(authenticated_app, f"/api/project-configs/{expected_id}")
+        assert summary.status_code == 200, summary.text
+        assert summary.json()["project"]["project_id"] == expected_id
+
+        skills = await _get(authenticated_app, f"/api/project-configs/{expected_id}/skills")
+        assert skills.status_code == 200, skills.text
+        assert [s["skill_id"] for s in skills.json()] == ["demo"]
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)

--- a/tests/backend/api/test_workflow_authz.py
+++ b/tests/backend/api/test_workflow_authz.py
@@ -1,0 +1,499 @@
+"""Authorization regression tests for the workflow-adjacent routers.
+
+Two layers on purpose:
+
+* handler-direct tests exercise the RBAC branches with a stub database, because
+  a non-privileged identity in the ASGI app would reach a real ``AsyncSession``
+  and surface as 503 rather than 403;
+* ASGI tests assert the routers are actually mounted and gated -- ``app.py``
+  imports them through ``safe_import``, which swallows ImportError, so a broken
+  import would silently remove the routes while handler tests still passed.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+ADMIN = SimpleNamespace(id="admin", role="admin", is_admin=True, is_active=True)
+MEMBER = SimpleNamespace(id="member", role="user", is_admin=False, is_active=True)
+
+
+def _stub_db():
+    return SimpleNamespace(execute=AsyncMock(side_effect=AssertionError("unexpected query")))
+
+
+# ── Router wiring: every workflow-adjacent route is authenticated ──────
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/api/workflows/runs/run-1/artifacts"),
+        ("get", "/api/workflows/artifacts/a-1"),
+        ("get", "/api/workflows/artifacts/a-1/download"),
+        ("delete", "/api/workflows/artifacts/a-1"),
+        ("get", "/api/workflows/templates"),
+        ("post", "/api/workflows/templates"),
+        ("get", "/api/workflows/templates/t-1"),
+        ("delete", "/api/workflows/templates/t-1"),
+        ("post", "/api/workflows/from-template/t-1"),
+        ("get", "/api/workflows/wf-1/webhooks"),
+        ("post", "/api/workflows/wf-1/webhooks"),
+        ("delete", "/api/workflows/wf-1/webhooks/wh-1"),
+    ],
+)
+async def test_workflow_adjacent_routes_require_authentication(client, method, path):
+    """401, not 404/422: the route exists and rejects before doing any work."""
+    response = await getattr(client, method)(path)
+    assert response.status_code == 401, f"{method.upper()} {path} -> {response.status_code}"
+
+
+@pytest.mark.anyio
+async def test_blank_project_id_query_is_rejected(client, authenticated_app):
+    """``?project_id=`` must not degrade into an unfiltered listing."""
+    response = await client.get("/api/workflows?project_id=")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid project identifier"
+
+
+@pytest.mark.anyio
+async def test_scoped_listing_still_works_for_authorized_user(client, authenticated_app):
+    """Guard against "fixed by rejecting everything"."""
+    response = await client.get("/api/workflows?project_id=some-project")
+    assert response.status_code == 200
+    assert response.json()["total"] == 0
+
+
+# ── list_workflows: the response never leaves the authorized scope ─────
+
+
+@pytest.mark.anyio
+async def test_scoped_listing_drops_global_and_foreign_workflows(monkeypatch):
+    """A scoped request must not return global (project_id=None) workflows."""
+    from api import workflows as workflows_api
+
+    async def allow(*_args, **_kwargs):
+        return None
+
+    rows = [
+        {"id": "w-mine", "project_id": "p1"},
+        {"id": "w-global", "project_id": None},
+        {"id": "w-other", "project_id": "p2"},
+    ]
+    monkeypatch.setattr(workflows_api, "authorize_workflow_project", allow)
+    monkeypatch.setattr(
+        workflows_api,
+        "get_workflow_service",
+        lambda: SimpleNamespace(list_workflows=lambda project_id=None: list(rows)),
+    )
+    monkeypatch.setattr(workflows_api, "_to_workflow_response", lambda w: w)
+
+    result = await workflows_api.list_workflows(project_id="p1", db=_stub_db(), current_user=MEMBER)
+
+    assert [w["id"] for w in result["workflows"]] == ["w-mine"]
+    assert result["total"] == 1
+
+
+@pytest.mark.anyio
+async def test_unscoped_listing_is_privileged_only():
+    """No project filter means "everything", so it stays operator-only."""
+    from api import workflows as workflows_api
+
+    with pytest.raises(HTTPException) as exc_info:
+        await workflows_api.list_workflows(project_id=None, db=_stub_db(), current_user=MEMBER)
+    assert exc_info.value.status_code == 403
+
+
+# ── update_workflow: both sides of a project move are authorized ───────
+
+
+def _patch_update_authz(monkeypatch, *, existing_project, target_allowed=True):
+    from api import workflows as workflows_api
+
+    calls: list[tuple] = []
+
+    async def fake_authorize_workflow(workflow_id, _user, _db, min_role="viewer"):
+        calls.append(("workflow", workflow_id, min_role))
+        return {"id": workflow_id, "project_id": existing_project}
+
+    async def fake_authorize_project(project_id, _user, _db, min_role="viewer"):
+        calls.append(("project", project_id, min_role))
+        if not target_allowed:
+            raise HTTPException(status_code=403, detail="Target project access denied")
+
+    monkeypatch.setattr(workflows_api, "authorize_workflow", fake_authorize_workflow)
+    monkeypatch.setattr(workflows_api, "authorize_workflow_project", fake_authorize_project)
+    return calls
+
+
+@pytest.mark.anyio
+async def test_project_move_authorizes_the_target_project(monkeypatch):
+    """Moving a workflow needs editor rights on the destination, not just the source."""
+    from api import workflows as workflows_api
+    from models.workflow import WorkflowUpdate
+
+    calls = _patch_update_authz(monkeypatch, existing_project="p1")
+    updated = {"id": "wf-1", "project_id": "p2"}
+    monkeypatch.setattr(
+        workflows_api,
+        "get_workflow_service",
+        lambda: SimpleNamespace(update_workflow=lambda *_a, **_k: updated),
+    )
+    monkeypatch.setattr(workflows_api, "_to_workflow_response", lambda w: w)
+
+    await workflows_api.update_workflow(
+        "wf-1", WorkflowUpdate(project_id="p2"), db=_stub_db(), current_user=MEMBER
+    )
+
+    assert ("workflow", "wf-1", "editor") in calls
+    assert ("project", "p2", "editor") in calls
+
+
+@pytest.mark.anyio
+async def test_project_move_to_unauthorized_target_is_denied(monkeypatch):
+    """An unauthorized destination blocks the update before it is persisted."""
+    from api import workflows as workflows_api
+    from models.workflow import WorkflowUpdate
+
+    _patch_update_authz(monkeypatch, existing_project="p1", target_allowed=False)
+
+    def must_not_run(*_args, **_kwargs):
+        raise AssertionError("update reached the service layer")
+
+    monkeypatch.setattr(
+        workflows_api,
+        "get_workflow_service",
+        lambda: SimpleNamespace(update_workflow=must_not_run),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await workflows_api.update_workflow(
+            "wf-1", WorkflowUpdate(project_id="p2"), db=_stub_db(), current_user=MEMBER
+        )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_project_move_to_global_requires_privilege(monkeypatch):
+    """``project_id: null`` is the global scope -- it must not be a free target."""
+    from api import workflows as workflows_api
+    from models.workflow import WorkflowUpdate
+
+    async def fake_authorize_workflow(workflow_id, _user, _db, min_role="viewer"):
+        return {"id": workflow_id, "project_id": "p1"}
+
+    monkeypatch.setattr(workflows_api, "authorize_workflow", fake_authorize_workflow)
+    monkeypatch.setattr(
+        workflows_api,
+        "get_workflow_service",
+        lambda: SimpleNamespace(
+            update_workflow=lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("update reached the service layer")
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await workflows_api.update_workflow(
+            "wf-1", WorkflowUpdate(project_id=None), db=_stub_db(), current_user=MEMBER
+        )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_update_without_project_change_does_not_reauthorize_target(monkeypatch):
+    """A plain rename must not demand rights it never needed."""
+    from api import workflows as workflows_api
+    from models.workflow import WorkflowUpdate
+
+    calls = _patch_update_authz(monkeypatch, existing_project="p1")
+    monkeypatch.setattr(
+        workflows_api,
+        "get_workflow_service",
+        lambda: SimpleNamespace(update_workflow=lambda *_a, **_k: {"id": "wf-1"}),
+    )
+    monkeypatch.setattr(workflows_api, "_to_workflow_response", lambda w: w)
+
+    await workflows_api.update_workflow(
+        "wf-1", WorkflowUpdate(name="renamed"), db=_stub_db(), current_user=MEMBER
+    )
+
+    assert [c[0] for c in calls] == ["workflow"]
+
+
+# ── Templates: a template is not a route into someone else's project ──
+
+
+@pytest.mark.anyio
+async def test_create_from_template_denies_unauthorized_project(monkeypatch):
+    from api import templates as templates_api
+
+    async def deny(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    monkeypatch.setattr(templates_api, "authorize_workflow_project", deny)
+    monkeypatch.setattr(
+        templates_api,
+        "get_template_service",
+        lambda: SimpleNamespace(
+            create_workflow_from_template=lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("workflow was created despite denial")
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await templates_api.create_from_template(
+            "t-1", name=None, project_id="p2", db=_stub_db(), current_user=MEMBER
+        )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_create_from_template_into_global_requires_privilege():
+    from api import templates as templates_api
+
+    with pytest.raises(HTTPException) as exc_info:
+        await templates_api.create_from_template(
+            "t-1", name=None, project_id=None, db=_stub_db(), current_user=MEMBER
+        )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_create_from_template_rejects_blank_project():
+    from api import templates as templates_api
+
+    with pytest.raises(HTTPException) as exc_info:
+        await templates_api.create_from_template(
+            "t-1", name=None, project_id="  ", db=_stub_db(), current_user=ADMIN
+        )
+    assert exc_info.value.status_code == 400
+
+
+# ── Artifacts: authorization walks run -> workflow -> project ──────────
+
+
+@pytest.mark.anyio
+async def test_artifact_listing_is_denied_without_run_access(monkeypatch):
+    from api import artifacts as artifacts_api
+
+    async def deny(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    monkeypatch.setattr(artifacts_api, "authorize_run", deny)
+    monkeypatch.setattr(
+        artifacts_api,
+        "get_artifact_service",
+        lambda: SimpleNamespace(
+            list_artifacts=lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("artifacts were read despite denial")
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await artifacts_api.list_artifacts("run-1", db=_stub_db(), current_user=MEMBER)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_artifact_download_authorizes_the_owning_run(monkeypatch):
+    from api import artifacts as artifacts_api
+
+    seen: list[tuple] = []
+
+    async def record(run_id, _user, _db, min_role="viewer"):
+        seen.append((run_id, min_role))
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    monkeypatch.setattr(artifacts_api, "authorize_run", record)
+    monkeypatch.setattr(
+        artifacts_api,
+        "get_artifact_service",
+        lambda: SimpleNamespace(
+            get_artifact=lambda _id: {"id": "a-1", "run_id": "run-9", "name": "x"},
+            get_artifact_data=lambda _id: (_ for _ in ()).throw(
+                AssertionError("artifact bytes were read despite denial")
+            ),
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await artifacts_api.download_artifact("a-1", db=_stub_db(), current_user=MEMBER)
+
+    assert exc_info.value.status_code == 403
+    assert seen == [("run-9", "viewer")]
+
+
+# ── Webhooks ──────────────────────────────────────────────────────────
+
+
+class _Request:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    async def body(self) -> bytes:
+        return self._body
+
+    async def json(self):
+        import json
+
+        return json.loads(self._body)
+
+
+@pytest.mark.anyio
+async def test_unsigned_webhook_is_rejected_without_executing(monkeypatch):
+    """The signature is the only credential, so it cannot be optional."""
+    from api import webhooks as webhooks_api
+
+    handle = AsyncMock()
+    monkeypatch.setattr(
+        webhooks_api,
+        "get_webhook_service",
+        lambda: SimpleNamespace(
+            get_webhook=lambda _id: {"id": "wh-1", "workflow_id": "wf-1"},
+            verify_signature=lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("verification ran for an unsigned request")
+            ),
+            handle_webhook=handle,
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await webhooks_api.receive_webhook(
+            "wh-1",
+            _Request(b'{"ref": "refs/heads/main"}'),
+            x_github_event="push",
+            x_hub_signature_256=None,
+        )
+
+    assert exc_info.value.status_code == 401
+    handle.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_invalid_webhook_signature_is_rejected_without_executing(monkeypatch):
+    from api import webhooks as webhooks_api
+
+    handle = AsyncMock()
+    monkeypatch.setattr(
+        webhooks_api,
+        "get_webhook_service",
+        lambda: SimpleNamespace(
+            get_webhook=lambda _id: {"id": "wh-1", "workflow_id": "wf-1"},
+            verify_signature=lambda *_a, **_k: False,
+            handle_webhook=handle,
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await webhooks_api.receive_webhook(
+            "wh-1",
+            _Request(b'{"ref": "refs/heads/main"}'),
+            x_github_event="push",
+            x_hub_signature_256="sha256=deadbeef",
+        )
+
+    assert exc_info.value.status_code == 401
+    handle.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_correctly_signed_webhook_is_executed():
+    """Guard against "fixed by rejecting everything"."""
+    import hashlib
+    import hmac
+
+    from api import webhooks as webhooks_api
+    from services.webhook_service import WebhookService
+
+    service = WebhookService()
+    webhook = service.create_webhook("wf-1")
+    body = b'{"ref": "refs/heads/main"}'
+    signature = "sha256=" + hmac.new(webhook["secret"].encode(), body, hashlib.sha256).hexdigest()
+
+    assert service.verify_signature(webhook["id"], body, signature) is True
+    # A non-ASCII header must fail verification rather than raise.
+    assert service.verify_signature(webhook["id"], body, "sha256=é") is False
+
+    triggered: list[tuple] = []
+
+    async def handle(webhook_id, event_type, payload):
+        triggered.append((webhook_id, event_type, payload))
+        return {"status": "triggered", "run_id": "r-1"}
+
+    service.handle_webhook = handle  # type: ignore[method-assign]
+    original = webhooks_api.get_webhook_service
+    webhooks_api.get_webhook_service = lambda: service  # type: ignore[assignment]
+    try:
+        result = await webhooks_api.receive_webhook(
+            webhook["id"],
+            _Request(body),
+            x_github_event="push",
+            x_hub_signature_256=signature,
+        )
+    finally:
+        webhooks_api.get_webhook_service = original  # type: ignore[assignment]
+
+    assert result["status"] == "triggered"
+    assert triggered and triggered[0][1] == "push"
+
+
+@pytest.mark.anyio
+async def test_webhook_delete_is_scoped_to_its_workflow(monkeypatch):
+    """A webhook owned by another workflow must not be deletable via this path."""
+    from api import webhooks as webhooks_api
+
+    async def allow(*_args, **_kwargs):
+        return {"id": "wf-1", "project_id": "p1"}
+
+    deleted: list[str] = []
+    monkeypatch.setattr(webhooks_api, "authorize_workflow", allow)
+    monkeypatch.setattr(
+        webhooks_api,
+        "get_webhook_service",
+        lambda: SimpleNamespace(
+            get_webhook=lambda _id: {"id": "wh-2", "workflow_id": "wf-OTHER"},
+            delete_webhook=lambda wid: deleted.append(wid) or True,
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await webhooks_api.delete_webhook("wf-1", "wh-2", db=_stub_db(), current_user=MEMBER)
+
+    assert exc_info.value.status_code == 404
+    assert deleted == []
+
+
+@pytest.mark.anyio
+async def test_webhook_management_requires_workflow_authorization(monkeypatch):
+    from api import webhooks as webhooks_api
+
+    async def deny(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    monkeypatch.setattr(webhooks_api, "authorize_workflow", deny)
+    monkeypatch.setattr(
+        webhooks_api,
+        "get_webhook_service",
+        lambda: SimpleNamespace(
+            create_webhook=lambda *_a: (_ for _ in ()).throw(
+                AssertionError("webhook created despite denial")
+            ),
+            get_webhooks_for_workflow=lambda *_a: (_ for _ in ()).throw(
+                AssertionError("webhooks listed despite denial")
+            ),
+        ),
+    )
+
+    for coro in (
+        webhooks_api.create_webhook("wf-1", db=_stub_db(), current_user=MEMBER),
+        webhooks_api.list_webhooks("wf-1", db=_stub_db(), current_user=MEMBER),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await coro
+        assert exc_info.value.status_code == 403

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -17,6 +17,18 @@ os.environ["USE_DATABASE"] = "false"
 os.environ["LLM_PROVIDER"] = "ollama"
 os.environ["OLLAMA_MODEL"] = "qwen2.5:7b"
 
+# RateLimitService is a process-global singleton keyed by client IP, and every
+# suite here shares the one TestClient IP. A request-heavy module therefore
+# drains the shared free-tier budget (60 req/min) and whichever module runs
+# next fails with 429 — an ordering-dependent break invisible in a single-file
+# run. test_playground_authorization.py already disables the middleware for
+# exactly this reason; doing it once here covers every suite.
+# Nothing loses coverage: the service itself is tested directly in
+# test_rate_limit_service.py, and the 429 asserted in
+# tests/backend/api/test_agent_registry.py comes from the independent
+# api/v1/rate_limiter.py, which does not read this flag.
+os.environ["RATE_LIMIT_ENABLED"] = "false"
+
 # Force HuggingFace offline so tests never download models (HF 429 flake
 # guard for every pytest invocation, local and CI). An unmocked model load
 # fails loudly instead of hitting the network — mark such tests

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -309,7 +309,9 @@ async def test_terminal_execution_writes_audit_event(client, app, monkeypatch):
     app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
         id="operator-user", role="admin", is_admin=True, is_active=True
     )
-    monkeypatch.setattr("api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp"))
+    monkeypatch.setattr(
+        "api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
+    )
     monkeypatch.setattr("api.terminal.get_terminal_service", lambda: Service())
     try:
         response = await client.post(
@@ -337,6 +339,7 @@ async def test_project_config_lookup_fails_closed_on_database_error(monkeypatch)
     from api.project_configs.core import list_projects
 
     monkeypatch.setenv("USE_DATABASE", "true")
+
     async def broken_lookup(*_args, **_kwargs):
         raise RuntimeError("database unavailable")
 
@@ -390,9 +393,7 @@ async def test_terminal_audit_redacts_adapter_error(monkeypatch):
     from api.terminal import TerminalExecuteRequest, _log_terminal_execution
     from services.audit_service import _audit_logs
 
-    request = TerminalExecuteRequest(
-        terminal="orca", project_id="project", command="echo secret"
-    )
+    request = TerminalExecuteRequest(terminal="orca", project_id="project", command="echo secret")
     before = len(_audit_logs)
     _log_terminal_execution(
         request,
@@ -415,7 +416,9 @@ async def test_terminal_resolution_failure_is_audited(client, app, monkeypatch):
     app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
         id="operator", role="admin", is_admin=True, is_active=True
     )
-    monkeypatch.setattr("api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp"))
+    monkeypatch.setattr(
+        "api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
+    )
     monkeypatch.setattr(
         "api.terminal.get_terminal_service",
         lambda: (_ for _ in ()).throw(RuntimeError("secret adapter details")),
@@ -457,7 +460,9 @@ async def test_terminal_malformed_result_is_audited(client, app, monkeypatch):
     app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
         id="operator", role="admin", is_admin=True, is_active=True
     )
-    monkeypatch.setattr("api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp"))
+    monkeypatch.setattr(
+        "api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
+    )
     monkeypatch.setattr("api.terminal.get_terminal_service", lambda: Service())
     before = len(_audit_logs)
     try:
@@ -518,9 +523,7 @@ async def test_project_config_query_project_id_cannot_bypass_global_guard(client
         id="regular", role="user", is_admin=False, is_active=True
     )
     try:
-        response = await client.get(
-            "/api/project-configs/paths?project_id=authorized-project"
-        )
+        response = await client.get("/api/project-configs/paths?project_id=authorized-project")
     finally:
         app.dependency_overrides.pop(get_current_user, None)
 
@@ -559,6 +562,7 @@ async def test_db_project_context_does_not_execute_legacy_filesystem_handler(mon
     from api.context import get_project_context
 
     monkeypatch.setenv("USE_DATABASE", "true")
+
     async def allow_project_role(*_args, **_kwargs):
         return "admin"
 
@@ -678,7 +682,9 @@ async def test_db_project_deletion_routes_fail_closed_before_cleanup(monkeypatch
     monkeypatch.setenv("USE_DATABASE", "true")
     monkeypatch.setattr("api.routes.require_project_role", AsyncMock())
     cleanup_service = AsyncMock()
-    monkeypatch.setattr("services.project_cleanup_service.get_cleanup_service", lambda: cleanup_service)
+    monkeypatch.setattr(
+        "services.project_cleanup_service.get_cleanup_service", lambda: cleanup_service
+    )
     user = SimpleNamespace(id="owner", role="admin", is_admin=True, is_active=True)
 
     for handler in (get_deletion_preview, delete_project):
@@ -740,7 +746,9 @@ async def test_debug_environment_enables_standard_docs(monkeypatch):
     monkeypatch.setenv("DEBUG", "true")
     monkeypatch.setenv("ENABLE_API_DOCS", "false")
     debug_app = create_app(debug=False)
-    async with AsyncClient(transport=ASGITransport(app=debug_app), base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=debug_app), base_url="http://test"
+    ) as client:
         assert (await client.get("/docs")).status_code == 200
 
 
@@ -795,7 +803,10 @@ def test_setup_and_compose_do_not_print_secret_fragments():
     compose_text = compose.read_text()
     assert "NEW_SECRET: -4" not in setup_text
     assert "NEW_PG_PW: -4" not in setup_text
-    assert "postgresql+asyncpg://${POSTGRES_USER:-aos}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-aos}" in compose_text
+    assert (
+        "postgresql+asyncpg://${POSTGRES_USER:-aos}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-aos}"
+        in compose_text
+    )
 
 
 @pytest.mark.asyncio
@@ -898,9 +909,10 @@ async def test_projects_db_failure_returns_503_without_filesystem_listing(monkey
             raise RuntimeError("database unavailable")
 
     monkeypatch.setenv("USE_DATABASE", "true")
-    monkeypatch.setattr("api.routes.list_projects", lambda: (_ for _ in ()).throw(
-        AssertionError("filesystem listing must not run in DB mode")
-    ))
+    monkeypatch.setattr(
+        "api.routes.list_projects",
+        lambda: (_ for _ in ()).throw(AssertionError("filesystem listing must not run in DB mode")),
+    )
     with pytest.raises(HTTPException) as exc_info:
         await get_projects(
             current_user=SimpleNamespace(id="admin", role="admin", is_admin=True),
@@ -972,9 +984,12 @@ async def test_db_project_route_rejects_unregistered_id_before_filesystem_lookup
             return Result()
 
     monkeypatch.setenv("USE_DATABASE", "true")
-    monkeypatch.setattr("api.routes.get_project", lambda _project_id: (_ for _ in ()).throw(
-        AssertionError("legacy filesystem lookup must not run")
-    ))
+    monkeypatch.setattr(
+        "api.routes.get_project",
+        lambda _project_id: (_ for _ in ()).throw(
+            AssertionError("legacy filesystem lookup must not run")
+        ),
+    )
     with pytest.raises(HTTPException) as exc_info:
         await get_project_by_id(
             "filesystem-only",
@@ -1096,7 +1111,11 @@ async def test_filesystem_project_config_mutation_requires_editor(monkeypatch):
     monkeypatch.setattr(access_module, "require_project_role", fake_require)
 
     user = SimpleNamespace(id="regular", role="user", is_admin=False, is_active=True)
-    for method, project_id in (("GET", "read-proj"), ("POST", "write-proj"), ("DELETE", "del-proj")):
+    for method, project_id in (
+        ("GET", "read-proj"),
+        ("POST", "write-proj"),
+        ("DELETE", "del-proj"),
+    ):
         await access_module.require_project_config_access(
             _request_stub(method, project_id, f"/api/project-configs/{project_id}/skills"),
             user,
@@ -1447,7 +1466,6 @@ async def test_create_session_uses_the_project_resolver(monkeypatch):
     assert response.session_id == "sess-1"
     assert called["project_id"] == "db-uuid-1"
     assert called["project_passed"].id == "db-uuid-1"
-
 
 
 # ─────────────────────────────────────────────────────────────
@@ -1810,3 +1828,100 @@ async def test_git_route_reachable_when_authenticated(client, authenticated_app,
     branches = response.json()["branches"]
     assert [b["name"] for b in branches] == ["work"]
     assert branches[0]["is_current"] is True
+
+
+# ── Project role authorization: fail-closed shape checks ───────────────
+
+
+def _stub_db():
+    """A session that must never be queried by these tests."""
+    return SimpleNamespace(execute=AsyncMock(side_effect=AssertionError("unexpected query")))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("project_id", ["", "   ", None, 123])
+async def test_blank_project_identifier_is_rejected_for_every_role(monkeypatch, project_id):
+    """A blank id must not authorize anyone -- including system admins.
+
+    Downstream listing code treats a falsy project_id as "no filter", so a
+    blank id that survived authorization would widen to every project.
+    """
+    from api.deps import require_project_role
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+
+    for user in (
+        SimpleNamespace(id="admin", role="admin", is_admin=True, is_active=True),
+        SimpleNamespace(id="user", role="user", is_admin=False, is_active=True),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await require_project_role(project_id, user, _stub_db())
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Invalid project identifier"
+
+
+@pytest.mark.asyncio
+async def test_unknown_min_role_is_rejected_before_admin_bypass(monkeypatch):
+    """An unknown ``min_role`` must fail the same way for admins and users.
+
+    Consumed at the comparison site it would silently 403 normal users while
+    letting admins through -- a role-dependent failure that hides typos.
+    """
+    from api.deps import require_project_role
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+
+    for user in (
+        SimpleNamespace(id="admin", role="admin", is_admin=True, is_active=True),
+        SimpleNamespace(id="user", role="user", is_admin=False, is_active=True),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await require_project_role("p1", user, _stub_db(), min_role="superuser")
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Unknown project role requirement"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stored_role", ["", "administrator", "VIEWER", 5])
+async def test_malformed_acl_role_fails_closed(monkeypatch, stored_role):
+    """An ACL role outside the hierarchy must deny, not fall back to viewer."""
+    from api.deps import require_project_role
+    from services.project_access_service import ProjectAccessService
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+
+    async def has_acl(*_args, **_kwargs):
+        return True
+
+    async def malformed_role(*_args, **_kwargs):
+        return stored_role
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", malformed_role)
+    user = SimpleNamespace(id="user", role="user", is_admin=False, is_active=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_project_role("p1", user, _stub_db(), min_role="viewer")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Unrecognized project role"
+
+
+@pytest.mark.asyncio
+async def test_known_acl_role_still_authorizes(monkeypatch):
+    """Guard against "fixed by denying everyone": a real role still passes."""
+    from api.deps import require_project_role
+    from services.project_access_service import ProjectAccessService
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+
+    async def has_acl(*_args, **_kwargs):
+        return True
+
+    async def editor_role(*_args, **_kwargs):
+        return "editor"
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", editor_role)
+    user = SimpleNamespace(id="user", role="user", is_admin=False, is_active=True)
+
+    assert await require_project_role("p1", user, _stub_db(), min_role="editor") == "editor"

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -1,16 +1,15 @@
 """Regression tests for high-risk API authentication and permission auditing."""
 
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-from httpx import ASGITransport, AsyncClient
 import pytest
 from fastapi import HTTPException, WebSocketException
+from httpx import ASGITransport, AsyncClient
 
 from models.permissions import AgentPermission
 from services.audit_service import AuditAction
-
 
 PROTECTED_ROUTE_PREFIXES = (
     "/api/audit",
@@ -581,7 +580,7 @@ async def test_db_project_context_does_not_execute_legacy_filesystem_handler(mon
 @pytest.mark.asyncio
 async def test_project_config_copy_target_requires_access(monkeypatch):
     """Copy destinations must be registered and independently authorized."""
-    from api.project_configs.access import require_project_config_target_access
+    from api.project_configs import access as access_module
 
     target = SimpleNamespace(id="target", path="/target", organization_id="org-other")
 
@@ -592,24 +591,21 @@ async def test_project_config_copy_target_requires_access(monkeypatch):
         def scalars(self):
             return SimpleNamespace(all=lambda: self.value)
 
-        def scalar_one_or_none(self):
-            return self.value
-
     class Database:
-        def __init__(self):
-            self.calls = 0
-
         async def execute(self, *_args, **_kwargs):
-            self.calls += 1
-            return Result([target] if self.calls == 1 else None)
+            return Result([target])
 
     async def no_admin_orgs(_user):
         return []
 
+    async def deny_target_role(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail="Target project access denied")
+
     monkeypatch.setenv("USE_DATABASE", "true")
     monkeypatch.setattr("api.projects._get_admin_org_ids", no_admin_orgs)
+    monkeypatch.setattr(access_module, "require_project_role", deny_target_role)
     with pytest.raises(HTTPException) as exc_info:
-        await require_project_config_target_access(
+        await access_module.require_project_config_target_access(
             "target",
             SimpleNamespace(id="user", role="user", is_admin=False),
             Database(),
@@ -1569,8 +1565,8 @@ async def test_db_project_config_allows_privileged_operator(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_db_project_config_allows_explicit_grant(monkeypatch):
-    """A non-privileged user with a ProjectAccess row is authorized."""
+async def test_db_project_config_applies_viewer_role(monkeypatch):
+    """A non-privileged project reader is authorized through the central guard."""
     from api.project_configs import access as access_module
 
     monkeypatch.setenv("USE_DATABASE", "true")
@@ -1578,21 +1574,29 @@ async def test_db_project_config_allows_explicit_grant(monkeypatch):
     async def no_admin_orgs(_user):
         return []
 
+    seen: list[tuple[str, str]] = []
+
+    async def require_viewer(project_id, _user, _db, min_role="viewer"):
+        seen.append((project_id, min_role))
+        return "viewer"
+
     monkeypatch.setattr("api.projects._get_admin_org_ids", no_admin_orgs)
+    monkeypatch.setattr(access_module, "require_project_role", require_viewer)
     member = SimpleNamespace(id="member-1", role="user", is_admin=False, is_active=True)
 
     result = await access_module.require_project_config_access(
         _request_stub("GET", "proj-uuid", "/api/project-configs/proj-uuid/skills"),
         member,
-        db=_ProjectConfigDbStub([_db_project()], direct_grant="proj-uuid"),
+        db=_ProjectConfigDbStub([_db_project()]),
     )
 
     assert result is member
+    assert seen == [("proj-uuid", "viewer")]
 
 
 @pytest.mark.asyncio
 async def test_db_project_config_denies_user_without_grant(monkeypatch):
-    """No org-admin scope and no ProjectAccess row still means 403, not access."""
+    """A central role denial still blocks the DB-mode config route."""
     from api.project_configs import access as access_module
 
     monkeypatch.setenv("USE_DATABASE", "true")
@@ -1602,14 +1606,74 @@ async def test_db_project_config_denies_user_without_grant(monkeypatch):
 
     monkeypatch.setattr("api.projects._get_admin_org_ids", no_admin_orgs)
 
+    async def deny_project_role(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    monkeypatch.setattr(access_module, "require_project_role", deny_project_role)
+
     with pytest.raises(HTTPException) as exc_info:
         await access_module.require_project_config_access(
             _request_stub("GET", "proj-uuid", "/api/project-configs/proj-uuid/skills"),
             SimpleNamespace(id="outsider", role="user", is_admin=False, is_active=True),
-            db=_ProjectConfigDbStub([_db_project()], direct_grant=None),
+            db=_ProjectConfigDbStub([_db_project()]),
         )
 
     assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_db_project_config_mutation_requires_editor(monkeypatch):
+    """A viewer cannot reach a DB-mode project-config mutation route."""
+    from api.project_configs import access as access_module
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    monkeypatch.setattr("api.projects._get_admin_org_ids", AsyncMock(return_value=[]))
+
+    seen: list[str] = []
+
+    async def require_editor(_project_id, _user, _db, min_role="viewer"):
+        seen.append(min_role)
+        if min_role == "editor":
+            raise HTTPException(status_code=403, detail="editor role required")
+        return "viewer"
+
+    monkeypatch.setattr(access_module, "require_project_role", require_editor)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access_module.require_project_config_access(
+            _request_stub("POST", "proj-uuid", "/api/project-configs/proj-uuid/skills"),
+            SimpleNamespace(id="viewer", role="user", is_admin=False, is_active=True),
+            db=_ProjectConfigDbStub([_db_project()]),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert seen == ["editor"]
+
+
+@pytest.mark.asyncio
+async def test_db_project_config_copy_target_requires_editor(monkeypatch):
+    """A viewer cannot use a DB-mode project-config copy target."""
+    from api.project_configs import access as access_module
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    monkeypatch.setattr("api.projects._get_admin_org_ids", AsyncMock(return_value=[]))
+    seen: list[tuple[str, str]] = []
+
+    async def require_editor(project_id, _user, _db, min_role="viewer"):
+        seen.append((project_id, min_role))
+        raise HTTPException(status_code=403, detail="editor role required")
+
+    monkeypatch.setattr(access_module, "require_project_role", require_editor)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access_module.require_project_config_target_access(
+            "proj-uuid",
+            SimpleNamespace(id="viewer", role="user", is_admin=False),
+            _ProjectConfigDbStub([_db_project()]),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert seen == [("proj-uuid", "editor")]
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_workflow.py
+++ b/tests/backend/test_workflow.py
@@ -464,13 +464,40 @@ class TestWorkflowAPI:
 
     @pytest.fixture
     def client(self):
-        """Create async httpx test client."""
-        from httpx import ASGITransport, AsyncClient
+        """Create async httpx test client with an explicit privileged test user."""
+        from types import SimpleNamespace
 
         from api.app import app
+        from api.deps import get_current_user
+        from httpx import ASGITransport, AsyncClient
 
+        app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+            id="test-admin",
+            role="admin",
+            is_admin=True,
+            is_active=True,
+        )
         transport = ASGITransport(app=app)
-        return AsyncClient(transport=transport, base_url="http://test")
+        client = AsyncClient(transport=transport, base_url="http://test")
+        yield client
+        app.dependency_overrides.pop(get_current_user, None)
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_requests_are_rejected(self, client):
+        from api.app import app
+        from api.deps import get_current_user
+
+        app.dependency_overrides.pop(get_current_user, None)
+        try:
+            async with client as c:
+                response = await c.get("/api/workflows")
+            assert response.status_code == 401
+        finally:
+            app.dependency_overrides[get_current_user] = lambda: type(
+                "TestAdmin",
+                (),
+                {"id": "test-admin", "role": "admin", "is_admin": True, "is_active": True},
+            )()
 
     @pytest.mark.asyncio
     async def test_list_empty(self, client):


### PR DESCRIPTION
## Summary
- Restore Project Monitor health/config/check behavior in database mode.
- Resolve project identity through canonical `ProjectModel.id` and the DB-registered path only.
- Preserve authentication, project RBAC, fail-closed legacy filesystem behavior, authenticated SSE, and stale-state protections.
- Add DB identity, monitoring authorization, and regression coverage.

## Verification
- Backend full suite: 1,820 passed, 33 skipped, 12 warnings
- Dashboard full suite: 211 files, 4,461 passed
- Dashboard type-check: passed
- Dashboard lint: passed
- Dashboard build: passed
- `git diff --check`: passed

## Security note
The independent Security reviewer did not return a terminal PASS because its Orca session reached max turns. The owner explicitly authorized commit, push, and main-branch application. No credentials or secrets were read or changed.
