### PR TITLE
test: keep an opt-in path for rate limit middleware coverage

### DIFF
--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -23,11 +23,13 @@ os.environ["OLLAMA_MODEL"] = "qwen2.5:7b"
 # next fails with 429 — an ordering-dependent break invisible in a single-file
 # run. test_playground_authorization.py already disables the middleware for
 # exactly this reason; doing it once here covers every suite.
-# Nothing loses coverage: the service itself is tested directly in
+# Nothing loses coverage today: the service itself is tested directly in
 # test_rate_limit_service.py, and the 429 asserted in
 # tests/backend/api/test_agent_registry.py comes from the independent
-# api/v1/rate_limiter.py, which does not read this flag.
-os.environ["RATE_LIMIT_ENABLED"] = "false"
+# api/v1/rate_limiter.py, which does not read this flag. setdefault (not a
+# plain assignment) keeps the opt-in escape hatch open for a future suite that
+# does want the middleware dispatching: RATE_LIMIT_ENABLED=1 pytest ...
+os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
 # Force HuggingFace offline so tests never download models (HF 429 flake
 # guard for every pytest invocation, local and CI). An unmocked model load


### PR DESCRIPTION
## Summary

Follow-up to #365, addressing a Codex review P2 on the fix that landed there.

#365 silenced an ordering-dependent 429 flake by hard-setting `RATE_LIMIT_ENABLED=false` in `tests/backend/conftest.py`. That works, but a plain assignment also makes an explicit `RATE_LIMIT_ENABLED=true` unable to re-enable the middleware — closing the door on any future suite that wants to exercise `RateLimitMiddleware` dispatch, headers, or 429 responses over HTTP.

`setdefault` keeps the flake fixed (CI sets no such variable, so it still resolves to `false`) while leaving the escape hatch open. This matches the `HF_HUB_OFFLINE` precedent two blocks below in the same file, which already uses the setdefault-plus-documented-opt-in shape.

No coverage is lost today either way: `RateLimitService` is tested directly in `test_rate_limit_service.py`, and the 429 asserted in `tests/backend/api/test_agent_registry.py` comes from the independent `api/v1/rate_limiter.py`, which does not read this flag.

## Test plan

- Opt-in reaches the app: `RATE_LIMIT_ENABLED=true pytest tests/backend/test_e2e_hitl.py -s` logs `Rate limiting middleware enabled` **4x**; with the variable unset, **0x**. The merged hard-assignment prints 0 in both cases — this is a real behavioural difference, not a cosmetic one.
- CI condition (variable unset): `pytest tests/backend/api tests/backend/test_e2e_hitl.py tests/backend/test_rate_limit_service.py tests/backend/test_playground_authorization.py` → **308 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K5h7VSRbqEwF5Tviqik51