### PR TITLE
fix: harden authenticated monitoring streams

### DIFF
--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -5,7 +5,7 @@ import uuid
 from pathlib import Path
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -165,6 +165,7 @@ else:
     llm_proxy_router = safe_import("api.llm_proxy", "router")
     llm_usage_router = safe_import("api.llm_usage", "router")
     llm_access_router = safe_import("api.llm_access", "router")
+    agent_monitor_router = safe_import("api.v1.agent_monitor", "router")
 
     # Optional orchestrator
     try:
@@ -665,6 +666,15 @@ else:
             app.include_router(llm_usage_router, prefix="/api")
         if llm_access_router:
             app.include_router(llm_access_router, prefix="/api")
+        if agent_monitor_router:
+            # Router already declares its full "/api/v1/agents" prefix internally —
+            # no extra prefix here. The router itself already requires
+            # get_current_user (api/v1/agent_monitor.py); this adds the same
+            # dependency again at include-time as defense-in-depth so the route
+            # stays gated even if the router-level dependency is ever dropped.
+            from api.deps import get_current_user
+
+            app.include_router(agent_monitor_router, dependencies=[Depends(get_current_user)])
 
         # Add Rate Limiting Middleware
         rate_limit_enabled = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"

--- a/src/backend/api/claude_sessions/activity.py
+++ b/src/backend/api/claude_sessions/activity.py
@@ -8,6 +8,7 @@
 """
 
 import asyncio
+import logging
 from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -21,6 +22,8 @@ from models.claude_session import (
 )
 
 from .resolver import resolve_session
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(get_current_admin_or_manager_user)])
 
@@ -125,8 +128,12 @@ async def stream_session_activity(session_id: str):
                     yield f"event: session_completed\ndata: {json.dumps({'session_id': session_id})}\n\n"
                     break
 
-            except Exception as e:
-                yield f"event: error\ndata: {json.dumps({'error': str(e)})}\n\n"
+            except Exception:
+                logger.exception("Error streaming activity for session %s", session_id)
+                error_data = json.dumps(
+                    {"error": "Internal error while streaming activity", "session_id": session_id}
+                )
+                yield f"event: error\ndata: {error_data}\n\n"
                 break
 
     return StreamingResponse(

--- a/src/backend/api/claude_sessions/sessions.py
+++ b/src/backend/api/claude_sessions/sessions.py
@@ -161,8 +161,12 @@ async def stream_session(session_id: str):
                     yield f"event: session_completed\ndata: {details.model_dump_json()}\n\n"
                     break
 
-            except Exception as e:
-                yield f"event: error\ndata: {json.dumps({'error': str(e)})}\n\n"
+            except Exception:
+                logger.exception("Error streaming session %s", session_id)
+                error_data = json.dumps(
+                    {"error": "Internal error while streaming session", "session_id": session_id}
+                )
+                yield f"event: error\ndata: {error_data}\n\n"
                 break
 
     return StreamingResponse(

--- a/src/backend/api/monitoring.py
+++ b/src/backend/api/monitoring.py
@@ -4,6 +4,7 @@ Obsidian vault health checks: links, frontmatter, orphans, images via SSE stream
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Literal, NamedTuple
@@ -29,6 +30,8 @@ from models.monitoring import (
 from models.project import get_project
 from services.project_runner import get_check_config, get_runner
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["orchestration"])
 
 # In-memory storage for project health (could be replaced with DB)
@@ -38,6 +41,11 @@ _project_health: dict[str, ProjectHealth] = {}
 # directory. Kept distinct from the generic dependency-failure detail so the
 # two 503 causes stay separable by callers and by tests.
 NO_MONITORED_PATH_DETAIL = "Project has no registered filesystem path for health monitoring"
+
+# Generic message surfaced to SSE clients on check failure. Exception details
+# (which may contain secrets, tokens, or filesystem paths from tool output)
+# are logged server-side only via logger.exception.
+CHECK_ERROR_DETAIL = "Health check failed unexpectedly"
 
 
 class MonitoredProject(NamedTuple):
@@ -322,8 +330,9 @@ async def run_all_checks(
                         )
                         yield f"event: check_completed\ndata: {event.model_dump_json()}\n\n"
 
-            except Exception as e:
-                error_data = json.dumps({"error": str(e), "check_type": check_id})
+            except Exception:
+                logger.exception("Health check %s failed for project %s", check_id, project_id)
+                error_data = json.dumps({"error": CHECK_ERROR_DETAIL, "check_type": check_id})
                 yield f"event: error\ndata: {error_data}\n\n"
 
         yield "event: all_checks_done\ndata: {}\n\n"
@@ -408,8 +417,9 @@ async def run_check(
                     )
                     yield f"event: check_completed\ndata: {event.model_dump_json()}\n\n"
 
-        except Exception as e:
-            error_data = json.dumps({"error": str(e)})
+        except Exception:
+            logger.exception("Health check %s failed for project %s", check_type, project_id)
+            error_data = json.dumps({"error": CHECK_ERROR_DETAIL, "check_type": check_type})
             yield f"event: error\ndata: {error_data}\n\n"
 
     return StreamingResponse(

--- a/src/backend/api/v1/agent_monitor.py
+++ b/src/backend/api/v1/agent_monitor.py
@@ -9,11 +9,17 @@ from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
-router = APIRouter(prefix="/api/v1/agents", tags=["agent-monitor"])
+from api.deps import get_current_user
+
+router = APIRouter(
+    prefix="/api/v1/agents",
+    tags=["agent-monitor"],
+    dependencies=[Depends(get_current_user)],
+)
 
 
 # ─────────────────────────────────────────────────────────────

--- a/src/dashboard/src/stores/__tests__/agentMonitor.test.ts
+++ b/src/dashboard/src/stores/__tests__/agentMonitor.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { useAgentMonitorStore } from '../agentMonitor'
 
 // ─────────────────────────────────────────────────────────────
 // Mocks
@@ -8,26 +7,27 @@ import { useAgentMonitorStore } from '../agentMonitor'
 const mockFetch = vi.fn()
 global.fetch = mockFetch
 
-interface MockEventSourceInstance {
+type MockStatus = 'authentication-failed' | 'permission-denied' | 'error' | 'closed'
+
+interface MockSseClientInstance {
   url: string
+  onStatus?: (status: MockStatus) => void
   listeners: Record<string, ((e: MessageEvent) => void)[]>
   close: ReturnType<typeof vi.fn>
-  onopen: (() => void) | null
-  onerror: (() => void) | null
   addEventListener: (event: string, handler: (e: MessageEvent) => void) => void
 }
 
-let lastEventSource: MockEventSourceInstance | null = null
+let lastEventSource: MockSseClientInstance | null = null
 
-class MockEventSource implements MockEventSourceInstance {
+class MockSseClient implements MockSseClientInstance {
   url: string
+  onStatus?: (status: MockStatus) => void
   listeners: Record<string, ((e: MessageEvent) => void)[]> = {}
   close = vi.fn()
-  onopen: (() => void) | null = null
-  onerror: (() => void) | null = null
 
-  constructor(url: string) {
+  constructor(url: string, options?: { onStatus?: (status: MockStatus) => void }) {
     this.url = url
+    this.onStatus = options?.onStatus
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     lastEventSource = this
   }
@@ -43,10 +43,18 @@ class MockEventSource implements MockEventSourceInstance {
       handler({ data: JSON.stringify(data) } as MessageEvent)
     }
   }
+
+  _status(status: MockStatus) {
+    this.onStatus?.(status)
+  }
 }
 
-// @ts-expect-error - Mock EventSource for testing
-global.EventSource = MockEventSource
+vi.mock('../../services/authenticatedSse', () => ({
+  createAuthenticatedSseClient: (url: string, options?: { onStatus?: (status: MockStatus) => void }) =>
+    new MockSseClient(url, options),
+}))
+
+const { useAgentMonitorStore } = await import('../agentMonitor')
 
 function resetStore() {
   useAgentMonitorStore.setState({
@@ -95,14 +103,51 @@ describe('agentMonitor store', () => {
       expect(lastEventSource?.url).toContain('/api/v1/agents/monitor/stream')
     })
 
-    it('sets connected status on open', () => {
+    it('sets connected status on first heartbeat', () => {
       useAgentMonitorStore.getState().connect()
 
-      // Simulate onopen
-      lastEventSource?.onopen?.()
+      lastEventSource?._emit('heartbeat', { timestamp: '2025-01-01T00:00:00Z' })
 
       expect(useAgentMonitorStore.getState().connectionStatus).toBe('connected')
       expect(useAgentMonitorStore.getState().reconnectAttempts).toBe(0)
+    })
+
+    it('uses the authenticated SSE client (not native EventSource) for the stream', () => {
+      useAgentMonitorStore.getState().connect()
+
+      expect(lastEventSource).not.toBeNull()
+      expect(typeof lastEventSource?.onStatus).toBe('function')
+    })
+
+    it('schedules a reconnect with backoff on transport error status', () => {
+      useAgentMonitorStore.getState().connect()
+      const firstSource = lastEventSource
+
+      firstSource?._status('error')
+
+      const state = useAgentMonitorStore.getState()
+      expect(state.connectionStatus).toBe('reconnecting')
+      expect(state.eventSource).toBeNull()
+      expect(state.reconnectAttempts).toBe(1)
+
+      vi.advanceTimersByTime(1000)
+
+      expect(lastEventSource).not.toBe(firstSource)
+      expect(useAgentMonitorStore.getState().connectionStatus).toBe('connecting')
+    })
+
+    it('stops without reconnecting on authentication-failed status', () => {
+      useAgentMonitorStore.getState().connect()
+
+      lastEventSource?._status('authentication-failed')
+
+      const state = useAgentMonitorStore.getState()
+      expect(state.connectionStatus).toBe('disconnected')
+      expect(state.eventSource).toBeNull()
+      expect(state.error).toBeTruthy()
+
+      vi.advanceTimersByTime(60000)
+      expect(useAgentMonitorStore.getState().connectionStatus).toBe('disconnected')
     })
 
     it('disconnect closes EventSource and resets state', () => {

--- a/src/dashboard/src/stores/agentMonitor.ts
+++ b/src/dashboard/src/stores/agentMonitor.ts
@@ -7,6 +7,7 @@
 
 import { create } from 'zustand'
 import { apiClient } from '../services/apiClient'
+import { createAuthenticatedSseClient, type AuthenticatedSseClient } from '../services/authenticatedSse'
 import { getApiUrl } from '../config/api'
 
 // ─────────────────────────────────────────────────────────────
@@ -87,7 +88,7 @@ const BACKOFF_MULTIPLIER = 2
 interface AgentMonitorState {
   // Connection
   connectionStatus: ConnectionStatus
-  eventSource: EventSource | null
+  eventSource: AuthenticatedSseClient | null
   reconnectAttempts: number
   reconnectTimer: ReturnType<typeof setTimeout> | null
 
@@ -157,7 +158,50 @@ export const useAgentMonitorStore = create<AgentMonitorState>((set, get) => ({
     set({ connectionStatus: 'connecting', error: null })
 
     const url = getApiUrl('/api/v1/agents/monitor/stream?interval=5')
-    const source = new EventSource(url)
+
+    const scheduleReconnect = () => {
+      const { reconnectAttempts, reconnectTimer } = get()
+
+      // Clear existing timer
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer)
+      }
+
+      // Calculate exponential backoff delay
+      const delay = Math.min(
+        INITIAL_RECONNECT_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, reconnectAttempts),
+        MAX_RECONNECT_DELAY_MS,
+      )
+
+      set({
+        connectionStatus: 'reconnecting',
+        eventSource: null,
+        reconnectAttempts: reconnectAttempts + 1,
+      })
+
+      // Schedule reconnection
+      const timer = setTimeout(() => {
+        set({ reconnectTimer: null })
+        get().connect()
+      }, delay)
+
+      set({ reconnectTimer: timer })
+    }
+
+    const source = createAuthenticatedSseClient(url, {
+      onStatus: (status) => {
+        if (status === 'authentication-failed') {
+          set({ connectionStatus: 'disconnected', eventSource: null, error: 'Authentication required for agent monitor stream' })
+          return
+        }
+        if (status === 'permission-denied') {
+          set({ connectionStatus: 'disconnected', eventSource: null, error: 'You do not have permission to view the agent monitor stream' })
+          return
+        }
+        // 'error' | 'closed' — transport dropped, auto-reconnect with backoff
+        scheduleReconnect()
+      },
+    })
 
     source.addEventListener('agent_status', (event: MessageEvent) => {
       const data: AgentStatusEvent = JSON.parse(event.data)
@@ -194,50 +238,11 @@ export const useAgentMonitorStore = create<AgentMonitorState>((set, get) => ({
 
       // Heartbeat confirms connection is alive
       if (get().connectionStatus !== 'connected') {
-        set({ connectionStatus: 'connected' })
+        set({ connectionStatus: 'connected', reconnectAttempts: 0 })
       }
 
       get().addEvent({ type: 'heartbeat', data })
     })
-
-    source.onopen = () => {
-      set({
-        connectionStatus: 'connected',
-        reconnectAttempts: 0,
-      })
-    }
-
-    source.onerror = () => {
-      const { reconnectAttempts, reconnectTimer } = get()
-
-      // Clean up current source
-      source.close()
-
-      // Clear existing timer
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer)
-      }
-
-      // Calculate exponential backoff delay
-      const delay = Math.min(
-        INITIAL_RECONNECT_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, reconnectAttempts),
-        MAX_RECONNECT_DELAY_MS,
-      )
-
-      set({
-        connectionStatus: 'reconnecting',
-        eventSource: null,
-        reconnectAttempts: reconnectAttempts + 1,
-      })
-
-      // Schedule reconnection
-      const timer = setTimeout(() => {
-        set({ reconnectTimer: null })
-        get().connect()
-      }, delay)
-
-      set({ reconnectTimer: timer })
-    }
 
     set({ eventSource: source })
   },

--- a/tests/backend/api/test_agent_monitor.py
+++ b/tests/backend/api/test_agent_monitor.py
@@ -3,27 +3,39 @@
 Tests cover SSE streaming, metrics, summary, and error handling.
 """
 
-import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
+from api import deps as api_deps
 from api.v1.agent_monitor import (
-    router,
-    _agents,
-    _sse_subscribers,
     AgentRecord,
     AgentStatus,
+    _agents,
+    _sse_subscribers,
+    router,
 )
+
+
+def _fake_authenticated_user() -> MagicMock:
+    """Stand-in for api.deps.get_current_user's return value."""
+    return MagicMock(id="test-user", role="admin", is_admin=True, is_active=True)
 
 
 @pytest.fixture
 def app() -> FastAPI:
-    """Create test FastAPI app with agent monitor router."""
+    """Create test FastAPI app with agent monitor router.
+
+    The router itself declares Depends(get_current_user), so requests are
+    rejected with 401 unless this override explicitly bypasses auth for
+    these endpoint-behavior tests.
+    """
     test_app = FastAPI()
     test_app.include_router(router)
+    test_app.dependency_overrides[api_deps.get_current_user] = _fake_authenticated_user
     return test_app
 
 
@@ -226,6 +238,7 @@ async def test_get_summary_empty_agents() -> None:
     """
     test_app = FastAPI()
     test_app.include_router(router)
+    test_app.dependency_overrides[api_deps.get_current_user] = _fake_authenticated_user
 
     # Make sure _agents is empty and won't auto-seed
     _agents.clear()

--- a/tests/backend/api/test_agent_monitor_registration.py
+++ b/tests/backend/api/test_agent_monitor_registration.py
@@ -1,0 +1,59 @@
+"""Regression test: the Agent Monitor router must be mounted on the real app.
+
+``api.v1.agent_monitor.router`` existed but was never passed to
+``app.include_router`` in ``api/app.py`` — every route in the file 404'd in
+production even though ``tests/backend/api/test_agent_monitor.py`` passed
+(it builds its own throwaway ``FastAPI()`` app). This pins the router to the
+app actually served by ``create_app()``, and pins that it inherits the same
+auth dependency other protected routers use (``api.deps.get_current_user``)
+rather than being mounted wide open.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from api import deps as api_deps
+
+
+@pytest_asyncio.fixture
+async def app():
+    from api.app import create_app
+
+    test_app = create_app(title="Agent Monitor Registration Test", debug=True)
+    test_app.dependency_overrides[api_deps.get_db_session] = lambda: MagicMock()
+    yield test_app
+    test_app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_metrics_summary_route_is_mounted_on_the_real_app(app, client):
+    """Router must be registered — a 404 here means it's still orphaned."""
+    app.dependency_overrides[api_deps.get_current_user] = lambda: MagicMock(
+        id="u1", role="admin", is_admin=True, is_active=True
+    )
+    res = await client.get("/api/v1/agents/metrics/summary")
+    assert res.status_code != 404, "agent_monitor router is not mounted on the app"
+    assert res.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_metrics_summary_requires_authentication(app, client):
+    """Unauthenticated callers must not reach agent monitoring data."""
+    res = await client.get("/api/v1/agents/metrics/summary")
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_monitor_agents_list_requires_authentication(app, client):
+    res = await client.get("/api/v1/agents/monitor/agents")
+    assert res.status_code == 401

--- a/tests/backend/api/test_agent_sessions.py
+++ b/tests/backend/api/test_agent_sessions.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import pytest
 from fastapi import HTTPException
 
+from api.claude_sessions import activity as activity_routes
 from api.claude_sessions import core
 from api.claude_sessions import sessions as session_routes
 from models.claude_session import ClaudeSessionInfo
@@ -108,3 +109,60 @@ async def test_codex_session_mutations_are_rejected(
 
     assert stream_error.value.status_code == 409
     assert summary_error.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_stream_session_error_event_hides_exception_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSE `error` events must not leak internal exception text to the client."""
+    claude = _session("claude", "claude-1")
+    secret = "leaked-token-xyz db password 12345"
+
+    class _Monitor:
+        def get_session_details(self, session_id: str):
+            raise RuntimeError(secret)
+
+    monkeypatch.setattr(session_routes, "resolve_session", lambda _: (_Monitor(), claude))
+
+    async def fast_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(session_routes.asyncio, "sleep", fast_sleep)
+
+    response = await session_routes.stream_session("claude-1")
+    body = "".join([chunk async for chunk in response.body_iterator])
+
+    assert "event: error" in body
+    assert secret not in body
+    assert "RuntimeError" not in body
+
+
+@pytest.mark.asyncio
+async def test_stream_session_activity_error_event_hides_exception_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSE `error` events on the activity stream must not leak exception text."""
+    claude = _session("claude", "claude-1")
+    secret = "leaked-token-xyz db password 12345"
+
+    class _Monitor:
+        def get_session_activity(self, session_id: str, offset: int = 0, limit: int = 100):
+            return [], 0
+
+        def get_new_activity_since_size(self, session_id: str, last_size: int):
+            raise RuntimeError(secret)
+
+    monkeypatch.setattr(activity_routes, "resolve_session", lambda _: (_Monitor(), claude))
+
+    async def fast_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(activity_routes.asyncio, "sleep", fast_sleep)
+
+    response = await activity_routes.stream_session_activity("claude-1")
+    body = "".join([chunk async for chunk in response.body_iterator])
+
+    assert "event: error" in body
+    assert secret not in body
+    assert "RuntimeError" not in body

--- a/tests/backend/api/test_monitoring_db_health.py
+++ b/tests/backend/api/test_monitoring_db_health.py
@@ -351,7 +351,9 @@ async def test_db_project_without_path_stays_fail_closed(authenticated_app, monk
 
 
 @pytest.mark.asyncio
-async def test_database_failure_is_reported_as_unavailable(authenticated_app, tmp_path, monkeypatch):
+async def test_database_failure_is_reported_as_unavailable(
+    authenticated_app, tmp_path, monkeypatch
+):
     """DB 조회 자체가 실패하면 503 — 위의 '경로 없음' 503 과 detail 이 다르다."""
     from api.deps import get_db_session
 
@@ -395,9 +397,11 @@ async def test_filesystem_mode_still_uses_the_legacy_registry(
     monkeypatch.setenv("USE_DATABASE", "false")
     monkeypatch.setattr(
         "api.monitoring.get_project",
-        lambda pid: SimpleNamespace(name="fs-project", path=str(project_path))
-        if pid == "fs-project"
-        else None,
+        lambda pid: (
+            SimpleNamespace(name="fs-project", path=str(project_path))
+            if pid == "fs-project"
+            else None
+        ),
     )
 
     async def _override():
@@ -420,3 +424,79 @@ async def test_filesystem_mode_still_uses_the_legacy_registry(
         assert missing.status_code == 404, missing.text
     finally:
         authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 6. SSE 오류 이벤트는 내부 예외 내용을 클라이언트에 노출하지 않는다
+# ─────────────────────────────────────────────────────────────
+
+
+class _ExplodingRunner:
+    """모든 체크에서 즉시 실패하는 러너 — 내부 예외 텍스트가 새는지 검증한다."""
+
+    def __init__(self, secret: str):
+        self._secret = secret
+
+    async def stream_check(self, project_id, check_type):
+        raise RuntimeError(self._secret)
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+
+@pytest.mark.asyncio
+async def test_run_check_error_event_hides_exception_details(monkeypatch):
+    """단일 체크 SSE 스트림의 `error` 이벤트는 원본 예외 문자열을 담지 않는다."""
+    from api.monitoring import MonitoredProject, run_check
+
+    secret = "leaked-token-xyz db password 12345"
+    monkeypatch.setattr("api.monitoring.require_project_role", lambda *a, **kw: _async_ok("editor"))
+    monkeypatch.setattr(
+        "api.monitoring._monitored_project",
+        lambda *a, **kw: _async_value(
+            MonitoredProject(project_id="proj-1", name="Proj", path="/tmp/proj-1")
+        ),
+    )
+    monkeypatch.setattr(
+        "api.monitoring.get_check_config", lambda path: {"probe": {"label": "Probe", "command": ""}}
+    )
+    monkeypatch.setattr("api.monitoring.get_runner", lambda path: _ExplodingRunner(secret))
+
+    response = await run_check("proj-1", "probe", current_user=object(), db=object())
+    body = "".join([chunk async for chunk in response.body_iterator])
+
+    assert "event: error" in body
+    assert secret not in body
+    assert "RuntimeError" not in body
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_error_event_hides_exception_details(monkeypatch):
+    """전체 체크 SSE 스트림의 `error` 이벤트도 원본 예외 문자열을 담지 않는다."""
+    from api.monitoring import MonitoredProject, run_all_checks
+
+    secret = "leaked-token-xyz db password 12345"
+    monkeypatch.setattr("api.monitoring.require_project_role", lambda *a, **kw: _async_ok("editor"))
+    monkeypatch.setattr(
+        "api.monitoring._monitored_project",
+        lambda *a, **kw: _async_value(
+            MonitoredProject(project_id="proj-1", name="Proj", path="/tmp/proj-1")
+        ),
+    )
+    monkeypatch.setattr(
+        "api.monitoring.get_check_config", lambda path: {"probe": {"label": "Probe", "command": ""}}
+    )
+    monkeypatch.setattr("api.monitoring.get_runner", lambda path: _ExplodingRunner(secret))
+
+    response = await run_all_checks("proj-1", current_user=object(), db=object())
+    body = "".join([chunk async for chunk in response.body_iterator])
+
+    assert "event: error" in body
+    assert secret not in body
+    assert "RuntimeError" not in body
+
+
+async def _async_ok(value):
+    return value
+
+
+async def _async_value(value):
+    return value


### PR DESCRIPTION
## Summary
- Mount the agent monitor router on the real FastAPI app with authentication enforcement.
- Use authenticated fetch-based SSE for the dashboard agent monitor with reconnect and auth failure handling.
- Prevent internal exception details from leaking through SSE error events.
- Add backend registration/auth/error regression coverage and frontend transport/reconnect coverage.

## Validation
- Backend targeted tests: 32 passed, 2 skipped
- Backend Ruff check: passed
- Backend Ruff format check: passed
- Dashboard agent monitor tests: 18 passed
- Dashboard type-check: passed
- Dashboard lint: passed
- Dashboard production build: passed

## Notes
- No merge or deployment performed.