### PR TITLE
fix: enable database-mode project context with safe path boundaries

### DIFF
--- a/src/backend/api/context.py
+++ b/src/backend/api/context.py
@@ -4,6 +4,7 @@ Project context (CLAUDE.md, dev docs) and context window usage meter.
 """
 
 import os
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -16,10 +17,86 @@ from api.deps import (
     require_project_role,
 )
 from models.context_usage import ContextUsage, get_context_limit
-from models.project import get_project
+from models.project import Project, get_project
 from orchestrator import OrchestrationEngine
 
 router = APIRouter(tags=["orchestration"])
+
+# Returned when an authorized database-mode project carries no readable
+# directory. Kept distinct from the generic dependency-failure detail so the
+# two 503 causes stay separable by callers and by tests. Mirrors
+# ``api/diagnostics.NO_DIAGNOSTIC_PATH_DETAIL``.
+NO_CONTEXT_PATH_DETAIL = "Project has no registered filesystem path for context"
+
+
+def _use_database() -> bool:
+    return os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+async def _resolve_database_project(project_id: str, db) -> Project | None:
+    """Resolve the canonical DB project row into a readable context target.
+
+    Only ``ProjectModel.id`` is matched — the path-derived identifiers used by
+    the legacy filesystem registry are deliberately not accepted, so they
+    cannot reach the filesystem through the context surface.
+
+    Returns ``None`` when the registration has no usable directory. The caller
+    keeps that fail-closed instead of guessing a path.
+    """
+    from sqlalchemy import select
+
+    from db.models import ProjectModel
+
+    try:
+        result = await db.execute(
+            select(ProjectModel).where(
+                ProjectModel.id == project_id,
+                ProjectModel.is_active == True,  # noqa: E712
+            )
+        )
+        row = result.scalar_one_or_none()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Project context is temporarily unavailable",
+        ) from exc
+
+    if row is None:
+        return None
+
+    path = str(row.path or "").strip()
+    if not path or not Path(path).is_dir():
+        return None
+
+    # `Project.from_path` 로 구성한다 — CLAUDE.md 본문과 `.aos-project.json`
+    # 메타데이터를 읽는 유일한 생성자다. 필드를 손으로 옮기면 `claude_md` 가
+    # 항상 None 이 되어 패널이 조용히 빈 화면이 된다.
+    project = Project.from_path(str(row.id), path)
+
+    # 이름·설명의 권위는 DB 행이다.
+    return project.model_copy(update={"name": row.name, "description": row.description or ""})
+
+
+async def _context_target(project_id: str, db) -> Project:
+    """Resolve the read project *after* the caller has authorized access.
+
+    Database mode reads the DB registry, which is authoritative for both
+    identity and path. Filesystem mode keeps the legacy registry lookup behind
+    ``reject_legacy_project_operation_in_database_mode`` — that guard is
+    unreachable from here in database mode by construction, and is kept as a
+    standing assertion that the legacy branch never runs in that mode.
+    """
+    if _use_database():
+        resolved = await _resolve_database_project(project_id, db)
+        if resolved is None:
+            raise HTTPException(status_code=503, detail=NO_CONTEXT_PATH_DETAIL)
+        return resolved
+
+    reject_legacy_project_operation_in_database_mode()
+    legacy = get_project(project_id)
+    if not legacy:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return legacy
 
 
 # ─────────────────────────────────────────────────────────────
@@ -66,14 +143,9 @@ async def get_project_context(
     - Current session info (if active)
     """
     from datetime import UTC, datetime
-    from pathlib import Path
 
-    if hasattr(current_user, "role") and hasattr(db, "execute"):
-        await require_project_role(project_id, current_user, db, min_role="viewer")
-        reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    await require_project_role(project_id, current_user, db, min_role="viewer")
+    project = await _context_target(project_id, db)
 
     # Get dev docs from dev/active folder
     dev_docs: list[DevDocFile] = []
@@ -143,12 +215,8 @@ async def get_project_claude_md(
     db=Depends(get_db_session),
 ):
     """Get raw CLAUDE.md content for a project."""
-    if hasattr(current_user, "role") and hasattr(db, "execute"):
-        await require_project_role(project_id, current_user, db, min_role="viewer")
-        reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    await require_project_role(project_id, current_user, db, min_role="viewer")
+    project = await _context_target(project_id, db)
 
     if not project.claude_md:
         raise HTTPException(status_code=404, detail="No CLAUDE.md found for this project")

--- a/src/backend/api/context.py
+++ b/src/backend/api/context.py
@@ -4,11 +4,11 @@ Project context (CLAUDE.md, dev docs) and context window usage meter.
 """
 
 import os
-from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from api.db_project import load_registered_project, safe_project_child
 from api.deps import (
     get_current_user,
     get_db_session,
@@ -34,47 +34,14 @@ def _use_database() -> bool:
 
 
 async def _resolve_database_project(project_id: str, db) -> Project | None:
-    """Resolve the canonical DB project row into a readable context target.
-
-    Only ``ProjectModel.id`` is matched — the path-derived identifiers used by
-    the legacy filesystem registry are deliberately not accepted, so they
-    cannot reach the filesystem through the context surface.
-
-    Returns ``None`` when the registration has no usable directory. The caller
-    keeps that fail-closed instead of guessing a path.
-    """
-    from sqlalchemy import select
-
-    from db.models import ProjectModel
-
+    """Resolve the canonical DB project row into a safe context target."""
     try:
-        result = await db.execute(
-            select(ProjectModel).where(
-                ProjectModel.id == project_id,
-                ProjectModel.is_active == True,  # noqa: E712
-            )
-        )
-        row = result.scalar_one_or_none()
+        return await load_registered_project(db, project_id)
     except Exception as exc:
         raise HTTPException(
             status_code=503,
             detail="Project context is temporarily unavailable",
         ) from exc
-
-    if row is None:
-        return None
-
-    path = str(row.path or "").strip()
-    if not path or not Path(path).is_dir():
-        return None
-
-    # `Project.from_path` 로 구성한다 — CLAUDE.md 본문과 `.aos-project.json`
-    # 메타데이터를 읽는 유일한 생성자다. 필드를 손으로 옮기면 `claude_md` 가
-    # 항상 None 이 되어 패널이 조용히 빈 화면이 된다.
-    project = Project.from_path(str(row.id), path)
-
-    # 이름·설명의 권위는 DB 행이다.
-    return project.model_copy(update={"name": row.name, "description": row.description or ""})
 
 
 async def _context_target(project_id: str, db) -> Project:
@@ -144,28 +111,35 @@ async def get_project_context(
     """
     from datetime import UTC, datetime
 
-    await require_project_role(project_id, current_user, db, min_role="viewer")
+    # Preserve direct service-level callers used by the orchestration engine
+    # tests; FastAPI supplies real user/session objects on the HTTP route.
+    if hasattr(current_user, "role") and hasattr(db, "execute"):
+        await require_project_role(project_id, current_user, db, min_role="viewer")
     project = await _context_target(project_id, db)
 
     # Get dev docs from dev/active folder
     dev_docs: list[DevDocFile] = []
-    project_path = Path(project.path)
-    dev_active_path = project_path / "dev" / "active"
+    dev_active_path = safe_project_child(project.path, "dev", "active", strict=True)
 
-    if dev_active_path.exists():
+    if dev_active_path is not None and dev_active_path.is_dir():
         for file_path in dev_active_path.glob("*.md"):
+            safe_file_path = safe_project_child(
+                project.path, "dev", "active", file_path.name, strict=True
+            )
+            if safe_file_path is None or not safe_file_path.is_file():
+                continue
             try:
-                stat = file_path.stat()
-                content = file_path.read_text(encoding="utf-8")
+                stat = safe_file_path.stat()
+                content = safe_file_path.read_text(encoding="utf-8")
                 dev_docs.append(
                     DevDocFile(
-                        name=file_path.name,
-                        path=str(file_path),
+                        name=safe_file_path.name,
+                        path=str(safe_file_path),
                         content=content,
                         modified_at=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
                     )
                 )
-            except Exception:
+            except (OSError, UnicodeError):
                 pass  # Skip files that can't be read
 
     # Sort by modified time, most recent first

--- a/src/backend/api/db_project.py
+++ b/src/backend/api/db_project.py
@@ -1,0 +1,88 @@
+"""Safe resolution of database-registered project filesystem targets."""
+
+from pathlib import Path
+
+from models.project import Project
+
+
+def resolve_registered_root(path: str | None) -> Path | None:
+    """Return the canonical registered directory, or ``None`` if unusable."""
+    raw_path = str(path or "").strip()
+    if not raw_path:
+        return None
+    try:
+        root = Path(raw_path).resolve(strict=True)
+    except OSError:
+        return None
+    return root if root.is_dir() else None
+
+
+def safe_project_child(
+    project_root: str | Path,
+    *parts: str,
+    strict: bool = False,
+) -> Path | None:
+    """Resolve a project child while rejecting symlink escapes.
+
+    The DB-registered root is the trust boundary. A child may be a symlink only
+    when its resolved target remains inside that root. ``strict=False`` is used
+    for files that may be created by a self-healing action.
+    """
+    root = resolve_registered_root(str(project_root))
+    if root is None:
+        return None
+    try:
+        resolved = root.joinpath(*parts).resolve(strict=strict)
+    except OSError:
+        return None
+    if resolved != root and root not in resolved.parents:
+        return None
+    return resolved
+
+
+def build_registered_project(row) -> Project | None:
+    """Build a Project from DB fields without trusting filesystem metadata.
+
+    `.aos-project.json` is not an authority for DB identity, organization, or
+    Git location. DB projects have no separate git_path column, so diagnostics
+    inspect only the registered project root.
+    """
+    root = resolve_registered_root(getattr(row, "path", None))
+    if root is None:
+        return None
+
+    claude_md = None
+    claude_path = safe_project_child(root, "CLAUDE.md", strict=True)
+    if claude_path is not None and claude_path.is_file():
+        try:
+            claude_md = claude_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            claude_md = None
+
+    git_dir = safe_project_child(root, ".git", strict=True)
+    return Project(
+        id=str(row.id),
+        name=str(row.name),
+        path=str(root),
+        description=str(row.description or ""),
+        claude_md=claude_md,
+        git_path=None,
+        git_enabled=git_dir is not None and git_dir.is_dir(),
+        organization_id=getattr(row, "organization_id", None),
+    )
+
+
+async def load_registered_project(db, project_id: str) -> Project | None:
+    """Load an active DB project and build its safe filesystem view."""
+    from sqlalchemy import select
+
+    from db.models import ProjectModel
+
+    result = await db.execute(
+        select(ProjectModel).where(
+            ProjectModel.id == project_id,
+            ProjectModel.is_active == True,  # noqa: E712
+        )
+    )
+    row = result.scalar_one_or_none()
+    return build_registered_project(row) if row is not None else None

--- a/src/backend/api/diagnostics.py
+++ b/src/backend/api/diagnostics.py
@@ -3,6 +3,9 @@
 Provides workspace, MCP, Git, and quota health checks per project.
 """
 
+import os
+from pathlib import Path
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from api.deps import (
@@ -12,10 +15,90 @@ from api.deps import (
     require_project_role,
 )
 from models.diagnostics import DiagnosticCategory, FixRequest, FixResult, ProjectDiagnostics
-from models.project import get_project
+from models.project import Project, get_project
 from services.environment_diagnostic_service import execute_fix, run_diagnostics
 
 router = APIRouter(tags=["orchestration"])
+
+# Returned when an authorized database-mode project carries no inspectable
+# directory. Kept distinct from the generic dependency-failure detail so the
+# two 503 causes stay separable by callers and by tests. Mirrors
+# ``api/monitoring.NO_MONITORED_PATH_DETAIL``.
+NO_DIAGNOSTIC_PATH_DETAIL = "Project has no registered filesystem path for environment diagnostics"
+
+
+def _use_database() -> bool:
+    return os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+async def _resolve_database_project(project_id: str, db) -> Project | None:
+    """Resolve the canonical DB project row into a diagnosable target.
+
+    Only ``ProjectModel.id`` is matched — the path-derived identifiers used by
+    the legacy filesystem registry and by ProjectConfigMonitor are deliberately
+    not accepted here, so they cannot reach the filesystem through diagnostics.
+
+    Returns ``None`` when the registration has no usable directory. The caller
+    keeps that fail-closed instead of guessing a path.
+    """
+    from sqlalchemy import select
+
+    from db.models import ProjectModel
+
+    try:
+        result = await db.execute(
+            select(ProjectModel).where(
+                ProjectModel.id == project_id,
+                ProjectModel.is_active == True,  # noqa: E712
+            )
+        )
+        row = result.scalar_one_or_none()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Project diagnostics are temporarily unavailable",
+        ) from exc
+
+    if row is None:
+        return None
+
+    path = str(row.path or "").strip()
+    if not path or not Path(path).is_dir():
+        return None
+
+    # `Project.from_path` 로 구성한다 (`api/git/_shared.resolve_project` 와 같은
+    # 이유). 필드를 손으로 옮기면 `.aos-project.json` 의 `git_path` 와
+    # `_check_git_repository` 파생 `git_enabled` 가 빠져 git 카테고리가 모든 DB
+    # 프로젝트에서 "Not a Git repository" 로 굳는다 — 테스트는 초록인데 화면만 틀린다.
+    project = Project.from_path(str(row.id), path)
+
+    # 이름·설명의 권위는 DB 행이다. `organization_id` 는 일부러 덮지 않는다 —
+    # 쿼터 진단이 조회하는 `OrganizationService` 는 인메모리 레지스트리라 DB 의
+    # org id 를 넘기면 "Organization not found" 라는 새 오진이 생긴다. 그 배선은
+    # 이 변경의 범위 밖이다.
+    return project.model_copy(update={"name": row.name, "description": row.description or ""})
+
+
+async def _diagnostic_target(project_id: str, db) -> Project:
+    """Resolve the diagnosed project *after* the caller has authorized access.
+
+    Database mode reads the DB registry, which is authoritative for both
+    identity and path. Filesystem mode keeps the legacy registry lookup behind
+    ``reject_legacy_project_operation_in_database_mode`` — that guard is
+    unreachable from here in database mode by construction, and is kept as a
+    standing assertion that the legacy branch never runs in that mode.
+    """
+    if _use_database():
+        resolved = await _resolve_database_project(project_id, db)
+        if resolved is None:
+            raise HTTPException(status_code=503, detail=NO_DIAGNOSTIC_PATH_DETAIL)
+        return resolved
+
+    reject_legacy_project_operation_in_database_mode()
+    legacy = get_project(project_id)
+    if not legacy:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return legacy
 
 
 @router.get(
@@ -32,10 +115,7 @@ async def get_project_diagnostics(
     Checks workspace, MCP, Git, and quota status.
     """
     await require_project_role(project_id, current_user, db, min_role="viewer")
-    reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = await _diagnostic_target(project_id, db)
 
     return run_diagnostics(project)
 
@@ -55,10 +135,7 @@ async def get_project_diagnostics_by_category(
     Valid categories: workspace, mcp, git, quota.
     """
     await require_project_role(project_id, current_user, db, min_role="viewer")
-    reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = await _diagnostic_target(project_id, db)
 
     return run_diagnostics(project, categories=[category])
 
@@ -77,12 +154,14 @@ async def fix_diagnostic_issue(
 
     Available actions: create_aos_config, create_claude_md, enable_mcp_servers.
     Returns the fix result with updated diagnostics.
+
+    The fix actions write files under the project directory, so they resolve
+    through the same fail-closed target resolver as the read paths — there is
+    no second, laxer lookup for the write surface — and the ``editor``
+    authorization check stays the first statement, before any resolution.
     """
     await require_project_role(project_id, current_user, db, min_role="editor")
-    reject_legacy_project_operation_in_database_mode()
-    project = get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = await _diagnostic_target(project_id, db)
 
     result = execute_fix(project, request.fix_action, request.params)
     if not result.success:

--- a/src/backend/api/diagnostics.py
+++ b/src/backend/api/diagnostics.py
@@ -4,10 +4,10 @@ Provides workspace, MCP, Git, and quota health checks per project.
 """
 
 import os
-from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from api.db_project import load_registered_project
 from api.deps import (
     get_current_user,
     get_db_session,
@@ -32,51 +32,14 @@ def _use_database() -> bool:
 
 
 async def _resolve_database_project(project_id: str, db) -> Project | None:
-    """Resolve the canonical DB project row into a diagnosable target.
-
-    Only ``ProjectModel.id`` is matched — the path-derived identifiers used by
-    the legacy filesystem registry and by ProjectConfigMonitor are deliberately
-    not accepted here, so they cannot reach the filesystem through diagnostics.
-
-    Returns ``None`` when the registration has no usable directory. The caller
-    keeps that fail-closed instead of guessing a path.
-    """
-    from sqlalchemy import select
-
-    from db.models import ProjectModel
-
+    """Resolve the canonical DB project row into a safe diagnosable target."""
     try:
-        result = await db.execute(
-            select(ProjectModel).where(
-                ProjectModel.id == project_id,
-                ProjectModel.is_active == True,  # noqa: E712
-            )
-        )
-        row = result.scalar_one_or_none()
+        return await load_registered_project(db, project_id)
     except Exception as exc:
         raise HTTPException(
             status_code=503,
             detail="Project diagnostics are temporarily unavailable",
         ) from exc
-
-    if row is None:
-        return None
-
-    path = str(row.path or "").strip()
-    if not path or not Path(path).is_dir():
-        return None
-
-    # `Project.from_path` 로 구성한다 (`api/git/_shared.resolve_project` 와 같은
-    # 이유). 필드를 손으로 옮기면 `.aos-project.json` 의 `git_path` 와
-    # `_check_git_repository` 파생 `git_enabled` 가 빠져 git 카테고리가 모든 DB
-    # 프로젝트에서 "Not a Git repository" 로 굳는다 — 테스트는 초록인데 화면만 틀린다.
-    project = Project.from_path(str(row.id), path)
-
-    # 이름·설명의 권위는 DB 행이다. `organization_id` 는 일부러 덮지 않는다 —
-    # 쿼터 진단이 조회하는 `OrganizationService` 는 인메모리 레지스트리라 DB 의
-    # org id 를 넘기면 "Organization not found" 라는 새 오진이 생긴다. 그 배선은
-    # 이 변경의 범위 밖이다.
-    return project.model_copy(update={"name": row.name, "description": row.description or ""})
 
 
 async def _diagnostic_target(project_id: str, db) -> Project:

--- a/src/backend/api/diagnostics.py
+++ b/src/backend/api/diagnostics.py
@@ -31,15 +31,22 @@ def _use_database() -> bool:
     return os.getenv("USE_DATABASE", "false").lower() == "true"
 
 
-def _unverifiable_categories() -> set[DiagnosticCategory]:
-    """Categories this deployment mode cannot resolve.
+def _unverifiable_categories(project: Project) -> set[DiagnosticCategory]:
+    """Categories whose backing data is out of reach for this project.
 
-    Quota reads ``OrganizationService``, which is backed by the legacy
-    in-memory registry. A database-mode project carries a DB organization id
-    that registry never holds, so running the check would report a healthy
-    project as ``Organization not found``.
+    Quota resolves organizations through ``OrganizationService``, which is
+    backed by the legacy in-memory registry and is never populated from the
+    database. So a database-mode project that carries a DB organization id
+    would be reported as ``Organization not found`` — a healthy project shown
+    as failed.
+
+    The gate is the organization, not the mode: a project with no organization
+    is diagnosed without any registry lookup, so its quota result stays
+    verifiable and must not be overridden.
     """
-    return {DiagnosticCategory.QUOTA} if _use_database() else set()
+    if _use_database() and project.organization_id:
+        return {DiagnosticCategory.QUOTA}
+    return set()
 
 
 async def _resolve_database_project(project_id: str, db) -> Project | None:
@@ -91,7 +98,7 @@ async def get_project_diagnostics(
     await require_project_role(project_id, current_user, db, min_role="viewer")
     project = await _diagnostic_target(project_id, db)
 
-    return run_diagnostics(project, unverifiable_categories=_unverifiable_categories())
+    return run_diagnostics(project, unverifiable_categories=_unverifiable_categories(project))
 
 
 @router.get(
@@ -114,7 +121,7 @@ async def get_project_diagnostics_by_category(
     return run_diagnostics(
         project,
         categories=[category],
-        unverifiable_categories=_unverifiable_categories(),
+        unverifiable_categories=_unverifiable_categories(project),
     )
 
 
@@ -141,7 +148,12 @@ async def fix_diagnostic_issue(
     await require_project_role(project_id, current_user, db, min_role="editor")
     project = await _diagnostic_target(project_id, db)
 
-    result = execute_fix(project, request.fix_action, request.params)
+    result = execute_fix(
+        project,
+        request.fix_action,
+        request.params,
+        unverifiable_categories=_unverifiable_categories(project),
+    )
     if not result.success:
         raise HTTPException(status_code=400, detail=result.message)
 

--- a/src/backend/api/diagnostics.py
+++ b/src/backend/api/diagnostics.py
@@ -31,6 +31,17 @@ def _use_database() -> bool:
     return os.getenv("USE_DATABASE", "false").lower() == "true"
 
 
+def _unverifiable_categories() -> set[DiagnosticCategory]:
+    """Categories this deployment mode cannot resolve.
+
+    Quota reads ``OrganizationService``, which is backed by the legacy
+    in-memory registry. A database-mode project carries a DB organization id
+    that registry never holds, so running the check would report a healthy
+    project as ``Organization not found``.
+    """
+    return {DiagnosticCategory.QUOTA} if _use_database() else set()
+
+
 async def _resolve_database_project(project_id: str, db) -> Project | None:
     """Resolve the canonical DB project row into a safe diagnosable target."""
     try:
@@ -80,7 +91,7 @@ async def get_project_diagnostics(
     await require_project_role(project_id, current_user, db, min_role="viewer")
     project = await _diagnostic_target(project_id, db)
 
-    return run_diagnostics(project)
+    return run_diagnostics(project, unverifiable_categories=_unverifiable_categories())
 
 
 @router.get(
@@ -100,7 +111,11 @@ async def get_project_diagnostics_by_category(
     await require_project_role(project_id, current_user, db, min_role="viewer")
     project = await _diagnostic_target(project_id, db)
 
-    return run_diagnostics(project, categories=[category])
+    return run_diagnostics(
+        project,
+        categories=[category],
+        unverifiable_categories=_unverifiable_categories(),
+    )
 
 
 @router.post(

--- a/src/backend/services/environment_diagnostic_service.py
+++ b/src/backend/services/environment_diagnostic_service.py
@@ -465,23 +465,52 @@ CATEGORY_RUNNERS = {
 }
 
 
+def _unverifiable_result(category: DiagnosticCategory) -> CategoryResult:
+    """A category the caller declared unverifiable in this deployment.
+
+    Reported as DEGRADED rather than HEALTHY or UNHEALTHY: the check did not
+    pass, but nothing about the project failed either.
+    """
+    return CategoryResult(
+        category=category,
+        status=DiagnosticStatus.DEGRADED,
+        checks=[
+            DiagnosticCheck(
+                name="unverifiable",
+                status=DiagnosticStatus.DEGRADED,
+                message=f"{category.value} cannot be verified in this deployment mode",
+            )
+        ],
+    )
+
+
 def run_diagnostics(
     project: Project,
     categories: list[DiagnosticCategory] | None = None,
+    unverifiable_categories: set[DiagnosticCategory] | None = None,
 ) -> ProjectDiagnostics:
     """Run environment diagnostics for a project.
 
     Args:
         project: The project to diagnose.
         categories: Specific categories to check. None means all.
+        unverifiable_categories: Categories whose backing data this deployment
+            cannot reach. Reported as DEGRADED instead of being run, so a check
+            that is merely out of reach is never rendered as a project failure.
+            The caller owns this decision — the diagnosers stay unaware of the
+            deployment mode.
 
     Returns:
         ProjectDiagnostics with results per category.
     """
     target_categories = categories or list(DiagnosticCategory)
+    unverifiable = unverifiable_categories or set()
     results: dict[str, CategoryResult] = {}
 
     for cat in target_categories:
+        if cat in unverifiable:
+            results[cat.value] = _unverifiable_result(cat)
+            continue
         runner = CATEGORY_RUNNERS.get(cat)
         if runner:
             try:

--- a/src/backend/services/environment_diagnostic_service.py
+++ b/src/backend/services/environment_diagnostic_service.py
@@ -623,6 +623,7 @@ def execute_fix(
     project: Project,
     fix_action: str,
     params: dict | None = None,
+    unverifiable_categories: set[DiagnosticCategory] | None = None,
 ) -> FixResult:
     """Execute a self-healing fix and re-diagnose.
 
@@ -644,7 +645,7 @@ def execute_fix(
 
     try:
         message = handler(project, params or {})
-        diagnostics = run_diagnostics(project)
+        diagnostics = run_diagnostics(project, unverifiable_categories=unverifiable_categories)
         return FixResult(
             fix_action=fix_action,
             success=True,

--- a/src/backend/services/environment_diagnostic_service.py
+++ b/src/backend/services/environment_diagnostic_service.py
@@ -9,6 +9,7 @@ import os
 import shutil
 from pathlib import Path
 
+from api.db_project import safe_project_child
 from models.diagnostics import (
     CategoryResult,
     DiagnosticCategory,
@@ -63,8 +64,8 @@ def _diagnose_workspace(project: Project) -> CategoryResult:
         )
 
     # 2. .aos-project.json validity
-    config_file = project_path / ".aos-project.json"
-    if config_file.exists():
+    config_file = safe_project_child(project.path, ".aos-project.json", strict=True)
+    if config_file is not None and config_file.is_file():
         try:
             data = json.loads(config_file.read_text(encoding="utf-8"))
             checks.append(
@@ -95,8 +96,8 @@ def _diagnose_workspace(project: Project) -> CategoryResult:
         )
 
     # 3. CLAUDE.md exists
-    claude_md = project_path / "CLAUDE.md"
-    if claude_md.exists():
+    claude_md = safe_project_child(project.path, "CLAUDE.md", strict=True)
+    if claude_md is not None and claude_md.is_file():
         size_kb = claude_md.stat().st_size / 1024
         checks.append(
             DiagnosticCheck(
@@ -167,11 +168,10 @@ def _diagnose_workspace(project: Project) -> CategoryResult:
 def _diagnose_mcp(project: Project) -> CategoryResult:
     """Check MCP server configuration health."""
     checks: list[DiagnosticCheck] = []
-    project_path = Path(project.path)
 
     # 1. Project-level MCP config (.claude/mcp.json)
-    mcp_json = project_path / ".claude" / "mcp.json"
-    if mcp_json.exists():
+    mcp_json = safe_project_child(project.path, ".claude", "mcp.json", strict=True)
+    if mcp_json is not None and mcp_json.is_file():
         try:
             data = json.loads(mcp_json.read_text(encoding="utf-8"))
             servers = data.get("mcpServers", {})
@@ -524,7 +524,9 @@ def run_diagnostics(
 
 def _fix_create_aos_config(project: Project, params: dict) -> str:
     """Create a default .aos-project.json."""
-    config_file = Path(project.path) / ".aos-project.json"
+    config_file = safe_project_child(project.path, ".aos-project.json")
+    if config_file is None:
+        raise ValueError("Refused to access a path outside the registered project root")
     if config_file.exists():
         return ".aos-project.json already exists"
 
@@ -541,7 +543,9 @@ def _fix_create_aos_config(project: Project, params: dict) -> str:
 
 def _fix_create_claude_md(project: Project, params: dict) -> str:
     """Create a minimal CLAUDE.md."""
-    claude_md = Path(project.path) / "CLAUDE.md"
+    claude_md = safe_project_child(project.path, "CLAUDE.md")
+    if claude_md is None:
+        raise ValueError("Refused to access a path outside the registered project root")
     if claude_md.exists():
         return "CLAUDE.md already exists"
 
@@ -552,7 +556,9 @@ def _fix_create_claude_md(project: Project, params: dict) -> str:
 
 def _fix_enable_mcp_servers(project: Project, params: dict) -> str:
     """Enable all disabled MCP servers in project config."""
-    mcp_json = Path(project.path) / ".claude" / "mcp.json"
+    mcp_json = safe_project_child(project.path, ".claude", "mcp.json")
+    if mcp_json is None:
+        raise ValueError("Refused to access a path outside the registered project root")
     if not mcp_json.exists():
         return "No .claude/mcp.json found"
 

--- a/src/dashboard/src/stores/__tests__/monitoring.test.ts
+++ b/src/dashboard/src/stores/__tests__/monitoring.test.ts
@@ -180,7 +180,7 @@ describe('monitoring store', () => {
       expect(eventSourceInstances).toHaveLength(0)
       expect(useMonitoringStore.getState().error).toContain('Database-backed')
     })
-    it('does not call the legacy context endpoint in database mode', async () => {
+    it('fetches project context in database mode', async () => {
       const capabilities = {
         project_id: 'p1' as string,
         mode: 'database' as const,
@@ -190,13 +190,23 @@ describe('monitoring store', () => {
         reason: 'Database-backed project monitoring is not available',
       }
       useMonitoringStore.setState({ monitoringCapabilitiesMap: {} })
-      mockApiClient.get.mockResolvedValueOnce(capabilities)
+      mockApiClient.get
+        .mockResolvedValueOnce(capabilities)
+        .mockResolvedValueOnce({
+          project_id: 'p1',
+          project_name: 'Database project',
+          project_path: '/registered/project',
+          claude_md: '# DB context',
+          dev_docs: [],
+          session_info: null,
+        })
 
       await useMonitoringStore.getState().fetchProjectContext('p1')
 
       expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects/p1/monitoring-capabilities')
-      expect(mockApiClient.get).not.toHaveBeenCalledWith('/api/projects/p1/context')
-      expect(useMonitoringStore.getState().contextUnavailableReason).toContain('Database-backed')
+      expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects/p1/context')
+      expect(useMonitoringStore.getState().projectContext?.claude_md).toBe('# DB context')
+      expect(useMonitoringStore.getState().contextUnavailableReason).toBeNull()
       expect(useMonitoringStore.getState().error).toBeNull()
     })
     it('clears stale context when capability loading fails', async () => {
@@ -226,10 +236,17 @@ describe('monitoring store', () => {
       })
       mockApiClient.get.mockReturnValueOnce(p1Context as any)
 
-      const p1Request = useMonitoringStore.getState().fetchProjectContext('p1')
+      const p1Capabilities = {
+        project_id: 'p1' as string,
+        mode: 'filesystem' as const,
+        health_config: 'available' as const,
+        health: 'available' as const,
+        checks: 'available' as const,
+        reason: null,
+      }
       useMonitoringStore.setState({
         monitoringCapabilitiesMap: {
-          p1: useMonitoringStore.getState().monitoringCapabilitiesMap.p1,
+          p1: p1Capabilities,
           p2: {
             project_id: 'p2',
             mode: 'database',
@@ -239,6 +256,15 @@ describe('monitoring store', () => {
             reason: 'Database-backed project monitoring is not available',
           },
         },
+      })
+      const p1Request = useMonitoringStore.getState().fetchProjectContext('p1')
+      mockApiClient.get.mockResolvedValueOnce({
+        project_id: 'p2',
+        project_name: 'Current project',
+        project_path: '/current',
+        claude_md: '# current',
+        dev_docs: [],
+        session_info: null,
       })
       const p2Request = useMonitoringStore.getState().fetchProjectContext('p2')
       await p2Request
@@ -253,8 +279,9 @@ describe('monitoring store', () => {
       })
       await p1Request
 
-      expect(useMonitoringStore.getState().projectContext).toBeNull()
-      expect(useMonitoringStore.getState().contextUnavailableReason).toContain('Database-backed')
+      expect(useMonitoringStore.getState().projectContext?.project_id).toBe('p2')
+      expect(useMonitoringStore.getState().projectContext?.claude_md).toBe('# current')
+      expect(useMonitoringStore.getState().contextUnavailableReason).toBeNull()
     })
 
     it('re-fetches capabilities when the cached project identity is inconsistent', async () => {
@@ -308,13 +335,21 @@ describe('monitoring store', () => {
           },
         },
       })
+      mockApiClient.get.mockResolvedValueOnce({
+        project_id: 'p2',
+        project_name: 'Current project',
+        project_path: '/current',
+        claude_md: '# current',
+        dev_docs: [],
+        session_info: null,
+      })
       await useMonitoringStore.getState().fetchProjectContext('p2')
 
       rejectP1(new Error('previous project capability request failed'))
       await p1Request
 
       expect(useMonitoringStore.getState().error).toBeNull()
-      expect(useMonitoringStore.getState().contextUnavailableReason).toContain('Database-backed')
+      expect(useMonitoringStore.getState().contextUnavailableReason).toBeNull()
     })
 
     it('rejects capability responses for a different project', async () => {

--- a/src/dashboard/src/stores/__tests__/monitoring.test.ts
+++ b/src/dashboard/src/stores/__tests__/monitoring.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../services/apiClient', () => ({
 
 import { useMonitoringStore } from '../monitoring'
 import { apiClient } from '../../services/apiClient'
+import { ApiError } from '../../services/errors'
 
 const mockApiClient = vi.mocked(apiClient)
 
@@ -208,6 +209,23 @@ describe('monitoring store', () => {
       expect(useMonitoringStore.getState().projectContext?.claude_md).toBe('# DB context')
       expect(useMonitoringStore.getState().contextUnavailableReason).toBeNull()
       expect(useMonitoringStore.getState().error).toBeNull()
+    })
+    it('stores a 503 context failure as a project-scoped unavailable state', async () => {
+      mockApiClient.get.mockRejectedValueOnce(
+        new ApiError({
+          message: 'Project has no registered filesystem path for context',
+          status: 503,
+          code: 'SERVICE_UNAVAILABLE',
+        }),
+      )
+
+      await useMonitoringStore.getState().fetchProjectContext('p1')
+
+      expect(useMonitoringStore.getState().error).toBeNull()
+      expect(useMonitoringStore.getState().contextUnavailableProjectId).toBe('p1')
+      expect(useMonitoringStore.getState().contextUnavailableReason).toBe(
+        'Project has no registered filesystem path for context',
+      )
     })
     it('clears stale context when capability loading fails', async () => {
       useMonitoringStore.setState({

--- a/src/dashboard/src/stores/__tests__/monitoring.test.ts
+++ b/src/dashboard/src/stores/__tests__/monitoring.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../services/apiClient', () => ({
   },
 }))
 
-import { useMonitoringStore } from '../monitoring'
+import { useMonitoringStore, CONTEXT_PATH_UNAVAILABLE_DETAIL } from '../monitoring'
 import { apiClient } from '../../services/apiClient'
 import { ApiError } from '../../services/errors'
 
@@ -226,6 +226,32 @@ describe('monitoring store', () => {
       expect(useMonitoringStore.getState().contextUnavailableReason).toBe(
         'Project has no registered filesystem path for context',
       )
+    })
+    it('pins the permanent-unavailability detail to the backend constant', () => {
+      // 백엔드 `api.context.NO_CONTEXT_PATH_DETAIL` 과 글자 단위로 같아야 한다.
+      // 한쪽만 바뀌면 영구/일시 503 구분이 조용히 무너진다 — 같은 리터럴을
+      // 양쪽 테스트에 고정해 그 변경이 반드시 빨간불을 내게 한다.
+      expect(CONTEXT_PATH_UNAVAILABLE_DETAIL).toBe(
+        'Project has no registered filesystem path for context',
+      )
+    })
+    it('keeps a transient 503 in the retryable error path', async () => {
+      // 일시적 DB 장애의 503 을 영구 불가로 분류하면 ContextPanel 이
+      // Refresh 버튼을 비활성화해(ContextPanel.tsx: disabled={Boolean(contextUnavailable)})
+      // 복구 가능한 장애에서 사용자가 재시도할 방법을 잃는다.
+      mockApiClient.get.mockRejectedValueOnce(
+        new ApiError({
+          message: 'Project context is temporarily unavailable',
+          status: 503,
+          code: 'SERVICE_UNAVAILABLE',
+        }),
+      )
+
+      await useMonitoringStore.getState().fetchProjectContext('p1')
+
+      expect(useMonitoringStore.getState().error).toBe('Project context is temporarily unavailable')
+      expect(useMonitoringStore.getState().contextUnavailableReason).toBeNull()
+      expect(useMonitoringStore.getState().contextUnavailableProjectId).toBeNull()
     })
     it('clears stale context when capability loading fails', async () => {
       useMonitoringStore.setState({

--- a/src/dashboard/src/stores/monitoring.ts
+++ b/src/dashboard/src/stores/monitoring.ts
@@ -3,6 +3,15 @@ import { apiClient } from '../services/apiClient'
 import { ApiError } from '../services/errors'
 import { createAuthenticatedSseClient } from '../services/authenticatedSse'
 import { getApiUrl } from '../config/api'
+
+/**
+ * 백엔드 `api.context.NO_CONTEXT_PATH_DETAIL` 의 사본.
+ *
+ * 이 문자열은 두 503 원인 중 **영구** 쪽(등록된 경로 없음)만 지목한다.
+ * 백엔드와 글자 단위로 같아야 하며, 양쪽 테스트가 같은 리터럴을 고정한다.
+ */
+export const CONTEXT_PATH_UNAVAILABLE_DETAIL =
+  'Project has no registered filesystem path for context'
 import {
   CheckType,
   CheckConfig,
@@ -400,7 +409,11 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
     } catch (e) {
       if (requestId !== projectContextRequestId) return
       const errorMessage = e instanceof Error ? e.message : 'Unknown error'
-      const contextUnavailable = e instanceof ApiError && e.status === 503
+      // 503 에는 두 가지 원인이 있다. 등록된 경로가 없는 것은 재시도해도 달라지지
+      // 않는 영구 상태이지만, 의존성 장애는 재시도로 회복된다. 후자를 영구 상태로
+      // 분류하면 ContextPanel 이 Refresh 를 비활성화해 회복 경로를 막는다.
+      const contextUnavailable =
+        e instanceof ApiError && e.status === 503 && e.message === CONTEXT_PATH_UNAVAILABLE_DETAIL
       set({
         error: contextUnavailable ? null : errorMessage,
         isLoadingContext: false,

--- a/src/dashboard/src/stores/monitoring.ts
+++ b/src/dashboard/src/stores/monitoring.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { apiClient } from '../services/apiClient'
+import { ApiError } from '../services/errors'
 import { createAuthenticatedSseClient } from '../services/authenticatedSse'
 import { getApiUrl } from '../config/api'
 import {
@@ -399,7 +400,13 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
     } catch (e) {
       if (requestId !== projectContextRequestId) return
       const errorMessage = e instanceof Error ? e.message : 'Unknown error'
-      set({ error: errorMessage, isLoadingContext: false })
+      const contextUnavailable = e instanceof ApiError && e.status === 503
+      set({
+        error: contextUnavailable ? null : errorMessage,
+        isLoadingContext: false,
+        contextUnavailableReason: contextUnavailable ? errorMessage : null,
+        contextUnavailableProjectId: contextUnavailable ? projectId : null,
+      })
     }
   },
 

--- a/src/dashboard/src/stores/monitoring.ts
+++ b/src/dashboard/src/stores/monitoring.ts
@@ -384,16 +384,6 @@ export const useMonitoringStore = create<MonitoringState>((set, get) => ({
       set({ isLoadingContext: false, error: capabilityError ?? null })
       return
     }
-    if (capabilities.mode === 'database') {
-      set({
-        projectContext: null,
-        isLoadingContext: false,
-        contextUnavailableReason: capabilities.reason ?? 'Project context is unavailable in database mode',
-        contextUnavailableProjectId: projectId,
-      })
-      return
-    }
-
     try {
       const data = await apiClient.get<ProjectContext>(`/api/projects/${projectId}/context`)
       if (requestId !== projectContextRequestId) return

--- a/tests/backend/api/test_context_db_mode.py
+++ b/tests/backend/api/test_context_db_mode.py
@@ -1,0 +1,422 @@
+"""DB 모드에서 우측 Project Context 패널이 실제로 동작해야 한다.
+
+`#328` 이후 DB 모드의 `/projects/{id}/context` 와 `/projects/{id}/claude-md` 는
+`reject_legacy_project_operation_in_database_mode()` 로 통째로 503 이었다.
+그 게이트는 레거시 파일시스템 레지스트리(`models.project.get_project`)가 DB
+모드의 인가 경계 밖에 있기 때문에 옳았지만, 대신 Context 패널이 통째로
+"Project context is unavailable in database mode" 로 죽었다.
+
+여기서 고정하는 계약 (`test_monitoring_db_health.py` 와 같은 계약을 context
+표면에 적용한다):
+
+  1. **공개 신원은 `ProjectModel.id`** — 응답의 `project_id` 는 요청한 정규
+     id 와 같아야 한다. 대시보드가 그 값으로 다음 요청을 만든다.
+  2. **읽는 경로는 DB 행의 `path` 하나뿐** — 경로 파생 id 나 임의 경로가
+     권위가 되지 않는다. 레거시 레지스트리(`get_project`)는 DB 모드에서 절대
+     호출되지 않는다.
+  3. **인가가 파일시스템 접근보다 먼저** — 401/403/404 는 그대로, 503 은 진짜
+     사용 불가한 DB 의존성과 '등록된 디렉터리 없음' 에만.
+
+라우트 전체(프레임워크 배선 포함)를 지나가게 한다 — 핸들러 직접 호출은
+`Depends(get_current_user)` 와 경로 파라미터 추출을 건너뛰어 이 계약을 검증하지
+못한다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+DB_UUID = "3f9c1b74-6d20-4a8e-9c31-5b7e0d2a8f61"
+UNREGISTERED_UUID = "00000000-0000-4000-8000-000000000000"
+
+CLAUDE_MD_BODY = "# Registered project\n\nRead from the DB-registered directory."
+DEV_DOC_BODY = "# Active task\n\nnotes"
+
+
+def _make_project_tree(root):
+    """CLAUDE.md 와 `dev/active` 문서를 가진 최소 프로젝트.
+
+    두 파일의 내용이 응답에 그대로 나타나야 **이 경로를 실제로 읽었다**는
+    증거가 된다 — 경로만 에코하는 구현으로는 통과하지 못한다.
+    """
+    root.mkdir(parents=True)
+    (root / "CLAUDE.md").write_text(CLAUDE_MD_BODY, encoding="utf-8")
+    dev_active = root / "dev" / "active"
+    dev_active.mkdir(parents=True)
+    (dev_active / "task.md").write_text(DEV_DOC_BODY, encoding="utf-8")
+    return root
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return SimpleNamespace(all=lambda: list(self._rows))
+
+    def all(self):
+        return [(r.id, r.path, r.organization_id) for r in self._rows]
+
+
+class _IdAwareDatabase:
+    """등록된 행의 id 가 쿼리에 바인딩됐을 때만 그 행을 돌려주는 세션 스텁.
+
+    id 를 무시하고 항상 행을 돌려주는 스텁이면 "미등록 id → 404" 테스트가
+    스텁의 고장으로도 통과한다(거짓 초록). 반대로 항상 빈 결과를 돌려주는
+    스텁이면 성공 케이스가 깨진다 — 두 케이스를 같은 스텁으로 짝지어 두면
+    스텁 자체가 검증된다.
+    """
+
+    def __init__(self, row):
+        self.row = row
+
+    async def execute(self, statement, *_args, **_kwargs):
+        try:
+            bound = {str(value) for value in statement.compile().params.values()}
+        except Exception:  # pragma: no cover - 방어적
+            bound = set()
+        if str(self.row.id) in bound:
+            return _Result([self.row])
+        return _Result([])
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+def _row(path, name="Agent-System"):
+    return SimpleNamespace(
+        id=DB_UUID,
+        name=name,
+        slug="agent-system",
+        description="",
+        path=path,
+        is_active=True,
+        settings={},
+        organization_id=None,
+        created_by=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+
+def _install_db(app, monkeypatch, row):
+    from api.deps import get_db_session
+
+    database = _IdAwareDatabase(row)
+
+    async def _override():
+        yield database
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    app.dependency_overrides[get_db_session] = _override
+    return database
+
+
+@pytest_asyncio.fixture
+async def db_mode_app(authenticated_app, tmp_path, monkeypatch):
+    """DB 에 경로를 가진 프로젝트 1건만 등록된 DB 모드 앱 (관리자 신원)."""
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+
+    # 레거시 레지스트리는 DB 모드에서 호출되면 안 된다 — 호출되면 즉시 터진다.
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("legacy filesystem project registry must not be used in DB mode")
+
+    monkeypatch.setattr("api.context.get_project", _forbidden)
+
+    from api.deps import get_db_session
+
+    yield authenticated_app, str(project_path)
+    authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+async def _get(app, url):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get(url)
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. 인가된 DB 모드 성공 경로
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_context_reads_the_registered_db_path(db_mode_app):
+    """context 는 **DB 행의 경로**에서 CLAUDE.md 와 dev/active 를 읽는다."""
+    app, project_path = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/context")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["project_id"] == DB_UUID
+    assert body["project_name"] == "Agent-System"
+    assert body["project_path"] == project_path
+    assert body["claude_md"] == CLAUDE_MD_BODY
+    assert [doc["name"] for doc in body["dev_docs"]] == ["task.md"]
+    assert body["dev_docs"][0]["content"] == DEV_DOC_BODY
+
+
+@pytest.mark.asyncio
+async def test_claude_md_reads_the_registered_db_path(db_mode_app):
+    """`/claude-md` 도 같은 경로에서 읽는다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/claude-md")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["content"] == CLAUDE_MD_BODY
+
+
+@pytest.mark.asyncio
+async def test_missing_claude_md_is_not_found_not_unavailable(authenticated_app, tmp_path, monkeypatch):
+    """등록 경로는 있는데 CLAUDE.md 만 없으면 404 — 503 이 아니다.
+
+    503 은 '검사 가능한 디렉터리가 없음' 하나에만 남겨 둔다. 두 원인을 같은
+    코드로 뭉개면 대시보드가 '설정 문제'와 '파일 없음'을 구분하지 못한다.
+    """
+    from api.deps import get_db_session
+
+    project_path = tmp_path / "no-claude-md"
+    project_path.mkdir()
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/claude-md")
+        assert response.status_code == 404, response.text
+
+        context = await _get(authenticated_app, f"/api/projects/{DB_UUID}/context")
+        assert context.status_code == 200, context.text
+        assert context.json()["claude_md"] is None
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. 인증·인가
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_request_is_rejected(app, tmp_path, monkeypatch):
+    """토큰 없는 요청은 401 — DB 모드에서도 그대로다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+
+    try:
+        for url in (
+            f"/api/projects/{DB_UUID}/context",
+            f"/api/projects/{DB_UUID}/claude-md",
+        ):
+            response = await _get(app, url)
+            assert response.status_code == 401, f"{url} -> {response.status_code}"
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_denied_project_access_is_forbidden_before_filesystem_access(
+    app, tmp_path, monkeypatch
+):
+    """권한 없는 인증 사용자는 403 — 파일시스템에 닿기 전에 막힌다."""
+    from api.deps import get_current_user, get_db_session
+    from services.project_access_service import ProjectAccessService
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="outsider", role="user", is_admin=False, is_active=True
+    )
+
+    async def _has_acl(*_args, **_kwargs):
+        return True
+
+    async def _no_access(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", _has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", _no_access)
+
+    async def _forbidden(*_args, **_kwargs):
+        raise AssertionError("project resolution must not run before authorization")
+
+    # 인가 실패는 대상 해석(=파일시스템 접근의 유일한 문)보다 먼저 나야 한다.
+    monkeypatch.setattr("api.context._context_target", _forbidden)
+
+    try:
+        for url in (
+            f"/api/projects/{DB_UUID}/context",
+            f"/api/projects/{DB_UUID}/claude-md",
+        ):
+            response = await _get(app, url)
+            assert response.status_code == 403, f"{url} -> {response.text}"
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. 신원 — 미등록·오형식·레거시 폴백 금지
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unregistered_canonical_id_is_not_found(db_mode_app):
+    """DB 에 없는 UUID 는 404 (같은 스텁이 위 테스트에서 200 을 낸다)."""
+    app, _ = db_mode_app
+
+    for url in (
+        f"/api/projects/{UNREGISTERED_UUID}/context",
+        f"/api/projects/{UNREGISTERED_UUID}/claude-md",
+    ):
+        response = await _get(app, url)
+        assert response.status_code == 404, f"{url} -> {response.text}"
+
+
+@pytest.mark.asyncio
+async def test_path_derived_id_is_not_authority_in_database_mode(db_mode_app):
+    """경로 파생 id 로는 닿지 못한다 — 레거시 파일시스템 폴백이 없다."""
+    app, project_path = db_mode_app
+    leaked_id = project_path.replace("/", "-")
+
+    response = await _get(app, f"/api/projects/{leaked_id}/context")
+
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_blank_identity_is_rejected(db_mode_app):
+    """공백 식별자는 400 — 빈 문자열이 필터를 넓히지 못하게 한다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, "/api/projects/%20/context")
+
+    assert response.status_code == 400, response.text
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. 503 은 두 원인뿐 — detail 로 구분된다
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_db_project_without_path_stays_fail_closed(authenticated_app, monkeypatch):
+    """경로 없는 DB 프로젝트는 503 이고 detail 이 경로 문제를 명시한다."""
+    from api.deps import get_db_session
+
+    _install_db(authenticated_app, monkeypatch, _row(None))
+    try:
+        for url in (
+            f"/api/projects/{DB_UUID}/context",
+            f"/api/projects/{DB_UUID}/claude-md",
+        ):
+            response = await _get(authenticated_app, url)
+            assert response.status_code == 503, f"{url} -> {response.text}"
+            assert "path" in response.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_registered_path_that_is_not_a_directory_stays_fail_closed(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """등록 경로가 디렉터리가 아니면 503 — 파일을 프로젝트 루트로 쓰지 않는다."""
+    from api.deps import get_db_session
+
+    not_a_dir = tmp_path / "regular-file"
+    not_a_dir.write_text("not a project", encoding="utf-8")
+    _install_db(authenticated_app, monkeypatch, _row(str(not_a_dir)))
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/context")
+        assert response.status_code == 503, response.text
+        assert "path" in response.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_database_failure_is_reported_as_unavailable(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """DB 조회 자체가 실패하면 503 — 위의 '경로 없음' 503 과 detail 이 다르다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    database = _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+
+    calls = {"n": 0}
+    original = database.execute
+
+    async def _fail_after_authorization(statement, *args, **kwargs):
+        calls["n"] += 1
+        # 1번째는 `require_project_role` 의 등록 확인 — 통과시킨다.
+        if calls["n"] == 1:
+            return await original(statement, *args, **kwargs)
+        raise RuntimeError("database connection lost")
+
+    monkeypatch.setattr(database, "execute", _fail_after_authorization)
+
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/context")
+        assert response.status_code == 503, response.text
+        assert "temporarily unavailable" in response.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 5. 파일시스템 모드는 그대로
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filesystem_mode_still_uses_the_legacy_registry(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """파일시스템 모드는 레거시 레지스트리와 경로 파생 id 를 그대로 쓴다."""
+    from api.deps import get_db_session
+    from models.project import Project
+
+    project_path = _make_project_tree(tmp_path / "fs-project")
+    legacy = Project.from_path("fs-project", str(project_path))
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+    monkeypatch.setattr(
+        "api.context.get_project",
+        lambda pid: legacy if pid == "fs-project" else None,
+    )
+
+    async def _override():
+        yield SimpleNamespace()
+
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    try:
+        response = await _get(authenticated_app, "/api/projects/fs-project/context")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["project_id"] == "fs-project"
+        assert body["claude_md"] == CLAUDE_MD_BODY
+        assert [doc["name"] for doc in body["dev_docs"]] == ["task.md"]
+
+        claude_md = await _get(authenticated_app, "/api/projects/fs-project/claude-md")
+        assert claude_md.status_code == 200, claude_md.text
+        assert claude_md.json()["content"] == CLAUDE_MD_BODY
+
+        missing = await _get(authenticated_app, "/api/projects/nope/context")
+        assert missing.status_code == 404, missing.text
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)

--- a/tests/backend/api/test_context_db_mode.py
+++ b/tests/backend/api/test_context_db_mode.py
@@ -16,6 +16,9 @@
      호출되지 않는다.
   3. **인가가 파일시스템 접근보다 먼저** — 401/403/404 는 그대로, 503 은 진짜
      사용 불가한 DB 의존성과 '등록된 디렉터리 없음' 에만.
+  4. **DB `Project` 는 파일시스템 metadata를 identity로 사용하지 않음** — DB의
+     name·description·organization_id가 권위이고, 별도 DB git_path가 없으므로
+     context는 등록된 프로젝트 루트의 CLAUDE.md와 dev/active만 읽는다.
 
 라우트 전체(프레임워크 배선 포함)를 지나가게 한다 — 핸들러 직접 호출은
 `Depends(get_current_user)` 와 경로 파라미터 추출을 건너뛰어 이 계약을 검증하지
@@ -167,6 +170,28 @@ async def test_context_reads_the_registered_db_path(db_mode_app):
     assert body["claude_md"] == CLAUDE_MD_BODY
     assert [doc["name"] for doc in body["dev_docs"]] == ["task.md"]
     assert body["dev_docs"][0]["content"] == DEV_DOC_BODY
+
+
+@pytest.mark.asyncio
+async def test_context_rejects_dev_active_symlink_escape(authenticated_app, tmp_path, monkeypatch):
+    """dev/active 심링크가 DB 등록 루트 밖으로 나가면 읽지 않는다."""
+    from api.deps import get_db_session
+
+    project_path = tmp_path / "Agent-System"
+    project_path.mkdir()
+    (project_path / "CLAUDE.md").write_text(CLAUDE_MD_BODY, encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("not for this project", encoding="utf-8")
+    (project_path / "dev").mkdir()
+    (project_path / "dev" / "active").symlink_to(outside, target_is_directory=True)
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+
+    response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/context")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["dev_docs"] == []
+    authenticated_app.dependency_overrides.pop(get_db_session, None)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/api/test_context_db_mode.py
+++ b/tests/backend/api/test_context_db_mode.py
@@ -445,3 +445,19 @@ async def test_filesystem_mode_still_uses_the_legacy_registry(
         assert missing.status_code == 404, missing.text
     finally:
         authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+def test_no_context_path_detail_is_pinned_to_the_dashboard_literal():
+    """영구 불가 503 의 detail 은 대시보드와 글자 단위로 같아야 한다.
+
+    `apiClient.buildApiError()` 는 FastAPI 의 `detail` 을 그대로 `ApiError.message`
+    에 넣고, 대시보드 스토어는 그 문자열로 **영구(경로 없음)** 와 **일시(의존성
+    장애)** 503 을 구분한다. 한쪽만 바뀌면 일시 장애가 영구 불가로 표시되어
+    Refresh 버튼이 잠긴다 — 그 회귀를 여기서 빨간불로 만든다.
+
+    대응 상수: `src/dashboard/src/stores/monitoring.ts`
+    의 `CONTEXT_PATH_UNAVAILABLE_DETAIL`.
+    """
+    from api.context import NO_CONTEXT_PATH_DETAIL
+
+    assert NO_CONTEXT_PATH_DETAIL == "Project has no registered filesystem path for context"

--- a/tests/backend/api/test_diagnostics_db_mode.py
+++ b/tests/backend/api/test_diagnostics_db_mode.py
@@ -13,8 +13,9 @@
      권위가 되지 않는다. 레거시 레지스트리는 DB 모드에서 절대 호출되지 않는다.
   3. **인가가 파일시스템 접근보다 먼저** — 401/403/404 는 그대로, 503 은 진짜
      사용 불가한 의존성(또는 경로 없는 등록)에만.
-  4. **`Project` 는 `Project.from_path` 로 구성** — 필드를 손으로 옮기면
-     `.aos-project.json` 의 `git_path` 가 조용히 무시된다.
+  4. **DB `Project` 는 파일시스템 metadata를 identity로 사용하지 않음** — DB의
+     name·description·organization_id가 권위이고, 별도 DB git_path가 없으므로
+     진단 Git 대상은 등록된 프로젝트 루트로 제한한다.
 
 라우트 전체(프레임워크 배선 포함)를 지나가게 한다 — 핸들러 직접 호출은
 `Depends(get_current_user)` 와 경로 파라미터 추출을 건너뛰어 이 계약을 검증하지
@@ -94,7 +95,7 @@ class _IdAwareDatabase:
         return None
 
 
-def _row(path):
+def _row(path, organization_id=None):
     return SimpleNamespace(
         id=DB_UUID,
         name="Agent-System",
@@ -103,7 +104,7 @@ def _row(path):
         path=path,
         is_active=True,
         settings={},
-        organization_id=None,
+        organization_id=organization_id,
         created_by=None,
         created_at=None,
         updated_at=None,
@@ -197,21 +198,85 @@ async def test_single_category_diagnostics_succeeds(db_mode_app):
 
 
 @pytest.mark.asyncio
-async def test_git_metadata_comes_from_the_registered_path(db_mode_app):
-    """git 카테고리는 `.aos-project.json` 의 `git_path` 를 본다.
-
-    이 단언이 없으면 DB 행 필드를 손으로 옮겨 `Project` 를 만드는 구현이 초록으로
-    통과한다 — 그 구현에서는 `git_path` 가 None 이고 `git_enabled` 가 영구히
-    False 라, 모든 DB 프로젝트가 자기 경로로 "Not a Git repository" 를 보고한다.
-    """
+async def test_git_metadata_cannot_escape_the_registered_path(db_mode_app):
+    """DB 프로젝트는 metadata의 외부 git_path를 진단 대상로 사용하지 않는다."""
     app, project_path = db_mode_app
 
     response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics/git")
 
     assert response.status_code == 200, response.text
     checks = {c["name"]: c for c in response.json()["categories"]["git"]["checks"]}
-    assert checks["git_repository"]["details"]["path"] == METADATA_GIT_PATH
-    assert checks["git_repository"]["details"]["path"] != project_path
+    assert checks["git_repository"]["details"]["path"] == project_path
+
+
+@pytest.mark.asyncio
+async def test_db_identity_overrides_filesystem_metadata(authenticated_app, tmp_path, monkeypatch):
+    """DB 조직 ID가 metadata의 조직 ID보다 우선하고 외부 git_path는 제거된다."""
+    from api.db_project import load_registered_project
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    (project_path / ".aos-project.json").write_text(
+        json.dumps(
+            {
+                "organization_id": "filesystem-org",
+                "git_path": "/outside/repository",
+            }
+        ),
+        encoding="utf-8",
+    )
+    database = _install_db(
+        authenticated_app, monkeypatch, _row(str(project_path), organization_id="db-org")
+    )
+
+    try:
+        project = await load_registered_project(database, DB_UUID)
+        assert project is not None
+        assert project.organization_id == "db-org"
+        assert project.git_path is None
+        assert project.path == str(project_path.resolve())
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_rejects_project_config_symlink_escape(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """진단 읽기·self-healing 쓰기는 등록 루트 밖의 symlink를 따라가지 않는다."""
+    from api.deps import get_db_session
+
+    project_path = tmp_path / "Agent-System"
+    project_path.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_config = outside / "mcp.json"
+    outside_config.write_text(
+        json.dumps({"mcpServers": {"outside": {"disabled": True}}}), encoding="utf-8"
+    )
+    (project_path / ".claude").symlink_to(outside, target_is_directory=True)
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+    _forbid_legacy_registry(monkeypatch)
+
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/diagnostics/mcp")
+        assert response.status_code == 200, response.text
+        checks = {c["name"]: c for c in response.json()["categories"]["mcp"]["checks"]}
+        assert checks["mcp_project_config"]["message"] == (
+            "No project-level MCP config (using global)"
+        )
+
+        fix_response = await _post(
+            authenticated_app,
+            f"/api/projects/{DB_UUID}/diagnostics/fix",
+            {"fix_action": "enable_mcp_servers", "params": {}},
+        )
+        assert fix_response.status_code == 400, fix_response.text
+        assert json.loads(outside_config.read_text(encoding="utf-8"))["mcpServers"]["outside"][
+            "disabled"
+        ] is True
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/api/test_diagnostics_db_mode.py
+++ b/tests/backend/api/test_diagnostics_db_mode.py
@@ -1,0 +1,515 @@
+"""DB 모드에서 Environment Diagnostics 가 실제로 동작해야 한다.
+
+`/api/projects/{id}/diagnostics` 는 `reject_legacy_project_operation_in_database_mode()`
+로 통째로 503 이었다. 그 게이트는 레거시 파일시스템 레지스트리
+(`models.project.get_project`)가 DB 모드의 인가 경계 밖에 있기 때문에 옳았지만,
+대신 Monitor 화면의 Environment Diagnostics 패널이 오류 배너로 죽었다.
+
+여기서 고정하는 계약 (`test_monitoring_db_health.py` 와 같은 계약):
+
+  1. **공개 신원은 `ProjectModel.id`** — 응답의 `project_id` 는 요청한 정규 id 와
+     같아야 한다. 대시보드가 그 값으로 다음 요청을 만든다.
+  2. **진단 대상 경로는 DB 행의 `path` 하나뿐** — 경로 파생 id 나 임의 경로가
+     권위가 되지 않는다. 레거시 레지스트리는 DB 모드에서 절대 호출되지 않는다.
+  3. **인가가 파일시스템 접근보다 먼저** — 401/403/404 는 그대로, 503 은 진짜
+     사용 불가한 의존성(또는 경로 없는 등록)에만.
+  4. **`Project` 는 `Project.from_path` 로 구성** — 필드를 손으로 옮기면
+     `.aos-project.json` 의 `git_path` 가 조용히 무시된다.
+
+라우트 전체(프레임워크 배선 포함)를 지나가게 한다 — 핸들러 직접 호출은
+`Depends(get_current_user)` 와 경로 파라미터 추출을 건너뛰어 이 계약을 검증하지
+못한다.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+DB_UUID = "7b2d4e19-8c53-4f61-a0d7-3e5c9f18b240"
+UNREGISTERED_UUID = "00000000-0000-4000-8000-000000000000"
+
+# `.aos-project.json` 에만 있는 값들. 응답에 나타나면 **이 경로를 실제로 읽었다**는
+# 증거가 된다.
+METADATA_NAME = "name-from-metadata"
+METADATA_GIT_PATH = "/nonexistent/declared-git-path"
+
+
+def _make_project_tree(root, *, with_metadata: bool = True):
+    """`.aos-project.json` 을 가진 최소 프로젝트 디렉터리."""
+    root.mkdir(parents=True)
+    if with_metadata:
+        (root / ".aos-project.json").write_text(
+            json.dumps({"name": METADATA_NAME, "git_path": METADATA_GIT_PATH}),
+            encoding="utf-8",
+        )
+    return root
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return SimpleNamespace(all=lambda: list(self._rows))
+
+    def all(self):
+        return [(r.id, r.path, r.organization_id) for r in self._rows]
+
+
+class _IdAwareDatabase:
+    """등록된 행의 id 가 쿼리에 바인딩됐을 때만 그 행을 돌려주는 세션 스텁.
+
+    id 를 무시하고 항상 행을 돌려주는 스텁이면 "미등록 id → 404" 테스트가
+    스텁의 고장으로도 통과한다(거짓 초록). 반대로 항상 빈 결과를 돌려주는
+    스텁이면 성공 케이스가 깨진다 — 두 케이스를 같은 스텁으로 짝지어 두면
+    스텁 자체가 검증된다.
+    """
+
+    def __init__(self, row):
+        self.row = row
+
+    async def execute(self, statement, *_args, **_kwargs):
+        try:
+            bound = {str(value) for value in statement.compile().params.values()}
+        except Exception:  # pragma: no cover - 방어적
+            bound = set()
+        if str(self.row.id) in bound:
+            return _Result([self.row])
+        return _Result([])
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+def _row(path):
+    return SimpleNamespace(
+        id=DB_UUID,
+        name="Agent-System",
+        slug="agent-system",
+        description="registered in the database",
+        path=path,
+        is_active=True,
+        settings={},
+        organization_id=None,
+        created_by=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+
+def _install_db(app, monkeypatch, row):
+    from api.deps import get_db_session
+
+    database = _IdAwareDatabase(row)
+
+    async def _override():
+        yield database
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    app.dependency_overrides[get_db_session] = _override
+    return database
+
+
+def _forbid_legacy_registry(monkeypatch):
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("legacy filesystem project registry must not be used in DB mode")
+
+    monkeypatch.setattr("api.diagnostics.get_project", _forbidden)
+
+
+@pytest_asyncio.fixture
+async def db_mode_app(authenticated_app, tmp_path, monkeypatch):
+    """DB 에 경로를 가진 프로젝트 1건만 등록된 DB 모드 앱 (관리자 신원)."""
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+    _forbid_legacy_registry(monkeypatch)
+
+    from api.deps import get_db_session
+
+    yield authenticated_app, str(Path(project_path).resolve())
+    authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+async def _get(app, url):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get(url)
+
+
+async def _post(app, url, payload):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.post(url, json=payload)
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. 인가된 DB 모드 성공 경로
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_full_diagnostics_reads_the_registered_db_path(db_mode_app):
+    """전체 진단은 200 이고, DB 행의 경로를 실제로 읽는다."""
+    app, project_path = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # 공개 신원은 정규 DB id — 대시보드가 이 값으로 다음 요청을 만든다.
+    assert body["project_id"] == DB_UUID
+    # 이름의 권위는 DB 행이다 (`.aos-project.json` 의 이름이 아니다).
+    assert body["project_name"] == "Agent-System"
+    assert body["project_name"] != METADATA_NAME
+
+    workspace = body["categories"]["workspace"]
+    checks = {c["name"]: c for c in workspace["checks"]}
+    # `.aos-project.json` 은 이 tmp 경로에만 있다 — 읽었다는 증거.
+    assert checks["aos_config"]["message"] == ".aos-project.json is valid"
+    assert checks["path_accessible"]["status"] == "healthy"
+    assert project_path in checks["path_accessible"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_single_category_diagnostics_succeeds(db_mode_app):
+    """카테고리 단건 진단도 200 이며 그 카테고리만 돌려준다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics/workspace")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["project_id"] == DB_UUID
+    assert list(body["categories"]) == ["workspace"]
+
+
+@pytest.mark.asyncio
+async def test_git_metadata_comes_from_the_registered_path(db_mode_app):
+    """git 카테고리는 `.aos-project.json` 의 `git_path` 를 본다.
+
+    이 단언이 없으면 DB 행 필드를 손으로 옮겨 `Project` 를 만드는 구현이 초록으로
+    통과한다 — 그 구현에서는 `git_path` 가 None 이고 `git_enabled` 가 영구히
+    False 라, 모든 DB 프로젝트가 자기 경로로 "Not a Git repository" 를 보고한다.
+    """
+    app, project_path = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics/git")
+
+    assert response.status_code == 200, response.text
+    checks = {c["name"]: c for c in response.json()["categories"]["git"]["checks"]}
+    assert checks["git_repository"]["details"]["path"] == METADATA_GIT_PATH
+    assert checks["git_repository"]["details"]["path"] != project_path
+
+
+@pytest.mark.asyncio
+async def test_fix_writes_into_the_registered_db_path(authenticated_app, tmp_path, monkeypatch):
+    """self-healing 수정은 DB 행의 경로 안에만 쓴다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+    _forbid_legacy_registry(monkeypatch)
+
+    try:
+        response = await _post(
+            authenticated_app,
+            f"/api/projects/{DB_UUID}/diagnostics/fix",
+            {"fix_action": "create_claude_md", "params": {}},
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is True
+        assert body["diagnostics"]["project_id"] == DB_UUID
+        assert (project_path / "CLAUDE.md").exists()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. 인증·인가 (파일시스템 접근보다 먼저)
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_request_is_rejected(app, tmp_path, monkeypatch):
+    """토큰 없는 요청은 401 — DB 모드에서도 그대로다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+
+    try:
+        for url in (
+            f"/api/projects/{DB_UUID}/diagnostics",
+            f"/api/projects/{DB_UUID}/diagnostics/workspace",
+        ):
+            response = await _get(app, url)
+            assert response.status_code == 401, f"{url} -> {response.status_code}"
+
+        posted = await _post(
+            app,
+            f"/api/projects/{DB_UUID}/diagnostics/fix",
+            {"fix_action": "create_claude_md", "params": {}},
+        )
+        assert posted.status_code == 401, posted.text
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_denied_project_access_is_forbidden(app, tmp_path, monkeypatch):
+    """권한 없는 인증 사용자는 403 — 진단이 파일시스템에 닿기 전에 막힌다."""
+    from api.deps import get_current_user, get_db_session
+    from services.project_access_service import ProjectAccessService
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="outsider", role="user", is_admin=False, is_active=True
+    )
+
+    async def _has_acl(*_args, **_kwargs):
+        return True
+
+    async def _no_access(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", _has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", _no_access)
+
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("diagnostics must not run before authorization")
+
+    monkeypatch.setattr("api.diagnostics.run_diagnostics", _forbidden)
+
+    try:
+        response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics")
+        assert response.status_code == 403, response.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_viewer_can_read_but_cannot_execute_fix(app, tmp_path, monkeypatch):
+    """읽기는 viewer, 수정은 editor — DB 모드에서도 등급이 유지된다."""
+    from api.deps import get_current_user, get_db_session
+    from services.project_access_service import ProjectAccessService
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    _install_db(app, monkeypatch, _row(str(project_path)))
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id="reader", role="user", is_admin=False, is_active=True
+    )
+
+    async def _has_acl(*_args, **_kwargs):
+        return True
+
+    async def _viewer(*_args, **_kwargs):
+        return "viewer"
+
+    monkeypatch.setattr(ProjectAccessService, "has_any_access_control", _has_acl)
+    monkeypatch.setattr(ProjectAccessService, "check_access", _viewer)
+
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("fix must not touch the filesystem before authorization")
+
+    monkeypatch.setattr("api.diagnostics.execute_fix", _forbidden)
+
+    try:
+        readable = await _get(app, f"/api/projects/{DB_UUID}/diagnostics")
+        assert readable.status_code == 200, readable.text
+
+        response = await _post(
+            app,
+            f"/api/projects/{DB_UUID}/diagnostics/fix",
+            {"fix_action": "create_claude_md", "params": {}},
+        )
+        assert response.status_code == 403, response.text
+        assert not (project_path / "CLAUDE.md").exists()
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. 신원 — 미등록·오형식·레거시 폴백 금지
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unregistered_canonical_id_is_not_found(db_mode_app):
+    """DB 에 없는 UUID 는 404 (같은 스텁이 위 테스트에서 200 을 낸다)."""
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/projects/{UNREGISTERED_UUID}/diagnostics")
+
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_path_derived_id_is_not_authority_in_database_mode(db_mode_app):
+    """경로 파생 id 로는 닿지 못한다 — 레거시 파일시스템 폴백이 없다."""
+    app, project_path = db_mode_app
+    leaked_id = project_path.replace("/", "-")
+
+    response = await _get(app, f"/api/projects/{leaked_id}/diagnostics")
+
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_blank_identity_is_rejected(db_mode_app):
+    """공백 식별자는 400 — 빈 문자열이 필터를 넓히지 못하게 한다."""
+    app, _ = db_mode_app
+
+    response = await _get(app, "/api/projects/%20/diagnostics")
+
+    assert response.status_code == 400, response.text
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. fail-closed 503 — 두 원인을 detail 로 분리해 검증
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_db_project_without_path_stays_fail_closed(authenticated_app, monkeypatch):
+    """경로 없는 DB 프로젝트는 세 표면 모두 503 — 레거시로 폴백하지 않는다."""
+    from api.deps import get_db_session
+
+    _install_db(authenticated_app, monkeypatch, _row(None))
+    _forbid_legacy_registry(monkeypatch)
+
+    try:
+        for url in (
+            f"/api/projects/{DB_UUID}/diagnostics",
+            f"/api/projects/{DB_UUID}/diagnostics/workspace",
+        ):
+            response = await _get(authenticated_app, url)
+            assert response.status_code == 503, f"{url} -> {response.text}"
+            assert "path" in response.json()["detail"].lower()
+
+        posted = await _post(
+            authenticated_app,
+            f"/api/projects/{DB_UUID}/diagnostics/fix",
+            {"fix_action": "create_claude_md", "params": {}},
+        )
+        assert posted.status_code == 503, posted.text
+        assert "path" in posted.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_db_project_with_non_directory_path_stays_fail_closed(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """등록된 경로가 디렉터리가 아니면 503 — 존재만으로는 통과시키지 않는다."""
+    from api.deps import get_db_session
+
+    not_a_directory = tmp_path / "registered-as-a-file"
+    not_a_directory.write_text("not a project", encoding="utf-8")
+    _install_db(authenticated_app, monkeypatch, _row(str(not_a_directory)))
+    _forbid_legacy_registry(monkeypatch)
+
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/diagnostics")
+        assert response.status_code == 503, response.text
+        assert "path" in response.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_database_failure_is_reported_as_unavailable(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """DB 조회 자체가 실패하면 503 — 위의 '경로 없음' 503 과 detail 이 다르다."""
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    database = _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+    _forbid_legacy_registry(monkeypatch)
+
+    calls = {"n": 0}
+    original = database.execute
+
+    async def _fail_after_authorization(statement, *args, **kwargs):
+        calls["n"] += 1
+        # 1번째는 `require_project_role` 의 등록 확인 — 통과시킨다.
+        if calls["n"] == 1:
+            return await original(statement, *args, **kwargs)
+        raise RuntimeError("database connection lost")
+
+    monkeypatch.setattr(database, "execute", _fail_after_authorization)
+
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/diagnostics")
+        assert response.status_code == 503, response.text
+        assert "temporarily unavailable" in response.json()["detail"].lower()
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 5. 파일시스템 모드는 그대로
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filesystem_mode_still_uses_the_legacy_registry(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """파일시스템 모드는 레거시 레지스트리와 경로 파생 id 를 그대로 쓴다."""
+    from api.deps import get_db_session
+    from models.project import Project
+
+    project_path = _make_project_tree(tmp_path / "fs-project")
+    legacy = Project.from_path("fs-project", str(project_path))
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+    monkeypatch.setattr(
+        "api.diagnostics.get_project",
+        lambda pid: legacy if pid == "fs-project" else None,
+    )
+
+    async def _override():
+        yield SimpleNamespace()
+
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    try:
+        response = await _get(authenticated_app, "/api/projects/fs-project/diagnostics")
+        assert response.status_code == 200, response.text
+        assert response.json()["project_id"] == "fs-project"
+
+        category = await _get(authenticated_app, "/api/projects/fs-project/diagnostics/workspace")
+        assert category.status_code == 200, category.text
+        assert list(category.json()["categories"]) == ["workspace"]
+
+        fixed = await _post(
+            authenticated_app,
+            "/api/projects/fs-project/diagnostics/fix",
+            {"fix_action": "create_claude_md", "params": {}},
+        )
+        assert fixed.status_code == 200, fixed.text
+        assert (project_path / "CLAUDE.md").exists()
+
+        missing = await _get(authenticated_app, "/api/projects/nope/diagnostics")
+        assert missing.status_code == 404, missing.text
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)

--- a/tests/backend/api/test_diagnostics_db_mode.py
+++ b/tests/backend/api/test_diagnostics_db_mode.py
@@ -669,3 +669,44 @@ async def test_filesystem_mode_quota_still_runs_the_real_check(
         assert quota["checks"][0]["name"] == "organization"
     finally:
         authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_personal_db_project_keeps_the_real_quota_check(db_mode_app):
+    """조직이 없는 DB 프로젝트의 quota 는 그대로 확인 가능하다.
+
+    `organization_id` 가 없으면 `_diagnose_quota` 는 조직 조회 없이 "개인
+    프로젝트"로 HEALTHY 를 낸다 — 레거시 레지스트리가 필요 없으므로 DB 모드에서도
+    확인 불가가 아니다. 모드만 보고 덮으면 멀쩡한 초록이 거짓 노랑이 된다.
+    """
+    app, _ = db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics/quota")
+
+    assert response.status_code == 200, response.text
+    quota = response.json()["categories"]["quota"]
+    assert quota["status"] == "healthy", quota
+    assert quota["checks"][0]["name"] == "organization"
+
+
+@pytest.mark.asyncio
+async def test_fix_result_diagnostics_follow_the_same_quota_policy(org_linked_db_mode_app):
+    """fix 응답에 실린 재진단도 같은 정책을 따른다.
+
+    같은 프로젝트가 진단 엔드포인트에서는 DEGRADED, fix 응답에서는 UNHEALTHY 로
+    갈리면 대시보드가 어느 쪽을 읽었는지에 따라 건강 상태가 뒤바뀐다.
+    """
+    app = org_linked_db_mode_app
+
+    response = await _post(
+        app,
+        f"/api/projects/{DB_UUID}/diagnostics/fix",
+        {"fix_action": "create_claude_md", "params": {}},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["success"] is True, body
+    quota = body["diagnostics"]["categories"]["quota"]
+    assert quota["status"] == "degraded", quota
+    assert body["diagnostics"]["overall_status"] != "unhealthy", body["diagnostics"]

--- a/tests/backend/api/test_diagnostics_db_mode.py
+++ b/tests/backend/api/test_diagnostics_db_mode.py
@@ -578,3 +578,94 @@ async def test_filesystem_mode_still_uses_the_legacy_registry(
         assert missing.status_code == 404, missing.text
     finally:
         authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 6. DB 조직이 연결된 프로젝트의 quota 진단
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def org_linked_db_mode_app(authenticated_app, tmp_path, monkeypatch):
+    """조직이 연결된 DB 프로젝트 1건만 등록된 DB 모드 앱.
+
+    조직은 DB 에만 존재한다 — 레거시 인메모리 `OrganizationService` 는 이 id 를
+    모른다. 그것이 DB 모드의 정상 상태이지 프로젝트의 결함이 아니다.
+    """
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    row = _row(str(project_path), organization_id="org-only-in-database")
+    _install_db(authenticated_app, monkeypatch, row)
+    _forbid_legacy_registry(monkeypatch)
+
+    from api.deps import get_db_session
+
+    yield authenticated_app
+    authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.mark.asyncio
+async def test_db_organization_does_not_make_diagnostics_unhealthy(org_linked_db_mode_app):
+    """DB 전용 조직은 quota 를 UNHEALTHY 로 만들지 않는다.
+
+    quota 진단은 인메모리 `OrganizationService` 만 읽을 수 있다. DB 모드에서
+    조직을 못 찾는 것은 "조직 없음"이 아니라 "여기서 확인 불가"이므로,
+    `Organization not found` 라는 거짓 red 대신 DEGRADED 로 표현되어야 한다.
+    """
+    app = org_linked_db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    quota = body["categories"]["quota"]
+    assert quota["status"] == "degraded", quota
+    messages = " ".join(c["message"] for c in quota["checks"])
+    assert "not found" not in messages.lower(), messages
+    assert body["overall_status"] != "unhealthy", body["overall_status"]
+
+
+@pytest.mark.asyncio
+async def test_single_quota_category_is_degraded_in_database_mode(org_linked_db_mode_app):
+    """카테고리 단건 조회도 같은 계약을 따른다."""
+    app = org_linked_db_mode_app
+
+    response = await _get(app, f"/api/projects/{DB_UUID}/diagnostics/quota")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert list(body["categories"]) == ["quota"]
+    assert body["categories"]["quota"]["status"] == "degraded", body
+
+
+@pytest.mark.asyncio
+async def test_filesystem_mode_quota_still_runs_the_real_check(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """파일시스템 모드에서는 quota 진단이 그대로 실행된다 (DEGRADED 로 덮이지 않는다).
+
+    DB 모드 전용 처리가 다른 배포 모드로 새면 실제 quota 위반이 조용히 숨는다.
+    """
+    from api.deps import get_db_session
+    from models.project import Project
+
+    project_path = _make_project_tree(tmp_path / "fs-quota")
+    legacy = Project.from_path("fs-quota", str(project_path))
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+    monkeypatch.setattr(
+        "api.diagnostics.get_project",
+        lambda pid: legacy if pid == "fs-quota" else None,
+    )
+
+    async def _override():
+        yield SimpleNamespace()
+
+    authenticated_app.dependency_overrides[get_db_session] = _override
+    try:
+        response = await _get(authenticated_app, "/api/projects/fs-quota/diagnostics/quota")
+        assert response.status_code == 200, response.text
+        quota = response.json()["categories"]["quota"]
+        assert quota["status"] == "healthy", quota
+        assert quota["checks"][0]["name"] == "organization"
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)


### PR DESCRIPTION
## Summary
- Database 모드에서 프로젝트 컨텍스트/진단이 항상 비어 있던 문제를 해결한다 — DB 레지스트리를 신원·경로의 권위로 삼아 실제 컨텍스트를 제공한다.
- DB 등록 루트를 신뢰 경계로 고정하고, 그 밖으로 나가는 심링크 탈출을 차단하는 공용 헬퍼 `api/db_project.py`를 도입한다.
- 프론트엔드의 "database 모드 = 컨텍스트 없음" 하드코딩 분기를 제거하고, 백엔드 503 응답으로 판정하도록 일원화한다.

> #367(`fix: harden authenticated monitoring streams`)에 이어지는 후속 작업이다. #367은 squash 머지(`e7425c5` → `c53d734`)되었고, 그 이후 같은 브랜치에 쌓인 커밋 2건을 최신 `main` 위로 옮겨 이 PR로 분리했다. 따라서 이 PR의 diff에는 #367에서 이미 머지된 변경이 포함되지 않는다.

## Changes

### 백엔드
- **`api/db_project.py` (신규)** — DB 등록 프로젝트의 파일시스템 접근을 한곳으로 모은다.
  - `resolve_registered_root()`: 등록 경로를 canonical 디렉토리로 해석, 사용 불가 시 `None`.
  - `safe_project_child()`: `resolve()` 후 등록 루트의 하위인지 검사해 심링크 탈출을 거부. 자가 치유로 생성될 수 있는 파일에는 `strict=False`.
  - `build_registered_project()`: 신원·조직·Git 위치를 DB 행에서만 구성한다. `.aos-project.json`을 권위로 신뢰하지 않는다.
  - `load_registered_project()`: `is_active` 프로젝트만 로드.
- **`api/context.py`** — 인가 통과 *후* `_context_target()`으로 읽기 대상 프로젝트를 해석한다. Database 모드는 DB 레지스트리를, 파일시스템 모드는 기존 레거시 조회를 사용한다. `dev/active/*.md` 순회를 `safe_project_child(strict=True)` 경유로 바꾸고, 광범위한 `except Exception`을 `(OSError, UnicodeError)`로 좁혔다. 등록 경로가 없는 경우는 일반 의존성 장애 503과 구분되도록 `NO_CONTEXT_PATH_DETAIL`로 분리했다.
- **`api/diagnostics.py` / `services/environment_diagnostic_service.py`** — 같은 경계 규칙을 진단 경로에 적용하고, 경로 없음 503을 `NO_DIAGNOSTIC_PATH_DETAIL`로 구분한다.

### 프론트엔드
- **`stores/monitoring.ts`** — `capabilities.mode === 'database'` 조기 반환 제거. 컨텍스트 조회 실패 시 `ApiError.status === 503`이면 `error` 대신 `contextUnavailableReason`으로 처리해, 모드 판정이 백엔드 한 곳에만 존재하도록 했다.

### 테스트
- `tests/backend/api/test_context_db_mode.py` (신규), `tests/backend/api/test_diagnostics_db_mode.py` (신규) — DB 모드 경로 해석, 심링크 탈출 거부, 503 사유 구분, 인가 순서를 커버.
- `src/dashboard/src/stores/__tests__/monitoring.test.ts` — 503 기반 판정으로 갱신.

## Test Plan
- [x] BE `uv run ruff check .` — 위반 0개
- [x] BE `uv run ruff format --check .` — 334 files already formatted
- [x] BE `uv run mypy . --ignore-missing-imports` — `Success: no issues found in 334 source files`
- [x] BE `uv run pytest ../../tests/backend` — 1856 passed, 33 skipped, 0 failed
- [x] FE `npm run type-check` / `npm run lint` — 에러 0개
- [x] FE `npm run test:coverage` — 211 files / 4465 tests passed, 커버리지 임계치 충족
- [x] FE `npm run build` — 성공

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)