### PR TITLE
fix: treat symlink loops as unusable registered project paths

### DIFF
--- a/src/backend/api/db_project.py
+++ b/src/backend/api/db_project.py
@@ -4,6 +4,12 @@ from pathlib import Path
 
 from models.project import Project
 
+# ``Path.resolve()`` reports a symlink loop as ``RuntimeError``, not ``OSError``
+# (measured on CPython 3.11, for both ``strict`` values). Catching only
+# ``OSError`` would let that escape and turn an unusable path into a 500
+# instead of a closed door.
+_UNRESOLVABLE = (OSError, RuntimeError)
+
 
 def resolve_registered_root(path: str | None) -> Path | None:
     """Return the canonical registered directory, or ``None`` if unusable."""
@@ -12,7 +18,7 @@ def resolve_registered_root(path: str | None) -> Path | None:
         return None
     try:
         root = Path(raw_path).resolve(strict=True)
-    except OSError:
+    except _UNRESOLVABLE:
         return None
     return root if root.is_dir() else None
 
@@ -33,7 +39,7 @@ def safe_project_child(
         return None
     try:
         resolved = root.joinpath(*parts).resolve(strict=strict)
-    except OSError:
+    except _UNRESOLVABLE:
         return None
     if resolved != root and root not in resolved.parents:
         return None

--- a/tests/backend/api/test_context_db_mode.py
+++ b/tests/backend/api/test_context_db_mode.py
@@ -461,3 +461,51 @@ def test_no_context_path_detail_is_pinned_to_the_dashboard_literal():
     from api.context import NO_CONTEXT_PATH_DETAIL
 
     assert NO_CONTEXT_PATH_DETAIL == "Project has no registered filesystem path for context"
+
+
+def test_symlink_loop_is_treated_as_an_unusable_path(tmp_path):
+    """심링크 루프는 fail-closed 여야 한다 — 예외로 새어 나가면 안 된다.
+
+    `Path.resolve()` 는 심링크 루프에서 `OSError` 가 아니라 `RuntimeError` 를
+    던진다(실측: CPython 3.11). `OSError` 만 잡으면 이 헬퍼가 예외를 그대로
+    올려보내 라우트가 500 을 내고, "사용 불가한 경로는 None" 이라는 계약이
+    깨진다.
+    """
+    from api.db_project import resolve_registered_root, safe_project_child
+
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "a").symlink_to(root / "b")
+    (root / "b").symlink_to(root / "a")
+
+    assert safe_project_child(root, "a", strict=True) is None
+    assert safe_project_child(root, "a", strict=False) is None
+    assert resolve_registered_root(str(root / "a")) is None
+
+
+@pytest.mark.asyncio
+async def test_context_route_fails_closed_on_a_symlink_loop(
+    authenticated_app, tmp_path, monkeypatch
+):
+    """루프가 `dev/active` 에 있어도 라우트는 500 이 아니라 정상 응답을 낸다.
+
+    읽을 수 없는 문서 디렉터리는 "문서 없음"이지 서버 오류가 아니다.
+    """
+    from api.deps import get_db_session
+
+    project_path = _make_project_tree(tmp_path / "Agent-System")
+    dev_active = project_path / "dev" / "active"
+    for child in dev_active.iterdir():
+        child.unlink()
+    dev_active.rmdir()
+    dev_active.symlink_to(project_path / "dev" / "loop")
+    (project_path / "dev" / "loop").symlink_to(dev_active)
+
+    _install_db(authenticated_app, monkeypatch, _row(str(project_path)))
+    try:
+        response = await _get(authenticated_app, f"/api/projects/{DB_UUID}/context")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["dev_docs"] == []
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)


### PR DESCRIPTION
## Summary
- 심링크 루프가 걸린 등록 경로에서 프로젝트 컨텍스트 조회가 **500** 을 내던 문제를 수정한다. 읽을 수 없는 경로는 서버 오류가 아니라 fail-closed 여야 한다.

> #368 의 후속이다. #368 리뷰 라운드에서 발견됐으나 그 PR 이 머지된 뒤여서 별도 PR 로 분리했다.

## Changes
- **`api/db_project.py`** — `Path.resolve()` 는 심링크 루프를 `OSError` 가 아니라 **`RuntimeError`** 로 보고한다(실측: CPython 3.11, `strict` 값과 무관). `OSError` 만 잡던 두 해석 지점(`resolve_registered_root`, `safe_project_child`)이 그 예외를 그대로 올려보내 "사용 불가한 경로는 `None`" 이라는 계약이 깨졌다. 두 지점 모두 루프를 사용 불가 경로로 처리한다.

```python
# Path.resolve() 는 심링크 루프를 RuntimeError 로 보고한다 (OSError 아님)
_UNRESOLVABLE = (OSError, RuntimeError)
```

## Test Plan
- [x] `test_symlink_loop_is_treated_as_an_unusable_path` — 헬퍼 단위: `strict` 양쪽 모두 `None`
- [x] `test_context_route_fails_closed_on_a_symlink_loop` — 라우트 전체: `dev/active` 가 루프여도 500 이 아니라 200 + `dev_docs: []`
- [x] Red-Green: 수정 전 두 테스트 모두 `RuntimeError: Symlink loop` 로 FAIL → 수정 후 PASS
- [x] BE `ruff check` / `ruff format --check` / `mypy` — 에러 0개
- [x] BE `pytest ../../tests/backend` — 1864 passed, 33 skipped, 0 failed
- [x] FE `type-check` / `lint` / `test:coverage` (211 files, 4467 tests) / `build` — 모두 통과

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)