### PR TITLE
chore: ignore the Hermes agent workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,10 @@ paseo.json
 _workspace/
 _workspace_*/
 
+# Hermes 에이전트 작업 디렉토리 — 진행 중 계획서 등 산출물. `.claude/plans/` ·
+# `dev/active/` 와 같은 성격이라 추적하지 않는다. 남길 가치가 있는 계획은
+# `docs/plans/` 로 옮긴다.
+.hermes/
+
 # AOS 런타임이 직접 쓰는 프로젝트별 로컬 메타데이터 (머신 종속)
 .aos-project.json


### PR DESCRIPTION
## Summary
- `.hermes/` 를 `.gitignore` 에 추가한다. Hermes 에이전트가 `.hermes/plans/` 에 떨구는 진행 중 계획서가 매 세션 untracked 로 남아 커밋 노이즈가 된다.

## Changes
- `.gitignore` 에 `.hermes/` 1줄 추가 (하네스 산출물 블록 바로 아래).

이 레포는 이미 같은 성격의 에이전트 작업 디렉토리를 전부 무시하고 있어 새 방침이 아니라 기존 규칙의 적용이다:

| 무시 대상 | 위치 |
|-----------|------|
| `.claude/plans/`, `.claude/coordination/`, `.claude/workflows/` | 79, 78, 106행 |
| `.agents/`, `.codex/` | 110-111행 |
| `.serena/`, `.gstack/` | 97-98행 |
| `_workspace/`, `_workspace_*/` | 117-118행 |
| **`dev/active/`** — 프로젝트 자체 "Dev Docs 3-파일 시스템" 위치 | 93행 |

`dev/active/` 가 이미 무시 대상이라는 점이 근거다. 진행 중 계획서는 추적하지 않고, 남길 가치가 있는 것만 `docs/plans/`(현재 14개 추적)로 옮기는 구조다.

## Test Plan
- [x] `git check-ignore -v .hermes/plans/*.md` → 두 파일 모두 `.gitignore:123:.hermes/` 로 매칭
- [x] `git status --short` → `.hermes/` untracked 항목 사라짐, `.gitignore` 변경만 남음
- [x] `git ls-files | grep -i hermes` → **0건** (새 패턴이 추적 중인 파일을 삼키지 않음)
- [ ] 빌드/테스트 게이트는 실행하지 않았다 — `.gitignore` 만 변경했고 코드·빌드 입력에 영향이 없다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)