### PR TITLE
fix: clean up the dashboard by port instead of a stale PID file

### DIFF
--- a/infra/scripts/start-all.sh
+++ b/infra/scripts/start-all.sh
@@ -116,7 +116,7 @@ fi
 # Kill any orphaned uvicorn processes and workers on port 8000
 # Match AOS backend (regex; \. escaped to avoid any-char false-positives)
 pkill -9 -f "uvicorn.*api\.app:app" 2>/dev/null || true
-lsof -ti :8000 | xargs kill -9 2>/dev/null || true
+lsof -ti :8000 -sTCP:LISTEN 2>/dev/null | xargs kill -9 2>/dev/null || true
 sleep 0.5
 
 # Create logs directory
@@ -147,7 +147,7 @@ if [ ! -d "node_modules" ]; then
     npm install --silent
 fi
 
-# Kill existing dashboard if running
+# Kill existing dashboard if running (PID file + port holder + npm wrapper)
 if [ -f "$PID_DIR/dashboard.pid" ]; then
     OLD_PID=$(cat "$PID_DIR/dashboard.pid")
     if kill -0 "$OLD_PID" 2>/dev/null; then
@@ -156,6 +156,39 @@ if [ -f "$PID_DIR/dashboard.pid" ]; then
         sleep 1
     fi
 fi
+# A stale PID file leaves the real vite alive, so also kill whoever actually
+# holds the port, and the npm wrapper with it or the wrapper lingers.
+# -sTCP:LISTEN: never kill a client merely connected to the port.
+# The `| tr -d ' '` below is load-bearing under `set -e`: it makes the pipeline
+# exit 0 when the process dies between lsof and ps.
+for pid in $(lsof -ti :5173 -sTCP:LISTEN 2>/dev/null); do
+    # 5173 is vite's default port, so a sibling project may legitimately hold it.
+    # vite's argv carries the project's absolute path (that is why a port-pattern
+    # kill cannot work, and why a path check can) - only kill what is ours.
+    CMD=$(ps -ww -o command= -p "$pid" 2>/dev/null | tr -d '\n')
+    case "$CMD" in
+        *"$PROJECT_ROOT/src/dashboard/"*) ;;
+        *)
+            echo -e "${YELLOW}      Port 5173 held by another project (PID $pid): $CMD${NC}"
+            echo -e "${YELLOW}      Leaving it alone - dashboard will start on another port.${NC}"
+            echo -e "${YELLOW}      stop-all.sh only cleans 5173; stop that one manually.${NC}"
+            continue
+            ;;
+    esac
+    PARENT_PID=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [ -n "$PARENT_PID" ] && ps -ww -o command= -p "$PARENT_PID" 2>/dev/null | grep -q "npm"; then
+        kill -9 "$PARENT_PID" 2>/dev/null || true
+    fi
+    kill -9 "$pid" 2>/dev/null || true
+done
+# Wait for the port to clear; vite has no strictPort, so a lingering holder
+# would silently push the new dashboard to 5174.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if [ -z "$(lsof -ti :5173 -sTCP:LISTEN 2>/dev/null)" ]; then
+        break
+    fi
+    sleep 0.3
+done
 
 # Start dashboard in background
 nohup npm run dev > "$PROJECT_ROOT/logs/dashboard.log" 2>&1 &

--- a/infra/scripts/stop-all.sh
+++ b/infra/scripts/stop-all.sh
@@ -45,8 +45,29 @@ if [ -f "$PID_DIR/dashboard.pid" ]; then
 else
     echo -e "${YELLOW}Dashboard PID file not found${NC}"
 fi
-# Always kill remaining vite processes (child processes may survive)
-pkill -f "vite.*5173" 2>/dev/null || true
+# Always kill whatever still holds the dashboard port. A pattern kill cannot
+# work here: vite's argv is just `node .../node_modules/.bin/vite` with no port
+# in it, so the old `pkill -f "vite.*5173"` never matched anything.
+# -sTCP:LISTEN: never kill a client merely connected to the port.
+for pid in $(lsof -ti :5173 -sTCP:LISTEN 2>/dev/null); do
+    # 5173 is vite's default port, so a sibling project may legitimately hold it.
+    # vite's argv carries the project's absolute path (that is why a port-pattern
+    # kill cannot work, and why a path check can) - only kill what is ours.
+    CMD=$(ps -ww -o command= -p "$pid" 2>/dev/null | tr -d '\n')
+    case "$CMD" in
+        *"$PROJECT_ROOT/src/dashboard/"*) ;;
+        *)
+            echo -e "${YELLOW}Port 5173 held by another project (PID $pid): $CMD${NC}"
+            echo -e "${YELLOW}Leaving it alone - not an AOS dashboard.${NC}"
+            continue
+            ;;
+    esac
+    PARENT_PID=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [ -n "$PARENT_PID" ] && ps -ww -o command= -p "$PARENT_PID" 2>/dev/null | grep -q "npm"; then
+        kill -9 "$PARENT_PID" 2>/dev/null || true
+    fi
+    kill -9 "$pid" 2>/dev/null || true
+done
 
 # Stop Backend
 if [ -f "$PID_DIR/backend.pid" ]; then


### PR DESCRIPTION
## 문제

`/start-all` 후 대시보드가 조용히 5174로 밀리고, 이전 vite가 5173에 남아 있는 경우가 있었습니다. 원인은 두 스크립트의 대시보드 정리 경로입니다.

- `start-all.sh`는 대시보드를 `.pids/dashboard.pid`로만 종료합니다. PID 파일이 stale이면 **실제 vite는 살아남습니다.**
- `stop-all.sh`의 백스톱 `pkill -f "vite.*5173"`은 **한 번도 매칭된 적이 없습니다.** vite의 argv는 `node .../node_modules/.bin/vite`이고 포트가 들어 있지 않습니다(포트는 `vite.config.ts`에 있습니다). `pgrep`으로 확인했습니다.
- `vite.config.ts`에 `strictPort`가 없어, 5173이 점유돼 있으면 새 대시보드는 **에러 없이** 5174로 이동합니다.

백엔드는 이미 포트 기반(`lsof -ti :8000`)으로 정리하고 있어, 대시보드만 비대칭이었습니다.

## 변경

두 스크립트 모두 `lsof -ti :5173 -sTCP:LISTEN`으로 포트 보유자를 찾아 npm 래퍼와 함께 종료합니다.

소유권은 **argv에 박힌 프로젝트 절대경로**로 확인합니다(`$PROJECT_ROOT/src/dashboard/`). 5173은 vite 기본 포트라 다른 로컬 프로젝트가 정당하게 쥘 수 있고, 그 경우 죽이지 않고 경고 후 건너뜁니다. 후행 슬래시가 있어 `src/dashboard-demo` 같은 형제 경로는 매칭되지 않습니다.

`pkill`을 무력화시킨 사실(argv에 포트 없음)이 그대로 수정의 근거입니다 — **경로는 argv에 있습니다.**

기존 `lsof -ti :8000` 줄에도 같은 `-sTCP:LISTEN` 필터를 넣었습니다. 없으면 포트에 연결만 한 클라이언트까지 죽습니다.

## 테스트

판별 단언은 `curl 200`이 **아닙니다** — 살아남은 유령도 200을 돌려줍니다. 기준은 "5173 LISTEN 보유자가 `.pids/dashboard.pid`의 자식인가 + 5174가 비었는가"입니다.

| 시나리오 | 결과 |
|---|---|
| RED: stale PID + 살아있는 vite, 변경 전 코드 | 유령 생존, 두 가드 모두 무력 |
| GREEN: 같은 조건, 변경 후 | vite·npm 정리, 5173 해제, 5174 미점유 |
| 남의 서비스(`python3 -m http.server 5173`) | 생존 + 경고 출력 + 5173 유지 |
| 경로 경계(`src/dashboard-demo`) | 슬래시 없으면 둘 다 매칭 / 있으면 우리 것만 |
| **실제 `start-all.sh` 전체 실행** | 보유자 = 기록된 PID의 자식, 5174 free, 자기 오판 경고 없음 |

마지막 항목이 핵심입니다. 앞선 테스트들은 `PROJECT_ROOT`를 손으로 넣었지만 실제 스크립트는 `$(cd "$SCRIPT_DIR/../.." && pwd)`로 계산합니다. 두 문자열이 어긋나면 가드가 **자기 대시보드를 남의 것으로 오판**해 영원히 5174로 밀리는데, 격리 테스트로는 보이지 않습니다.

`set -e` 동작도 실측했습니다: `ppid=$(ps ... | tr -d ' ')`의 파이프는 방어 장치입니다. 파이프를 빼면 `lsof`와 `ps` 사이에 프로세스가 죽을 때 스크립트가 중단됩니다.

## 미반영 (이 변경 이전부터 있던 동작)

다른 프로젝트가 5173을 쥐면 vite는 5174로 뜨는데 요약은 여전히 `http://localhost:5173`을 안내합니다.

변경 전 `start-all.sh`에는 대시보드 포트 처리가 **전혀 없었고**(5173은 요약 출력 한 줄뿐), 같은 누수가 경고조차 없이 존재했습니다. 실제 포트를 기록하려면 vite stdout 파싱이 필요하고 `strictPort`는 `vite.config.ts` 소관이라, 둘 다 "종료 경로 통일" 범위 밖으로 두었습니다. 대신 충돌 경고에 폴백 인스턴스를 수동 종료하라는 안내를 추가해 정보 갭만 닫았습니다.

## 검증

- Codex 리뷰 3라운드 (`--scope working-tree`): P1(무관한 서비스 종료)·P2(경로 경계) 반영, 위 폴백 건은 근거와 함께 미반영
- `bash -n` — 워킹트리가 아니라 커밋된 내용에 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yWhmN9Vrgah5XfF4bSDSE
