### PR TITLE
feat: add safe LLM model policy guards

### DIFF
--- a/PLANS/MODEL_POLICY_GUARDS_IMPLEMENTATION.md
+++ b/PLANS/MODEL_POLICY_GUARDS_IMPLEMENTATION.md
@@ -1,0 +1,112 @@
+---
+title: "Model policy guards and execution attribution"
+tags: [llm, playground, fallback, registry, regression]
+status: active
+created: 2026-08-31
+---
+
+# 목적
+
+Buzz 검토와 `AGENT_SYSTEM_MODEL_ALIAS_CODE_EVIDENCE.md`,
+`AGENT_SYSTEM_MODEL_POLICY_ISSUE_372_373_VERIFICATION.md`의 코드 근거를 반영해,
+모델 자동 업데이트를 새 alias UI로 확장하기 전에 현재 안전성 결함을 최소 범위로
+수정한다. 기본 브랜치에는 변경하지 않고 이 전용 worktree에서만 구현한다.
+
+# 범위
+
+1. **실행 게이트**: disabled/미등록 모델이 인증된 runtime resolver와 직접 LLM 생성
+   경로를 우회해 실행되지 않도록 한다. DB discovery 모델은 registry에 있고 enabled인
+   경우 실제 runtime config로 실행 가능해야 한다.
+2. **fallback 무변이**: stale 모델 fallback은 해당 실행의 retry에만 적용한다.
+   `PlaygroundSession.model`을 성공 전/후에 자동 재작성하지 않는다. 실패한 fallback
+   target도 세션에 영구 저장되지 않아야 한다.
+3. **실행 단위 귀속**: `PlaygroundExecution`에 요청 모델과 실제 성공 모델을 기록한다.
+   기존 JSON 파일/DB JSON 컬럼과 backward compatibility를 유지하며 DB migration은
+   만들지 않는다.
+4. **stream parity**: non-tools streaming도 첫 출력 전 inaccessible model 오류 시
+   동일한 fallback을 적용한다. 이미 출력한 뒤 오류가 나면 중복 재시도하지 않고
+   실패를 유지한다. tools/non-tools 모두 resolved model을 사용해 비용을 계산한다.
+5. **registry sync 승격 차단**: 이미 해당 provider의 DB 모델 행이 있으면, code
+   registry의 새 `is_default=True` 모델을 12시간 sync가 자동 default로 승격하지
+   않는다. 완전히 초기화된 provider의 bootstrap default만 예외로 둔다. disabled
+   기존 default가 있는 경우에도 기존 관리자 결정을 덮지 않는다.
+
+# 제외 범위
+
+- 실제 품질 골든셋, shadow/canary, 자동 승격 workflow 구축
+- 신규 alias UI/API 설계 및 기존 세션을 alias-follow로 일괄 전환
+- provider discovery 대상 확대
+- 배포, DB 데이터 변경, Git commit/push/PR/merge
+
+# 예상 변경 파일
+
+- `src/backend/services/llm_runtime_resolver.py`
+- `src/backend/services/llm_service.py`
+- `src/backend/services/playground_service/llm.py`
+- `src/backend/services/playground_service/service.py`
+- `src/backend/models/playground.py`
+- `src/backend/models/llm_models.py`
+- 관련 `tests/backend/test_*.py`
+
+# 수용 기준
+
+- disabled requested model은 resolver에서 `LLMRuntimeResolutionError`가 발생한다.
+- DB-only + enabled registry model은 `_get_llm`이 legacy static map 부재만으로
+  `Unknown model`을 내지 않고 registry metadata로 build한다.
+- fallback 성공 후 `session.model`은 원래 requested model 그대로이며, execution에는
+  requested/resolved model이 각각 남는다.
+- fallback target 자체가 build 불가능하면 실패를 세션 모델로 commit하지 않는다.
+- non-tools stream stale model은 fallback 성공 시 정상 결과와 resolved model 비용을
+  사용하고, 첫 chunk 이후 오류는 재시도하지 않는다.
+- startup sync는 disabled 기존 default를 새 code default로 자동 교체하지 않는다.
+- 직접 추가한 regression test가 먼저 RED가 되고, GREEN 뒤 backend 전체 테스트를
+  `cd src/backend && uv run pytest ../../tests/backend -v --tb=short`로 실행한다.
+- 테스트·정적 검토 외에 runtime 적용, 배포, 원격 쓰기는 하지 않는다.
+
+# Developer 지시
+
+엄격한 TDD로 한 vertical slice씩 진행한다. 먼저 현재 테스트와 관련 호출 경로를
+읽고 각 acceptance criterion을 재현하는 failing test를 추가한 뒤, 최소 구현을 한다.
+기존 테스트의 정책 기대값이 새 안전선과 충돌하면 이유를 명시해 갱신하되, unrelated
+refactor는 하지 않는다. 모든 변경 파일·명령·결과를 보고하고, commit/push는 하지
+말고 worktree를 남긴다. `ultrathink`로 fallback async-generator 경계와 persistence
+경로를 특히 검토한다.
+
+# Security review 계약
+
+변경 후 별도 관점에서 disabled model bypass, entitlement/provider mismatch,
+fallback retry loop, session poisoning, usage/cost misattribution, DB sync race,
+정보 노출을 읽기 전용으로 검토한다. 독립 보안 검토가 끝나기 전에는 완료로 판정하지
+않는다.
+
+# 후속 구현 범위 — 2026-09-01 승인
+Buzz 최종 검토의 권고 중 외부 provider 호출·canary·배포 없이 검증 가능한 안전 범위만
+진행한다. 기본 브랜치와 runtime은 변경하지 않는다.
+
+1. Playground 세션 생성·수정 시 Registry에 존재하고 enabled인 모델만 저장한다.
+   기존 세션 로딩 및 legacy 데이터 호환은 보존하며, 거부는 원자적으로 처리한다.
+2. `get_default()`의 암묵적인 첫 enabled 모델 선택을 deterministic fail-closed 정책으로
+   바꿀지 현재 호출부·기존 테스트를 확인하고, 호환성 영향이 크면 명시적 fallback을
+   추가한다. provider별 기본값 충돌이 조용히 숨겨지지 않아야 한다.
+3. stream generator가 cancellation·client disconnect·초기화 예외에서도 RUNNING
+   execution을 남기지 않도록 최소 수정하고, 정상·실패·취소 상태 및 resolved model
+   귀속을 테스트한다.
+4. alias/concrete 모델과 registry revision 등 계측은 기존 JSON/DB schema를 깨지 않는
+   optional metadata로 설계한다. 실제 provider 응답을 확인하지 못한 모델은 자동
+   승격하지 않는다.
+5. code seed에서 `gpt-5.5`를 즉시 enabled로 두지 않도록 되돌리고, Anthropic 기본값은
+   기존 검증된 `claude-sonnet-5`로 복원한다. `gpt-5.6` alias 및 `gemini-3.7-flash`
+   기본 승격은 live smoke 전까지 보류한다.
+
+# 후속 수용 기준
+- 신규/수정 세션에 disabled·unknown 모델을 저장하려 하면 명확한 검증 오류가 나고,
+  기존 세션의 다른 설정은 변경되지 않는다.
+- provider별 code default가 하나만 존재하며, 기본값이 없을 때 순서 의존적인 모델을
+  조용히 선택하지 않는다.
+- stream 취소·예외 뒤 반환/영속화되는 execution은 RUNNING이 아니며, 성공 시 실제
+  resolved model을 기록한다.
+- 후속 회귀 테스트는 각 구현 전에 RED, 구현 후 GREEN을 실제 실행으로 확인한다.
+- backend 전체 테스트 `cd src/backend && uv run pytest ../../tests/backend -v --tb=short`
+  및 가능한 정적 검사를 실행한다.
+- commit, push, PR, merge, DB 데이터 변경, runtime 재기동, 외부 provider smoke,
+  자동 승격은 실행하지 않는다.

--- a/src/backend/agents/base.py
+++ b/src/backend/agents/base.py
@@ -27,15 +27,40 @@ from services.llm_runtime_resolver import (
 from services.llm_service import LLMService
 from services.llm_usage_ledger_service import record_usage_best_effort
 
-# Default model resolved from the configured provider (LLM_PROVIDER).
-# Headless deploys set LLM_PROVIDER=google/openai; local dev defaults to codex_cli.
-_DEFAULT_AGENT_MODEL = LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli"))
 
-# Specialist agent model (configurable via env, defaults to registry default)
-SPECIALIST_AGENT_MODEL = os.getenv(
-    "SPECIALIST_AGENT_MODEL",
-    _DEFAULT_AGENT_MODEL,
-)
+def _resolve_default_agent_model() -> str:
+    """Resolve the default agent model from the configured provider (LLM_PROVIDER).
+
+    Headless deploys set LLM_PROVIDER=google/openai; local dev defaults to
+    codex_cli. 임포트 시점이 아니라 AgentConfig 생성 시점에 평가된다 — 임포트
+    시점 해석은 rogue/enabled-0 provider 에서 모듈 임포트를 죽이고, api/app.py
+    safe_import 가 agents 라우터 트리를 조용히 제거한다.
+
+    Raises:
+        ValueError: LLM_PROVIDER 가 미지이거나 enabled 모델이 0개
+            (registry fail-closed LookupError 를 이 모듈의 실패 계약 타입으로
+            번역 — 타 provider 모델을 조용히 대입하지 않는다).
+    """
+    try:
+        return LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli"))
+    except LookupError as e:
+        raise ValueError(str(e)) from e
+
+
+def _specialist_agent_model() -> str:
+    """Specialist agent model (env override first, else registry default)."""
+    override = os.getenv("SPECIALIST_AGENT_MODEL")
+    if override:
+        return override
+    return _resolve_default_agent_model()
+
+
+def __getattr__(name: str) -> str:
+    # PEP 562: `from agents.base import SPECIALIST_AGENT_MODEL` 를 유지하면서
+    # registry 해석을 임포트 이후(specialist 인스턴스화 시점)로 미룬다.
+    if name == "SPECIALIST_AGENT_MODEL":
+        return _specialist_agent_model()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _enum_value(value: Any) -> Any:
@@ -177,7 +202,7 @@ class AgentConfig(BaseModel):
     name: str
     description: str
     system_prompt: str
-    model_name: str = _DEFAULT_AGENT_MODEL
+    model_name: str = Field(default_factory=_resolve_default_agent_model)
     temperature: float = 0.7
     max_tokens: int = 4096
     tools: list[str] = Field(default_factory=list)

--- a/src/backend/agents/lead_orchestrator.py
+++ b/src/backend/agents/lead_orchestrator.py
@@ -5,7 +5,6 @@
 """
 
 import json
-import os
 import time
 import uuid
 from datetime import datetime
@@ -15,7 +14,6 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from agents.base import AgentConfig, AgentResult, BaseAgent
-from models.llm_models import LLMModelRegistry
 from models.llm_usage import LLMUsageSource
 from services.agent_registry import (
     EffortLevel,
@@ -260,7 +258,9 @@ class LeadOrchestratorAgent(BaseAgent):
             name="LeadOrchestrator",
             description="Multi-agent workflow coordinator that decomposes complex tasks and delegates to specialized agents",
             system_prompt=LEAD_ORCHESTRATOR_SYSTEM_PROMPT,
-            model_name=LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli")),
+            # model_name 은 AgentConfig default_factory 가 provider 기반으로
+            # 해석한다 — rogue/enabled-0 provider 는 ValueError 로 fail-closed
+            # (uncaught LookupError·codex-cli 조용한 대입 금지).
             temperature=0.0,  # 일관된 분석 결과를 위해 temperature 0
             max_tokens=4096,
         )

--- a/src/backend/api/llm.py
+++ b/src/backend/api/llm.py
@@ -156,7 +156,12 @@ async def get_default_model(
     provider: str | None = Query(None, description="Get default for specific provider"),
 ) -> DefaultModelResponse:
     """Get the default model."""
-    model_id = LLMModelRegistry.get_default(provider)
+    try:
+        model_id = LLMModelRegistry.get_default(provider)
+    except LookupError as e:
+        # fail-closed: enabled 모델이 0개인 provider — 타 provider 모델을
+        # 대답하지 않고 404 로 알린다.
+        raise HTTPException(status_code=404, detail=str(e))
     model = LLMModelRegistry.get_by_id(model_id)
 
     if model:
@@ -370,9 +375,15 @@ async def get_providers() -> dict:
     result = {}
     for provider in LLMProvider:
         models = LLMModelRegistry.get_by_provider(provider)
+        try:
+            default = LLMModelRegistry.get_default(provider)
+        except LookupError:
+            # enabled 모델이 0개인 provider: 타 provider 모델 이름을 대입하던
+            # 과거 오답 대신 None 으로 보고한다 (목록 전체가 500 나면 안 됨).
+            default = None
         result[provider.value] = {
             "models": [m.id for m in models],
-            "default": LLMModelRegistry.get_default(provider),
+            "default": default,
             "count": len(models),
         }
     return result

--- a/src/backend/api/playground.py
+++ b/src/backend/api/playground.py
@@ -92,7 +92,11 @@ async def create_session(
     the authenticated caller, never a client-supplied value.
     """
     data.user_id = str(current_user.id)
-    return PlaygroundService.create_session(data)
+    try:
+        return PlaygroundService.create_session(data)
+    except ValueError as e:
+        # 모델 등록 게이트(unknown/disabled model) — 잘못된 입력이므로 400.
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.get(
@@ -195,28 +199,32 @@ async def update_session_settings(
     background_tasks: BackgroundTasks,
 ):
     """Update session settings. Auto-triggers indexing when RAG is enabled."""
-    session = PlaygroundService.update_session_settings(
-        session_id,
-        name=data.name,
-        agent_id=data.agent_id,
-        model=data.model,
-        temperature=data.temperature,
-        max_tokens=data.max_tokens,
-        system_prompt=data.system_prompt,
-        enabled_tools=data.enabled_tools,
-        project_id=data.project_id,
-        working_directory=data.working_directory,
-        rag_enabled=data.rag_enabled,
-        rag_k=data.rag_k,
-        rag_hybrid_override=data.rag_hybrid_override,
-        rag_rerank_override=data.rag_rerank_override,
-        rag_include_shared=data.rag_include_shared,
-        rules_mode=data.rules_mode,
-        memory_mode=data.memory_mode,
-        selected_rule_ids=data.selected_rule_ids,
-        selected_memory_ids=data.selected_memory_ids,
-        context_budget_tokens=data.context_budget_tokens,
-    )
+    try:
+        session = PlaygroundService.update_session_settings(
+            session_id,
+            name=data.name,
+            agent_id=data.agent_id,
+            model=data.model,
+            temperature=data.temperature,
+            max_tokens=data.max_tokens,
+            system_prompt=data.system_prompt,
+            enabled_tools=data.enabled_tools,
+            project_id=data.project_id,
+            working_directory=data.working_directory,
+            rag_enabled=data.rag_enabled,
+            rag_k=data.rag_k,
+            rag_hybrid_override=data.rag_hybrid_override,
+            rag_rerank_override=data.rag_rerank_override,
+            rag_include_shared=data.rag_include_shared,
+            rules_mode=data.rules_mode,
+            memory_mode=data.memory_mode,
+            selected_rule_ids=data.selected_rule_ids,
+            selected_memory_ids=data.selected_memory_ids,
+            context_budget_tokens=data.context_budget_tokens,
+        )
+    except ValueError as e:
+        # 모델 등록 게이트(unknown/disabled model) — 검증 실패는 원자적 거부.
+        raise HTTPException(status_code=400, detail=str(e))
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -158,6 +158,12 @@ def get_settings() -> Settings:
 def get_model_for_provider(provider: str) -> str:
     """Get the default model for a provider from the LLM Model Registry (DB-backed).
 
+    get_default 는 미지 provider·enabled 모델 0개 provider 에
+    fail-closed(LookupError) 한다. 이 헬퍼는 orchestrator/router 초기화
+    경로에서 불리므로 예외를 흘리지 않고 구성된 기본 모델로 폴백한다 —
+    entitlement 게이트가 아니라 내부 기본값 선택이며, 반환값은 실행 시
+    LLMService._get_llm 의 unknown/disabled 게이트를 다시 통과해야 한다.
+
     Args:
         provider: Provider name ('google', 'anthropic', 'openai', 'ollama')
 
@@ -168,12 +174,23 @@ def get_model_for_provider(provider: str) -> str:
 
     try:
         return LLMModelRegistry.get_default(LLMProvider(provider))
-    except ValueError:
-        return LLMModelRegistry.get_default()
+    except (ValueError, LookupError):
+        # Unknown provider name, or a provider with zero enabled models —
+        # fall through to the configured default.
+        return get_default_model()
 
 
 def get_default_model() -> str:
-    """Get the default model from the LLM Model Registry (DB-backed)."""
+    """Get the default model from the LLM Model Registry (DB-backed).
+
+    LLM_PROVIDER 가 미지 문자열이거나 구성 provider 에 enabled 모델이 0개면
+    legacy "codex-cli" 폴백을 유지한다 (models/playground.py 관례 — 그 값이
+    실제로 못 쓰는 모델이면 LLMService._get_llm 게이트가 명확한 ValueError
+    로 거부한다).
+    """
     from models.llm_models import LLMModelRegistry
 
-    return LLMModelRegistry.get_default()
+    try:
+        return LLMModelRegistry.get_default()
+    except LookupError:
+        return "codex-cli"

--- a/src/backend/models/llm_models.py
+++ b/src/backend/models/llm_models.py
@@ -44,12 +44,24 @@ class LLMModelConfig(BaseModel):
 # All supported models with their configurations
 _MODELS: list[LLMModelConfig] = [
     # ─────────────────────────────────────────────────────────
-    # Anthropic Claude Models (updated 2026-05-30)
-    # Pricing: USD per 1K tokens. Docs: https://docs.anthropic.com/en/docs/about-claude/models
+    # Anthropic Claude Models (updated 2026-08-31)
+    # Pricing: USD per 1K tokens. Docs: https://platform.claude.com/docs/en/about-claude/models/overview
     # ─────────────────────────────────────────────────────────
     LLMModelConfig(
         id="claude-opus-4-8",
         display_name="Claude Opus 4.8",
+        provider=LLMProvider.ANTHROPIC,
+        context_window=1000000,  # 1M tokens
+        input_price=0.005,  # $5.00/1M tokens
+        output_price=0.025,  # $25.00/1M tokens
+        is_default=False,
+        supports_tools=True,
+        supports_vision=True,
+    ),
+    # claude-opus-4-7: official model docs, verified 2026-08-31
+    LLMModelConfig(
+        id="claude-opus-4-7",
+        display_name="Claude Opus 4.7",
         provider=LLMProvider.ANTHROPIC,
         context_window=1000000,  # 1M tokens
         input_price=0.005,  # $5.00/1M tokens
@@ -65,7 +77,7 @@ _MODELS: list[LLMModelConfig] = [
         context_window=1000000,  # 1M tokens
         input_price=0.003,  # $3.00/1M tokens
         output_price=0.015,  # $15.00/1M tokens
-        is_default=True,  # Default Anthropic model
+        is_default=False,
         supports_tools=True,
         supports_vision=True,
     ),
@@ -76,7 +88,7 @@ _MODELS: list[LLMModelConfig] = [
         context_window=1000000,  # 1M tokens
         input_price=0.003,  # $3.00/1M tokens
         output_price=0.015,  # $15.00/1M tokens
-        is_default=False,
+        is_default=True,  # Default Anthropic model (current GA balanced, policy 2026-08-31)
         supports_tools=True,
         supports_vision=True,
     ),
@@ -92,9 +104,21 @@ _MODELS: list[LLMModelConfig] = [
         supports_vision=True,
     ),
     # ─────────────────────────────────────────────────────────
-    # Google Gemini Models (updated 2026-05-30)
+    # Google Gemini Models (updated 2026-08-31)
     # Pricing: USD per 1K tokens. Docs: https://ai.google.dev/gemini-api/docs/models
     # ─────────────────────────────────────────────────────────
+    # gemini-3.7-flash: official model docs (current stable Flash), verified 2026-08-31
+    LLMModelConfig(
+        id="gemini-3.7-flash",
+        display_name="Gemini 3.7 Flash",
+        provider=LLMProvider.GOOGLE,
+        context_window=1048576,
+        input_price=0.00075,  # $0.75/1M tokens
+        output_price=0.00375,  # $3.75/1M tokens
+        is_default=True,  # Default Google model (policy 2026-08-31)
+        supports_tools=True,
+        supports_vision=True,
+    ),
     LLMModelConfig(
         id="gemini-3-flash-preview",
         display_name="Gemini 3 Flash",
@@ -102,7 +126,7 @@ _MODELS: list[LLMModelConfig] = [
         context_window=1000000,
         input_price=0.0005,  # $0.50/1M tokens
         output_price=0.003,  # $3.00/1M tokens
-        is_default=True,  # Default Google model
+        is_default=False,
         supports_tools=True,
         supports_vision=True,
     ),
@@ -161,7 +185,7 @@ _MODELS: list[LLMModelConfig] = [
         context_window=128000,
         input_price=0.00015,  # $0.15/1M tokens
         output_price=0.0006,  # $0.60/1M tokens
-        is_default=True,  # Conservative default for broad API project access
+        is_default=False,
         supports_tools=True,
         supports_vision=True,
     ),
@@ -176,15 +200,62 @@ _MODELS: list[LLMModelConfig] = [
         supports_tools=True,
         supports_vision=True,
     ),
+    # GPT-5.6 family: official model/pricing docs, verified 2026-08-31.
+    # The gpt-5.6 alias routes to GPT-5.6 Sol.
+    LLMModelConfig(
+        id="gpt-5.6",
+        display_name="GPT-5.6 (Sol alias)",
+        provider=LLMProvider.OPENAI,
+        context_window=1050000,
+        input_price=0.004,  # $4.00/1M tokens
+        output_price=0.02,  # $20.00/1M tokens
+        is_default=True,  # Default OpenAI model (policy 2026-08-31)
+        supports_tools=True,
+        supports_vision=True,
+    ),
+    LLMModelConfig(
+        id="gpt-5.6-sol",
+        display_name="GPT-5.6 Sol",
+        provider=LLMProvider.OPENAI,
+        context_window=1050000,
+        input_price=0.004,  # $4.00/1M tokens
+        output_price=0.02,  # $20.00/1M tokens
+        is_default=False,
+        supports_tools=True,
+        supports_vision=True,
+    ),
+    LLMModelConfig(
+        id="gpt-5.6-terra",
+        display_name="GPT-5.6 Terra",
+        provider=LLMProvider.OPENAI,
+        context_window=1050000,
+        input_price=0.002,  # $2.00/1M tokens
+        output_price=0.012,  # $12.00/1M tokens
+        is_default=False,
+        supports_tools=True,
+        supports_vision=True,
+    ),
+    LLMModelConfig(
+        id="gpt-5.6-luna",
+        display_name="GPT-5.6 Luna",
+        provider=LLMProvider.OPENAI,
+        context_window=1050000,
+        input_price=0.0002,  # $0.20/1M tokens
+        output_price=0.0012,  # $1.20/1M tokens
+        is_default=False,
+        supports_tools=True,
+        supports_vision=True,
+    ),
+    # gpt-5.5: retained for compatibility; no longer the default.
     LLMModelConfig(
         id="gpt-5.5",
         display_name="GPT-5.5",
         provider=LLMProvider.OPENAI,
-        context_window=1000000,
-        input_price=0.005,
-        output_price=0.03,
+        context_window=1050000,
+        input_price=0.005,  # $5.00/1M tokens
+        output_price=0.03,  # $30.00/1M tokens
         is_default=False,
-        is_enabled=False,
+        is_enabled=True,
         supports_tools=True,
         supports_vision=True,
     ),
@@ -431,7 +502,7 @@ class LLMModelRegistry:
         Returns:
             Dict with 'inserted' and 'updated' counts.
         """
-        from sqlalchemy import delete, select, update
+        from sqlalchemy import delete, select
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
         from db.models import LLMModelConfigModel, LLMModelSuppressionModel
@@ -458,18 +529,16 @@ class LLMModelRegistry:
         result = await session.execute(select(LLMModelConfigModel.id))
         existing_ids = {row[0] for row in result.fetchall()}
 
-        # Providers that already have an ENABLED default row in DB.
-        # Guard: a NEW model with is_default=True must not create a second
-        # default for a provider whose DB default is admin-controlled.
-        # A disabled default row does not count — the new model should
-        # still become the provider default in that case.
+        # Providers that already have ANY row in DB (after the self-heal
+        # delete above). Guard: a NEW code model with is_default=True may
+        # only bootstrap the provider default when the provider has ZERO
+        # DB rows. Any existing row — including a disabled prior default —
+        # is admin-controlled state, so the new model is inserted
+        # non-default and no admin flag is cleared or overridden.
         result = await session.execute(
-            select(LLMModelConfigModel.provider).where(
-                LLMModelConfigModel.is_default.is_(True),
-                LLMModelConfigModel.is_enabled.is_(True),
-            )
+            select(LLMModelConfigModel.provider).distinct()
         )
-        providers_with_db_default = {row[0] for row in result.fetchall()}
+        providers_with_db_rows = {row[0] for row in result.fetchall()}
 
         inserted = 0
         updated = 0
@@ -484,33 +553,16 @@ class LLMModelRegistry:
             if (
                 is_default
                 and model.id not in existing_ids
-                and model.provider.value in providers_with_db_default
+                and model.provider.value in providers_with_db_rows
             ):
-                # Respect the existing DB default for this provider:
-                # insert the new model as non-default to avoid dual defaults.
+                # The provider already has admin-controlled rows in DB
+                # (possibly a disabled prior default): insert the new model
+                # as non-default. Promotion is an explicit admin action, not
+                # a side effect of the periodic sync. No UPDATE touches the
+                # existing rows' is_default/is_enabled flags here — the only
+                # bootstrap path is a provider with zero rows, where there
+                # is nothing to clear.
                 is_default = False
-
-            if is_default and model.id not in existing_ids:
-                # This new model is about to be INSERTed as the provider
-                # default (the guard above passed, so any remaining default
-                # rows for this provider are disabled). Clear their
-                # is_default flag so a later admin re-enable of an old row
-                # cannot resurrect a second default for the provider.
-                # is_enabled=False is part of the WHERE on purpose: under
-                # READ COMMITTED an admin could re-enable the old default
-                # between the guard SELECT and this UPDATE, so the "only
-                # clear DISABLED defaults" invariant must live in the SQL
-                # itself, not just in the pre-check.
-                await session.execute(
-                    update(LLMModelConfigModel)
-                    .where(
-                        LLMModelConfigModel.provider == model.provider.value,
-                        LLMModelConfigModel.is_default.is_(True),
-                        LLMModelConfigModel.is_enabled.is_(False),
-                        LLMModelConfigModel.id != model.id,
-                    )
-                    .values(is_default=False)
-                )
 
             values = {
                 "id": model.id,

--- a/src/backend/models/llm_models.py
+++ b/src/backend/models/llm_models.py
@@ -4,11 +4,14 @@
 모델 추가/수정 시 이 파일만 변경하면 전체 시스템에 반영됩니다.
 """
 
+import logging
 import os
 from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 
 class LLMProvider(str, Enum):
@@ -35,6 +38,11 @@ class LLMModelConfig(BaseModel):
     is_enabled: bool = True  # Whether model is enabled
     supports_tools: bool = True  # Tool/function calling support
     supports_vision: bool = False  # Vision/image support
+    # Optional code-seed metadata: 문서상 이 alias 가 라우팅하는 concrete 모델 id.
+    # DB 스키마에 컬럼이 없으므로 sync_to_db 값에 포함하지 않고(no migration),
+    # DB-loaded config 에서는 항상 None 이다. provider 응답으로 확인된 값이
+    # 아니므로 실행 귀속(resolved_model)에는 쓰지 않는다.
+    alias_for: str | None = None
 
 
 # ─────────────────────────────────────────────────────────────
@@ -77,7 +85,7 @@ _MODELS: list[LLMModelConfig] = [
         context_window=1000000,  # 1M tokens
         input_price=0.003,  # $3.00/1M tokens
         output_price=0.015,  # $15.00/1M tokens
-        is_default=False,
+        is_default=True,  # Default Anthropic model (restored, follow-up policy 2026-09-01)
         supports_tools=True,
         supports_vision=True,
     ),
@@ -88,7 +96,7 @@ _MODELS: list[LLMModelConfig] = [
         context_window=1000000,  # 1M tokens
         input_price=0.003,  # $3.00/1M tokens
         output_price=0.015,  # $15.00/1M tokens
-        is_default=True,  # Default Anthropic model (current GA balanced, policy 2026-08-31)
+        is_default=False,
         supports_tools=True,
         supports_vision=True,
     ),
@@ -212,6 +220,7 @@ _MODELS: list[LLMModelConfig] = [
         is_default=True,  # Default OpenAI model (policy 2026-08-31)
         supports_tools=True,
         supports_vision=True,
+        alias_for="gpt-5.6-sol",  # documented routing target (docs, not a provider response)
     ),
     LLMModelConfig(
         id="gpt-5.6-sol",
@@ -246,7 +255,9 @@ _MODELS: list[LLMModelConfig] = [
         supports_tools=True,
         supports_vision=True,
     ),
-    # gpt-5.5: retained for compatibility; no longer the default.
+    # gpt-5.5: retained for compatibility; disabled until a live smoke run
+    # validates it (follow-up policy 2026-09-01). Enabling is an explicit
+    # admin action, not a code-seed default.
     LLMModelConfig(
         id="gpt-5.5",
         display_name="GPT-5.5",
@@ -255,7 +266,7 @@ _MODELS: list[LLMModelConfig] = [
         input_price=0.005,  # $5.00/1M tokens
         output_price=0.03,  # $30.00/1M tokens
         is_default=False,
-        is_enabled=True,
+        is_enabled=False,
         supports_tools=True,
         supports_vision=True,
     ),
@@ -397,6 +408,11 @@ _MODELS: list[LLMModelConfig] = [
 # Index by model ID for fast lookup
 _MODEL_INDEX: dict[str, LLMModelConfig] = {m.id: m for m in _MODELS}
 
+# Code-seed revision stamp — bump when policy-relevant seed contents change
+# (defaults, enabled flags, model set). Recorded on Playground executions as
+# optional audit metadata; see LLMModelRegistry.get_revision().
+REGISTRY_REVISION = "2026-09-01"
+
 
 class LLMModelRegistry:
     """Central registry for LLM model configurations.
@@ -535,9 +551,7 @@ class LLMModelRegistry:
         # DB rows. Any existing row — including a disabled prior default —
         # is admin-controlled state, so the new model is inserted
         # non-default and no admin flag is cleared or overridden.
-        result = await session.execute(
-            select(LLMModelConfigModel.provider).distinct()
-        )
+        result = await session.execute(select(LLMModelConfigModel.provider).distinct())
         providers_with_db_rows = {row[0] for row in result.fetchall()}
 
         inserted = 0
@@ -634,27 +648,66 @@ class LLMModelRegistry:
         return [m for m in cls._models() if m.provider == provider and m.is_enabled]
 
     @classmethod
+    def get_revision(cls) -> str:
+        """Registry snapshot marker for execution metadata (JSON-safe string).
+
+        ``code:`` = in-memory seed serving, ``db:`` = DB cache serving. The
+        date part is the code-seed revision this process was built with.
+        """
+        mode = "db" if cls._db_cache is not None else "code"
+        return f"{mode}:{REGISTRY_REVISION}"
+
+    @classmethod
     def get_default(cls, provider: LLMProvider | str | None = None) -> str:
-        """Get the default model ID for a provider.
+        """Get the default model ID for a provider (deterministic, fail-closed).
 
-        Args:
-            provider: Specific provider, or None to use the first available.
+        - 명시적 enabled default 가 있으면 그것을 쓴다. 둘 이상이면(DB drift)
+          id 순으로 결정하고 경고를 남긴다 — 충돌을 조용히 숨기지 않는다.
+        - enabled default 가 없으면 목록 순서가 아니라 최저가(합산 per-1k,
+          id tie-break) 모델로 결정론적 폴백하고 경고를 남긴다.
+        - enabled 모델이 하나도 없으면 LookupError 로 fail-closed 한다 —
+          타 provider 모델("codex-cli")을 조용히 반환하지 않는다.
+        - 미지 provider 문자열도 LookupError 로 fail-closed 한다 — 임의
+          문자열이 Codex 실행 경로로 조용히 라우팅되면 provider 정책·
+          entitlement 게이트가 우회된다. 기동 경로의 폴백은 이 함수가 아니라
+          각 호출부의 명시적 LookupError 처리로 옮겼다.
 
-        Returns:
-            Default model ID string.
+        Raises:
+            LookupError: unknown provider, or the provider has zero enabled
+                models.
         """
         if provider:
             if isinstance(provider, str):
                 try:
                     provider = LLMProvider(provider)
                 except ValueError:
-                    return "codex-cli"  # Fallback
+                    logger.error(
+                        "get_default: unknown provider %r — failing closed",
+                        provider,
+                    )
+                    raise LookupError(f"Unknown provider: {provider}") from None
 
             models = cls.get_by_provider(provider)
-            for m in models:
-                if m.is_default:
-                    return m.id
-            return models[0].id if models else "codex-cli"
+            defaults = [m for m in models if m.is_default]
+            if len(defaults) > 1:
+                logger.warning(
+                    "get_default: multiple enabled defaults for provider %s (%s), "
+                    "resolving deterministically by id",
+                    provider.value,
+                    [m.id for m in defaults],
+                )
+            if defaults:
+                return min(defaults, key=lambda m: m.id).id
+            if models:
+                fallback = min(models, key=lambda m: (m.input_price + m.output_price, m.id))
+                logger.warning(
+                    "get_default: no enabled default for provider %s, "
+                    "using deterministic cheapest fallback %s",
+                    provider.value,
+                    fallback.id,
+                )
+                return fallback.id
+            raise LookupError(f"No enabled models for provider {provider.value}")
 
         # No provider specified - resolve from the configured provider so the
         # registry default stays consistent with LLM_PROVIDER (headless deploys

--- a/src/backend/models/playground.py
+++ b/src/backend/models/playground.py
@@ -14,8 +14,17 @@ from utils.time import normalize_aware_utc, utcnow
 
 # Get default model from central registry
 def _get_default_model() -> str:
-    """Get default model for playground, resolved from the configured provider."""
-    return LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli"))
+    """Get default model for playground, resolved from the configured provider.
+
+    get_default 는 provider 에 enabled 모델이 0개면 fail-closed(LookupError)
+    한다. 이 함수는 요청 body 파싱 중(default_factory) 불리므로 예외를 500 으로
+    흘리지 않고 legacy "codex-cli" 폴백을 유지한다 — 그 값이 실제로 못 쓰는
+    모델이면 create 경로의 등록 게이트가 명확한 검증 오류(400)로 거부한다.
+    """
+    try:
+        return LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli"))
+    except LookupError:
+        return "codex-cli"
 
 
 class PlaygroundExecutionStatus(str, Enum):
@@ -71,6 +80,11 @@ class PlaygroundExecution(BaseModel):
     # 남는다. 구버전 JSON 레코드에는 없는 필드라 None 기본값이 필수.
     requested_model: str | None = None
     resolved_model: str | None = None
+    # 실행 시점의 registry snapshot 표식 (LLMModelRegistry.get_revision()).
+    # optional 계측 metadata — 구버전 레코드 호환을 위해 None 기본값 필수.
+    # provider 가 실제 서빙한 concrete 모델 id 는 provider 응답 없이는 알 수
+    # 없으므로 여기 기록하지 않는다 (resolved_model 은 '우리가 호출한' id).
+    registry_revision: str | None = None
 
     # Metrics
     total_tokens: int = 0

--- a/src/backend/models/playground.py
+++ b/src/backend/models/playground.py
@@ -66,6 +66,12 @@ class PlaygroundExecution(BaseModel):
     result: str | None = None
     error: str | None = None
 
+    # Model attribution — 실행 단위 귀속. session.model은 사용자의 저장된
+    # 선택으로 남고, fallback retry가 다른 모델로 성공한 사실은 여기에만
+    # 남는다. 구버전 JSON 레코드에는 없는 필드라 None 기본값이 필수.
+    requested_model: str | None = None
+    resolved_model: str | None = None
+
     # Metrics
     total_tokens: int = 0
     input_tokens: int = 0

--- a/src/backend/services/agent_registry.py
+++ b/src/backend/services/agent_registry.py
@@ -24,8 +24,16 @@ def _default_agent_model() -> str:
     import), so LLM_PROVIDER changes and DB-loaded registry defaults present
     at that moment are honored. See _build_default_agents() for the
     once-per-process singleton limitation.
+
+    get_default 는 미지 provider·enabled 모델 0개에 fail-closed(LookupError)
+    한다. 이 함수는 default_factory 로 불리므로 예외를 등록 경로로 흘리지
+    않고 legacy "codex-cli" 폴백을 유지한다 (models/playground.py 관례 —
+    실행 시 LLMService._get_llm 게이트가 unknown/disabled 를 거부한다).
     """
-    return LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli"))
+    try:
+        return LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER", "codex_cli"))
+    except LookupError:
+        return "codex-cli"
 
 
 class AgentCategory(str, Enum):

--- a/src/backend/services/llm_runtime_resolver.py
+++ b/src/backend/services/llm_runtime_resolver.py
@@ -10,7 +10,7 @@ from models.llm_access import (
     LLMCLIProfileResponse,
     LLMEntitlementResponse,
 )
-from models.llm_models import LLMModelRegistry
+from models.llm_models import LLMModelRegistry, LLMProvider
 
 
 class LLMRuntimeResolutionError(PermissionError):
@@ -57,6 +57,14 @@ def _enum_value(value: Any) -> Any:
     return value.value if hasattr(value, "value") else value
 
 
+def _is_known_provider(provider: str) -> bool:
+    try:
+        LLMProvider(provider)
+    except ValueError:
+        return False
+    return True
+
+
 def _runtime_mode_for_provider(provider: str) -> str:
     if provider.endswith("_cli"):
         return "cli"
@@ -78,6 +86,10 @@ def _enabled_entitlements(
         entitlement
         for entitlement in access.entitlements
         if entitlement.enabled
+        # Reject providers outside the LLMProvider enum: "somefake_cli" would
+        # otherwise derive mode "cli", win the CLI-first preference, and pull
+        # a default model it has no right to (policy bypass).
+        and _is_known_provider(entitlement.provider)
         # Reject malformed pairs: mode must be derivable from provider, or the
         # mode gate and the provider-based executor disagree (policy bypass).
         and entitlement.mode == _runtime_mode_for_provider(entitlement.provider)
@@ -144,7 +156,13 @@ def _model_for_resolution(
 ) -> str:
     if requested_model_id:
         return requested_model_id
-    return LLMModelRegistry.get_default(entitlement.provider)
+    try:
+        return LLMModelRegistry.get_default(entitlement.provider)
+    except LookupError as exc:
+        # entitlement 의 provider 에 enabled 모델이 0개 — 타 provider 모델이
+        # 조용히 대입되면 entitlement 게이트가 우회되므로, resolver 계약
+        # 타입으로 번역해 fail-closed 한다.
+        raise LLMRuntimeResolutionError(str(exc)) from exc
 
 
 def resolve_llm_runtime(

--- a/src/backend/services/llm_runtime_resolver.py
+++ b/src/backend/services/llm_runtime_resolver.py
@@ -78,6 +78,9 @@ def _enabled_entitlements(
         entitlement
         for entitlement in access.entitlements
         if entitlement.enabled
+        # Reject malformed pairs: mode must be derivable from provider, or the
+        # mode gate and the provider-based executor disagree (policy bypass).
+        and entitlement.mode == _runtime_mode_for_provider(entitlement.provider)
         and _source_matches(entitlement.source_scope, source)
         and (
             request.organization_id is None
@@ -89,10 +92,12 @@ def _enabled_entitlements(
 def _provider_for_requested_model(requested_model_id: str | None) -> str | None:
     if not requested_model_id:
         return None
-    provider = LLMModelRegistry.get_provider(requested_model_id)
-    if provider is None:
+    model = LLMModelRegistry.get_by_id(requested_model_id)
+    if model is None:
         raise LLMRuntimeResolutionError(f"Unknown model: {requested_model_id}")
-    return provider.value
+    if not model.is_enabled:
+        raise LLMRuntimeResolutionError(f"Model disabled: {requested_model_id}")
+    return model.provider.value
 
 
 def _select_entitlement(

--- a/src/backend/services/llm_service.py
+++ b/src/backend/services/llm_service.py
@@ -14,7 +14,7 @@ from langchain_core.messages import (
 )
 
 from models.llm_access import LLMAccessResponse
-from models.llm_models import LLMModelRegistry, get_model_configs
+from models.llm_models import LLMModelRegistry
 from models.llm_usage import (
     LLMRuntimeMode,
     LLMUsageMeasurementMethod,
@@ -32,9 +32,6 @@ from services.llm_usage_ledger_service import (
     enforce_usage_quota_preflight_best_effort,
     record_usage_best_effort,
 )
-
-# Use central registry for model configurations
-MODEL_CONFIGS = get_model_configs()
 
 
 def _runtime_mode_for_provider(provider: str) -> LLMRuntimeMode:
@@ -95,8 +92,8 @@ def _resolve_runtime_from_context(
     source = _usage_context_value(usage_context, "source")
     if not access or not source:
         resolved_model = model_id or LLMModelRegistry.get_default()
-        config = MODEL_CONFIGS.get(resolved_model, {})
-        return resolved_model, config.get("provider", "unknown"), usage_context
+        provider = LLMModelRegistry.get_provider(resolved_model)
+        return resolved_model, provider.value if provider else "unknown", usage_context
 
     resolution = resolve_llm_runtime(
         access,
@@ -270,14 +267,22 @@ class LLMService:
         temperature: float = 0.7,
         max_tokens: int = 4096,
     ) -> Any:
-        """Get or create LLM instance for the specified model."""
+        """Get or create LLM instance for the specified model.
+
+        Gates on the live registry (DB-aware), not a static snapshot: a model
+        must be registered AND enabled to build. DB-discovered models carry
+        enough metadata (provider + id) to build without a code entry.
+        """
         if not model_id:
             model_id = LLMModelRegistry.get_default()
-        config = MODEL_CONFIGS.get(model_id)
-        if not config:
+        model = LLMModelRegistry.get_by_id(model_id)
+        if model is None:
             raise ValueError(f"Unknown model: {model_id}")
+        if not model.is_enabled:
+            raise ValueError(f"Model disabled: {model_id}")
 
-        provider = config["provider"]
+        provider = model.provider.value
+        model_name = model.id
         cache_key = f"{model_id}:{temperature}:{max_tokens}"
 
         if cache_key in cls._instances:
@@ -292,7 +297,7 @@ class LLMService:
             if not api_key:
                 raise ValueError("GOOGLE_API_KEY not set")
             llm = ChatGoogleGenerativeAI(
-                model=config["model"],
+                model=model_name,
                 temperature=temperature,
                 max_output_tokens=max_tokens,
                 google_api_key=api_key,
@@ -305,7 +310,7 @@ class LLMService:
             if not api_key:
                 raise ValueError("ANTHROPIC_API_KEY not set")
             llm = ChatAnthropic(
-                model=config["model"],
+                model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 api_key=api_key,
@@ -318,7 +323,7 @@ class LLMService:
             if not api_key:
                 raise ValueError("OPENAI_API_KEY not set")
             llm = ChatOpenAI(
-                model=config["model"],
+                model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 api_key=api_key,
@@ -327,18 +332,18 @@ class LLMService:
         elif provider == "codex_cli":
             from services.codex_cli_chat_model import CodexCliChatModel
 
-            llm = CodexCliChatModel(model_name=config["model"])
+            llm = CodexCliChatModel(model_name=model_name)
 
         elif provider == "claude_cli":
             from services.claude_cli_chat_model import ClaudeCliChatModel
 
-            llm = ClaudeCliChatModel(model_name=config["model"])
+            llm = ClaudeCliChatModel(model_name=model_name)
 
         elif provider == "ollama":
             from langchain_ollama import ChatOllama
 
             llm = ChatOllama(
-                model=config["model"],
+                model=model_name,
                 temperature=temperature,
                 num_predict=max_tokens,
                 base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),

--- a/src/backend/services/llm_service.py
+++ b/src/backend/services/llm_service.py
@@ -91,7 +91,12 @@ def _resolve_runtime_from_context(
     access = _usage_context_access(usage_context)
     source = _usage_context_value(usage_context, "source")
     if not access or not source:
-        resolved_model = model_id or LLMModelRegistry.get_default()
+        try:
+            resolved_model = model_id or LLMModelRegistry.get_default()
+        except LookupError as e:
+            # 구성 provider 가 미지이거나 enabled 모델 0개 — 이 모듈의 실패
+            # 계약 타입(ValueError, cf. Unknown model/Model disabled)으로 번역.
+            raise ValueError(str(e)) from e
         provider = LLMModelRegistry.get_provider(resolved_model)
         return resolved_model, provider.value if provider else "unknown", usage_context
 
@@ -274,7 +279,11 @@ class LLMService:
         enough metadata (provider + id) to build without a code entry.
         """
         if not model_id:
-            model_id = LLMModelRegistry.get_default()
+            try:
+                model_id = LLMModelRegistry.get_default()
+            except LookupError as e:
+                # 이 메서드의 기존 실패 계약(ValueError)으로 번역한다.
+                raise ValueError(str(e)) from e
         model = LLMModelRegistry.get_by_id(model_id)
         if model is None:
             raise ValueError(f"Unknown model: {model_id}")
@@ -640,8 +649,15 @@ class LLMService:
         """Get the default model based on available API keys.
 
         Uses the central LLMModelRegistry.
+
+        Raises:
+            ValueError: 구성 provider 가 미지이거나 enabled 모델이 0개
+                (registry fail-closed 를 서비스 계약 타입으로 번역).
         """
-        return LLMModelRegistry.get_default()
+        try:
+            return LLMModelRegistry.get_default()
+        except LookupError as e:
+            raise ValueError(str(e)) from e
 
     @classmethod
     async def invoke_with_tools(

--- a/src/backend/services/model_update_service.py
+++ b/src/backend/services/model_update_service.py
@@ -24,6 +24,18 @@ UPDATE_CHECK_TIMEOUT = int(os.getenv("LLM_UPDATE_CHECK_TIMEOUT", "30"))
 USE_DATABASE = os.getenv("USE_DATABASE", "false").lower() == "true"
 
 
+def _provider_probe_available(provider: LLMProvider | str) -> bool:
+    """update check 대상 provider 프로브 (API 키 존재 여부 대용).
+
+    get_default 는 enabled 모델이 0개인 provider 에 fail-closed(LookupError)
+    한다 — 스케줄러가 죽지 않도록 그 경우를 '사용 불가'(skip)로 취급한다.
+    """
+    try:
+        return LLMModelRegistry.is_available(LLMModelRegistry.get_default(provider))
+    except LookupError:
+        return False
+
+
 # ─────────────────────────────────────────────────────────────
 # Data Structures
 # ─────────────────────────────────────────────────────────────
@@ -336,8 +348,8 @@ class ModelUpdateService:
         results: list[UpdateCheckResult] = []
 
         for provider in _FETCHERS:
-            # Skip providers without API keys
-            if not LLMModelRegistry.is_available(LLMModelRegistry.get_default(provider)):
+            # Skip providers without API keys (or without any enabled model)
+            if not _provider_probe_available(provider):
                 continue
 
             result = await ModelUpdateService.check_provider(provider, apply_updates=apply_updates)
@@ -558,9 +570,5 @@ class ModelUpdateService:
             "enabled": USE_DATABASE,
             "check_interval_hours": UPDATE_CHECK_INTERVAL_HOURS,
             "last_check": last_check,
-            "configured_providers": [
-                p.value
-                for p in _FETCHERS
-                if LLMModelRegistry.is_available(LLMModelRegistry.get_default(p))
-            ],
+            "configured_providers": [p.value for p in _FETCHERS if _provider_probe_available(p)],
         }

--- a/src/backend/services/playground_service/llm.py
+++ b/src/backend/services/playground_service/llm.py
@@ -162,7 +162,13 @@ async def _invoke_with_model_fallback(
     invoke,
     **kwargs: Any,
 ) -> LLMResponse:
-    """Invoke once, then retry with the configured safe default for stale models."""
+    """Invoke once, then retry with the configured safe default for stale models.
+
+    The retry is execution-scoped: ``session.model`` is the user's saved
+    choice and is never rewritten here — a successful fallback is recorded on
+    the execution (requested/resolved), and a failed fallback target must not
+    be persisted into the session either.
+    """
     try:
         return await invoke(model_id=session.model, **kwargs)
     except Exception as exc:
@@ -170,10 +176,8 @@ async def _invoke_with_model_fallback(
         if not fallback_model or not _is_inaccessible_model_error(exc):
             raise
 
-        stale_model = session.model
         logger.warning(
             "playground_model_inaccessible_retry",
-            extra={"stale_model": stale_model, "fallback_model": fallback_model},
+            extra={"stale_model": session.model, "fallback_model": fallback_model},
         )
-        session.model = fallback_model
         return await invoke(model_id=fallback_model, **kwargs)

--- a/src/backend/services/playground_service/llm.py
+++ b/src/backend/services/playground_service/llm.py
@@ -152,7 +152,12 @@ def _safe_playground_fallback_model(
         entitled = resolution.model_id
         return entitled if entitled and entitled != current_model else None
 
-    configured_default = LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER") or "codex_cli")
+    try:
+        configured_default = LLMModelRegistry.get_default(os.getenv("LLM_PROVIDER") or "codex_cli")
+    except LookupError:
+        # 구성된 provider 에 enabled 모델이 0개(fail-closed) — 재시도할 안전한
+        # 대상이 없다. None 을 돌려 원래 오류가 그대로 표면화되게 한다.
+        return None
     fallback = configured_default or "codex-cli"
     return fallback if fallback and fallback != current_model else None
 

--- a/src/backend/services/playground_service/service.py
+++ b/src/backend/services/playground_service/service.py
@@ -27,6 +27,7 @@ from models.playground import (
     PlaygroundSessionCreate,
     PlaygroundToolTest,
 )
+from services.llm_runtime_resolver import LLMRuntimeResolutionError
 from services.llm_service import LLMService
 from services.playground_context import build_effective_system_prompt
 from utils.time import utcnow
@@ -35,7 +36,9 @@ from .config import DEFAULT_SYSTEM_PROMPT, PLAYGROUND_TOOLS
 from .llm import (
     _coerce_llm_content,
     _invoke_with_model_fallback,
+    _is_inaccessible_model_error,
     _playground_usage_context,
+    _safe_playground_fallback_model,
     _to_lc_messages,
 )
 from .mock import _generate_mock_tool_result
@@ -236,6 +239,7 @@ class PlaygroundService:
             temperature=request.temperature or session.temperature,
             max_tokens=request.max_tokens or session.max_tokens,
             tools_enabled=request.tools or session.enabled_tools,
+            requested_model=session.model,
         )
 
         execution.status = PlaygroundExecutionStatus.RUNNING
@@ -366,6 +370,8 @@ class PlaygroundService:
             # Update execution metrics
             execution.result = content
             execution.status = PlaygroundExecutionStatus.COMPLETED
+            # 실제 성공한 모델(무변이 fallback retry면 fallback model)을 귀속.
+            execution.resolved_model = llm_response.model or session.model
             execution.input_tokens = llm_response.input_tokens
             execution.output_tokens = llm_response.output_tokens
             execution.total_tokens = llm_response.total_tokens
@@ -418,12 +424,37 @@ class PlaygroundService:
         if not session:
             raise ValueError(f"Session {session_id} not found")
 
+        # Execution record — 스트리밍도 execute() 와 같은 실행 단위 귀속을 남긴다.
+        execution = PlaygroundExecution(
+            agent_id=session.agent_id or "default",
+            prompt=request.prompt,
+            context=request.context,
+            temperature=request.temperature or session.temperature,
+            max_tokens=request.max_tokens or session.max_tokens,
+            tools_enabled=request.tools or session.enabled_tools,
+            requested_model=session.model,
+        )
+        execution.status = PlaygroundExecutionStatus.RUNNING
+        execution.started_at = utcnow()
+
         # Add user message to session
         user_msg = PlaygroundMessage(
             role="user",
             content=request.prompt,
         )
+        execution.messages.append(user_msg)
         session.messages.append(user_msg)
+        session.executions.append(execution)
+
+        def _record_stream_failure(message: str) -> None:
+            # 실패 execution 도 영속화하되, 성공 집계(total_*)는 올리지 않는다
+            # (기존 계약 — 실패 스트림은 세션 집계에 반영되지 않는다).
+            execution.status = PlaygroundExecutionStatus.FAILED
+            execution.error = message
+            execution.completed_at = utcnow()
+            session.updated_at = utcnow()
+            _save_sessions()
+            _fire_and_forget(PlaygroundService.save_session_to_db(session))
 
         # Multi-turn history as LangChain messages (excl. the just-appended user)
         history = _to_lc_messages(session.messages[-11:-1])
@@ -482,6 +513,10 @@ class PlaygroundService:
             llm_access=llm_access,
         )
 
+        # 실제 성공한 모델. fallback retry가 다른 모델로 성공하면 갱신되며,
+        # 비용/토큰 추정은 session.model이 아니라 이 값으로 계산한다.
+        resolved_model = session.model
+
         try:
             if enabled_tools:
                 # Tool-enabled: single-shot invoke_with_tools, yield final answer.
@@ -499,6 +534,7 @@ class PlaygroundService:
                     working_directory=session.working_directory,
                     usage_context=usage_context,
                 )
+                resolved_model = resp.model or session.model
                 full_response = _coerce_llm_content(resp.content)
                 yield full_response
                 token_info = {
@@ -509,37 +545,76 @@ class PlaygroundService:
                 for tc, tr in zip(resp.tool_calls, resp.tool_results, strict=False):
                     yield f"\n\n__TOOL_CALL__{json.dumps({'call': tc, 'result': tr}, ensure_ascii=False)}"
             else:
-                async for chunk, info in LLMService.stream_with_tokens(
-                    prompt=request.prompt,
-                    model_id=session.model,
-                    system_prompt=effective_system_prompt,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    context=request.context or None,
-                    history=history,
-                    rag_context=rag_context_str,
-                    usage_context=usage_context,
-                ):
-                    if info:
-                        if info.get("error"):
-                            # Structured error — surface plain text to user
-                            yield chunk
-                            return
-                        token_info = info
-                    elif chunk:
-                        full_response += chunk
-                        yield chunk
+                # Non-tools: same stale-model fallback as the non-streaming
+                # path, but only while nothing has been emitted yet — once a
+                # chunk reached the client a retry would duplicate content, so
+                # a later error is surfaced as-is. session.model is never
+                # rewritten (the retry is execution-scoped).
+                attempt_model = session.model
+                retried = False
+                while True:
+                    error: Exception | None = None
+                    error_chunk = ""
+                    try:
+                        async for chunk, info in LLMService.stream_with_tokens(
+                            prompt=request.prompt,
+                            model_id=attempt_model,
+                            system_prompt=effective_system_prompt,
+                            temperature=temperature,
+                            max_tokens=max_tokens,
+                            context=request.context or None,
+                            history=history,
+                            rag_context=rag_context_str,
+                            usage_context=usage_context,
+                        ):
+                            if info:
+                                if info.get("error"):
+                                    # Structured error sentinel from the stream
+                                    error = Exception(str(info.get("message") or chunk))
+                                    error_chunk = chunk
+                                    break
+                                token_info = info
+                            elif chunk:
+                                full_response += chunk
+                                yield chunk
+                    except LLMRuntimeResolutionError as exc:
+                        # Resolver rejects on first iteration — raised raw, not
+                        # wrapped in the error sentinel.
+                        error = exc
+                        error_chunk = f"\n\n[Error: {exc}]"
+
+                    if error is None:
+                        resolved_model = attempt_model
+                        break
+
+                    fallback_model = (
+                        None
+                        if (retried or full_response)
+                        else _safe_playground_fallback_model(attempt_model, usage_context)
+                    )
+                    if not fallback_model or not _is_inaccessible_model_error(error):
+                        # Surface plain text to user (no retry available)
+                        _record_stream_failure(str(error))
+                        yield error_chunk
+                        return
+
+                    logger.warning(
+                        "playground_stream_model_inaccessible_retry",
+                        extra={"stale_model": attempt_model, "fallback_model": fallback_model},
+                    )
+                    attempt_model = fallback_model
+                    retried = True
 
             # Calculate token usage
             if token_info:
                 input_tokens = token_info.get("input_tokens", 0)
                 output_tokens = token_info.get("output_tokens", 0)
             else:
-                input_tokens = estimate_tokens(request.prompt, session.model)
-                output_tokens = estimate_tokens(full_response, session.model)
+                input_tokens = estimate_tokens(request.prompt, resolved_model)
+                output_tokens = estimate_tokens(full_response, resolved_model)
 
             total_tokens = input_tokens + output_tokens
-            cost = calculate_cost(input_tokens, output_tokens, session.model)
+            cost = calculate_cost(input_tokens, output_tokens, resolved_model)
 
             # Persist assistant message
             assistant_msg = PlaygroundMessage(
@@ -549,6 +624,17 @@ class PlaygroundService:
                 rag_sources=rag_sources,
             )
             session.messages.append(assistant_msg)
+
+            # Finalize the execution record with the resolved-model attribution.
+            execution.result = full_response
+            execution.status = PlaygroundExecutionStatus.COMPLETED
+            execution.resolved_model = resolved_model
+            execution.input_tokens = input_tokens
+            execution.output_tokens = output_tokens
+            execution.total_tokens = total_tokens
+            execution.cost = cost
+            execution.completed_at = utcnow()
+
             session.total_executions += 1
             session.total_tokens += total_tokens
             session.total_cost += cost
@@ -560,6 +646,10 @@ class PlaygroundService:
                 yield f"\n\n__RAG_SOURCES__{json.dumps(rag_sources, ensure_ascii=False)}"
 
         except Exception as e:
+            # 비-tools 루프에서 이미 finalize 된 실패는 여기로 오지 않지만,
+            # tools 분기 등에서 RUNNING 인 채 떨어진 예외는 여기서 한 번만 마감한다.
+            if execution.status == PlaygroundExecutionStatus.RUNNING:
+                _record_stream_failure(str(e))
             yield f"\n\n[Error: {str(e)}]"
 
     # ─────────────────────────────────────────────────────────────

--- a/src/backend/services/playground_service/service.py
+++ b/src/backend/services/playground_service/service.py
@@ -9,6 +9,7 @@ DB 영속화 5 함수는 `storage.py` 로 들어올린 뒤 클래스에 같은 �
 `monkeypatch.setattr(playground_service.service, "_load_sessions", ...)`.
 """
 
+import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -16,6 +17,7 @@ from typing import Any
 
 from models.cost import calculate_cost, estimate_tokens
 from models.llm_access import LLMAccessResponse
+from models.llm_models import LLMModelRegistry
 from models.playground import (
     PlaygroundCompareRequest,
     PlaygroundCompareResult,
@@ -57,6 +59,21 @@ from .storage import (
 logger = logging.getLogger(__name__)
 
 
+def _require_registered_enabled_model(model_id: str) -> None:
+    """세션 저장 경로의 모델 등록 게이트.
+
+    Registry 에 존재하고 enabled 인 모델만 세션에 저장될 수 있다. 검증은
+    쓰기 경로(create/update)에만 있다 — 기존 세션 로딩(legacy JSON/DB)은
+    stale 모델이어도 그대로 파싱되고, 실행 시 resolver/fallback 이 처리한다.
+    오류 메시지는 llm_runtime_resolver 와 동일한 관례를 따른다.
+    """
+    model = LLMModelRegistry.get_by_id(model_id)
+    if model is None:
+        raise ValueError(f"Unknown model: {model_id}")
+    if not model.is_enabled:
+        raise ValueError(f"Model disabled: {model_id}")
+
+
 class PlaygroundService:
     """Service for managing playground sessions and executions."""
 
@@ -66,8 +83,13 @@ class PlaygroundService:
 
     @staticmethod
     def create_session(data: PlaygroundSessionCreate) -> PlaygroundSession:
-        """Create a new playground session."""
+        """Create a new playground session.
+
+        Raises:
+            ValueError: ``data.model`` is not a registered, enabled model.
+        """
         _load_sessions()  # Ensure sessions are loaded
+        _require_registered_enabled_model(data.model)
 
         session = PlaygroundSession(
             name=data.name,
@@ -165,11 +187,19 @@ class PlaygroundService:
         selected_memory_ids: list[str] | None = None,
         context_budget_tokens: int | None = None,
     ) -> PlaygroundSession | None:
-        """Update session settings."""
+        """Update session settings.
+
+        Raises:
+            ValueError: ``model`` is not a registered, enabled model. 검증은
+                어떤 필드도 반영되기 전에 수행된다 — 거부는 원자적이다.
+        """
         _load_sessions()  # Ensure sessions are loaded
         session = _sessions.get(session_id)
         if not session:
             return None
+
+        if model is not None:
+            _require_registered_enabled_model(model)
 
         if name is not None:
             session.name = name
@@ -240,6 +270,7 @@ class PlaygroundService:
             max_tokens=request.max_tokens or session.max_tokens,
             tools_enabled=request.tools or session.enabled_tools,
             requested_model=session.model,
+            registry_revision=LLMModelRegistry.get_revision(),
         )
 
         execution.status = PlaygroundExecutionStatus.RUNNING
@@ -433,6 +464,7 @@ class PlaygroundService:
             max_tokens=request.max_tokens or session.max_tokens,
             tools_enabled=request.tools or session.enabled_tools,
             requested_model=session.model,
+            registry_revision=LLMModelRegistry.get_revision(),
         )
         execution.status = PlaygroundExecutionStatus.RUNNING
         execution.started_at = utcnow()
@@ -446,78 +478,84 @@ class PlaygroundService:
         session.messages.append(user_msg)
         session.executions.append(execution)
 
-        def _record_stream_failure(message: str) -> None:
-            # 실패 execution 도 영속화하되, 성공 집계(total_*)는 올리지 않는다
-            # (기존 계약 — 실패 스트림은 세션 집계에 반영되지 않는다).
-            execution.status = PlaygroundExecutionStatus.FAILED
+        def _record_stream_failure(
+            message: str,
+            status: PlaygroundExecutionStatus = PlaygroundExecutionStatus.FAILED,
+        ) -> None:
+            # 실패/취소 execution 도 영속화하되, 성공 집계(total_*)는 올리지
+            # 않는다 (기존 계약 — 실패 스트림은 세션 집계에 반영되지 않는다).
+            execution.status = status
             execution.error = message
             execution.completed_at = utcnow()
             session.updated_at = utcnow()
             _save_sessions()
             _fire_and_forget(PlaygroundService.save_session_to_db(session))
 
-        # Multi-turn history as LangChain messages (excl. the just-appended user)
-        history = _to_lc_messages(session.messages[-11:-1])
-
-        # Inject RAG context if enabled
-        rag_sources: list[dict] | None = None
-        rag_context_str: str | None = None
-        if session.rag_enabled and session.project_id:
-            try:
-                from services.rag_service import get_project_context_with_sources
-
-                k = (
-                    request.rag_k
-                    if getattr(request, "rag_k", None)
-                    else getattr(session, "rag_k", None) or 5
-                )
-                force_hybrid = (
-                    request.rag_hybrid_override
-                    if getattr(request, "rag_hybrid_override", None) is not None
-                    else getattr(session, "rag_hybrid_override", None)
-                )
-                force_rerank = (
-                    request.rag_rerank_override
-                    if getattr(request, "rag_rerank_override", None) is not None
-                    else getattr(session, "rag_rerank_override", None)
-                )
-                include_shared = (
-                    request.rag_include_shared
-                    if getattr(request, "rag_include_shared", None) is not None
-                    else bool(getattr(session, "rag_include_shared", False))
-                )
-                rag_context_str, rag_sources = await get_project_context_with_sources(
-                    project_id=session.project_id,
-                    query=request.prompt,
-                    k=k,
-                    include_shared=include_shared,
-                    force_hybrid=force_hybrid,
-                    force_rerank=force_rerank,
-                )
-            except Exception as e:
-                logger.warning("RAG context retrieval failed: %s", e)
-
-        # Choose streaming path vs tool-enabled path
-        enabled_tools = request.tools or session.enabled_tools or []
-        temperature = request.temperature or session.temperature
-        max_tokens = request.max_tokens or session.max_tokens
-
-        full_response = ""
-        token_info: dict | None = None
-
-        # Compose once — shared by streaming and tool-enabled branches.
-        effective_system_prompt = build_effective_system_prompt(session)
-        usage_context = _playground_usage_context(
-            session,
-            metadata={"tools_enabled": bool(enabled_tools), "streaming": True},
-            llm_access=llm_access,
-        )
-
-        # 실제 성공한 모델. fallback retry가 다른 모델로 성공하면 갱신되며,
-        # 비용/토큰 추정은 session.model이 아니라 이 값으로 계산한다.
-        resolved_model = session.model
-
+        # history/RAG 준비부터 성공 마감까지 전 구간을 하나의 try 로 감싼다 —
+        # 초기화 단계 예외·태스크 취소·클라이언트 disconnect 어느 경로에서도
+        # RUNNING execution 이 영속화 대상으로 남지 않게 하기 위함이다.
         try:
+            # Multi-turn history as LangChain messages (excl. the just-appended user)
+            history = _to_lc_messages(session.messages[-11:-1])
+
+            # Inject RAG context if enabled
+            rag_sources: list[dict] | None = None
+            rag_context_str: str | None = None
+            if session.rag_enabled and session.project_id:
+                try:
+                    from services.rag_service import get_project_context_with_sources
+
+                    k = (
+                        request.rag_k
+                        if getattr(request, "rag_k", None)
+                        else getattr(session, "rag_k", None) or 5
+                    )
+                    force_hybrid = (
+                        request.rag_hybrid_override
+                        if getattr(request, "rag_hybrid_override", None) is not None
+                        else getattr(session, "rag_hybrid_override", None)
+                    )
+                    force_rerank = (
+                        request.rag_rerank_override
+                        if getattr(request, "rag_rerank_override", None) is not None
+                        else getattr(session, "rag_rerank_override", None)
+                    )
+                    include_shared = (
+                        request.rag_include_shared
+                        if getattr(request, "rag_include_shared", None) is not None
+                        else bool(getattr(session, "rag_include_shared", False))
+                    )
+                    rag_context_str, rag_sources = await get_project_context_with_sources(
+                        project_id=session.project_id,
+                        query=request.prompt,
+                        k=k,
+                        include_shared=include_shared,
+                        force_hybrid=force_hybrid,
+                        force_rerank=force_rerank,
+                    )
+                except Exception as e:
+                    logger.warning("RAG context retrieval failed: %s", e)
+
+            # Choose streaming path vs tool-enabled path
+            enabled_tools = request.tools or session.enabled_tools or []
+            temperature = request.temperature or session.temperature
+            max_tokens = request.max_tokens or session.max_tokens
+
+            full_response = ""
+            token_info: dict | None = None
+
+            # Compose once — shared by streaming and tool-enabled branches.
+            effective_system_prompt = build_effective_system_prompt(session)
+            usage_context = _playground_usage_context(
+                session,
+                metadata={"tools_enabled": bool(enabled_tools), "streaming": True},
+                llm_access=llm_access,
+            )
+
+            # 실제 성공한 모델. fallback retry가 다른 모델로 성공하면 갱신되며,
+            # 비용/토큰 추정은 session.model이 아니라 이 값으로 계산한다.
+            resolved_model = session.model
+
             if enabled_tools:
                 # Tool-enabled: single-shot invoke_with_tools, yield final answer.
                 resp = await _invoke_with_model_fallback(
@@ -645,9 +683,21 @@ class PlaygroundService:
             if rag_sources:
                 yield f"\n\n__RAG_SOURCES__{json.dumps(rag_sources, ensure_ascii=False)}"
 
+        except (asyncio.CancelledError, GeneratorExit):
+            # 클라이언트 disconnect(aclose→GeneratorExit)와 태스크 취소는
+            # BaseException 이라 아래 except Exception 이 못 잡는다 — CANCELLED
+            # 로 마감만 하고 반드시 재전파한다 (GeneratorExit 를 삼키면
+            # RuntimeError, CancelledError 를 삼키면 취소 유실).
+            if execution.status == PlaygroundExecutionStatus.RUNNING:
+                _record_stream_failure(
+                    "stream cancelled before completion",
+                    status=PlaygroundExecutionStatus.CANCELLED,
+                )
+            raise
         except Exception as e:
             # 비-tools 루프에서 이미 finalize 된 실패는 여기로 오지 않지만,
-            # tools 분기 등에서 RUNNING 인 채 떨어진 예외는 여기서 한 번만 마감한다.
+            # 초기화 단계·tools 분기 등에서 RUNNING 인 채 떨어진 예외는 여기서
+            # 한 번만 마감한다.
             if execution.status == PlaygroundExecutionStatus.RUNNING:
                 _record_stream_failure(str(e))
             yield f"\n\n[Error: {str(e)}]"

--- a/tests/backend/test_agent_registry.py
+++ b/tests/backend/test_agent_registry.py
@@ -183,7 +183,7 @@ class TestAgentMetadata:
             description="Test",
             category=AgentCategory.DEVELOPMENT,
         )
-        assert agent.model == "claude-sonnet-5"
+        assert agent.model == "claude-sonnet-4-6"
 
         # 인스턴스 생성 시점 평가 확인 (import 시점 고정이 아님)
         monkeypatch.setenv("LLM_PROVIDER", "codex_cli")

--- a/tests/backend/test_agent_registry.py
+++ b/tests/backend/test_agent_registry.py
@@ -183,7 +183,8 @@ class TestAgentMetadata:
             description="Test",
             category=AgentCategory.DEVELOPMENT,
         )
-        assert agent.model == "claude-sonnet-4-6"
+        # Policy 2026-09-01: restore the verified Anthropic code default.
+        assert agent.model == "claude-sonnet-5"
 
         # 인스턴스 생성 시점 평가 확인 (import 시점 고정이 아님)
         monkeypatch.setenv("LLM_PROVIDER", "codex_cli")

--- a/tests/backend/test_default_model_callers_failclosed.py
+++ b/tests/backend/test_default_model_callers_failclosed.py
@@ -1,0 +1,342 @@
+"""get_default fail-closed(LookupError) 전파에 대한 호출부 가드 회귀 테스트.
+
+LLMModelRegistry.get_default 는 미지 provider·enabled 모델 0개 provider 에
+LookupError 로 fail-closed 한다 (타 provider 모델 "codex-cli" 조용한 대입
+금지 — 정책 2026-09-01). 이 파일은 그 예외가 각 호출부에서 500/기동 실패가
+아니라 '통제된' 실패로 번역되는지 고정한다:
+
+- config.py 헬퍼: 구성 기본값 → legacy "codex-cli" 폴백 (내부 기본값 선택,
+  실행 시 LLMService._get_llm 게이트가 unknown/disabled 를 재검증)
+- services/agent_registry.py: default_factory 경로의 legacy "codex-cli" 폴백
+- services/llm_service.py: 모듈 실패 계약 타입(ValueError)으로 번역
+- services/llm_runtime_resolver.py: LLMProvider enum 밖 entitlement 거부
+  (계약 타입 LLMRuntimeResolutionError)
+- agents/base.py: import 시점 해석 금지(safe_import 가 라우터 트리를 조용히
+  제거하는 경로 차단) + 인스턴스 생성 시점 ValueError 로 fail-closed
+- agents/lead_orchestrator.py: 생성자 경로가 LookupError 를 흘리지 않고
+  가드된 기본값 해석(ValueError 계약)에 위임
+"""
+
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from models.llm_access import LLMAccessResponse, LLMEntitlementResponse
+from models.llm_models import LLMModelConfig, LLMModelRegistry, LLMProvider
+from models.llm_usage import LLMUsageSource
+from services.llm_runtime_resolver import (
+    LLMRuntimeRequest,
+    LLMRuntimeResolutionError,
+    resolve_llm_runtime,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_cache():
+    """Ensure the registry serves the in-memory _MODELS list (no DB cache)."""
+    original_cache = LLMModelRegistry._db_cache
+    original_index = LLMModelRegistry._db_index
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+    yield
+    LLMModelRegistry._db_cache = original_cache
+    LLMModelRegistry._db_index = original_index
+
+
+def _cfg(
+    model_id: str,
+    *,
+    provider: LLMProvider = LLMProvider.GOOGLE,
+    is_default: bool = False,
+    is_enabled: bool = True,
+) -> LLMModelConfig:
+    return LLMModelConfig(
+        id=model_id,
+        display_name=model_id,
+        provider=provider,
+        context_window=100_000,
+        input_price=0.001,
+        output_price=0.002,
+        is_default=is_default,
+        is_enabled=is_enabled,
+    )
+
+
+def _serve_from_cache(models: list[LLMModelConfig]) -> None:
+    LLMModelRegistry._db_cache = models
+    LLMModelRegistry._db_index = {m.id: m for m in models}
+
+
+def _entitlement(
+    *,
+    provider: str,
+    mode: str,
+    id: str = "ent-1",
+) -> LLMEntitlementResponse:
+    now = datetime(2026, 9, 1, tzinfo=UTC)
+    return LLMEntitlementResponse(
+        id=id,
+        user_id="user-1",
+        organization_id=None,
+        provider=provider,
+        mode=mode,
+        source_scope="all",
+        enabled=True,
+        cli_profile_id=None,
+        allow_api_fallback=False,
+        quota_policy_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# config.py — get_model_for_provider / get_default_model
+# ─────────────────────────────────────────────────────────────
+
+
+class TestConfigDefaultModelHelpers:
+    def test_get_model_for_provider_passes_through_valid_provider(self):
+        from config import get_model_for_provider
+
+        assert get_model_for_provider("anthropic") == "claude-sonnet-5"
+
+    def test_empty_provider_falls_back_to_configured_default(self, monkeypatch):
+        """enabled 모델 0개 provider: LookupError 를 orchestrator/router 초기화
+        경로로 흘리지 않고 구성된 기본 모델로 폴백한다."""
+        from config import get_model_for_provider
+
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        _serve_from_cache(
+            [
+                _cfg("g-disabled", is_enabled=False),
+                _cfg("codex-cli", provider=LLMProvider.CODEX_CLI, is_default=True),
+            ]
+        )
+        assert get_model_for_provider("google") == "codex-cli"
+
+    def test_unknown_provider_name_falls_back_to_configured_default(self, monkeypatch):
+        from config import get_model_for_provider
+
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        assert get_model_for_provider("not-a-provider") == "codex-cli"
+
+    def test_get_default_model_rogue_env_falls_back_to_codex_cli(self, monkeypatch):
+        """LLM_PROVIDER 가 미지 문자열이면 registry 는 fail-closed 하지만,
+        config 헬퍼는 legacy "codex-cli" 로 폴백한다 (실행 시 _get_llm 게이트
+        가 재검증하는 문서화된 관례)."""
+        from config import get_default_model
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        assert get_default_model() == "codex-cli"
+
+
+# ─────────────────────────────────────────────────────────────
+# services/agent_registry.py — _default_agent_model (default_factory)
+# ─────────────────────────────────────────────────────────────
+
+
+class TestAgentRegistryDefaultModel:
+    def test_rogue_env_falls_back_to_codex_cli(self, monkeypatch):
+        """default_factory 경로: LookupError 가 AgentMetadata 생성(등록 초기화)
+        을 죽이면 안 된다 — legacy "codex-cli" 폴백."""
+        from services.agent_registry import _default_agent_model
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        assert _default_agent_model() == "codex-cli"
+
+    def test_configured_provider_still_resolves(self, monkeypatch):
+        from services.agent_registry import _default_agent_model
+
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        assert _default_agent_model() == "claude-sonnet-5"
+
+
+# ─────────────────────────────────────────────────────────────
+# services/llm_service.py — ValueError 계약 번역
+# ─────────────────────────────────────────────────────────────
+
+
+class TestLLMServiceLookupErrorTranslation:
+    def test_get_llm_translates_lookup_error_to_value_error(self, monkeypatch):
+        """빈 model_id 로 기본값을 해석하다 실패하면, 이 메서드의 기존 실패
+        계약(ValueError — Unknown model/Model disabled)과 같은 타입이어야
+        한다."""
+        from services.llm_service import LLMService
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        with pytest.raises(ValueError, match="rogue-provider"):
+            LLMService._get_llm("")
+
+    def test_get_default_model_translates_lookup_error(self, monkeypatch):
+        from services.llm_service import LLMService
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        with pytest.raises(ValueError, match="rogue-provider"):
+            LLMService.get_default_model()
+
+    def test_resolve_runtime_from_context_translates_lookup_error(self, monkeypatch):
+        """no-access/no-source 분기의 기본 모델 해석도 같은 계약으로 실패한다."""
+        from services.llm_service import _resolve_runtime_from_context
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        with pytest.raises(ValueError, match="rogue-provider"):
+            _resolve_runtime_from_context("", None)
+
+
+# ─────────────────────────────────────────────────────────────
+# agents/base.py — import 안전 + 인스턴스 생성 시점 fail-closed
+# ─────────────────────────────────────────────────────────────
+
+
+class TestAgentsBaseDefaultModel:
+    def test_import_survives_rogue_provider(self):
+        """safe_import 회귀: LLM_PROVIDER 가 rogue 여도 agents.base 임포트는
+        성공해야 한다 — 임포트가 죽으면 api/app.py safe_import 가 agents
+        라우터 트리를 조용히 제거한다(silent fail-open과 동급의 가용성 구멍)."""
+        import agents.base as base
+
+        backend_dir = Path(base.__file__).resolve().parents[1]
+        result = subprocess.run(
+            [sys.executable, "-c", "import agents.base"],
+            cwd=backend_dir,
+            env={**os.environ, "LLM_PROVIDER": "rogue-provider"},
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f"agents.base import failed under rogue LLM_PROVIDER:\n{result.stderr}"
+        )
+
+    def test_agent_config_default_rogue_provider_raises_value_error(self, monkeypatch):
+        """model_name 미지정 AgentConfig 생성은 rogue provider 에서 codex-cli
+        대입 없이 모듈 계약 타입(ValueError)으로 fail-closed 한다."""
+        from agents.base import AgentConfig
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        with pytest.raises(ValueError, match="rogue-provider"):
+            AgentConfig(name="a", description="b", system_prompt="c")
+
+    def test_agent_config_default_zero_enabled_provider_raises_value_error(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "google")
+        _serve_from_cache([_cfg("g-disabled", is_enabled=False)])
+        with pytest.raises(ValueError, match="google"):
+            from agents.base import AgentConfig
+
+            AgentConfig(name="a", description="b", system_prompt="c")
+
+    def test_agent_config_default_resolves_configured_provider(self, monkeypatch):
+        from agents.base import AgentConfig
+
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        config = AgentConfig(name="a", description="b", system_prompt="c")
+        assert config.model_name == "claude-sonnet-5"
+
+    def test_agent_config_explicit_model_name_bypasses_resolution(self, monkeypatch):
+        from agents.base import AgentConfig
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        config = AgentConfig(
+            name="a", description="b", system_prompt="c", model_name="claude-sonnet-5"
+        )
+        assert config.model_name == "claude-sonnet-5"
+
+    def test_specialist_model_env_override_short_circuits_registry(self, monkeypatch):
+        """SPECIALIST_AGENT_MODEL env 가 있으면 registry 를 건드리지 않는다 —
+        rogue provider 여도 override 값이 그대로 반환된다."""
+        import agents.base as base
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        monkeypatch.setenv("SPECIALIST_AGENT_MODEL", "my-override-model")
+        assert base.SPECIALIST_AGENT_MODEL == "my-override-model"
+
+    def test_specialist_model_rogue_provider_raises_value_error(self, monkeypatch):
+        import agents.base as base
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        monkeypatch.delenv("SPECIALIST_AGENT_MODEL", raising=False)
+        with pytest.raises(ValueError, match="rogue-provider"):
+            _ = base.SPECIALIST_AGENT_MODEL
+
+
+# ─────────────────────────────────────────────────────────────
+# agents/lead_orchestrator.py — 생성자 경로 fail-closed 위임
+# ─────────────────────────────────────────────────────────────
+
+
+class TestLeadOrchestratorDefaultModel:
+    def test_rogue_provider_fails_closed_with_value_error(self, monkeypatch):
+        """lazy 오케스트레이터 생성이 uncaught LookupError 대신 모듈 계약
+        타입(ValueError)으로 실패한다 — codex-cli 조용한 대입 금지."""
+        from agents.lead_orchestrator import LeadOrchestratorAgent
+
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        with pytest.raises(ValueError, match="rogue-provider"):
+            LeadOrchestratorAgent()
+
+    def test_zero_enabled_provider_fails_closed_with_value_error(self, monkeypatch):
+        """DB drift 로 구성 provider 의 enabled 모델이 0개인 경우."""
+        from agents.lead_orchestrator import LeadOrchestratorAgent
+
+        monkeypatch.setenv("LLM_PROVIDER", "google")
+        _serve_from_cache([_cfg("g-disabled", is_enabled=False)])
+        with pytest.raises(ValueError, match="google"):
+            LeadOrchestratorAgent()
+
+    def test_valid_provider_resolves_registry_default(self, monkeypatch):
+        from agents.base import BaseAgent
+        from agents.lead_orchestrator import LeadOrchestratorAgent
+
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setattr(BaseAgent, "_create_llm", staticmethod(lambda config: object()))
+        orchestrator = LeadOrchestratorAgent()
+        assert orchestrator.config.model_name == "claude-sonnet-5"
+
+
+# ─────────────────────────────────────────────────────────────
+# services/llm_runtime_resolver.py — enum 밖 entitlement provider 거부
+# ─────────────────────────────────────────────────────────────
+
+
+class TestResolverUnknownProviderEntitlements:
+    def test_unknown_cli_provider_entitlement_is_rejected(self):
+        """provider "somefake_cli" 는 mode 파생상 "cli" 라 CLI-first 선호까지 이길 수
+        있던 경로 — LLMProvider enum 밖 provider 는 entitlement 필터에서
+        거부되어야 한다 (조용한 기본 모델 대입 = 정책 우회)."""
+        access = LLMAccessResponse(
+            user_id="user-1",
+            api_fallback_enabled=False,
+            profiles=[],
+            entitlements=[_entitlement(provider="somefake_cli", mode="cli")],
+        )
+        with pytest.raises(LLMRuntimeResolutionError, match="No enabled LLM entitlement"):
+            resolve_llm_runtime(
+                access,
+                LLMRuntimeRequest(
+                    user_id="user-1",
+                    source=LLMUsageSource.PLAYGROUND,
+                    requested_model_id=None,
+                ),
+            )
+
+    def test_unknown_api_provider_entitlement_is_rejected(self):
+        access = LLMAccessResponse(
+            user_id="user-1",
+            api_fallback_enabled=False,
+            profiles=[],
+            entitlements=[_entitlement(provider="evilprov", mode="api")],
+        )
+        with pytest.raises(LLMRuntimeResolutionError, match="No enabled LLM entitlement"):
+            resolve_llm_runtime(
+                access,
+                LLMRuntimeRequest(
+                    user_id="user-1",
+                    source=LLMUsageSource.PLAYGROUND,
+                    requested_model_id=None,
+                ),
+            )

--- a/tests/backend/test_llm_execution_gate.py
+++ b/tests/backend/test_llm_execution_gate.py
@@ -1,0 +1,111 @@
+"""Execution-gate tests: ``LLMService._get_llm`` must honor the live registry.
+
+The legacy static ``MODEL_CONFIGS`` map was frozen at import time from the code
+``_MODELS`` list, which broke both directions of the gate:
+
+- DB-discovered models (present only in the registry cache) raised
+  ``Unknown model`` even when enabled, and
+- registry-disabled models still built real provider clients because the static
+  map carries disabled entries and never sees admin disable actions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from models.llm_models import LLMModelConfig, LLMModelRegistry, LLMProvider
+from services.llm_service import LLMService
+
+
+@pytest.fixture
+def _clean_llm_instances():
+    """Isolate the _get_llm instance cache so gates run for every test."""
+    original = dict(LLMService._instances)
+    LLMService._instances.clear()
+    yield
+    LLMService._instances.clear()
+    LLMService._instances.update(original)
+
+
+@pytest.fixture
+def _registry_cache():
+    """Snapshot/restore the registry DB cache mutated by these tests."""
+    original_cache = LLMModelRegistry._db_cache
+    original_index = LLMModelRegistry._db_index
+    yield
+    LLMModelRegistry._db_cache = original_cache
+    LLMModelRegistry._db_index = original_index
+
+
+def _install_db_models(models: list[LLMModelConfig]) -> None:
+    LLMModelRegistry._db_cache = models
+    LLMModelRegistry._db_index = {m.id: m for m in models}
+
+
+def test_get_llm_builds_db_only_enabled_registry_model(
+    _clean_llm_instances, _registry_cache
+) -> None:
+    """A model that exists only in the DB-loaded registry (not in the legacy
+    static map) must build from registry metadata when enabled."""
+    from services.codex_cli_chat_model import CodexCliChatModel
+
+    _install_db_models(
+        [
+            LLMModelConfig(
+                id="db-only-codex-model",
+                display_name="DB Only Codex",
+                provider=LLMProvider.CODEX_CLI,
+                context_window=200000,
+                input_price=0.0,
+                output_price=0.0,
+                is_enabled=True,
+            )
+        ]
+    )
+
+    llm = LLMService._get_llm("db-only-codex-model")
+
+    assert isinstance(llm, CodexCliChatModel)
+    assert llm.model_name == "db-only-codex-model"
+
+
+def test_get_llm_rejects_statically_disabled_model(
+    _clean_llm_instances, _registry_cache, monkeypatch
+) -> None:
+    """A disabled model from the code registry must not build a real provider
+    client even when the provider API key is present."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+
+    with pytest.raises(ValueError, match="Model disabled"):
+        LLMService._get_llm("gpt-5.4")
+
+
+def test_get_llm_rejects_db_disabled_model(_clean_llm_instances, _registry_cache) -> None:
+    """An admin-disabled DB model must be rejected as disabled — not silently
+    conflated with an unknown model."""
+    _install_db_models(
+        [
+            LLMModelConfig(
+                id="db-disabled-model",
+                display_name="DB Disabled",
+                provider=LLMProvider.CODEX_CLI,
+                context_window=200000,
+                input_price=0.0,
+                output_price=0.0,
+                is_enabled=False,
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Model disabled"):
+        LLMService._get_llm("db-disabled-model")
+
+
+def test_get_llm_unknown_model_still_rejected(_clean_llm_instances, _registry_cache) -> None:
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+
+    with pytest.raises(ValueError, match="Unknown model"):
+        LLMService._get_llm("no-such-model-anywhere")

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -37,8 +37,9 @@ class TestSonnet5RegistryEntry:
         assert model.supports_vision is True
         assert model.is_enabled is True
 
-    def test_sonnet5_is_anthropic_code_default(self):
-        assert LLMModelRegistry.get_default("anthropic") == "claude-sonnet-5"
+    def test_sonnet46_is_anthropic_code_default(self):
+        # Policy 2026-08-31: sonnet-4-6 is the current GA balanced model.
+        assert LLMModelRegistry.get_default("anthropic") == "claude-sonnet-4-6"
 
     def test_anthropic_has_exactly_one_code_default(self):
         defaults = [
@@ -46,7 +47,106 @@ class TestSonnet5RegistryEntry:
             for m in _MODELS
             if m.provider == LLMProvider.ANTHROPIC and m.is_default
         ]
-        assert defaults == ["claude-sonnet-5"]
+        assert defaults == ["claude-sonnet-4-6"]
+
+
+# ─────────────────────────────────────────────────────────────
+# (a3) 2026-08-31 provider default policy — registry entries
+# ─────────────────────────────────────────────────────────────
+
+
+class TestSonnet46RegistryEntry:
+    def test_sonnet46_spec_preserved(self):
+        """default 이관은 스펙을 건드리지 않는다 (ID/가격/context 보존)."""
+        model = LLMModelRegistry.get_by_id("claude-sonnet-4-6")
+        assert model is not None
+        assert model.provider == LLMProvider.ANTHROPIC
+        assert model.context_window == 1_000_000
+        assert model.input_price == 0.003
+        assert model.output_price == 0.015
+        assert model.supports_tools is True
+        assert model.supports_vision is True
+        assert model.is_enabled is True
+
+
+class TestOpus47RegistryEntry:
+    def test_opus47_exists_enabled_nondefault(self):
+        model = LLMModelRegistry.get_by_id("claude-opus-4-7")
+        assert model is not None
+        assert model.provider == LLMProvider.ANTHROPIC
+        assert model.context_window == 1_000_000
+        assert model.input_price == 0.005  # $5/1M tokens (per-1k)
+        assert model.output_price == 0.025  # $25/1M tokens (per-1k)
+        assert model.supports_tools is True
+        assert model.supports_vision is True
+        assert model.is_enabled is True
+        assert model.is_default is False
+
+
+class TestGpt56RegistryEntry:
+    def test_gpt56_alias_enabled_with_official_spec(self):
+        model = LLMModelRegistry.get_by_id("gpt-5.6")
+        assert model is not None
+        assert model.provider == LLMProvider.OPENAI
+        assert model.context_window == 1_050_000
+        assert model.input_price == 0.004  # $4/1M tokens (per-1k)
+        assert model.output_price == 0.02  # $20/1M tokens (per-1k)
+        assert model.supports_tools is True
+        assert model.supports_vision is True
+        assert model.is_enabled is True
+
+    def test_gpt56_is_openai_code_default(self):
+        assert LLMModelRegistry.get_default("openai") == "gpt-5.6"
+
+    def test_openai_has_exactly_one_code_default(self):
+        defaults = [
+            m.id
+            for m in _MODELS
+            if m.provider == LLMProvider.OPENAI and m.is_default
+        ]
+        assert defaults == ["gpt-5.6"]
+
+    @pytest.mark.parametrize(
+        ("model_id", "input_price", "output_price"),
+        [
+            ("gpt-5.6-sol", 0.004, 0.02),
+            ("gpt-5.6-terra", 0.002, 0.012),
+            ("gpt-5.6-luna", 0.0002, 0.0012),
+        ],
+    )
+    def test_gpt56_tiers_are_enabled(self, model_id, input_price, output_price):
+        model = LLMModelRegistry.get_by_id(model_id)
+        assert model is not None
+        assert model.provider == LLMProvider.OPENAI
+        assert model.context_window == 1_050_000
+        assert model.input_price == input_price
+        assert model.output_price == output_price
+        assert model.is_enabled is True
+        assert model.is_default is False
+
+
+class TestGemini37FlashRegistryEntry:
+    def test_gemini37_flash_exists_with_official_spec(self):
+        model = LLMModelRegistry.get_by_id("gemini-3.7-flash")
+        assert model is not None
+        assert model.provider == LLMProvider.GOOGLE
+        assert model.context_window == 1_048_576
+        assert model.input_price == 0.00075  # $0.75/1M tokens (per-1k)
+        assert model.output_price == 0.00375  # $3.75/1M tokens (per-1k)
+        assert model.supports_tools is True
+        assert model.supports_vision is True
+        assert model.is_enabled is True
+
+    def test_gemini37_flash_is_google_code_default(self):
+        assert LLMModelRegistry.get_default("google") == "gemini-3.7-flash"
+
+    def test_google_has_exactly_one_code_default(self):
+        defaults = [
+            m.id
+            for m in _MODELS
+            if m.provider == LLMProvider.GOOGLE and m.is_default
+        ]
+        assert defaults == ["gemini-3.7-flash"]
 
 
 # ─────────────────────────────────────────────────────────────
@@ -143,16 +243,50 @@ def _find_insert(session: _FakeSession, model_id: str):
     raise AssertionError(f"no insert captured for {model_id}")
 
 
+class _RowAwareFakeSession(_FakeSession):
+    """SQL-aware fake: answers each SELECT by applying its rendered WHERE
+    filters to a simulated llm_model_configs table, so the provider-guard
+    query's *semantics* (not the call order) determine the outcome.
+
+    rows: [{"id", "provider", "is_default", "is_enabled"}, ...]
+    """
+
+    def __init__(self, rows: list[dict]):
+        super().__init__(select_results=[])
+        self._rows = rows
+
+    async def execute(self, stmt):
+        if isinstance(stmt, (Insert, Update, Delete)):
+            return await super().execute(stmt)
+        self.selects.append(stmt)
+        sql = str(stmt.compile(dialect=postgresql.dialect()))
+        if "llm_model_suppressions" in sql:
+            return _FakeResult([])  # no suppressions in these scenarios
+        columns = sql.split("FROM", 1)[0]
+        if "display_name" in columns:
+            return _FakeResult([])  # final load_from_db entity select
+        rows = self._rows
+        if "is_default IS true" in sql:
+            rows = [r for r in rows if r["is_default"]]
+        if "is_enabled IS true" in sql:
+            rows = [r for r in rows if r["is_enabled"]]
+        if "llm_model_configs.provider" in columns:
+            return _FakeResult(sorted({(r["provider"],) for r in rows}))
+        if "llm_model_configs.id" in columns:
+            return _FakeResult([(r["id"],) for r in rows])
+        raise AssertionError(f"unrecognized select in fake session: {sql}")
+
+
 @pytest.mark.asyncio
 async def test_sync_to_db_new_default_demoted_when_db_default_exists():
     """New is_default=True model must INSERT as is_default=False when the
-    provider already has a default row in DB (existing DB default respected)."""
+    provider already has rows in DB (existing admin state respected)."""
     session = _FakeSession(
         select_results=[
             _FakeResult([]),  # suppressed ids (none)
             # existing IDs: sonnet-5 is NEW, sonnet-4-6 already exists
             _FakeResult([("claude-sonnet-4-6",), ("claude-opus-4-8",)]),
-            # providers that already have a DB default row
+            # providers that already have DB rows
             _FakeResult([("anthropic",)]),
             # final load_from_db select
             _FakeResult([]),
@@ -167,95 +301,90 @@ async def test_sync_to_db_new_default_demoted_when_db_default_exists():
 
 
 @pytest.mark.asyncio
-async def test_sync_to_db_new_default_kept_when_no_db_default():
-    """New is_default=True model keeps is_default=True when the provider has
-    no default row in DB."""
+async def test_sync_to_db_new_default_kept_when_provider_has_zero_rows():
+    """New is_default=True model keeps is_default=True only when the provider
+    has ZERO rows in DB (bootstrap of a fresh provider)."""
     session = _FakeSession(
         select_results=[
             _FakeResult([]),  # suppressed ids (none)
-            _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
-            _FakeResult([]),  # no provider has a DB default
+            _FakeResult([("gpt-4o",)]),  # only an openai row: anthropic is empty
+            _FakeResult([("openai",)]),  # providers with DB rows
             _FakeResult([]),  # final load_from_db select
         ]
     )
 
     await LLMModelRegistry.sync_to_db(session)
 
-    params = _insert_params(_find_insert(session, "claude-sonnet-5"))
+    params = _insert_params(_find_insert(session, "claude-sonnet-4-6"))
     assert params["is_default"] is True
 
 
 @pytest.mark.asyncio
-async def test_sync_to_db_default_guard_ignores_disabled_db_defaults():
-    """The dual-default guard must only count ENABLED default rows: a provider
-    whose only DB default is disabled still accepts the new code default."""
-    session = _FakeSession(
-        select_results=[
-            _FakeResult([]),  # suppressed ids (none)
-            _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
-            # Guard select returns no providers: the anthropic default row in
-            # DB is disabled, so the is_enabled filter excludes it.
-            _FakeResult([]),
-            _FakeResult([]),  # final load_from_db select
+async def test_sync_to_db_new_default_demoted_when_prior_default_is_disabled():
+    """승격 차단 회귀 (plan §5): provider의 유일한 default 행이 DISABLED여도
+    admin 결정이다 — 신규 code default는 non-default로 INSERT되고, 기존 행의
+    admin 플래그(is_default/is_enabled)를 건드리는 UPDATE가 발행되면 안 된다."""
+    session = _RowAwareFakeSession(
+        rows=[
+            {
+                "id": "claude-sonnet-4-6",
+                "provider": "anthropic",
+                "is_default": True,
+                "is_enabled": False,  # admin이 disable해 둔 구 default
+            }
         ]
     )
 
     await LLMModelRegistry.sync_to_db(session)
 
-    # The guard query itself must filter on BOTH is_default and is_enabled.
-    # selects[0]=suppressed ids, [1]=existing ids, [2]=providers_with_db_default.
-    guard_select = session.selects[2]
-    sql = str(guard_select.compile(dialect=postgresql.dialect()))
-    assert "is_default" in sql
-    assert "is_enabled" in sql
-
-    # And the new model keeps its code-level default flag
     params = _insert_params(_find_insert(session, "claude-sonnet-5"))
-    assert params["is_default"] is True
+    assert params["is_default"] is False
+    assert session.updates == [], (
+        "sync must not clear/override admin flags on existing rows"
+    )
 
 
 @pytest.mark.asyncio
-async def test_sync_to_db_clears_stale_disabled_default_before_new_default_insert():
-    """disable→sync→re-enable 시나리오: 구 default(예: sonnet-4-6)가 disabled인
-    상태에서 sync가 신규 default(sonnet-5)를 INSERT하면, 구 행의 is_default를
-    False로 클리어하는 UPDATE가 함께 발행되어야 한다 — 이후 admin이 구 행을
-    re-enable해도 provider default가 2개가 되지 않도록."""
-    session = _FakeSession(
-        select_results=[
-            _FakeResult([]),  # suppressed ids (none)
-            _FakeResult([("claude-sonnet-4-6",)]),  # sonnet-5 is NEW
-            # anthropic의 유일한 default 행이 disabled → enabled 필터에 걸러져
-            # 가드 통과 (신규 모델이 default로 INSERT되는 경로)
-            _FakeResult([]),
-            _FakeResult([]),  # final load_from_db select
+async def test_sync_to_db_new_default_demoted_when_provider_has_only_nondefault_rows():
+    """승격 차단 회귀 (plan §5): default 행이 하나도 없어도 provider에 DB 행이
+    존재하면 신규 code default는 non-default로 INSERT된다 — zero-row provider의
+    bootstrap만 예외."""
+    session = _RowAwareFakeSession(
+        rows=[
+            {
+                "id": "claude-opus-4-8",
+                "provider": "anthropic",
+                "is_default": False,
+                "is_enabled": True,
+            }
         ]
     )
 
     await LLMModelRegistry.sync_to_db(session)
 
-    # 신규 모델은 default로 INSERT됨
     params = _insert_params(_find_insert(session, "claude-sonnet-5"))
-    assert params["is_default"] is True
+    assert params["is_default"] is False
 
-    # anthropic provider의 잔존 default 행을 클리어하는 UPDATE 발행 확인
-    anthropic_clears = []
-    for stmt in session.updates:
-        compiled = stmt.compile(dialect=postgresql.dialect())
-        if (
-            "anthropic" in compiled.params.values()
-            and compiled.params.get("is_default") is False
-        ):
-            anthropic_clears.append(str(compiled))
-    assert anthropic_clears, "expected is_default-clearing UPDATE for anthropic"
-    sql = anthropic_clears[0]
-    assert "SET is_default" in sql
-    # 클리어 UPDATE는 is_default만 만지고 enable 상태는 건드리지 않는다
-    assert "is_enabled" not in sql.split("SET", 1)[1].split("WHERE", 1)[0]
-    # WHERE절이 is_enabled=False 조건을 포함해야 한다: 가드 SELECT와 이
-    # UPDATE 사이에 admin이 구 default를 re-enable하는 경쟁(READ COMMITTED)
-    # 에서도 "disabled default만 정리" 불변식이 SQL 자체로 보장되도록.
-    where_clause = sql.split("WHERE", 1)[1]
-    assert "is_enabled IS false" in where_clause
+
+@pytest.mark.asyncio
+async def test_sync_to_db_bootstraps_default_for_provider_with_zero_rows():
+    """다른 provider에 행이 있어도, 행이 0개인 provider의 code default는
+    그대로 bootstrap된다 (SQL-aware 시뮬레이션으로 의미론 검증)."""
+    session = _RowAwareFakeSession(
+        rows=[
+            {
+                "id": "gpt-4o",
+                "provider": "openai",
+                "is_default": True,
+                "is_enabled": True,
+            }
+        ]
+    )
+
+    await LLMModelRegistry.sync_to_db(session)
+
+    params = _insert_params(_find_insert(session, "claude-sonnet-4-6"))
+    assert params["is_default"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -1,5 +1,7 @@
 """Tests for claude-sonnet-5 registry entry, sync_to_db dual-default guard, and pricing."""
 
+import logging
+
 import pytest
 from sqlalchemy import Delete, Update
 from sqlalchemy.dialects import postgresql
@@ -37,9 +39,10 @@ class TestSonnet5RegistryEntry:
         assert model.supports_vision is True
         assert model.is_enabled is True
 
-    def test_sonnet46_is_anthropic_code_default(self):
-        # Policy 2026-08-31: sonnet-4-6 is the current GA balanced model.
-        assert LLMModelRegistry.get_default("anthropic") == "claude-sonnet-4-6"
+    def test_sonnet5_is_anthropic_code_default(self):
+        # 후속 정책 2026-09-01 (plan §5): 검증된 claude-sonnet-5 를
+        # anthropic code default 로 복원한다.
+        assert LLMModelRegistry.get_default("anthropic") == "claude-sonnet-5"
 
     def test_anthropic_has_exactly_one_code_default(self):
         defaults = [
@@ -47,7 +50,7 @@ class TestSonnet5RegistryEntry:
             for m in _MODELS
             if m.provider == LLMProvider.ANTHROPIC and m.is_default
         ]
-        assert defaults == ["claude-sonnet-4-6"]
+        assert defaults == ["claude-sonnet-5"]
 
 
 # ─────────────────────────────────────────────────────────────
@@ -147,6 +150,208 @@ class TestGemini37FlashRegistryEntry:
             if m.provider == LLMProvider.GOOGLE and m.is_default
         ]
         assert defaults == ["gemini-3.7-flash"]
+
+
+# ─────────────────────────────────────────────────────────────
+# (a4) 2026-09-01 follow-up policy — gpt-5.5 seed, alias/revision metadata
+# ─────────────────────────────────────────────────────────────
+
+
+class TestGpt55SeedPolicy:
+    def test_gpt55_seed_is_disabled(self):
+        """후속 정책 2026-09-01 (plan §5): gpt-5.5 는 live smoke 전까지 code
+        seed 에서 즉시 enabled 로 두지 않는다. 행 자체는 호환성 위해 유지."""
+        model = LLMModelRegistry.get_by_id("gpt-5.5")
+        assert model is not None
+        assert model.is_enabled is False
+        assert model.is_default is False
+
+
+class TestAliasAndRevisionMetadata:
+    def test_gpt56_alias_maps_to_documented_concrete_model(self):
+        """gpt-5.6 은 문서상 Sol 로 라우팅되는 alias — code-seed 의 optional
+        구조화 metadata 로만 기록한다. provider 응답으로 확인한 값이 아니므로
+        실행 귀속(resolved_model)에는 쓰지 않는다."""
+        model = LLMModelRegistry.get_by_id("gpt-5.6")
+        assert model is not None
+        assert model.alias_for == "gpt-5.6-sol"
+
+    def test_alias_for_defaults_none_for_regular_models(self):
+        """구버전 직렬화/DB-loaded config 호환: alias_for 는 optional 기본 None."""
+        model = LLMModelRegistry.get_by_id("claude-sonnet-5")
+        assert model is not None
+        assert model.alias_for is None
+
+    @pytest.mark.asyncio
+    async def test_sync_to_db_values_do_not_include_alias_for(self):
+        """alias_for 는 code-seed 전용 metadata: DB 스키마에 컬럼이 없으므로
+        INSERT values 에 포함되면 실제 DB 에서 sync 가 죽는다 (no migration)."""
+        session = _FakeSession(
+            select_results=[
+                _FakeResult([]),  # suppressed ids
+                _FakeResult([]),  # existing ids
+                _FakeResult([]),  # providers with DB rows
+                _FakeResult([]),  # final load_from_db select
+            ]
+        )
+        await LLMModelRegistry.sync_to_db(session)
+        for stmt in session.inserts:
+            assert "alias_for" not in _insert_params(stmt)
+
+    def test_registry_revision_reflects_serving_mode(self):
+        """실행 계측용 registry revision: code seed 서빙과 DB 캐시 서빙을
+        구분해 표시한다 (JSON-safe 문자열, 스키마 변경 없음)."""
+        from models.llm_models import REGISTRY_REVISION
+
+        assert LLMModelRegistry.get_revision() == f"code:{REGISTRY_REVISION}"
+        LLMModelRegistry._db_cache = []
+        LLMModelRegistry._db_index = {}
+        assert LLMModelRegistry.get_revision() == f"db:{REGISTRY_REVISION}"
+
+
+# ─────────────────────────────────────────────────────────────
+# (a5) get_default — deterministic + fail-closed selection policy
+# ─────────────────────────────────────────────────────────────
+
+
+def _policy_cfg(
+    model_id: str,
+    *,
+    is_default: bool = False,
+    is_enabled: bool = True,
+    input_price: float = 0.001,
+    output_price: float = 0.002,
+):
+    from models.llm_models import LLMModelConfig
+
+    return LLMModelConfig(
+        id=model_id,
+        display_name=model_id,
+        provider=LLMProvider.GOOGLE,
+        context_window=100_000,
+        input_price=input_price,
+        output_price=output_price,
+        is_default=is_default,
+        is_enabled=is_enabled,
+    )
+
+
+def _serve_from_cache(models: list) -> None:
+    LLMModelRegistry._db_cache = models
+    LLMModelRegistry._db_index = {m.id: m for m in models}
+
+
+class TestGetDefaultSelectionPolicy:
+    def test_every_seed_provider_has_exactly_one_enabled_default(self):
+        """provider 별 code default 는 정확히 하나, 그리고 enabled 여야 한다 —
+        disabled default 는 조용한 순서 의존 선택을 유발한다."""
+        providers = {m.provider for m in _MODELS}
+        for provider in providers:
+            defaults = [m for m in _MODELS if m.provider == provider and m.is_default]
+            assert len(defaults) == 1, (
+                f"{provider.value}: defaults={[m.id for m in defaults]}"
+            )
+            assert defaults[0].is_enabled, (
+                f"{provider.value}: default {defaults[0].id} is disabled"
+            )
+
+    def test_no_enabled_default_falls_back_to_cheapest_deterministically(self, caplog):
+        """default 가 disabled 된 provider: 목록 순서(첫 요소)가 아니라
+        결정론적(최저가 합산, id tie-break) 폴백을 고르고 경고를 남긴다."""
+        _serve_from_cache(
+            [
+                _policy_cfg("z-expensive", input_price=0.01, output_price=0.05),
+                _policy_cfg("a-cheap", input_price=0.0001, output_price=0.0004),
+                _policy_cfg("m-disabled-default", is_default=True, is_enabled=False),
+            ]
+        )
+        with caplog.at_level(logging.WARNING, logger="models.llm_models"):
+            assert LLMModelRegistry.get_default("google") == "a-cheap"
+        assert "no enabled default" in caplog.text
+
+    def test_fallback_is_order_independent(self):
+        models = [
+            _policy_cfg("z-expensive", input_price=0.01, output_price=0.05),
+            _policy_cfg("a-cheap", input_price=0.0001, output_price=0.0004),
+        ]
+        _serve_from_cache(models)
+        first = LLMModelRegistry.get_default("google")
+        _serve_from_cache(list(reversed(models)))
+        assert LLMModelRegistry.get_default("google") == first == "a-cheap"
+
+    def test_multiple_enabled_defaults_resolve_deterministically(self, caplog):
+        """DB drift 로 enabled default 가 2개면 목록 순서가 아니라 id 순으로
+        결정하고 경고를 남긴다 — 충돌을 조용히 숨기지 않는다."""
+        _serve_from_cache(
+            [
+                _policy_cfg("z-default", is_default=True),
+                _policy_cfg("a-default", is_default=True),
+            ]
+        )
+        with caplog.at_level(logging.WARNING, logger="models.llm_models"):
+            assert LLMModelRegistry.get_default("google") == "a-default"
+        assert "multiple enabled defaults" in caplog.text
+
+    def test_provider_without_enabled_models_fails_closed(self):
+        """enabled 모델이 0개인 provider 는 타 provider 모델("codex-cli")을
+        조용히 반환하지 않고 LookupError 로 fail-closed 한다."""
+        _serve_from_cache([_policy_cfg("g-disabled", is_enabled=False)])
+        with pytest.raises(LookupError, match="google"):
+            LLMModelRegistry.get_default("google")
+
+    def test_unknown_provider_string_fails_closed(self, caplog):
+        """미지 provider 문자열은 "codex-cli" 로 조용히 라우팅하지 않고
+        LookupError 로 fail-closed 한다 — 임의 문자열이 Codex 실행 경로로
+        흘러가면 provider 정책·entitlement 게이트가 우회된다."""
+        with caplog.at_level(logging.ERROR, logger="models.llm_models"):
+            with pytest.raises(LookupError, match="not-a-provider"):
+                LLMModelRegistry.get_default("not-a-provider")
+        assert "unknown provider" in caplog.text.lower()
+
+    def test_unknown_env_provider_fails_closed_without_provider_arg(self, monkeypatch):
+        """provider 인자 없는 호출은 LLM_PROVIDER env 로 해석되는데, env 가
+        미지 문자열이면 codex-cli 대체 없이 LookupError 로 fail-closed 한다."""
+        monkeypatch.setenv("LLM_PROVIDER", "rogue-provider")
+        with pytest.raises(LookupError, match="rogue-provider"):
+            LLMModelRegistry.get_default()
+
+
+class TestGetDefaultFailClosedCallerGuards:
+    """get_default 의 LookupError(fail-closed)가 조회성 표면을 500 으로
+    깨뜨리지 않도록, 명시적 폴백을 가진 호출부를 고정한다."""
+
+    @pytest.mark.asyncio
+    async def test_providers_endpoint_reports_none_default_for_empty_provider(self):
+        """/api/llm/providers 는 enabled 모델 0개인 provider 를 500 없이
+        default=None 으로 보고해야 한다 (타 provider 모델 이름을 대입하던
+        기존 오답도 함께 제거)."""
+        from api.llm import get_providers
+
+        _serve_from_cache([_policy_cfg("g-disabled", is_enabled=False)])
+        result = await get_providers()
+        assert result["google"]["default"] is None
+        assert result["google"]["models"] == []
+
+    @pytest.mark.asyncio
+    async def test_default_model_endpoint_returns_404_for_empty_provider(self):
+        """/api/llm/models/default?provider=google 은 enabled 모델이 0개면
+        500 이 아니라 404 로 fail-closed 한다."""
+        from fastapi import HTTPException
+
+        from api.llm import get_default_model
+
+        _serve_from_cache([_policy_cfg("g-disabled", is_enabled=False)])
+        with pytest.raises(HTTPException) as exc_info:
+            await get_default_model(provider="google")
+        assert exc_info.value.status_code == 404
+
+    def test_update_probe_treats_empty_provider_as_unavailable(self):
+        """12시간 update check 의 provider 프로브는 enabled 모델 0개를
+        '사용 불가'(skip)로 취급해야 한다 — 스케줄러가 죽으면 안 된다."""
+        from services.model_update_service import _provider_probe_available
+
+        _serve_from_cache([_policy_cfg("g-disabled", is_enabled=False)])
+        assert _provider_probe_available("google") is False
 
 
 # ─────────────────────────────────────────────────────────────
@@ -315,7 +520,8 @@ async def test_sync_to_db_new_default_kept_when_provider_has_zero_rows():
 
     await LLMModelRegistry.sync_to_db(session)
 
-    params = _insert_params(_find_insert(session, "claude-sonnet-4-6"))
+    # 2026-09-01 정책: anthropic code default 는 claude-sonnet-5 로 복원됨.
+    params = _insert_params(_find_insert(session, "claude-sonnet-5"))
     assert params["is_default"] is True
 
 
@@ -383,7 +589,8 @@ async def test_sync_to_db_bootstraps_default_for_provider_with_zero_rows():
 
     await LLMModelRegistry.sync_to_db(session)
 
-    params = _insert_params(_find_insert(session, "claude-sonnet-4-6"))
+    # 2026-09-01 정책: anthropic code default 는 claude-sonnet-5 로 복원됨.
+    params = _insert_params(_find_insert(session, "claude-sonnet-5"))
     assert params["is_default"] is True
 
 

--- a/tests/backend/test_llm_runtime_resolver.py
+++ b/tests/backend/test_llm_runtime_resolver.py
@@ -263,3 +263,45 @@ def test_resolve_rejects_disabled_requested_model(_static_registry) -> None:
                 requested_model_id="gpt-5.4",
             ),
         )
+
+
+def test_resolve_fails_closed_when_entitled_provider_has_no_enabled_models(
+    monkeypatch,
+) -> None:
+    """entitlement 의 provider 에 enabled 모델이 0개면, get_default 가 타
+    provider 모델("codex-cli")을 조용히 대입하던 기존 동작 대신 fail-closed
+    LookupError 가 나고, resolver 는 이를 계약 타입인
+    LLMRuntimeResolutionError 로 번역해야 한다 — provider/model 불일치
+    resolution 이 실행 경로로 흘러가면 entitlement 게이트가 무의미해진다."""
+    from models.llm_models import LLMModelConfig, LLMModelRegistry
+    from models.llm_models import LLMProvider as ModelProvider
+
+    stub = LLMModelConfig(
+        id="gpt-4o-stub",
+        display_name="stub",
+        provider=ModelProvider.OPENAI,
+        context_window=1_000,
+        input_price=0.0,
+        output_price=0.0,
+    )
+    monkeypatch.setattr(LLMModelRegistry, "_db_cache", [stub])
+    monkeypatch.setattr(LLMModelRegistry, "_db_index", {stub.id: stub})
+
+    access = LLMAccessResponse(
+        user_id="user-1",
+        api_fallback_enabled=False,
+        profiles=[],
+        entitlements=[
+            _entitlement(provider="ollama", mode="local", cli_profile_id=None)
+        ],
+    )
+
+    with pytest.raises(LLMRuntimeResolutionError, match="ollama"):
+        resolve_llm_runtime(
+            access,
+            LLMRuntimeRequest(
+                user_id="user-1",
+                source=LLMUsageSource.PLAYGROUND,
+                requested_model_id=None,
+            ),
+        )

--- a/tests/backend/test_llm_runtime_resolver.py
+++ b/tests/backend/test_llm_runtime_resolver.py
@@ -143,7 +143,118 @@ def test_resolve_rejects_api_model_without_fallback_policy() -> None:
         ],
     )
 
+    # gpt-4o (enabled) instead of gpt-5.4: the registry-disabled gate now fires
+    # before entitlement selection, and this test's intent is the fallback
+    # policy rejection, not the disabled-model rejection.
     with pytest.raises(LLMRuntimeResolutionError, match="API fallback is disabled"):
+        resolve_llm_runtime(
+            access,
+            LLMRuntimeRequest(
+                user_id="user-1",
+                source=LLMUsageSource.PLAYGROUND,
+                requested_model_id="gpt-4o",
+            ),
+        )
+
+
+def test_resolve_rejects_semantically_invalid_provider_mode_pair() -> None:
+    """A provider=openai/mode=cli entitlement is malformed: the mode gate
+    trusts `mode` (cli bypasses the API-fallback check) while the executor
+    builds by provider (ChatOpenAI). It must never be selected — with no
+    valid entitlement left, resolution fails closed."""
+    access = LLMAccessResponse(
+        user_id="user-1",
+        api_fallback_enabled=False,
+        profiles=[],
+        entitlements=[
+            _entitlement(
+                provider="openai",
+                mode="cli",
+                cli_profile_id=None,
+            )
+        ],
+    )
+
+    with pytest.raises(LLMRuntimeResolutionError, match="No enabled LLM entitlement"):
+        resolve_llm_runtime(
+            access,
+            LLMRuntimeRequest(
+                user_id="user-1",
+                source=LLMUsageSource.PLAYGROUND,
+                requested_model_id=None,
+            ),
+        )
+
+
+def test_resolve_skips_malformed_entitlement_in_favor_of_valid_one() -> None:
+    """When a malformed pair precedes a valid CLI entitlement, the default
+    (no requested model) path must select the valid one, not the malformed."""
+    access = LLMAccessResponse(
+        user_id="user-1",
+        api_fallback_enabled=False,
+        profiles=[_profile(id="profile-claude", provider="claude_cli")],
+        entitlements=[
+            _entitlement(
+                id="ent-malformed",
+                provider="openai",
+                mode="cli",
+                cli_profile_id=None,
+            ),
+            _entitlement(
+                id="ent-valid",
+                provider="claude_cli",
+                mode="cli",
+                cli_profile_id="profile-claude",
+            ),
+        ],
+    )
+
+    resolution = resolve_llm_runtime(
+        access,
+        LLMRuntimeRequest(
+            user_id="user-1",
+            source=LLMUsageSource.PLAYGROUND,
+            requested_model_id=None,
+        ),
+    )
+
+    assert resolution.entitlement_id == "ent-valid"
+    assert resolution.provider == "claude_cli"
+    assert resolution.mode == "cli"
+
+
+@pytest.fixture
+def _static_registry():
+    """Serve the in-memory _MODELS list (no DB cache) for registry-gate tests."""
+    from models.llm_models import LLMModelRegistry
+
+    original_cache = LLMModelRegistry._db_cache
+    original_index = LLMModelRegistry._db_index
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+    yield
+    LLMModelRegistry._db_cache = original_cache
+    LLMModelRegistry._db_index = original_index
+
+
+def test_resolve_rejects_disabled_requested_model(_static_registry) -> None:
+    """A registry-disabled model must be rejected even for a fully entitled
+    user — entitlements authorize the provider/mode, not a disabled model."""
+    access = LLMAccessResponse(
+        user_id="user-1",
+        api_fallback_enabled=True,
+        profiles=[],
+        entitlements=[
+            _entitlement(
+                provider="openai",
+                mode="api",
+                cli_profile_id=None,
+                allow_api_fallback=True,
+            )
+        ],
+    )
+
+    with pytest.raises(LLMRuntimeResolutionError, match="Model disabled"):
         resolve_llm_runtime(
             access,
             LLMRuntimeRequest(

--- a/tests/backend/test_playground_authorization.py
+++ b/tests/backend/test_playground_authorization.py
@@ -381,6 +381,56 @@ async def test_create_session_requires_authentication(app, client):
 
 
 # ─────────────────────────────────────────────────────────────
+# 6b. Session model registration gate (create / settings PATCH → 400)
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_session_with_unknown_model_returns_400(app, client):
+    """Registry 에 없는 모델은 세션 생성 전에 명확한 검증 오류(400)로 거부되고,
+    아무것도 영속화되지 않는다 (500 이나 조용한 저장 금지)."""
+    _authenticate_as(app, OWNER)
+    res = await client.post(
+        "/api/playground/sessions",
+        json={"name": "bad-model", "model": "no-such-model"},
+    )
+    assert res.status_code == 400
+    assert "no-such-model" in res.json()["detail"]
+    assert playground_service._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_create_session_with_disabled_model_returns_400(app, client):
+    """gpt-5.4 는 registry 에 있으나 disabled — 저장 전에 400 으로 거부."""
+    _authenticate_as(app, OWNER)
+    res = await client.post(
+        "/api/playground/sessions",
+        json={"name": "bad-model", "model": "gpt-5.4"},
+    )
+    assert res.status_code == 400
+    assert "gpt-5.4" in res.json()["detail"]
+    assert playground_service._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_settings_update_with_invalid_model_returns_400_atomically(
+    app, client, owned_session
+):
+    """settings PATCH 의 model 검증 실패는 400 이고, 같은 요청의 다른 필드
+    (name)도 반영되지 않아야 한다 — 원자적 거부."""
+    _authenticate_as(app, OWNER)
+    model_before = owned_session.model  # 같은 객체가 dict 에 있으므로 사전 캡처
+    res = await client.patch(
+        f"/api/playground/sessions/{owned_session.id}/settings",
+        json={"name": "should-not-apply", "model": "no-such-model"},
+    )
+    assert res.status_code == 400
+    unchanged = playground_service._sessions[owned_session.id]
+    assert unchanged.name == "owner private session"
+    assert unchanged.model == model_before
+
+
+# ─────────────────────────────────────────────────────────────
 # 7. Service layer: fail-closed listing without an identity
 # ─────────────────────────────────────────────────────────────
 

--- a/tests/backend/test_playground_model_policy_followup.py
+++ b/tests/backend/test_playground_model_policy_followup.py
@@ -1,0 +1,117 @@
+"""2026-09-01 후속 정책 — Playground API 라우트 레벨 회귀 (plan §1).
+
+서비스 레벨 게이트(생성/수정 시 unknown·disabled 모델 원자적 거부)는
+``test_playground_service.py`` 가 커버한다. 이 파일은 그 위 계층을 고정한다:
+라우트가 서비스의 ``ValueError`` 를 500 으로 흘리지 않고 HTTP 400 으로
+번역하는 계약. 라우터 의존성(get_current_user 등)은 라우터 레벨이라 핸들러
+직접 호출로 우회된다 — 여기서 검증하는 것은 핸들러의 오류 번역뿐이다.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from api import playground as playground_api
+from models.llm_models import LLMModelRegistry
+from models.playground import PlaygroundSessionCreate
+from services import playground_service
+from services.playground_service import PlaygroundService
+
+
+@pytest.fixture(autouse=True)
+def _serve_code_registry():
+    """다른 테스트가 남긴 DB 캐시 오염 방지 — code seed 기준으로 판정한다."""
+    original_cache = LLMModelRegistry._db_cache
+    original_index = LLMModelRegistry._db_index
+    LLMModelRegistry._db_cache = None
+    LLMModelRegistry._db_index = {}
+    yield
+    LLMModelRegistry._db_cache = original_cache
+    LLMModelRegistry._db_index = original_index
+
+
+@pytest.fixture(autouse=True)
+def _isolated_sessions(monkeypatch):
+    """파일/DB 영속화를 차단한다 (기존 테스트 패턴)."""
+    playground_service._sessions.clear()
+    monkeypatch.setattr(playground_service.service, "_load_sessions", lambda: None)
+    monkeypatch.setattr(playground_service.service, "_save_sessions", lambda: None)
+    monkeypatch.setattr(
+        playground_service.service, "_fire_and_forget", lambda coro: coro.close()
+    )
+    yield
+    playground_service._sessions.clear()
+
+
+def _fake_user(user_id: str = "user-1"):
+    return type("FakeUser", (), {"id": user_id})()
+
+
+@pytest.mark.asyncio
+async def test_create_route_maps_unknown_model_to_400() -> None:
+    """unknown 모델의 세션 생성은 500 이 아니라 명확한 400 검증 오류다."""
+    with pytest.raises(HTTPException) as exc_info:
+        await playground_api.create_session(
+            PlaygroundSessionCreate(name="x", model="no-such-model-xyz"),
+            current_user=_fake_user(),
+        )
+    assert exc_info.value.status_code == 400
+    assert "no-such-model-xyz" in str(exc_info.value.detail)
+    # 원자성: 거부된 요청은 세션을 남기지 않는다.
+    assert playground_service._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_create_route_maps_disabled_model_to_400() -> None:
+    # gpt-5.4 는 code seed 에서 is_enabled=False 다.
+    with pytest.raises(HTTPException) as exc_info:
+        await playground_api.create_session(
+            PlaygroundSessionCreate(name="x", model="gpt-5.4"),
+            current_user=_fake_user(),
+        )
+    assert exc_info.value.status_code == 400
+    assert "disabled" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_route_still_creates_with_enabled_model() -> None:
+    """오류 번역 try/except 가 정상 경로(owner 강제 포함)를 삼키지 않는다."""
+    session = await playground_api.create_session(
+        PlaygroundSessionCreate(name="ok", model="codex-cli"),
+        current_user=_fake_user("owner-9"),
+    )
+    assert session.model == "codex-cli"
+    assert session.user_id == "owner-9"
+
+
+@pytest.mark.asyncio
+async def test_update_route_maps_invalid_model_to_400() -> None:
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+    data = playground_api.SessionSettingsUpdate(model="gpt-5.4", name="renamed")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await playground_api.update_session_settings(
+            session.id, data, BackgroundTasks()
+        )
+
+    assert exc_info.value.status_code == 400
+    # 원자성: 같은 요청의 다른 필드도 반영되지 않는다.
+    assert session.name == "s"
+    assert session.model == "codex-cli"
+
+
+@pytest.mark.asyncio
+async def test_update_route_still_updates_with_enabled_model() -> None:
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+    data = playground_api.SessionSettingsUpdate(model="claude-sonnet-5")
+
+    updated = await playground_api.update_session_settings(
+        session.id, data, BackgroundTasks()
+    )
+
+    assert updated.model == "claude-sonnet-5"

--- a/tests/backend/test_playground_service.py
+++ b/tests/backend/test_playground_service.py
@@ -155,7 +155,10 @@ async def test_execute_retries_with_safe_default_when_saved_model_is_inaccessibl
     assert [ctx["session_id"] for ctx in usage_contexts] == [session.id, session.id]
     assert execution.status.value == "completed"
     assert execution.result == "fallback answer"
-    assert session.model == "codex-cli"
+    # 정책 변경(model policy guards): fallback은 retry 한정이며 세션의 저장된
+    # 모델 선택을 재작성하지 않는다. 성공 모델은 execution.resolved_model에 남는다.
+    assert session.model == "gpt-5.4"
+    assert execution.resolved_model == "codex-cli"
 
 
 @pytest.mark.asyncio
@@ -276,7 +279,105 @@ async def test_execute_retries_on_resolver_entitlement_error_for_authenticated_u
 
     assert calls == ["stale-model-xyz", entitled]
     assert execution.status.value == "completed"
-    assert session.model == entitled
+    # 정책 변경(model policy guards): entitled fallback 성공도 세션 모델을
+    # 재작성하지 않는다 — 귀속은 execution.resolved_model이 담당한다.
+    assert session.model == "stale-model-xyz"
+    assert execution.resolved_model == entitled
+
+
+@pytest.mark.asyncio
+async def test_fallback_retry_does_not_mutate_session_model_and_attributes_execution(
+    monkeypatch,
+) -> None:
+    """The stale-model fallback is execution-scoped: ``session.model`` (the
+    user's saved choice) must survive a successful retry untouched, while the
+    execution records both the requested and the actually-used model."""
+    playground_service._sessions.clear()
+    monkeypatch.setattr(playground_service.service, "_load_sessions", lambda: None)
+    monkeypatch.setattr(playground_service.service, "_save_sessions", lambda: None)
+
+    def close_background_coro(coro):
+        coro.close()
+
+    monkeypatch.setattr(playground_service.service, "_fire_and_forget", close_background_coro)
+    monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
+
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale", model="gpt-5.4")
+    )
+
+    async def fake_invoke(**kwargs):
+        model_id = kwargs["model_id"]
+        if model_id == "gpt-5.4":
+            raise RuntimeError(
+                "LLM invocation failed (gpt-5.4): "
+                "Error code: 403 - {'error': {'code': 'model_not_found'}}"
+            )
+        return LLMResponse(content="ok", model=model_id, provider="codex_cli")
+
+    monkeypatch.setattr(LLMService, "invoke", fake_invoke)
+
+    execution = await PlaygroundService.execute(
+        session.id,
+        PlaygroundExecuteRequest(prompt="hi"),
+    )
+
+    assert execution.status.value == "completed"
+    assert session.model == "gpt-5.4"
+    assert execution.requested_model == "gpt-5.4"
+    assert execution.resolved_model == "codex-cli"
+
+
+@pytest.mark.asyncio
+async def test_failed_fallback_target_is_not_persisted_to_session(monkeypatch) -> None:
+    """When the fallback target itself fails to build/invoke, the failure must
+    not be committed as the session model — otherwise a broken fallback
+    poisons every subsequent execution of the session."""
+    playground_service._sessions.clear()
+    monkeypatch.setattr(playground_service.service, "_load_sessions", lambda: None)
+    monkeypatch.setattr(playground_service.service, "_save_sessions", lambda: None)
+
+    def close_background_coro(coro):
+        coro.close()
+
+    monkeypatch.setattr(playground_service.service, "_fire_and_forget", close_background_coro)
+    monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
+
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale", model="gpt-5.4")
+    )
+
+    calls: list[str] = []
+
+    async def fake_invoke(**kwargs):
+        calls.append(kwargs["model_id"])
+        raise RuntimeError(
+            f"LLM invocation failed ({kwargs['model_id']}): "
+            "Error code: 403 - {'error': {'code': 'model_not_found'}}"
+        )
+
+    monkeypatch.setattr(LLMService, "invoke", fake_invoke)
+
+    execution = await PlaygroundService.execute(
+        session.id,
+        PlaygroundExecuteRequest(prompt="hi"),
+    )
+
+    assert calls == ["gpt-5.4", "codex-cli"]
+    assert execution.status.value == "failed"
+    assert session.model == "gpt-5.4"
+    assert execution.requested_model == "gpt-5.4"
+    assert execution.resolved_model is None
+
+
+def test_execution_model_attribution_fields_default_none_for_legacy_records() -> None:
+    """Legacy persisted executions (JSON without the new fields) must keep
+    parsing — attribution fields are additive and default to None."""
+    from models.playground import PlaygroundExecution
+
+    legacy = PlaygroundExecution(agent_id="a", prompt="p")
+    assert legacy.requested_model is None
+    assert legacy.resolved_model is None
 
 
 def test_safe_fallback_returns_none_when_authenticated_user_has_no_entitlement() -> None:
@@ -290,6 +391,322 @@ def test_safe_fallback_returns_none_when_authenticated_user_has_no_entitlement()
         "stale-model-xyz", {"llm_access": access, "user_id": "user-1"}
     )
     assert fallback is None
+
+
+# ─────────────────────────────────────────────────────────────
+# execute_stream fallback parity (non-tools) + resolved-model cost
+# ─────────────────────────────────────────────────────────────
+
+
+def _patch_stream_env(monkeypatch) -> list[float]:
+    """Common stream-test scaffolding; returns the captured cost-model list."""
+    playground_service._sessions.clear()
+    monkeypatch.setattr(playground_service.service, "_load_sessions", lambda: None)
+    monkeypatch.setattr(playground_service.service, "_save_sessions", lambda: None)
+
+    def close_background_coro(coro):
+        coro.close()
+
+    monkeypatch.setattr(playground_service.service, "_fire_and_forget", close_background_coro)
+    monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
+
+    cost_models: list[str] = []
+
+    def fake_calculate_cost(input_tokens: int, output_tokens: int, model: str) -> float:
+        cost_models.append(model)
+        return 0.5
+
+    # service.py의 import 바인딩을 패치한다 (정의처 models.cost가 아니라).
+    monkeypatch.setattr(playground_service.service, "calculate_cost", fake_calculate_cost)
+    return cost_models
+
+
+@pytest.mark.asyncio
+async def test_stream_retries_inaccessible_model_before_first_output(monkeypatch) -> None:
+    """Non-tools streaming must apply the same stale-model fallback as the
+    non-streaming path when the error arrives BEFORE any output chunk, and the
+    cost must be computed with the resolved (fallback) model."""
+    cost_models = _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
+    )
+
+    calls: list[str] = []
+
+    def fake_stream(**kwargs):
+        async def gen():
+            model_id = kwargs["model_id"]
+            calls.append(model_id)
+            if model_id == "gpt-5.4":
+                yield (
+                    "\n\n[Error: model_not_found]",
+                    {"error": True, "message": "model_not_found"},
+                )
+                return
+            yield ("hello ", None)
+            yield ("world", None)
+            yield ("", {"input_tokens": 3, "output_tokens": 5, "model": model_id})
+
+        return gen()
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    chunks = [
+        c
+        async for c in PlaygroundService.execute_stream(
+            session.id, PlaygroundExecuteRequest(prompt="hi")
+        )
+    ]
+
+    assert calls == ["gpt-5.4", "codex-cli"]
+    assert "".join(chunks) == "hello world"
+    # 무변이: 스트림 fallback도 세션의 저장된 선택을 재작성하지 않는다.
+    assert session.model == "gpt-5.4"
+    # 비용은 실제 성공한(resolved) 모델로 계산한다.
+    assert cost_models == ["codex-cli"]
+    assert session.total_executions == 1
+    assert session.total_cost == 0.5
+
+
+@pytest.mark.asyncio
+async def test_stream_retries_on_resolver_error_before_first_output(monkeypatch) -> None:
+    """The resolver rejecting the stale model raises a raw
+    LLMRuntimeResolutionError on first iteration — that shape must also
+    trigger the pre-output fallback, not just the provider error sentinel."""
+    from services.llm_runtime_resolver import LLMRuntimeResolutionError
+
+    _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale-stream", model="stale-model-xyz")
+    )
+
+    calls: list[str] = []
+
+    async def fake_stream(**kwargs):
+        model_id = kwargs["model_id"]
+        calls.append(model_id)
+        if model_id == "stale-model-xyz":
+            raise LLMRuntimeResolutionError(
+                "No enabled LLM entitlement for provider=openai, mode=api"
+            )
+        yield ("ok", None)
+        yield ("", {"input_tokens": 1, "output_tokens": 2, "model": model_id})
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    chunks = [
+        c
+        async for c in PlaygroundService.execute_stream(
+            session.id, PlaygroundExecuteRequest(prompt="hi")
+        )
+    ]
+
+    assert calls == ["stale-model-xyz", "codex-cli"]
+    assert "".join(chunks) == "ok"
+    assert session.model == "stale-model-xyz"
+
+
+@pytest.mark.asyncio
+async def test_stream_does_not_retry_after_first_output(monkeypatch) -> None:
+    """Once a chunk has been emitted to the client, a retry would duplicate
+    already-streamed content — the failure must be surfaced, not retried."""
+    _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
+    )
+
+    calls: list[str] = []
+
+    def fake_stream(**kwargs):
+        async def gen():
+            calls.append(kwargs["model_id"])
+            yield ("partial ", None)
+            yield (
+                "\n\n[Error: model_not_found]",
+                {"error": True, "message": "model_not_found"},
+            )
+
+        return gen()
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    chunks = [
+        c
+        async for c in PlaygroundService.execute_stream(
+            session.id, PlaygroundExecuteRequest(prompt="hi")
+        )
+    ]
+
+    assert calls == ["gpt-5.4"]
+    assert chunks[0] == "partial "
+    assert "[Error" in chunks[-1]
+    # 실패한 스트림은 세션 집계에 반영되지 않는다 (기존 계약 유지).
+    assert session.total_executions == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_tools_branch_costs_resolved_model(monkeypatch) -> None:
+    """Tools-path streaming already retries via _invoke_with_model_fallback;
+    its cost must also use the resolved model, not the stale session model."""
+    cost_models = _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
+    )
+    session.enabled_tools = ["web_search"]
+
+    async def fake_invoke_with_tools(**kwargs):
+        model_id = kwargs["model_id"]
+        if model_id == "gpt-5.4":
+            raise RuntimeError(
+                "LLM invocation with tools failed (gpt-5.4): "
+                "Error code: 403 - {'error': {'code': 'model_not_found'}}"
+            )
+        return LLMResponse(
+            content="tool answer",
+            input_tokens=3,
+            output_tokens=5,
+            model=model_id,
+            provider="codex_cli",
+        )
+
+    monkeypatch.setattr(LLMService, "invoke_with_tools", fake_invoke_with_tools)
+
+    chunks = [
+        c
+        async for c in PlaygroundService.execute_stream(
+            session.id, PlaygroundExecuteRequest(prompt="hi")
+        )
+    ]
+
+    assert chunks[0] == "tool answer"
+    assert session.model == "gpt-5.4"
+    assert cost_models == ["codex-cli"]
+
+
+@pytest.mark.asyncio
+async def test_stream_records_execution_with_requested_and_resolved_model(monkeypatch) -> None:
+    """A stream request must leave one PlaygroundExecution on the session,
+    attributing the requested (saved) model and the actually-used resolved
+    model, and the new fields must survive the existing DB serialization."""
+    _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
+    )
+
+    def fake_stream(**kwargs):
+        async def gen():
+            model_id = kwargs["model_id"]
+            if model_id == "gpt-5.4":
+                yield (
+                    "\n\n[Error: model_not_found]",
+                    {"error": True, "message": "model_not_found"},
+                )
+                return
+            yield ("hello ", None)
+            yield ("world", None)
+            yield ("", {"input_tokens": 3, "output_tokens": 5, "model": model_id})
+
+        return gen()
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    async for _ in PlaygroundService.execute_stream(
+        session.id, PlaygroundExecuteRequest(prompt="hi")
+    ):
+        pass
+
+    assert len(session.executions) == 1
+    execution = session.executions[0]
+    assert execution.status.value == "completed"
+    assert execution.requested_model == "gpt-5.4"
+    assert execution.resolved_model == "codex-cli"
+    assert execution.result == "hello world"
+    assert execution.input_tokens == 3
+    assert execution.output_tokens == 5
+    assert execution.total_tokens == 8
+    assert execution.cost == 0.5
+    # 기존 DB 직렬화(JSON 컬럼) 경로에 새 필드가 포함되어야 한다.
+    db_dict = PlaygroundService._pydantic_to_db_dict(session)
+    assert db_dict["executions"][0]["requested_model"] == "gpt-5.4"
+    assert db_dict["executions"][0]["resolved_model"] == "codex-cli"
+
+
+@pytest.mark.asyncio
+async def test_stream_failure_records_failed_execution_without_totals(monkeypatch) -> None:
+    """A stream that fails after the first chunk must persist a FAILED
+    execution (with error, no resolved model) while keeping the existing
+    contract that failed streams do not count toward session totals."""
+    _patch_stream_env(monkeypatch)
+    save_calls: list[bool] = []
+    monkeypatch.setattr(
+        playground_service.service, "_save_sessions", lambda: save_calls.append(True)
+    )
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
+    )
+    save_calls.clear()
+
+    def fake_stream(**kwargs):
+        async def gen():
+            yield ("partial ", None)
+            yield (
+                "\n\n[Error: model_not_found]",
+                {"error": True, "message": "model_not_found"},
+            )
+
+        return gen()
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    async for _ in PlaygroundService.execute_stream(
+        session.id, PlaygroundExecuteRequest(prompt="hi")
+    ):
+        pass
+
+    assert len(session.executions) == 1
+    execution = session.executions[0]
+    assert execution.status.value == "failed"
+    assert execution.error is not None and "model_not_found" in execution.error
+    assert execution.requested_model == "gpt-5.4"
+    assert execution.resolved_model is None
+    # 실패한 execution 도 영속화 경로는 타야 한다.
+    assert save_calls
+    # 기존 계약 유지: 실패 스트림은 성공 집계를 올리지 않는다.
+    assert session.total_executions == 0
+    assert session.total_tokens == 0
+    assert session.total_cost == 0.0
+
+
+@pytest.mark.asyncio
+async def test_stream_tools_branch_exception_records_failed_execution(monkeypatch) -> None:
+    """A non-fallback exception in the tools branch surfaces the generic
+    [Error: ...] chunk — that path must also leave a FAILED execution."""
+    _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="tools-stream", model="gpt-5.4")
+    )
+    session.enabled_tools = ["web_search"]
+
+    async def fake_invoke_with_tools(**kwargs):
+        raise RuntimeError("provider exploded")
+
+    monkeypatch.setattr(LLMService, "invoke_with_tools", fake_invoke_with_tools)
+
+    chunks = [
+        c
+        async for c in PlaygroundService.execute_stream(
+            session.id, PlaygroundExecuteRequest(prompt="hi")
+        )
+    ]
+
+    assert "[Error: provider exploded]" in chunks[-1]
+    assert len(session.executions) == 1
+    execution = session.executions[0]
+    assert execution.status.value == "failed"
+    assert execution.error == "provider exploded"
+    assert execution.requested_model == "gpt-5.4"
+    assert execution.resolved_model is None
+    assert session.total_executions == 0
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/backend/test_playground_service.py
+++ b/tests/backend/test_playground_service.py
@@ -106,6 +106,127 @@ def test_default_system_prompt_is_gemini_specific() -> None:
     assert "제공된 컨텍스트에 없습니다" in DEFAULT_SYSTEM_PROMPT
 
 
+def _register_stale_session(
+    model: str,
+    *,
+    name: str = "stale",
+    user_id: str | None = None,
+) -> PlaygroundSession:
+    """과거에 저장된(legacy/stale) 세션 시뮬레이션.
+
+    create_session 은 이제 unknown/disabled 모델을 거부한다(등록 게이트).
+    stale 세션은 '저장 당시엔 유효했지만 이후 disabled 된' 데이터이므로,
+    로딩 경로와 동일하게 모델 검증 없이 직접 구성해 레지스트리에 주입한다.
+    """
+    session = PlaygroundSession(name=name, model=model, user_id=user_id)
+    playground_service._sessions[session.id] = session
+    return session
+
+
+def _isolate_sessions(monkeypatch) -> list[bool]:
+    """세션 저장소 격리 + _save_sessions 호출 기록을 돌려준다."""
+    playground_service._sessions.clear()
+    saves: list[bool] = []
+    monkeypatch.setattr(playground_service.service, "_load_sessions", lambda: None)
+    monkeypatch.setattr(
+        playground_service.service, "_save_sessions", lambda: saves.append(True)
+    )
+    monkeypatch.setattr(
+        playground_service.service, "_fire_and_forget", lambda coro: coro.close()
+    )
+    return saves
+
+
+# ─────────────────────────────────────────────────────────────
+# Session model registration gate (create / settings update)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_create_session_rejects_unknown_model(monkeypatch) -> None:
+    """Registry 에 없는 모델은 세션 생성(영속화) 전에 거부된다."""
+    saves = _isolate_sessions(monkeypatch)
+    with pytest.raises(ValueError, match="Unknown model"):
+        PlaygroundService.create_session(
+            PlaygroundSessionCreate(name="bad", model="no-such-model")
+        )
+    assert playground_service._sessions == {}
+    assert saves == []
+
+
+def test_create_session_rejects_disabled_model(monkeypatch) -> None:
+    """gpt-5.4 는 registry 에 있으나 disabled — 저장 전에 거부되어야 한다."""
+    saves = _isolate_sessions(monkeypatch)
+    with pytest.raises(ValueError, match="Model disabled"):
+        PlaygroundService.create_session(
+            PlaygroundSessionCreate(name="bad", model="gpt-5.4")
+        )
+    assert playground_service._sessions == {}
+    assert saves == []
+
+
+def test_create_session_accepts_enabled_registry_model(monkeypatch) -> None:
+    _isolate_sessions(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="ok", model="codex-cli")
+    )
+    assert session.model == "codex-cli"
+    assert session.id in playground_service._sessions
+
+
+def test_update_settings_rejects_invalid_model_atomically(monkeypatch) -> None:
+    """model 검증 실패 시 같은 요청의 다른 필드(name 등)도 반영되지 않아야
+    한다 — 거부는 원자적이다 (부분 반영 금지)."""
+    saves = _isolate_sessions(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="before", model="codex-cli")
+    )
+    saves.clear()
+    before_updated_at = session.updated_at
+
+    with pytest.raises(ValueError, match="Unknown model"):
+        PlaygroundService.update_session_settings(
+            session.id, model="no-such-model", name="after", temperature=0.1
+        )
+
+    assert session.name == "before"
+    assert session.model == "codex-cli"
+    assert session.temperature == 0.7
+    assert session.updated_at == before_updated_at
+    assert saves == []
+
+
+def test_update_settings_rejects_disabled_model(monkeypatch) -> None:
+    _isolate_sessions(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+    with pytest.raises(ValueError, match="Model disabled"):
+        PlaygroundService.update_session_settings(session.id, model="gpt-5.4")
+    assert session.model == "codex-cli"
+
+
+def test_update_settings_accepts_enabled_model(monkeypatch) -> None:
+    _isolate_sessions(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+    updated = PlaygroundService.update_session_settings(
+        session.id, model="claude-sonnet-5"
+    )
+    assert updated is not None
+    assert updated.model == "claude-sonnet-5"
+
+
+def test_legacy_session_with_stale_model_still_loads(monkeypatch) -> None:
+    """검증은 저장 경로 전용 — 이미 저장된 stale 모델 세션은 로딩/조회가
+    그대로 되어야 한다 (legacy JSON/DB 호환, 실행 시 fallback 이 처리)."""
+    _isolate_sessions(monkeypatch)
+    stale = _register_stale_session("gpt-5.4")
+    loaded = PlaygroundService.get_session(stale.id)
+    assert loaded is stale
+    assert loaded.model == "gpt-5.4"
+
+
 @pytest.mark.asyncio
 async def test_execute_retries_with_safe_default_when_saved_model_is_inaccessible(
     monkeypatch,
@@ -121,9 +242,7 @@ async def test_execute_retries_with_safe_default_when_saved_model_is_inaccessibl
     monkeypatch.setattr(playground_service.service, "_fire_and_forget", close_background_coro)
     monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
 
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4")
     session.enabled_tools = ["web_search"]
 
     calls: list[str] = []
@@ -254,9 +373,7 @@ async def test_execute_retries_on_resolver_entitlement_error_for_authenticated_u
             requested_model_id=None,
         ),
     ).model_id
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale", model="stale-model-xyz", user_id="user-1")
-    )
+    session = _register_stale_session("stale-model-xyz", user_id="user-1")
 
     calls: list[str] = []
 
@@ -302,9 +419,7 @@ async def test_fallback_retry_does_not_mutate_session_model_and_attributes_execu
     monkeypatch.setattr(playground_service.service, "_fire_and_forget", close_background_coro)
     monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
 
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4")
 
     async def fake_invoke(**kwargs):
         model_id = kwargs["model_id"]
@@ -343,9 +458,7 @@ async def test_failed_fallback_target_is_not_persisted_to_session(monkeypatch) -
     monkeypatch.setattr(playground_service.service, "_fire_and_forget", close_background_coro)
     monkeypatch.setenv("LLM_PROVIDER", "codex_cli")
 
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4")
 
     calls: list[str] = []
 
@@ -427,9 +540,7 @@ async def test_stream_retries_inaccessible_model_before_first_output(monkeypatch
     non-streaming path when the error arrives BEFORE any output chunk, and the
     cost must be computed with the resolved (fallback) model."""
     cost_models = _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4", name="stale-stream")
 
     calls: list[str] = []
 
@@ -476,9 +587,7 @@ async def test_stream_retries_on_resolver_error_before_first_output(monkeypatch)
     from services.llm_runtime_resolver import LLMRuntimeResolutionError
 
     _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale-stream", model="stale-model-xyz")
-    )
+    session = _register_stale_session("stale-model-xyz", name="stale-stream")
 
     calls: list[str] = []
 
@@ -511,9 +620,7 @@ async def test_stream_does_not_retry_after_first_output(monkeypatch) -> None:
     """Once a chunk has been emitted to the client, a retry would duplicate
     already-streamed content — the failure must be surfaced, not retried."""
     _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4", name="stale-stream")
 
     calls: list[str] = []
 
@@ -549,9 +656,7 @@ async def test_stream_tools_branch_costs_resolved_model(monkeypatch) -> None:
     """Tools-path streaming already retries via _invoke_with_model_fallback;
     its cost must also use the resolved model, not the stale session model."""
     cost_models = _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4", name="stale-stream")
     session.enabled_tools = ["web_search"]
 
     async def fake_invoke_with_tools(**kwargs):
@@ -589,9 +694,7 @@ async def test_stream_records_execution_with_requested_and_resolved_model(monkey
     attributing the requested (saved) model and the actually-used resolved
     model, and the new fields must survive the existing DB serialization."""
     _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4", name="stale-stream")
 
     def fake_stream(**kwargs):
         async def gen():
@@ -641,9 +744,7 @@ async def test_stream_failure_records_failed_execution_without_totals(monkeypatc
     monkeypatch.setattr(
         playground_service.service, "_save_sessions", lambda: save_calls.append(True)
     )
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="stale-stream", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4", name="stale-stream")
     save_calls.clear()
 
     def fake_stream(**kwargs):
@@ -682,9 +783,7 @@ async def test_stream_tools_branch_exception_records_failed_execution(monkeypatc
     """A non-fallback exception in the tools branch surfaces the generic
     [Error: ...] chunk — that path must also leave a FAILED execution."""
     _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="tools-stream", model="gpt-5.4")
-    )
+    session = _register_stale_session("gpt-5.4", name="tools-stream")
     session.enabled_tools = ["web_search"]
 
     async def fake_invoke_with_tools(**kwargs):
@@ -707,6 +806,199 @@ async def test_stream_tools_branch_exception_records_failed_execution(monkeypatc
     assert execution.requested_model == "gpt-5.4"
     assert execution.resolved_model is None
     assert session.total_executions == 0
+
+
+# ─────────────────────────────────────────────────────────────
+# execute_stream lifecycle: cancellation / disconnect / init errors
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stream_client_disconnect_finalizes_execution_as_cancelled(
+    monkeypatch,
+) -> None:
+    """클라이언트 disconnect 로 generator 가 aclose() 되면(GeneratorExit)
+    execution 이 RUNNING 인 채 영속화 경로에 남으면 안 된다 — CANCELLED 로
+    마감하고 저장까지 탄다."""
+    _patch_stream_env(monkeypatch)
+    save_calls: list[bool] = []
+    monkeypatch.setattr(
+        playground_service.service, "_save_sessions", lambda: save_calls.append(True)
+    )
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+    save_calls.clear()
+
+    def fake_stream(**kwargs):
+        async def gen():
+            yield ("chunk-1 ", None)
+            yield ("chunk-2 ", None)
+            yield ("", {"input_tokens": 1, "output_tokens": 1, "model": kwargs["model_id"]})
+
+        return gen()
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    stream = PlaygroundService.execute_stream(
+        session.id, PlaygroundExecuteRequest(prompt="hi")
+    )
+    assert await stream.__anext__() == "chunk-1 "
+    await stream.aclose()
+
+    assert len(session.executions) == 1
+    execution = session.executions[0]
+    assert execution.status.value == "cancelled"
+    assert execution.completed_at is not None
+    assert save_calls, "취소 마감도 영속화 경로를 타야 한다"
+    # 취소는 성공 집계에 반영되지 않는다.
+    assert session.total_executions == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_task_cancellation_finalizes_execution_as_cancelled(
+    monkeypatch,
+) -> None:
+    """asyncio 취소(CancelledError)는 BaseException 이라 기존 except Exception
+    이 놓친다 — CANCELLED 로 마감한 뒤 그대로 재전파해야 한다."""
+    import asyncio
+
+    _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+
+    def fake_stream(**kwargs):
+        async def gen():
+            yield ("chunk-1 ", None)
+            yield ("chunk-2 ", None)
+
+        return gen()
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    stream = PlaygroundService.execute_stream(
+        session.id, PlaygroundExecuteRequest(prompt="hi")
+    )
+    assert await stream.__anext__() == "chunk-1 "
+    with pytest.raises(asyncio.CancelledError):
+        await stream.athrow(asyncio.CancelledError)
+
+    assert len(session.executions) == 1
+    execution = session.executions[0]
+    assert execution.status.value == "cancelled"
+    assert execution.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_stream_init_exception_does_not_leave_running_execution(
+    monkeypatch,
+) -> None:
+    """LLM 루프 진입 전(history/RAG 준비 단계) 예외도 RUNNING execution 을
+    남기지 않고 FAILED 로 마감한 뒤 in-band [Error] 청크로 표면화한다."""
+    _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+
+    def boom(_msgs):
+        raise RuntimeError("history exploded")
+
+    monkeypatch.setattr(playground_service.service, "_to_lc_messages", boom)
+
+    chunks = [
+        c
+        async for c in PlaygroundService.execute_stream(
+            session.id, PlaygroundExecuteRequest(prompt="hi")
+        )
+    ]
+
+    assert "[Error: history exploded]" in chunks[-1]
+    assert len(session.executions) == 1
+    execution = session.executions[0]
+    assert execution.status.value == "failed"
+    assert execution.error == "history exploded"
+
+
+# ─────────────────────────────────────────────────────────────
+# Optional execution metadata: registry revision
+# ─────────────────────────────────────────────────────────────
+
+
+def test_legacy_execution_json_defaults_registry_revision_none() -> None:
+    """구버전 JSON/DB 레코드(필드 부재)는 None 으로 파싱되어야 한다."""
+    from models.playground import PlaygroundExecution
+
+    legacy = PlaygroundExecution(agent_id="a", prompt="p")
+    assert legacy.registry_revision is None
+
+
+@pytest.mark.asyncio
+async def test_execute_stamps_registry_revision(monkeypatch) -> None:
+    """실행 레코드는 어느 registry snapshot 아래에서 돌았는지 optional
+    metadata 로 남긴다 (additive 필드 — 기존 JSON/DB schema 안전)."""
+    from models.llm_models import LLMModelRegistry
+
+    _isolate_sessions(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+
+    async def fake_invoke(**kwargs):
+        return LLMResponse(content="ok", model=kwargs["model_id"], provider="codex_cli")
+
+    monkeypatch.setattr(LLMService, "invoke", fake_invoke)
+
+    execution = await PlaygroundService.execute(
+        session.id, PlaygroundExecuteRequest(prompt="hi")
+    )
+
+    assert execution.registry_revision == LLMModelRegistry.get_revision()
+    # 기존 DB JSON 직렬화 경로에도 자동 포함된다 (model_dump 전량 직렬화).
+    db_dict = PlaygroundService._pydantic_to_db_dict(session)
+    assert db_dict["executions"][0]["registry_revision"] == execution.registry_revision
+
+
+@pytest.mark.asyncio
+async def test_stream_stamps_registry_revision(monkeypatch) -> None:
+    from models.llm_models import LLMModelRegistry
+
+    _patch_stream_env(monkeypatch)
+    session = PlaygroundService.create_session(
+        PlaygroundSessionCreate(name="s", model="codex-cli")
+    )
+
+    def fake_stream(**kwargs):
+        async def gen():
+            yield ("ok", None)
+            yield ("", {"input_tokens": 1, "output_tokens": 1, "model": kwargs["model_id"]})
+
+        return gen()
+
+    monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
+
+    async for _ in PlaygroundService.execute_stream(
+        session.id, PlaygroundExecuteRequest(prompt="hi")
+    ):
+        pass
+
+    assert session.executions[0].registry_revision == LLMModelRegistry.get_revision()
+
+
+def test_safe_fallback_returns_none_when_configured_provider_has_no_models(
+    monkeypatch,
+) -> None:
+    """익명 폴백 경로: 구성된 provider 에 enabled 모델이 0개면 get_default 가
+    fail-closed(LookupError) 한다 — 폴백 헬퍼는 이를 '재시도 없음'(None)으로
+    번역해 원래 오류가 그대로 표면화되게 해야 한다."""
+    from models.llm_models import LLMModelRegistry
+    from services.playground_service import _safe_playground_fallback_model
+
+    def raise_lookup(provider=None):
+        raise LookupError("No enabled models for provider google")
+
+    monkeypatch.setattr(LLMModelRegistry, "get_default", raise_lookup)
+    assert _safe_playground_fallback_model("stale-model", None) is None
 
 
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add registry and runtime guards for enabled/unknown LLM models.
- Fail closed on unknown providers and provider/entitlement mismatches.
- Handle no-enabled-model failures in existing default-model callers.
- Add Playground policy, fallback isolation, cancellation, and usage attribution coverage.
- Add regression tests and the implementation plan.

## Verification
- `uv run pytest ../../tests/backend -q --tb=short` — 1,953 passed, 32 skipped, 6 warnings
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy . --ignore-missing-imports` — passed
- `git diff --check` — passed
- Independent Security review — PASS; no blocking security or logic issues

## Scope
- No external provider smoke tests, canary, deployment, restart, or production default-model promotion were performed.
