### PR TITLE
fix: disable Ollama reasoning in session summary generation

### DIFF
--- a/src/backend/services/claude_session_monitor.py
+++ b/src/backend/services/claude_session_monitor.py
@@ -898,7 +898,9 @@ class ClaudeSessionMonitor:
     async def generate_summary(self, session_id: str) -> str:
         """Generate AI summary for a session.
 
-        Uses Haiku model for cost efficiency. Caches result to file.
+        Uses the configured Ollama model for cost efficiency. Disables reasoning
+        for thinking models so the response field contains the summary. Caches
+        result to file.
 
         Args:
             session_id: Session UUID
@@ -919,7 +921,7 @@ class ClaudeSessionMonitor:
         if not messages:
             return "대화 내용 없음"
 
-        # 3. Call Haiku for summary
+        # 3. Call Ollama for summary
         prompt = f"""다음 대화의 주제를 한 문장(30자 이내)으로 요약해주세요.
 마침표 없이 간결하게 작성하세요.
 
@@ -941,6 +943,7 @@ class ClaudeSessionMonitor:
                         "model": ollama_model,
                         "prompt": prompt,
                         "stream": False,
+                        "think": False,
                         "options": {
                             "num_predict": 50,
                             "temperature": 0.3,


### PR DESCRIPTION
## Summary
- `generate_summary()`는 Ollama `/api/generate` 응답의 `response` 필드만 읽는데, thinking 모델은 답을 `thinking` 필드에 넣고 `response`를 비워 둔다 → 요약이 빈 문자열로 저장됨
- 요청에 `"think": false`를 추가해 reasoning을 끄고, 요약이 항상 `response`에 오도록 고정
- 이 경로는 이미 Ollama 레지스트리 기본값을 쓰는데 docstring/주석에 "Haiku"가 남아 있어 함께 정리

## Changes
`src/backend/services/claude_session_monitor.py`
- `generate_summary()` 요청 바디에 `"think": False` 추가 (`services/claude_session_monitor.py:946`)
- docstring: "Uses Haiku model" → 설정된 Ollama 모델 + reasoning 비활성화 사유 명시
- 인라인 주석 `# 3. Call Haiku for summary` → `# 3. Call Ollama for summary`

## Test Plan
- [x] `ruff check` / `ruff format --check` — 통과
- [x] `mypy services/claude_session_monitor.py` — Success, no issues
- [x] `pytest tests/backend/test_claude_session_monitor.py tests/backend/test_claude_session_sync.py` — 7 passed
- [x] 라이브 프로브: `think: false` → Ollama 0.33.2 / `exaone3.5:7.8b`(비-thinking 모델)에서 HTTP 200 + 정상 `response` 반환. 비-thinking 모델이 400을 내지 않음을 실측 확인
- [x] Codex 리뷰(`--scope working-tree`) — 지적 0건

## Notes
- `generate_summary()`에는 기존 테스트 커버리지가 없어, 검증은 위 라이브 Ollama 프로브로 대신했다
- 현재 DB 레지스트리의 ollama 기본값(`exaone3.5:7.8b`)은 비-thinking 모델이라 이 플래그는 지금은 no-op이며, 기본값이 thinking 모델로 바뀌는 순간 동작을 좌우한다

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XormPM7a1qfZWPTdeYJp8v