### PR TITLE
feat: generate AI summaries for Codex sessions

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -110,7 +110,18 @@
 
 `/api/claude-sessions` 의 provider 중립 별칭입니다 (#320). 리소스 이름에 provider 를
 넣지 않은 동일 계약을 노출하며, **원본과 동일하게 admin/manager 권한을 요구합니다**.
-provider 별 mutation 을 지원하지 않을 때는 409 를 반환합니다.
+provider 별 mutation 을 지원하지 않을 때는 409 를 반환합니다 — Codex 는 `stream` /
+`save` / `DELETE` 가 409 입니다 (롤아웃 파일은 read-only).
+
+**요약은 두 provider 모두 지원합니다.** 요약은 롤아웃/JSONL 이 아니라 별도 캐시
+(`SUMMARY_CACHE_DIR`)에 쓰므로 read-only 계약을 깨지 않습니다. Codex 롤아웃은 첫
+user 메시지가 항상 하네스 주입 프리앰블(`<recommended_plugins>`,
+`# AGENTS.md instructions for ...`, 턴마다 반복되는 `[Base]` / `[Context]`)이라,
+요약 입력에서는 이를 건너뛰고 첫 실제 대화 턴부터 사용합니다
+(`services/codex_session_monitor._is_injected_preamble`). 주입 컨텍스트밖에 없는
+세션은 프리앰블을 그대로 쓰는 폴백으로 처리해 "대화 내용 없음"을 피합니다.
+요약 일괄 생성(`summaries/generate-batch`)은 두 provider 세션을 **last_activity
+기준으로 병합 정렬한 뒤** limit 을 적용합니다.
 
 | Method | Path | 설명 |
 |--------|------|------|

--- a/src/backend/api/claude_sessions/core.py
+++ b/src/backend/api/claude_sessions/core.py
@@ -127,11 +127,12 @@ async def list_sessions(
     # Check if more sessions are available
     has_more = offset + len(paginated_sessions) < filtered_count
 
-    # Add cached summaries to sessions
+    # Add cached summaries to sessions. The card falls back to the slug, which
+    # for Codex is the rollout timestamp — so a generated summary that is not
+    # attached here stays invisible in the list.
     for session in paginated_sessions:
-        cached_summary = (
-            monitor.get_cached_summary(session.session_id) if session.provider == "claude" else None
-        )
+        summary_source = get_codex_monitor() if session.provider == "codex" else monitor
+        cached_summary = summary_source.get_cached_summary(session.session_id)
         if cached_summary:
             session.summary = cached_summary
 

--- a/src/backend/api/claude_sessions/sessions.py
+++ b/src/backend/api/claude_sessions/sessions.py
@@ -99,11 +99,9 @@ async def get_session(session_id: str) -> ClaudeSessionDetail:
     if details is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
 
-    # Summaries are currently a Claude-only mutation/caching capability.
-    if details.provider == "claude":
-        cached_summary = monitor.get_cached_summary(session_id)  # type: ignore[attr-defined]
-        if cached_summary:
-            details.summary = cached_summary
+    cached_summary = monitor.get_cached_summary(session_id)
+    if cached_summary:
+        details.summary = cached_summary
 
     return details
 
@@ -414,11 +412,9 @@ async def generate_session_summary(session_id: str) -> dict:
     # Verify session exists
     if details is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
-    if details.provider != "claude":
-        raise HTTPException(status_code=409, detail="Codex session summaries are not supported")
 
     # Generate or retrieve cached summary
-    summary = await monitor.generate_summary(session_id)  # type: ignore[attr-defined]
+    summary = await monitor.generate_summary(session_id)
 
     return {
         "session_id": session_id,
@@ -439,11 +435,9 @@ async def get_session_summary(session_id: str) -> dict:
     monitor, details = resolve_session(session_id)
     if details is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
-    if details.provider != "claude":
-        raise HTTPException(status_code=409, detail="Codex session summaries are not supported")
 
     # Check cached summary
-    summary = monitor.get_cached_summary(session_id)  # type: ignore[attr-defined]
+    summary = monitor.get_cached_summary(session_id)
 
     return {
         "session_id": session_id,

--- a/src/backend/api/claude_sessions/summaries.py
+++ b/src/backend/api/claude_sessions/summaries.py
@@ -14,9 +14,42 @@ import logging
 from fastapi import APIRouter, Depends
 
 from api.deps import get_current_admin_or_manager_user
-from services.claude_session_monitor import get_monitor
+from models.claude_session import ClaudeSessionInfo
+from services.claude_session_monitor import ClaudeSessionMonitor, get_monitor
+from services.codex_session_monitor import CodexSessionMonitor, get_codex_monitor
+from utils.time import to_aware_utc
 
 logger = logging.getLogger(__name__)
+
+SessionMonitor = ClaudeSessionMonitor | CodexSessionMonitor
+
+
+def _discover_with_monitors() -> list[tuple[SessionMonitor, ClaudeSessionInfo]]:
+    """Pair every discovered session with the monitor that owns it.
+
+    Both providers cache summaries, so the batch must carry the owning monitor
+    rather than assuming a single one. The two lists are merged by recency
+    rather than concatenated: ``generate_batch_summaries`` applies its ``limit``
+    while walking this list, so a plain concatenation would let older Claude
+    sessions fill the budget before any Codex session is reached.
+    """
+    claude_monitor = get_monitor()
+    codex_monitor = get_codex_monitor()
+    paired: list[tuple[SessionMonitor, ClaudeSessionInfo]] = [
+        (claude_monitor, session) for session in claude_monitor.discover_sessions()
+    ]
+    paired.extend((codex_monitor, session) for session in codex_monitor.discover_sessions())
+    paired.sort(key=lambda pair: _recency(pair[1]), reverse=True)
+    return paired
+
+
+def _recency(session: ClaudeSessionInfo) -> float:
+    """Sort key for last activity; naive timestamps are read as UTC."""
+    last_activity = session.last_activity
+    if last_activity is None:
+        return 0.0
+    return to_aware_utc(last_activity).timestamp()
+
 
 router = APIRouter(dependencies=[Depends(get_current_admin_or_manager_user)])
 
@@ -31,12 +64,11 @@ async def get_pending_summary_count(project: str | None = None) -> dict:
     Returns:
         Count of sessions that need summary generation
     """
-    monitor = get_monitor()
-    all_sessions = monitor.discover_sessions()
+    all_sessions = _discover_with_monitors()
 
     pending_count = 0
     total_filtered = 0
-    for session in all_sessions:
+    for monitor, session in all_sessions:
         # Filter by project if specified
         if project and getattr(session, "project_name", None) != project:
             continue
@@ -76,12 +108,11 @@ async def generate_batch_summaries(
     """
     import asyncio
 
-    monitor = get_monitor()
-    all_sessions = monitor.discover_sessions()
+    all_sessions = _discover_with_monitors()
 
     # Filter sessions without summaries
-    sessions_to_process = []
-    for session in all_sessions:
+    sessions_to_process: list[tuple[SessionMonitor, ClaudeSessionInfo]] = []
+    for monitor, session in all_sessions:
         if skip_existing:
             cached = monitor.get_cached_summary(session.session_id)
             if cached:
@@ -91,7 +122,7 @@ async def generate_batch_summaries(
             continue
         if session.user_message_count == 0 and session.assistant_message_count == 0:
             continue
-        sessions_to_process.append(session)
+        sessions_to_process.append((monitor, session))
         if len(sessions_to_process) >= limit:
             break
 
@@ -109,7 +140,7 @@ async def generate_batch_summaries(
     retry_delay = 5.0  # seconds
     between_requests_delay = 2.0  # seconds
 
-    for idx, session in enumerate(sessions_to_process):
+    for idx, (monitor, session) in enumerate(sessions_to_process):
         # Log progress every 10 sessions
         if idx > 0 and idx % 10 == 0:
             logger.info(f"Batch summary progress: {idx}/{len(sessions_to_process)} processed")

--- a/src/backend/services/claude_session_monitor.py
+++ b/src/backend/services/claude_session_monitor.py
@@ -42,8 +42,6 @@ def _truncate_content(text: str | None, limit: int) -> tuple[str | None, bool, i
     return text, False, None
 
 
-import httpx
-
 from models.claude_session import (
     ActivityEvent,
     ActivityEventType,
@@ -58,6 +56,12 @@ from models.claude_session import (
     calculate_cost,
 )
 from services.session_file_cache import SessionFileCache
+from services.session_summary import (
+    format_messages_for_prompt,
+    generate_summary_from_messages,
+    read_cached_summary,
+    summary_cache_path,
+)
 from utils.time import to_aware_utc, utcnow
 
 # Global cache instance
@@ -786,26 +790,13 @@ class ClaudeSessionMonitor:
     def _get_summary_cache_path(self, session_id: str) -> Path:
         """Get cache file path for session summary.
 
-        Uses SUMMARY_CACHE_DIR env var if set, otherwise falls back to
-        ~/.claude/session_summaries/. In Docker, ~/.claude is read-only,
-        so we use /app/data/summaries instead.
-
         Args:
             session_id: Session UUID
 
         Returns:
             Path to the summary cache file
         """
-        cache_dir = os.getenv("SUMMARY_CACHE_DIR", "")
-        if cache_dir:
-            return Path(cache_dir) / f"{session_id}.txt"
-
-        # In Docker (CLAUDE_HOME is set), use /app/data/summaries to avoid read-only mount
-        claude_home = os.getenv("CLAUDE_HOME", "")
-        if claude_home:
-            return Path("/app/data/summaries") / f"{session_id}.txt"
-
-        return Path.home() / ".claude" / "session_summaries" / f"{session_id}.txt"
+        return summary_cache_path(session_id)
 
     def _get_first_messages(self, session_id: str, limit: int = 5) -> list[dict]:
         """Get first N user/assistant messages from a session.
@@ -888,19 +879,10 @@ class ClaudeSessionMonitor:
         Returns:
             Formatted string for prompt
         """
-        formatted = []
-        for msg in messages:
-            role = "사용자" if msg["role"] == "user" else "어시스턴트"
-            content = msg["content"][:200]  # Truncate for prompt
-            formatted.append(f"{role}: {content}")
-        return "\n".join(formatted)
+        return format_messages_for_prompt(messages)
 
     async def generate_summary(self, session_id: str) -> str:
         """Generate AI summary for a session.
-
-        Uses the configured Ollama model for cost efficiency. Disables reasoning
-        for thinking models so the response field contains the summary. Caches
-        result to file.
 
         Args:
             session_id: Session UUID
@@ -908,66 +890,14 @@ class ClaudeSessionMonitor:
         Returns:
             Generated summary string
         """
-        logger = logging.getLogger(__name__)
-
-        # 1. Check cache
-        cache_path = self._get_summary_cache_path(session_id)
-        if cache_path.exists():
-            logger.info(f"Using cached summary for session {session_id}")
-            return cache_path.read_text().strip()
-
-        # 2. Get first messages
+        # The cache is checked before the transcript is opened: a cached summary
+        # must not cost a file read, and must still be served when the session
+        # file has moved or is briefly unreadable.
+        cached = read_cached_summary(session_id)
+        if cached:
+            return cached
         messages = self._get_first_messages(session_id, limit=5)
-        if not messages:
-            return "대화 내용 없음"
-
-        # 3. Call Ollama for summary
-        prompt = f"""다음 대화의 주제를 한 문장(30자 이내)으로 요약해주세요.
-마침표 없이 간결하게 작성하세요.
-
-대화:
-{self._format_messages_for_prompt(messages)}
-
-요약:"""
-
-        try:
-            ollama_base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
-            from config import get_model_for_provider
-
-            ollama_model = get_model_for_provider("ollama")
-
-            async with httpx.AsyncClient(timeout=120.0) as client:
-                response = await client.post(
-                    f"{ollama_base_url}/api/generate",
-                    json={
-                        "model": ollama_model,
-                        "prompt": prompt,
-                        "stream": False,
-                        "think": False,
-                        "options": {
-                            "num_predict": 50,
-                            "temperature": 0.3,
-                        },
-                    },
-                )
-                response.raise_for_status()
-                data = response.json()
-                summary = data.get("response", "").strip()
-
-                # Clean up: take first line only
-                if "\n" in summary:
-                    summary = summary.split("\n")[0].strip()
-
-            # 4. Save to cache
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            cache_path.write_text(summary)
-
-            logger.info(f"Generated summary for session {session_id}: {summary}")
-            return summary
-
-        except Exception as e:
-            logger.error(f"Failed to generate summary for {session_id}: {e}")
-            return "요약 생성 실패"
+        return await generate_summary_from_messages(session_id, messages)
 
     def get_cached_summary(self, session_id: str) -> str | None:
         """Get cached summary if exists.
@@ -978,10 +908,7 @@ class ClaudeSessionMonitor:
         Returns:
             Cached summary or None
         """
-        cache_path = self._get_summary_cache_path(session_id)
-        if cache_path.exists():
-            return cache_path.read_text().strip()
-        return None
+        return read_cached_summary(session_id)
 
     def delete_session(self, session_id: str) -> bool:
         """Delete a session file.

--- a/src/backend/services/codex_session_monitor.py
+++ b/src/backend/services/codex_session_monitor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from collections import deque
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -29,6 +30,7 @@ from models.claude_session import (
     TokenUsage,
 )
 from services.session_file_cache import SessionFileCache
+from services.session_summary import generate_summary_from_messages, read_cached_summary
 from utils.time import to_aware_utc, utcnow
 
 logger = logging.getLogger(__name__)
@@ -200,6 +202,47 @@ class _Aggregate:
             message_output_tokens=self.message_output_tokens,
             tail_messages=tuple(self.tail_messages),
         )
+
+
+# Every rollout opens with context the harness injected, not with a real turn:
+# a survey of 150 local rollouts found `<recommended_plugins>` leading 63 of
+# them, `# AGENTS.md instructions for ...` leading 61 more, and per-turn
+# `[Base]` / `[Context]` blocks repeated verbatim across sessions. Summarizing
+# that prefix gives every Codex session the same worthless summary, so it is
+# dropped and the first genuine turn is used instead. Measured over 120 local
+# rollouts, dropping it changes the summary input for 40 of them.
+# Matching *any* lone `<tag>` line would drop a genuine request that happens to
+# open with an XML wrapper (`<task>`, say), so only the envelopes actually
+# observed in the survey are listed. An unknown envelope survives as content —
+# a worse summary, not a lost turn.
+_INJECTED_TAGS = frozenset(
+    {
+        "recommended_plugins",
+        "user_action",
+        "user_instructions",
+        "environment_context",
+        "realtime_delegation",
+    }
+)
+_TAG_ONLY_LINE = re.compile(r"<([a-z_][a-z0-9_]*)>")
+_PREAMBLE_PREFIXES = (
+    "# AGENTS.md instructions for",
+    "[Base]",
+    "[Context]",
+    "[New message",
+)
+
+
+def _is_injected_preamble(content: str) -> bool:
+    """Report whether a user message is harness-injected context."""
+    stripped = content.strip()
+    if not stripped:
+        return True
+    first_line = stripped.split("\n", 1)[0].strip()
+    tag = _TAG_ONLY_LINE.fullmatch(first_line)
+    if tag is not None and tag.group(1) in _INJECTED_TAGS:
+        return True
+    return stripped.startswith(_PREAMBLE_PREFIXES)
 
 
 class CodexSessionMonitor:
@@ -625,6 +668,88 @@ class CodexSessionMonitor:
             return [], details.file_size if details else last_size
         events, _ = self.get_session_activity(session_id, offset=0, limit=100)
         return events, details.file_size
+
+    def _get_first_messages(self, session_id: str, limit: int = 5) -> list[dict]:
+        """Get the first N conversational messages of a rollout.
+
+        Every rollout opens with harness-injected context rather than a real
+        turn, so the leading preamble is dropped — see ``_is_injected_preamble``.
+
+        Args:
+            session_id: Codex session id
+            limit: Maximum number of messages to return
+
+        Returns:
+            List of message dicts with role and content
+        """
+        path = self._find_file(session_id)
+        if path is None:
+            return []
+        kept, raw = self._scan_first_messages(path, limit)
+        # 4 of 120 local rollouts hold nothing but injected context. A
+        # boilerplate summary still beats reporting an empty conversation.
+        return kept or raw
+
+    def _scan_first_messages(self, path: Path, limit: int) -> tuple[list[dict], list[dict]]:
+        """Scan a rollout only until ``limit`` conversational messages are found.
+
+        A summary needs the opening turns, so the scan stops there instead of
+        materializing the whole rollout the way the detail path does — the
+        retention cap is 48MiB, and this runs once per session in a loop over
+        every session. ``raw`` keeps the preamble for the fallback above.
+        """
+        kept: list[dict] = []
+        raw: list[dict] = []
+        agg = _Aggregate()
+        try:
+            with path.open("rb") as stream:
+                for line in self._iter_lines(stream, agg):
+                    if len(kept) >= limit:
+                        break
+                    try:
+                        record = json.loads(line)
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    message = self._message_from_record(record)
+                    if message is None:
+                        continue
+                    content = (message.content or "").strip()
+                    if not content:
+                        continue
+                    if message.type == MessageType.USER:
+                        entry = {"role": "user", "content": content[:500]}
+                        if len(raw) < limit:
+                            raw.append(entry)
+                        if not _is_injected_preamble(content):
+                            kept.append(entry)
+                    elif message.type == MessageType.ASSISTANT:
+                        entry = {"role": "assistant", "content": content[:500]}
+                        if len(raw) < limit:
+                            raw.append(entry)
+                        kept.append(entry)
+        except OSError as exc:
+            logger.warning("Unable to read Codex rollout: %s", type(exc).__name__)
+        return kept, raw
+
+    async def generate_summary(self, session_id: str) -> str:
+        """Generate an AI summary for a Codex session.
+
+        The rollout file itself is never written to; only the summary cache is.
+        """
+        # The cache is checked before the rollout is opened: a cached summary
+        # must not cost a file read, and must still be served when the rollout
+        # has moved or is briefly unreadable.
+        cached = read_cached_summary(session_id)
+        if cached:
+            return cached
+        messages = self._get_first_messages(session_id, limit=5)
+        return await generate_summary_from_messages(session_id, messages)
+
+    def get_cached_summary(self, session_id: str) -> str | None:
+        """Get the cached summary for a Codex session, if one exists."""
+        return read_cached_summary(session_id)
 
     def get_session_tasks(self, session_id: str) -> tuple[dict[str, ClaudeCodeTask], list[str]]:
         """Codex task extraction is not exposed until its event semantics stabilize."""

--- a/src/backend/services/session_summary.py
+++ b/src/backend/services/session_summary.py
@@ -1,0 +1,138 @@
+"""Provider-neutral pieces of agent session summarization.
+
+Only three things are genuinely provider-independent: where a summary is
+cached, how messages are rendered into the prompt, and the Ollama call itself.
+Extracting the *first messages* is deliberately left to each monitor — a Claude
+JSONL and a Codex rollout share no structure, and a common extractor would only
+be a switch on provider wearing a shared name.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+SUMMARY_FAILED = "요약 생성 실패"
+SUMMARY_EMPTY = "대화 내용 없음"
+
+# A session id reaches the cache path as a file name. Claude ids come from a
+# file stem, but a Codex id is read out of the rollout's own metadata, so it is
+# untrusted input — anything that could escape the cache directory is rejected.
+_SAFE_SESSION_ID = re.compile(r"[A-Za-z0-9._-]{1,255}")
+
+
+def summary_cache_path(session_id: str) -> Path:
+    """Get the cache file path for a session summary.
+
+    Uses SUMMARY_CACHE_DIR env var if set, otherwise falls back to
+    ~/.claude/session_summaries/. In Docker, ~/.claude is read-only,
+    so /app/data/summaries is used instead.
+
+    Raises:
+        ValueError: If the session id is not safe to use as a file name.
+    """
+    if not _SAFE_SESSION_ID.fullmatch(session_id) or session_id in {".", ".."}:
+        raise ValueError("Unsafe session id")
+
+    cache_dir = os.getenv("SUMMARY_CACHE_DIR", "")
+    if cache_dir:
+        return Path(cache_dir) / f"{session_id}.txt"
+
+    # In Docker (CLAUDE_HOME is set), use /app/data/summaries to avoid read-only mount
+    if os.getenv("CLAUDE_HOME", ""):
+        return Path("/app/data/summaries") / f"{session_id}.txt"
+
+    return Path.home() / ".claude" / "session_summaries" / f"{session_id}.txt"
+
+
+def read_cached_summary(session_id: str) -> str | None:
+    """Return the cached summary for a session, or None."""
+    try:
+        cache_path = summary_cache_path(session_id)
+    except ValueError:
+        return None
+    if cache_path.exists():
+        return cache_path.read_text().strip()
+    return None
+
+
+def format_messages_for_prompt(messages: list[dict]) -> str:
+    """Render extracted messages into the summary prompt body."""
+    formatted = []
+    for msg in messages:
+        role = "사용자" if msg["role"] == "user" else "어시스턴트"
+        content = msg["content"][:200]  # Truncate for prompt
+        formatted.append(f"{role}: {content}")
+    return "\n".join(formatted)
+
+
+async def generate_summary_from_messages(session_id: str, messages: list[dict]) -> str:
+    """Generate and cache an AI summary from already-extracted messages.
+
+    Uses the configured Ollama model for cost efficiency. Disables reasoning for
+    thinking models so the response field carries the summary.
+    """
+    try:
+        cache_path = summary_cache_path(session_id)
+    except ValueError:
+        logger.warning("Refusing to cache a summary for an unsafe session id")
+        return SUMMARY_FAILED
+
+    if cache_path.exists():
+        logger.info(f"Using cached summary for session {session_id}")
+        return cache_path.read_text().strip()
+
+    if not messages:
+        return SUMMARY_EMPTY
+
+    prompt = f"""다음 대화의 주제를 한 문장(30자 이내)으로 요약해주세요.
+마침표 없이 간결하게 작성하세요.
+
+대화:
+{format_messages_for_prompt(messages)}
+
+요약:"""
+
+    try:
+        ollama_base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+        from config import get_model_for_provider
+
+        ollama_model = get_model_for_provider("ollama")
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.post(
+                f"{ollama_base_url}/api/generate",
+                json={
+                    "model": ollama_model,
+                    "prompt": prompt,
+                    "stream": False,
+                    "think": False,
+                    "options": {
+                        "num_predict": 50,
+                        "temperature": 0.3,
+                    },
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            summary = data.get("response", "").strip()
+
+            # Clean up: take first line only
+            if "\n" in summary:
+                summary = summary.split("\n")[0].strip()
+
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(summary)
+
+        logger.info(f"Generated summary for session {session_id}: {summary}")
+        return summary
+
+    except Exception as e:
+        logger.error(f"Failed to generate summary for {session_id}: {e}")
+        return SUMMARY_FAILED

--- a/src/dashboard/src/components/claude-sessions/SessionCard.tsx
+++ b/src/dashboard/src/components/claude-sessions/SessionCard.tsx
@@ -91,7 +91,7 @@ export function SessionCard({ session, isSelected, onClick }: SessionCardProps) 
           <span className="flex-shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
             {providerLabel}
           </span>
-          {!session.summary && isClaudeSession && (
+          {!session.summary && (
             <button
               onClick={handleGenerateSummary}
               disabled={isGenerating}

--- a/src/dashboard/src/components/claude-sessions/__tests__/SessionCard.test.tsx
+++ b/src/dashboard/src/components/claude-sessions/__tests__/SessionCard.test.tsx
@@ -173,7 +173,7 @@ describe('SessionCard', () => {
     expect(screen.getByText(/johndoe/)).toBeInTheDocument()
   })
 
-  it('renders Codex provider and model without Claude-only actions', () => {
+  it('offers summary generation for Codex while keeping deletion Claude-only', () => {
     const codexSession = {
       ...baseSession,
       provider: 'codex' as const,
@@ -184,8 +184,18 @@ describe('SessionCard', () => {
 
     expect(screen.getByText('Codex')).toBeInTheDocument()
     expect(screen.getByText('gpt-5.5')).toBeInTheDocument()
-    expect(screen.queryByTitle('AI 요약 생성')).not.toBeInTheDocument()
+    // 요약은 롤아웃 파일이 아니라 캐시에 쓰므로 read-only 계약을 깨지 않는다.
+    expect(screen.getByTitle('AI 요약 생성')).toBeInTheDocument()
     expect(screen.queryByTitle('빈 세션 삭제')).not.toBeInTheDocument()
+  })
+
+  it('generates a Codex summary when the sparkle button is clicked', () => {
+    const codexSession = { ...baseSession, provider: 'codex' as const, summary: undefined }
+    render(<SessionCard session={codexSession} isSelected={false} onClick={onClick} />)
+
+    fireEvent.click(screen.getByTitle('AI 요약 생성'))
+
+    expect(mockGenerateSummary).toHaveBeenCalledWith(codexSession.session_id)
   })
 
   it('renders different status colors for each status', () => {

--- a/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
+++ b/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
@@ -1198,6 +1198,20 @@ describe('claudeSessions store', () => {
       expect(useClaudeSessionsStore.getState().generatingSummaryFor).toBeNull()
     })
 
+    it('waits past the default client timeout for the Ollama round trip', async () => {
+      // 기본 30s 로 두면 브라우저가 먼저 끊고 "Request timed out" 을 띄우지만
+      // 백엔드는 계속 돌아 요약을 캐시에 쓴다 (실측 56.4s). 실패로 보이는데 결과는 남는다.
+      useClaudeSessionsStore.setState({
+        sessions: [{ session_id: 's-1', summary: null } as any],
+      })
+      mockApiClient.post.mockResolvedValueOnce({ summary: 'slow but done' })
+
+      await useClaudeSessionsStore.getState().generateSummary('s-1')
+
+      const [, , options] = mockApiClient.post.mock.calls[0]
+      expect((options as { timeout?: number } | undefined)?.timeout).toBeGreaterThanOrEqual(120_000)
+    })
+
     it('sets generatingSummaryFor during generation', async () => {
       let generating: string | null = null
       mockApiClient.post.mockImplementationOnce(() => {

--- a/src/dashboard/src/stores/claudeSessions/index.ts
+++ b/src/dashboard/src/stores/claudeSessions/index.ts
@@ -63,6 +63,13 @@ const denyIfForbidden = (
 }
 
 /** Claude 세션 목록/상세/스트리밍 상태 관리 스토어. */
+// 요약 생성은 Ollama 왕복이라 apiClient 기본 타임아웃(30s)보다 오래 걸린다.
+// 브라우저가 먼저 abort 해도 백엔드는 계속 돌아 요약을 캐시에 쓰므로, 사용자에게는
+// "실패"로 보이지만 결과는 남는 어긋남이 생긴다. 백엔드 httpx 타임아웃(120s)에 맞춘다.
+const SUMMARY_TIMEOUT_MS = 120_000
+// 일괄 생성은 세션 수만큼 순차 호출한다 (실측 395s). 백엔드가 스스로 끝낼 때까지 기다린다.
+const BATCH_SUMMARY_TIMEOUT_MS = 600_000
+
 export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => ({
   // Initial state
   sessions: [],
@@ -590,7 +597,11 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
     set({ generatingSummaryFor: sessionId })
 
     try {
-      const data = await apiClient.post<{ summary: string }>(`/api/claude-sessions/${sessionId}/summary`)
+      const data = await apiClient.post<{ summary: string }>(
+        `/api/claude-sessions/${sessionId}/summary`,
+        undefined,
+        { timeout: SUMMARY_TIMEOUT_MS },
+      )
 
       // Update session in list
       set((state) => ({
@@ -611,7 +622,11 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
     set({ generatingSummaryFor: sessionId })
 
     try {
-      const data = await apiClient.post<{ summary: string }>(`/api/claude-sessions/${sessionId}/summary`)
+      const data = await apiClient.post<{ summary: string }>(
+        `/api/claude-sessions/${sessionId}/summary`,
+        undefined,
+        { timeout: SUMMARY_TIMEOUT_MS },
+      )
 
       // Update session in list
       set((state) => ({
@@ -656,9 +671,7 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
       params.set('limit', '200')
 
       const data = await apiClient.get<ClaudeSessionResponse>(`/api/agent-sessions?${params.toString()}`)
-      const sessionsWithoutSummary = data.sessions.filter(
-        s => (s.provider || 'claude') === 'claude' && !s.summary,
-      )
+      const sessionsWithoutSummary = data.sessions.filter(s => !s.summary)
 
       // Generate summaries one by one to avoid overwhelming the LLM
       for (const session of sessionsWithoutSummary) {
@@ -801,7 +814,9 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
         success_count: number
         failed_count: number
         generated_summaries?: { session_id: string; summary: string }[]
-      }>(`/api/claude-sessions/summaries/generate-batch?${params.toString()}`)
+      }>(`/api/claude-sessions/summaries/generate-batch?${params.toString()}`, undefined, {
+        timeout: BATCH_SUMMARY_TIMEOUT_MS,
+      })
 
       // Update progress and immediately reduce pendingSummaryCount
       const currentPendingCount = get().pendingSummaryCount

--- a/tests/backend/api/test_agent_sessions.py
+++ b/tests/backend/api/test_agent_sessions.py
@@ -93,6 +93,7 @@ async def test_unknown_summary_returns_not_found(monkeypatch: pytest.MonkeyPatch
 async def test_codex_session_mutations_are_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Writing to a Codex rollout stays refused — summaries are not a write."""
     codex = _session("codex", "codex-1")
     detail = codex.model_copy(update={"recent_messages": [], "messages_truncated": False})
 
@@ -104,11 +105,37 @@ async def test_codex_session_mutations_are_rejected(
 
     with pytest.raises(HTTPException) as stream_error:
         await session_routes.stream_session("codex-1")
-    with pytest.raises(HTTPException) as summary_error:
-        await session_routes.get_session_summary("codex-1")
 
     assert stream_error.value.status_code == 409
-    assert summary_error.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_codex_session_summaries_are_served_and_generated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The summary routes must reach the Codex monitor instead of returning 409."""
+    codex = _session("codex", "codex-1")
+    detail = codex.model_copy(update={"recent_messages": [], "messages_truncated": False})
+    generated: list[str] = []
+
+    class _Monitor:
+        def get_cached_summary(self, session_id: str) -> str | None:
+            return "좀비 소켓 진단"
+
+        async def generate_summary(self, session_id: str) -> str:
+            generated.append(session_id)
+            return "좀비 소켓 진단"
+
+    monkeypatch.setattr(session_routes, "resolve_session", lambda _: (_Monitor(), detail))
+
+    cached = await session_routes.get_session_summary("codex-1")
+    created = await session_routes.generate_session_summary("codex-1")
+    details = await session_routes.get_session("codex-1")
+
+    assert cached == {"session_id": "codex-1", "summary": "좀비 소켓 진단"}
+    assert created == {"session_id": "codex-1", "summary": "좀비 소켓 진단"}
+    assert generated == ["codex-1"]
+    assert details.summary == "좀비 소켓 진단"
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_codex_session_monitor.py
+++ b/tests/backend/test_codex_session_monitor.py
@@ -740,3 +740,228 @@ def test_windowed_scan_does_not_collect_the_detail_tail(tmp_path: Path) -> None:
     assert windowed.record_count == whole.record_count == 60
     assert windowed.user_count == whole.user_count
     assert len(windowed.records) == 5
+
+
+def _write_preamble_rollout(root: Path) -> Path:
+    """Write a rollout that opens the way real ones do.
+
+    The record shapes come from a survey of 150 local rollouts: a
+    ``<recommended_plugins>`` blob and an ``# AGENTS.md instructions for`` blob
+    always precede the first genuine turn.
+    """
+    path = root / "2026" / "09" / "01" / "rollout-2026-09-01T10-00-00-01pre.jsonl"
+    path.parent.mkdir(parents=True)
+    records = [
+        {
+            "timestamp": "2026-09-01T01:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": "thread-preamble", "cwd": "/Users/tester/Work/AOS"},
+        },
+        {
+            "timestamp": "2026-09-01T01:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "<recommended_plugins>\nHere is a list of plugins.\n"
+                        "</recommended_plugins>",
+                    }
+                ],
+            },
+        },
+        {
+            "timestamp": "2026-09-01T01:00:02Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "# AGENTS.md instructions for /Users/tester/Work/AOS\n\n"
+                        "<INSTRUCTIONS>\n",
+                    }
+                ],
+            },
+        },
+        {
+            "timestamp": "2026-09-01T01:00:03Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "포트 8000 좀비 소켓 진단해줘"}],
+            },
+        },
+        {
+            "timestamp": "2026-09-01T01:00:04Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "model": "gpt-5.5",
+                "content": [{"type": "output_text", "text": "netstat 으로 확인하겠습니다."}],
+            },
+        },
+    ]
+    with path.open("wb") as stream:
+        for record in records:
+            stream.write(json.dumps(record).encode("utf-8") + b"\n")
+    return path
+
+
+def test_first_messages_skip_the_injected_preamble(tmp_path: Path) -> None:
+    """Summaries must come from the conversation, not the harness prologue.
+
+    Without the filter every Codex session summarizes the same two blobs.
+    """
+    _write_preamble_rollout(tmp_path)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    messages = monitor._get_first_messages("thread-preamble")
+
+    assert [message["role"] for message in messages] == ["user", "assistant"]
+    assert messages[0]["content"] == "포트 8000 좀비 소켓 진단해줘"
+    assert not any("recommended_plugins" in message["content"] for message in messages)
+    assert not any("AGENTS.md" in message["content"] for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_serves_the_cache_without_calling_ollama(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cached summary is returned as-is, so a Codex session needs no network."""
+    cache_dir = tmp_path / "summaries"
+    cache_dir.mkdir()
+    (cache_dir / "thread-preamble.txt").write_text("좀비 소켓 진단\n")
+    monkeypatch.setenv("SUMMARY_CACHE_DIR", str(cache_dir))
+    _write_preamble_rollout(tmp_path)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    assert monitor.get_cached_summary("thread-preamble") == "좀비 소켓 진단"
+    assert await monitor.generate_summary("thread-preamble") == "좀비 소켓 진단"
+
+
+def _write_preamble_only_rollout(root: Path) -> Path:
+    """A rollout whose every message is injected context and nothing else."""
+    path = root / "2026" / "09" / "01" / "rollout-2026-09-01T11-00-00-01only.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    records = [
+        {
+            "timestamp": "2026-09-01T02:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": "thread-preamble-only", "cwd": "/Users/tester/Work/AOS"},
+        },
+        {
+            "timestamp": "2026-09-01T02:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "<recommended_plugins>\nplugins\n"}],
+            },
+        },
+        {
+            "timestamp": "2026-09-01T02:00:02Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "[Base]\nYou are operating inside X."}],
+            },
+        },
+    ]
+    with path.open("wb") as stream:
+        for record in records:
+            stream.write(json.dumps(record).encode("utf-8") + b"\n")
+    return path
+
+
+def test_first_messages_skip_repeated_harness_blocks(tmp_path: Path) -> None:
+    """`[Base]`/`[Context]` repeat verbatim across sessions, so they are dropped.
+
+    Measured over 120 local rollouts, dropping them changes the summary input
+    for 40 — otherwise every session of the same harness summarizes alike.
+    """
+    _write_preamble_rollout(tmp_path)
+    monitor = CodexSessionMonitor(tmp_path)
+    path = tmp_path / "2026" / "09" / "01" / "rollout-2026-09-01T10-00-00-01pre.jsonl"
+    scanned = monitor._read_file(path).messages
+    harness = [
+        message
+        for message in scanned
+        if message.content and message.content.startswith(("[Base]", "[Context]"))
+    ]
+
+    assert not harness, "fixture guard: this rollout carries no harness blocks"
+    assert codex_monitor._is_injected_preamble("[Base]\nYou are operating inside Buzz.")
+    assert codex_monitor._is_injected_preamble("[Context]\nScope: thread")
+    assert codex_monitor._is_injected_preamble("[New message — arrived while you were working]")
+    assert not codex_monitor._is_injected_preamble("포트 8000 좀비 소켓 진단해줘")
+
+
+def test_first_messages_fall_back_when_only_preamble_exists(tmp_path: Path) -> None:
+    """A session of nothing but injected context still summarizes something.
+
+    4 of 120 local rollouts look like this; dropping everything would report
+    '대화 내용 없음' for a session that genuinely has content on screen.
+    """
+    _write_preamble_only_rollout(tmp_path)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    messages = monitor._get_first_messages("thread-preamble-only")
+
+    assert messages, "the fallback must not return an empty conversation"
+    assert messages[0]["content"].startswith("<recommended_plugins>")
+
+
+def test_xml_wrapped_user_request_is_not_treated_as_preamble() -> None:
+    """Only the observed envelopes are injected; a `<task>` turn is a real request.
+
+    Matching any lone `<tag>` line would drop the request and summarize the
+    replies to a question nobody can see.
+    """
+    assert codex_monitor._is_injected_preamble("<recommended_plugins>\nplugins")
+    assert codex_monitor._is_injected_preamble("<user_action>\nopened a file")
+    assert not codex_monitor._is_injected_preamble("<task>\n포트 8000 좀비 소켓 진단해줘")
+    assert not codex_monitor._is_injected_preamble("<spec>\nbuild the thing")
+
+
+def test_first_message_scan_stops_at_the_limit(tmp_path: Path) -> None:
+    """A summary reads the opening turns, not the whole rollout.
+
+    The detail path retains up to 48MiB; doing that once per session while
+    walking every session is the cost this bound exists to avoid.
+    """
+    _write_preamble_rollout(tmp_path)
+    monitor = CodexSessionMonitor(tmp_path)
+    path = tmp_path / "2026" / "09" / "01" / "rollout-2026-09-01T10-00-00-01pre.jsonl"
+
+    kept, raw = monitor._scan_first_messages(path, limit=1)
+
+    assert len(kept) == 1
+    assert kept[0]["content"] == "포트 8000 좀비 소켓 진단해줘"
+    assert len(raw) <= 1
+
+
+@pytest.mark.asyncio
+async def test_cached_summary_is_served_without_opening_the_rollout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cached summary must not cost a file read, nor need the file to exist."""
+    cache_dir = tmp_path / "summaries"
+    cache_dir.mkdir()
+    (cache_dir / "thread-preamble.txt").write_text("좀비 소켓 진단")
+    monkeypatch.setenv("SUMMARY_CACHE_DIR", str(cache_dir))
+    _write_preamble_rollout(tmp_path)
+    monitor = CodexSessionMonitor(tmp_path)
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError("the rollout must not be read when a summary is cached")
+
+    monkeypatch.setattr(monitor, "_get_first_messages", _fail)
+
+    assert await monitor.generate_summary("thread-preamble") == "좀비 소켓 진단"

--- a/tests/backend/test_session_summary.py
+++ b/tests/backend/test_session_summary.py
@@ -1,0 +1,45 @@
+"""Provider-neutral session summary helper tests."""
+
+from pathlib import Path
+
+import pytest
+
+from services.session_summary import (
+    SUMMARY_FAILED,
+    generate_summary_from_messages,
+    read_cached_summary,
+    summary_cache_path,
+)
+
+
+def test_cache_path_uses_the_configured_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SUMMARY_CACHE_DIR", str(tmp_path))
+
+    assert summary_cache_path("codex-1") == tmp_path / "codex-1.txt"
+
+
+@pytest.mark.parametrize("session_id", ["../escape", "nested/id", "", "."])
+def test_cache_path_rejects_ids_that_could_escape(
+    session_id: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Codex id comes out of the rollout's own metadata, so it is untrusted."""
+    monkeypatch.setenv("SUMMARY_CACHE_DIR", str(tmp_path))
+
+    with pytest.raises(ValueError):
+        summary_cache_path(session_id)
+
+    assert read_cached_summary(session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_refuses_an_unsafe_id_before_any_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SUMMARY_CACHE_DIR", str(tmp_path))
+
+    result = await generate_summary_from_messages("../escape", [{"role": "user", "content": "hi"}])
+
+    assert result == SUMMARY_FAILED
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## 문제

Agent Sessions에서 Codex 세션은 제목이 롤아웃 타임스탬프(`2026-09-01T10-32-40-…`)로만 표시됐다. 원인은 UI가 아니라 백엔드의 명시적 차단 — 요약 라우트가 Claude 이외 provider에 409를 반환하고 있었다.

요약은 롤아웃이 아니라 별도 캐시에 쓰므로, streaming·save·delete의 409가 지키는 read-only 계약과는 무관하다. 그 3개는 그대로 두고 요약 2개만 열었다.

## 변경

**백엔드**
- provider 중립 부분(캐시 경로·프롬프트 포맷·Ollama 호출)만 `services/session_summary.py`로 분리. 메시지 추출은 provider별로 유지 — Claude JSONL과 Codex 롤아웃은 구조가 전혀 다르다.
- `CodexSessionMonitor`에 전용 추출기 추가. **모든 롤아웃의 첫 user 메시지는 하네스 주입 프리앰블**이라(로컬 150건 조사: `<recommended_plugins>` 63건, `# AGENTS.md instructions for` 61건, 턴마다 반복되는 `[Base]`/`[Context]`) 이를 건너뛰고 첫 실제 대화 턴부터 사용. 주입 컨텍스트밖에 없는 세션(120건 중 4건)은 프리앰블로 폴백해 "대화 내용 없음"을 피한다.
- 필요한 만큼만 읽고 중단하는 스캔으로 전환 — 롤아웃 전체 적재(최대 48MiB) 대신. **120개 롤아웃 추출 0.4초.**
- 캐시된 요약은 파일을 열기 전에 반환 (두 provider 모두).
- 목록·상세에 Codex 캐시 요약을 붙인다. 카드는 요약이 없으면 slug로 폴백하는데 Codex의 slug가 바로 그 타임스탬프라, 이걸 빠뜨리면 요약을 만들어도 화면이 안 바뀐다.
- 일괄 생성은 두 provider를 `last_activity` 기준 병합 정렬한 뒤 limit 적용.
- 요약 캐시 경로에 안전 가드 — Codex id는 롤아웃 metadata에서 읽는 신뢰할 수 없는 입력인데 파일명으로 쓰인다.

**프론트엔드**
- 카드 ✨ 버튼과 자동 생성 루프의 Claude 전용 필터 제거 (삭제 버튼은 Claude 전용 유지).
- 요약 호출 타임아웃 상향: 단건 120s(백엔드 httpx와 일치), 일괄 600s. 백엔드는 120초를 기다리는데 `apiClient`가 30초에 abort해서, **요약이 실제로 성공·캐시됐는데도 화면엔 "Request timed out"**이 떴다 (실측: 단건 56.4s·65.8s, 일괄 395s).

## 검증

- 게이트: ruff / ruff format / mypy 통과, **pytest 1966 passed**, **vitest 4469 passed**, tsc / eslint / build 통과.
- 신규 테스트는 모두 Red-Green 확인 (가드를 끄면 실패, 되돌리면 통과).
- 실제 롤아웃 대조(합성 fixture로는 검증 불가한 파서): 120건 중 **empty 0건**, 프리앰블 폴백 4건.
- 대시보드 실측: Codex 카드·상세 패널 제목 모두 요약 표시, 타임아웃 배너 없음, 미요약 394 → 318로 자동 감소.

## Codex 리뷰

2라운드 진행, 지적 5건 전부 반영. 단 P1 하나는 **제안 그대로 적용하지 않았다** — `[Base]`/`[Context]`를 거르는 것 자체는 타당했으나(40건 개선) 그대로 넣으면 4건이 빈 대화로 전락해서, 폴백을 추가해 empty 0건을 유지했다. 2라운드의 "아무 `<tag>`나 거르면 `<task>` 같은 실제 요청이 사라진다"는 지적은 관측된 5개 태그 화이트리스트로 좁혀 반영했다.