### PR TITLE
fix: sync pending summary count after generation

### DIFF
--- a/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
+++ b/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
@@ -1212,6 +1212,64 @@ describe('claudeSessions store', () => {
       expect((options as { timeout?: number } | undefined)?.timeout).toBeGreaterThanOrEqual(120_000)
     })
 
+    it('decrements the pending count and resyncs it from the server', async () => {
+      // 카드/상세 제목은 바뀌는데 상단 "미요약 N개" 만 새로고침해도 그대로 남던 버그.
+      // 일괄 생성은 성공 수만큼 차감하지만 단건에는 그 대응이 없었다.
+      useClaudeSessionsStore.setState({
+        sessions: [{ session_id: 's-1', summary: null } as any],
+        pendingSummaryCount: 7,
+      })
+      mockApiClient.post.mockResolvedValueOnce({ summary: 'generated' })
+      mockApiClient.get.mockResolvedValueOnce({ pending_count: 5 })
+
+      await useClaudeSessionsStore.getState().generateSummary('s-1')
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('/summaries/pending-count'),
+      )
+      expect(useClaudeSessionsStore.getState().pendingSummaryCount).toBe(5)
+    })
+
+    it('keeps the optimistic decrement when the resync fails', async () => {
+      useClaudeSessionsStore.setState({
+        sessions: [{ session_id: 's-1', summary: null } as any],
+        pendingSummaryCount: 3,
+      })
+      mockApiClient.post.mockResolvedValueOnce({ summary: 'generated' })
+      mockApiClient.get.mockRejectedValueOnce(new Error('offline'))
+
+      await useClaudeSessionsStore.getState().generateSummary('s-1')
+
+      expect(useClaudeSessionsStore.getState().pendingSummaryCount).toBe(2)
+      expect(useClaudeSessionsStore.getState().error).toBeNull()
+    })
+
+    it('does not decrement when the session already had a summary', async () => {
+      // 이미 요약된 세션을 다시 생성하는 것은 미요약 수를 줄이지 않는다.
+      useClaudeSessionsStore.setState({
+        sessions: [{ session_id: 's-1', summary: 'old' } as any],
+        pendingSummaryCount: 4,
+      })
+      mockApiClient.post.mockResolvedValueOnce({ summary: 'new' })
+      mockApiClient.get.mockRejectedValueOnce(new Error('offline'))
+
+      await useClaudeSessionsStore.getState().generateSummary('s-1')
+
+      expect(useClaudeSessionsStore.getState().pendingSummaryCount).toBe(4)
+    })
+
+    it('leaves the pending count untouched when generation fails', async () => {
+      useClaudeSessionsStore.setState({
+        sessions: [{ session_id: 's-1', summary: null } as any],
+        pendingSummaryCount: 6,
+      })
+      mockApiClient.post.mockRejectedValueOnce(new Error('boom'))
+
+      await useClaudeSessionsStore.getState().generateSummary('s-1')
+
+      expect(useClaudeSessionsStore.getState().pendingSummaryCount).toBe(6)
+    })
+
     it('sets generatingSummaryFor during generation', async () => {
       let generating: string | null = null
       mockApiClient.post.mockImplementationOnce(() => {

--- a/src/dashboard/src/stores/claudeSessions/index.ts
+++ b/src/dashboard/src/stores/claudeSessions/index.ts
@@ -595,6 +595,9 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
 
   generateSummary: async (sessionId: string) => {
     set({ generatingSummaryFor: sessionId })
+    // 이미 요약이 있는 세션을 다시 생성해도 미요약 수는 줄지 않는다. 차감 여부는
+    // 요청 전 상태로 정하고, 재조회가 서버 값으로 덮어쓴다.
+    const wasPending = !get().sessions.find((s) => s.session_id === sessionId)?.summary
 
     try {
       const data = await apiClient.post<{ summary: string }>(
@@ -609,7 +612,16 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
           s.session_id === sessionId ? { ...s, summary: data.summary } : s
         ),
         generatingSummaryFor: null,
+        // 일괄 생성은 성공 수만큼 즉시 차감하는데 단건에는 그 대응이 없어, 카드
+        // 제목만 바뀌고 상단 "미요약 N개" 는 그대로 남아 있었다.
+        pendingSummaryCount: wasPending
+          ? Math.max(0, state.pendingSummaryCount - 1)
+          : state.pendingSummaryCount,
       }))
+
+      // 즉시 차감은 화면용이고, 권위는 서버에 있다 — 다른 세션이 동시에 요약을
+      // 만들었을 수 있으므로 성공 뒤에는 실제 값으로 맞춘다.
+      await get().fetchPendingSummaryCount()
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : 'Unknown error'
       denyIfForbidden(e, set, get)


### PR DESCRIPTION
## Summary\n- keep the pending-summary badge in sync after successful single-session generation\n- optimistically decrement the local count and reconcile with the authoritative pending-count endpoint\n- add regression coverage for success, resync failure, already-summarized, and generation failure paths\n\n## Validation\n- Aside Browser: Codex summary generation completed; pending counter changed 317 → 316\n- vitest: 189 passed\n- tsc --noEmit: passed\n- eslint: passed\n- git diff --check: passed\n\nFollow-up to #384.