### PR TITLE
fix(dashboard): 자동요약을 서버 배치에 위임해 목록 창 밖 세션까지 처리

### DIFF
--- a/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
+++ b/src/dashboard/src/stores/__tests__/claudeSessions.test.ts
@@ -48,6 +48,7 @@ vi.mock('../../services/authenticatedSse', () => ({
 
 import { useClaudeSessionsStore } from '../claudeSessions'
 import { apiClient } from '../../services/apiClient'
+import { ApiError, ApiErrorCode } from '../../services/errors'
 
 const mockApiClient = vi.mocked(apiClient)
 
@@ -90,6 +91,10 @@ function resetStore() {
     autoRefresh: true,
     refreshInterval: 5,
     error: null,
+    // 403 을 다루는 테스트가 이 플래그를 세운 채 끝난다. 리셋하지 않으면 뒤따르는
+    // 테스트가 권한 가드에 걸려 조기 return 하고, 호출이 안 나간 이유가 코드가
+    // 아니라 앞 테스트라는 사실이 드러나지 않는다.
+    permissionDenied: false,
     generatingSummaryFor: null,
     autoGenerateSummaries: false, // Disable for tests
     eventSource: null,
@@ -289,21 +294,25 @@ describe('claudeSessions store', () => {
         ...emptyResponse,
         sessions: [{ session_id: 's-1', summary: null }],
       })
-      // Second call: autoGenerateMissingSummaries internal fetch
-      mockApiClient.get.mockResolvedValueOnce({
-        ...emptyResponse,
-        sessions: [{ session_id: 's-1', summary: null }],
+      // Second call: the batch that autoGenerateMissingSummaries delegates to
+      mockApiClient.post.mockResolvedValueOnce({
+        total_processed: 1,
+        success_count: 1,
+        failed_count: 0,
+        generated_summaries: [{ session_id: 's-1', summary: 'Auto' }],
       })
-      // Third call: generateSummaryQuiet
-      mockApiClient.post.mockResolvedValueOnce({ summary: 'Auto' })
-      // Fourth call: fetchPendingSummaryCount
+      // Third call: fetchPendingSummaryCount
       mockApiClient.get.mockResolvedValueOnce({ pending_count: 0 })
 
       await useClaudeSessionsStore.getState().fetchSessions()
 
       // Wait for non-blocking auto-generate
       await vi.waitFor(() => {
-        expect(mockApiClient.get.mock.calls.length).toBeGreaterThanOrEqual(2)
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          expect.stringContaining('summaries/generate-batch'),
+          undefined,
+          expect.anything(),
+        )
       })
     })
 
@@ -1371,130 +1380,194 @@ describe('claudeSessions store', () => {
   // ── autoGenerateMissingSummaries ────────────────────────
 
   describe('autoGenerateMissingSummaries', () => {
+    const batchResult = (
+      summaries: { session_id: string; summary: string }[] = [],
+    ) => ({
+      total_processed: summaries.length,
+      success_count: summaries.length,
+      failed_count: 0,
+      generated_summaries: summaries,
+    })
+
     it('skips when autoGenerateSummaries is disabled', async () => {
       useClaudeSessionsStore.setState({ autoGenerateSummaries: false })
 
       await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
 
-      expect(mockApiClient.get).not.toHaveBeenCalled()
+      expect(mockApiClient.post).not.toHaveBeenCalled()
     })
 
-    it('skips when already generating a summary', async () => {
+    it('skips while a user-triggered batch is running', async () => {
       useClaudeSessionsStore.setState({
         autoGenerateSummaries: true,
-        generatingSummaryFor: 's-existing',
+        isBatchGenerating: true,
       })
 
       await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
 
-      expect(mockApiClient.get).not.toHaveBeenCalled()
+      expect(mockApiClient.post).not.toHaveBeenCalled()
     })
 
-    it('generates summaries for sessions without one', async () => {
+    // 카드에서 단건 생성을 누르면 `generatingSummaryFor` 가 선다. 배치가 그 세션을
+    // 다시 집으면 아직 캐시가 없어 같은 세션에 Ollama 요청이 두 번 나간다 (Codex [P2]).
+    it('skips while the user is generating a single summary', async () => {
       useClaudeSessionsStore.setState({
         autoGenerateSummaries: true,
-        sessions: [{ session_id: 's-1', summary: null } as any],
+        generatingSummaryFor: 's-1',
       })
-      // First call: fetch sessions to find those without summary
-      mockApiClient.get.mockResolvedValueOnce({
-        sessions: [
-          { session_id: 's-1', summary: null },
-          { session_id: 's-2', summary: 'has one' },
-        ],
-        total_count: 2,
-        filtered_count: 2,
-        active_count: 0,
-        has_more: false,
-        offset: 0,
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      expect(mockApiClient.post).not.toHaveBeenCalled()
+    })
+
+    it('skips when permission was denied', async () => {
+      useClaudeSessionsStore.setState({
+        autoGenerateSummaries: true,
+        permissionDenied: true,
       })
-      // Second call: generateSummaryQuiet for s-1
-      mockApiClient.post.mockResolvedValueOnce({ summary: 'Auto generated' })
-      // Third call: fetchPendingSummaryCount
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      expect(mockApiClient.post).not.toHaveBeenCalled()
+    })
+
+    // 이 스토어가 최근 N 건만 훑던 시절의 회귀 가드다. 목록 창을 넓히는 대신
+    // 창이 없는 서버 배치에 위임하므로, 백로그가 목록 밖에 있어도 닿는다.
+    it('delegates to the server batch instead of walking a session window', async () => {
+      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
+      mockApiClient.post.mockResolvedValueOnce(batchResult())
       mockApiClient.get.mockResolvedValueOnce({ pending_count: 0 })
 
       await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
 
-      // generateSummaryQuiet was called
-      expect(mockApiClient.get).toHaveBeenCalledTimes(2) // sessions fetch + pending count
-      expect(mockApiClient.post).toHaveBeenCalledTimes(1) // summary generation
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1)
+      const url = mockApiClient.post.mock.calls[0][0] as string
+      expect(url).toContain('/api/claude-sessions/summaries/generate-batch')
+      expect(url).toContain('skip_existing=true')
+
+      const fetched = mockApiClient.get.mock.calls.map((c) => c[0] as string)
+      expect(fetched.some((u) => u.includes('/api/agent-sessions'))).toBe(false)
     })
 
-    it('silently handles fetch error', async () => {
+    // 막히는 세션 하나가 372s(재시도 3회 × 120s)다. 20 건이면 1 건까지는 499s 로
+    // 클라이언트 타임아웃(600s) 안이다 — 2 건부터는 어떤 limit 으로도 못 막는다.
+    // 값이 조용히 커지면 그 1 건 여유마저 사라지므로 여기서 고정한다.
+    it('caps the batch so one stuck session cannot exceed the client timeout', async () => {
       useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
-      mockApiClient.get.mockRejectedValueOnce(new Error('fail'))
+      mockApiClient.post.mockResolvedValueOnce(batchResult())
+      mockApiClient.get.mockResolvedValueOnce({ pending_count: 0 })
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      expect(mockApiClient.post.mock.calls[0][0] as string).toContain('limit=20')
+    })
+
+    it('applies returned summaries to the session list', async () => {
+      useClaudeSessionsStore.setState({
+        autoGenerateSummaries: true,
+        sessions: [
+          { session_id: 's-1', summary: null } as any,
+          { session_id: 's-2', summary: 'kept' } as any,
+        ],
+      })
+      mockApiClient.post.mockResolvedValueOnce(
+        batchResult([{ session_id: 's-1', summary: 'fresh' }]),
+      )
+      mockApiClient.get.mockResolvedValueOnce({ pending_count: 0 })
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      const sessions = useClaudeSessionsStore.getState().sessions
+      expect(sessions[0].summary).toBe('fresh')
+      expect(sessions[1].summary).toBe('kept')
+    })
+
+    it('refreshes the pending count after generating', async () => {
+      useClaudeSessionsStore.setState({
+        autoGenerateSummaries: true,
+        pendingSummaryCount: 9,
+      })
+      mockApiClient.post.mockResolvedValueOnce(
+        batchResult([{ session_id: 's-1', summary: 'fresh' }]),
+      )
+      mockApiClient.get.mockResolvedValueOnce({ pending_count: 4 })
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      expect(useClaudeSessionsStore.getState().pendingSummaryCount).toBe(4)
+    })
+
+    // 실행 중임을 표시하지 않으면 새로고침·필터 변경·수동 버튼이 같은 후보를
+    // 다시 집어 Ollama 작업이 중복된다 (Codex [P1]).
+    it('marks itself in flight so a second batch cannot start', async () => {
+      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
+      let inFlight: boolean | null = null
+      mockApiClient.post.mockImplementationOnce(async () => {
+        inFlight = useClaudeSessionsStore.getState().isBatchGenerating
+        return batchResult()
+      })
+      mockApiClient.get.mockResolvedValueOnce({ pending_count: 0 })
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      expect(inFlight).toBe(true)
+      expect(useClaudeSessionsStore.getState().isBatchGenerating).toBe(false)
+    })
+
+    it('clears the in-flight flag even when the batch fails', async () => {
+      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
+      mockApiClient.post.mockRejectedValueOnce(new Error('boom'))
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      expect(useClaudeSessionsStore.getState().isBatchGenerating).toBe(false)
+    })
+
+    // 자동 생성은 사용자가 요청한 일이 아니다. `batchJustCompleted` 를 세우면
+    // 일괄 생성 버튼이 숨겨져 사용자가 백로그를 직접 소진할 수단을 잃는다.
+    it('leaves the manual batch UI state untouched', async () => {
+      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
+      mockApiClient.post.mockResolvedValueOnce(
+        batchResult([{ session_id: 's-1', summary: 'fresh' }]),
+      )
+      mockApiClient.get.mockResolvedValueOnce({ pending_count: 0 })
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      const state = useClaudeSessionsStore.getState()
+      expect(state.isBatchGenerating).toBe(false)
+      expect(state.batchJustCompleted).toBe(false)
+      expect(state.batchProgress).toEqual({
+        total: 0,
+        processed: 0,
+        success: 0,
+        failed: 0,
+      })
+    })
+
+    it('marks permission denied on 403', async () => {
+      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
+      mockApiClient.post.mockRejectedValueOnce(
+        new ApiError({
+          message: 'Forbidden',
+          status: 403,
+          code: ApiErrorCode.FORBIDDEN,
+        }),
+      )
+
+      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
+
+      expect(useClaudeSessionsStore.getState().permissionDenied).toBe(true)
+    })
+
+    it('silently handles errors', async () => {
+      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
+      mockApiClient.post.mockRejectedValueOnce(new Error('fail'))
 
       await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
 
       expect(useClaudeSessionsStore.getState().error).toBeNull()
-    })
-
-    it('stops generating if autoGenerateSummaries is disabled mid-loop', async () => {
-      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
-      // Return 2 sessions without summaries
-      mockApiClient.get.mockResolvedValueOnce({
-        sessions: [
-          { session_id: 's-1', summary: null },
-          { session_id: 's-2', summary: null },
-        ],
-        total_count: 2,
-        filtered_count: 2,
-        active_count: 0,
-        has_more: false,
-        offset: 0,
-      })
-      // For the first generateSummaryQuiet call, disable auto-generate
-      mockApiClient.post.mockImplementationOnce(() => {
-        useClaudeSessionsStore.setState({ autoGenerateSummaries: false })
-        return Promise.resolve({ summary: 'first' })
-      })
-      // fetchPendingSummaryCount is still called because sessionsWithoutSummary.length > 0
-      mockApiClient.get.mockResolvedValueOnce({ pending_count: 1 })
-
-      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
-
-      // s-2 was skipped because autoGenerateSummaries was disabled mid-loop
-      // Only 1 POST call (for s-1), not 2
-      expect(mockApiClient.post).toHaveBeenCalledTimes(1)
-    })
-
-    it('does not call fetchPendingSummaryCount when no sessions without summaries', async () => {
-      useClaudeSessionsStore.setState({ autoGenerateSummaries: true })
-      mockApiClient.get.mockResolvedValueOnce({
-        sessions: [{ session_id: 's-1', summary: 'already has one' }],
-        total_count: 1,
-        filtered_count: 1,
-        active_count: 0,
-        has_more: false,
-        offset: 0,
-      })
-
-      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
-
-      // Only the sessions fetch, no pending count fetch
-      expect(mockApiClient.get).toHaveBeenCalledTimes(1)
-    })
-
-    it('includes filter params', async () => {
-      useClaudeSessionsStore.setState({
-        autoGenerateSummaries: true,
-        projectFilter: 'MyProject',
-        sourceUserFilter: 'admin',
-      })
-      mockApiClient.get.mockResolvedValueOnce({
-        sessions: [],
-        total_count: 0,
-        filtered_count: 0,
-        active_count: 0,
-        has_more: false,
-        offset: 0,
-      })
-
-      await useClaudeSessionsStore.getState().autoGenerateMissingSummaries()
-
-      const url = mockApiClient.get.mock.calls[0][0] as string
-      expect(url).toContain('project=MyProject')
-      expect(url).toContain('source_user=admin')
-      expect(url).toContain('limit=200')
     })
   })
 

--- a/src/dashboard/src/stores/claudeSessions/index.ts
+++ b/src/dashboard/src/stores/claudeSessions/index.ts
@@ -69,6 +69,17 @@ const denyIfForbidden = (
 const SUMMARY_TIMEOUT_MS = 120_000
 // 일괄 생성은 세션 수만큼 순차 호출한다 (실측 395s). 백엔드가 스스로 끝낼 때까지 기다린다.
 const BATCH_SUMMARY_TIMEOUT_MS = 600_000
+// 자동 생성 1 회가 처리할 상한. 백엔드 실측은 건당 6.7s(요약 4.7s + 지연 2s)라
+// 20 건이면 약 133s 다. 막히는 세션은 재시도 3 회 × httpx 타임아웃 120s 로 그 건만
+// 372s 가 되는데, 20 건 기준 1 건까지는 499s 로 위 600s 안이고 2 건이면 864s 로
+// 넘어선다. limit 을 낮춰도 이 성질은 남는다(10 건이어도 2 건 막히면 797s) —
+// 막힌 건 하나의 비용이 배치 전체보다 크기 때문이라, 상한으로는 못 막는다.
+//
+// 넘어서면 클라이언트만 포기하고 서버는 계속 돌아 캐시를 쓴다. 작업이 유실되지는
+// 않고 다음 실행이 skip_existing 으로 이어받지만, 그 사이 서버에서 배치가 겹칠 수
+// 있다. 겹침을 없애려면 서버측 단일 실행 락이 필요하다 (이 변경의 범위 밖).
+// 남은 백로그는 다음 페이지 로드가 이어서 소진한다.
+const AUTO_SUMMARY_BATCH_LIMIT = 20
 
 export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => ({
   // Initial state
@@ -664,41 +675,76 @@ export const useClaudeSessionsStore = create<ClaudeSessionsState>((set, get) => 
     set({ autoGenerateSummaries: enabled })
   },
 
-  // Auto-generate summaries for sessions without one (up to 200 sessions)
+  // Auto-generate summaries for sessions without one.
+  //
+  // 목록을 직접 훑지 않고 서버 배치에 위임한다. 이전 구현은 최근 200 건만 조회해
+  // 그 창 밖의 미요약 세션에는 영원히 닿지 못했고(백로그는 수동 버튼으로만 소진),
+  // 세션마다 POST 를 순차 발사해 Ollama 페이싱도 없었다. 서버 배치는 창이 없고
+  // (`_discover_with_monitors` 가 전체를 훑는다) 요청 간 지연·재시도를 갖고 있다.
   autoGenerateMissingSummaries: async () => {
-    const { autoGenerateSummaries, projectFilter, sourceUserFilter, sortBy, sortOrder, generatingSummaryFor } = get()
-    if (!autoGenerateSummaries || generatingSummaryFor) return
+    const { autoGenerateSummaries, isBatchGenerating, generatingSummaryFor } = get()
+    // 사용자가 누른 일괄 생성이 도는 중이면 비켜선다. 같은 후보를 두 번 처리하는
+    // 낭비를 막고, 수동 배치의 진행률 표시를 흔들지 않는다.
+    //
+    // `generatingSummaryFor` 는 카드에서 단건 생성을 누른 동안 선다. 그 세션은 아직
+    // 캐시가 없어 배치의 후보에 그대로 들어오므로, 비켜서지 않으면 한 세션에
+    // Ollama 요청이 두 번 나간다 (Codex [P2]).
+    if (!autoGenerateSummaries || isBatchGenerating || generatingSummaryFor) return
 
     // Auto-generation is optimistic background work, not something the user
-    // asked for. Without this guard a denied account fires one 403 per session.
+    // asked for. Without this guard a denied account keeps firing 403s.
     if (get().permissionDenied) return
 
+    // 읽기만 하고 자기를 표시하지 않으면 가드가 자기 자신에게는 무력하다 — 배치가
+    // 도는 동안의 새로고침·필터 변경이 같은 후보를 다시 집어 Ollama 작업을
+    // 중복시킨다 (Codex [P1]). 버튼도 이 플래그로 비활성화되므로 표시가 정직해진다.
+    set({ isBatchGenerating: true })
+
     try {
+      // 화면의 project·source_user 필터는 싣지 않는다. 배치 엔드포인트가 받지 않기도
+      // 하지만, 받게 만들어도 필터를 건 사용자는 다른 프로젝트의 백로그에 영원히
+      // 닿지 못한다 — 이 변경이 없앤 "최근 200 건" 창과 축만 다른 같은 문제다.
+      // 필터 밖 세션의 요약은 버려지는 일이 아니라 선반영이고(캐시 값은 어디서
+      // 만들어도 같다), 미요약 배지도 필터가 없으면 전체를 센다 (Codex [P2], 미반영).
       const params = new URLSearchParams()
-      if (projectFilter) params.set('project', projectFilter)
-      if (sourceUserFilter) params.set('source_user', sourceUserFilter)
-      params.set('sort_by', sortBy)
-      params.set('sort_order', sortOrder)
-      params.set('offset', '0')
-      params.set('limit', '200')
+      params.set('limit', AUTO_SUMMARY_BATCH_LIMIT.toString())
+      params.set('skip_existing', 'true')
 
-      const data = await apiClient.get<ClaudeSessionResponse>(`/api/agent-sessions?${params.toString()}`)
-      const sessionsWithoutSummary = data.sessions.filter(s => !s.summary)
+      const data = await apiClient.post<{
+        success_count: number
+        generated_summaries?: { session_id: string; summary: string }[]
+      }>(`/api/claude-sessions/summaries/generate-batch?${params.toString()}`, undefined, {
+        timeout: BATCH_SUMMARY_TIMEOUT_MS,
+      })
 
-      // Generate summaries one by one to avoid overwhelming the LLM
-      for (const session of sessionsWithoutSummary) {
-        // 루프가 도는 동안 권한이 회수될 수 있다. 시작 시점 가드만으로는 최대
-        // 200 건의 403 POST 가 조용히 나간다 (Codex [P2]).
-        if (!get().autoGenerateSummaries || get().permissionDenied) break
-        await get().generateSummaryQuiet(session.session_id)
+      // 이전 구현은 루프 중간에 `autoGenerateSummaries` 를 다시 읽어 끄면 멈췄다.
+      // 서버 배치는 요청 1 회라 그 중단점이 없다 — 여기서 abort 해도 서버는 끝까지
+      // 돌기 때문에 취소는 표시상의 것일 뿐이다. 대신 한 번에 도는 시간이 최대 200
+      // 건에서 20 건으로 줄어 붙잡히는 구간 자체가 짧아졌다 (Codex [P2], 미반영).
+      //
+      // 수동 배치와 달리 batchProgress·batchJustCompleted 는 건드리지 않는다.
+      // 후자는 일괄 생성 버튼을 숨기는 플래그라, 자동 실행이 세우면 사용자가
+      // 남은 백로그를 직접 소진할 수단을 잃는다 (SessionList).
+      const generated = data.generated_summaries ?? []
+      if (generated.length > 0) {
+        const summaryMap = new Map(generated.map((item) => [item.session_id, item.summary]))
+        set((state) => ({
+          sessions: state.sessions.map((s) => {
+            const newSummary = summaryMap.get(s.session_id)
+            return newSummary ? { ...s, summary: newSummary } : s
+          }),
+        }))
       }
 
-      // Refresh pending count after generation
-      if (sessionsWithoutSummary.length > 0) {
-        await get().fetchPendingSummaryCount()
-      }
-    } catch {
-      // Silently fail for auto-generation
+      await get().fetchPendingSummaryCount()
+    } catch (e) {
+      // 403 만은 삼키지 않는다. 흘려보내면 페이지를 열 때마다 다시 발사된다.
+      denyIfForbidden(e, set, get)
+      // 그 외는 조용히 실패 — 사용자가 요청한 작업이 아니다.
+    } finally {
+      // 실패해도 반드시 내린다. 세워둔 채 끝나면 일괄 생성 버튼이 영구히
+      // 비활성화되고 이후 자동 실행도 자기 가드에 막힌다.
+      set({ isBatchGenerating: false })
     }
   },
 


### PR DESCRIPTION
## Summary

- 자동요약이 `GET /api/agent-sessions?limit=200` 으로 최근 200 건만 훑어 그 창 밖의 미요약 세션에 영원히 닿지 못하던 문제를 고친다
- 목록을 넓히는 대신 **창이 없는 서버 배치**(`generate-batch`)로 위임한다 — `_discover_with_monitors` 가 전체 세션을 훑는다
- 부수적으로 같은 세션에 1.7s 간격으로 두 번 POST 가 나가던 문제도 함께 사라진다

## 배경 (실측)

미요약 267 건이 **전부 창 밖의 오래된 Codex 세션**이었다. Codex 요약은 #384 로 하루 전 도입된 기능이라 회귀가 아닌 기능 이전 백로그지만, 자동으로는 소진되지 않고 수동 "일괄 요약 생성" 버튼(50 건)을 여섯 번 눌러야 하는 상태였다.

| 확인 항목 | 값 |
|---|---|
| 요약 생성 성공 / 실패 | 202 건 / 0 건 |
| 개별 자동요약 POST | 52 건, 전부 200 |
| 배치 처리량 | 50 요청 → 캐시 정확히 50 개 (실측 333s) |
| pending | 267 → 0 (`limit=300` 배치 1 회, 195/195 성공) |

## Changes

**`stores/claudeSessions/index.ts`**

- `autoGenerateMissingSummaries` 가 목록 조회 + 세션별 POST 루프 대신 `POST /api/claude-sessions/summaries/generate-batch?limit=20&skip_existing=true` 1 회를 호출
- 서버가 이미 가진 요청 간 지연 2s·재시도 3 회를 그대로 얻는다 (프론트 루프에는 페이싱이 없었다)
- 자동 실행도 `isBatchGenerating` 을 세우고 `finally` 에서 내린다 — 읽기만 하면 가드가 자기 자신에게 무력해 새로고침·필터 변경이 같은 후보를 다시 집는다
- 단건 생성(`generatingSummaryFor`)과도 상호 배제 — 그 세션은 아직 캐시가 없어 배치 후보에 그대로 들어온다
- 수동 배치의 `batchProgress`·`batchJustCompleted` 는 건드리지 않는다. 후자는 일괄 생성 버튼을 숨기는 플래그라 자동이 세우면 사용자가 백로그를 직접 소진할 수단을 잃는다

**`limit=20` 근거** — 건당 실측 6.7s 라 정상 133s. 막히는 세션 하나가 372s(재시도 3 회 × httpx 120s)라 1 건까지는 499s 로 클라이언트 타임아웃 600s 안이다. 2 건부터는 어떤 limit 으로도 못 막는다(10 건이어도 797s) — 막힌 건 하나의 비용이 배치 전체보다 크기 때문. 근거를 주석에 남겼다.

**`__tests__/claudeSessions.test.ts`**

- 새 동작 11 개 테스트 (위임·상한·in-flight·상호배제·UI 상태 불변·403)
- `resetStore()` 에 빠져 있던 `permissionDenied` 를 채웠다. 없으면 앞선 403 테스트가 세운 플래그가 뒤 테스트로 새어, 호출이 안 나간 이유가 코드가 아니라 앞 테스트라는 사실이 드러나지 않는다

## Codex 리뷰 3 라운드

| 라운드 | 지적 | 처리 |
|---|---|---|
| 1차 | [P1] 자동 배치가 자기를 in-flight 표시 안 함 | 반영 |
| 2차 | [P2] 단건 생성과 상호 배제 (회귀) | 반영 |
| 2차 | [P2] 최악 런타임 주석 과신 | 반영 (재계산 후 정정) |
| 2차 | [P2] 진행 중 끄기가 배치를 못 멈춤 | **미반영** — abort 해도 서버는 끝까지 돌아 취소가 표시상의 것일 뿐. 대신 붙잡히는 구간이 200 건에서 20 건으로 짧아졌다 |
| 3차 | [P2] 필터(project/source_user) 미전달 | **미반영** — 필터를 존중하면 필터를 건 사용자가 다른 프로젝트 백로그에 영원히 못 닿는다. 이 변경이 없앤 "최근 200 건" 창과 축만 다른 같은 문제다. 필터 밖 요약은 낭비가 아니라 선반영이고(캐시 값은 어디서 만들어도 같다) 미요약 배지도 필터가 없으면 전체를 센다 |

미반영 2 건은 사유를 코드 주석에 `(Codex [P2], 미반영)` 로 남겼다.

## 동작 변화

- 필터가 걸려 있어도 전체 세션을 대상으로 요약한다 (위 3차 항목 참조)
- 자동 실행 중에는 일괄 생성 버튼이 비활성화되고 스피너가 돈다 — 실제로 생성 중이므로 정직한 표시

## Test Plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run lint` — 0 건
- [x] `npx vitest run` — 4479 passed (211 files)
- [x] `npm run build` — OK
- [x] Red-Green: 구현을 HEAD 버전으로 되돌려 새 테스트 4 건이 실패하는 것을 확인 후 복원
- [ ] 대시보드에서 Agent Sessions 페이지 새로고침 → 미요약 배지가 남아 있으면 자동으로 20 건씩 줄어드는지 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Ud1j4pa5DZ54TL6DFfAi