### PR TITLE
feat: optimize dashboard bootstrap rendering

### DIFF
--- a/docs/plans/ssr-bootstrap-performance.md
+++ b/docs/plans/ssr-bootstrap-performance.md
@@ -1,0 +1,137 @@
+# SSR Bootstrap and Client Bundle Performance Implementation Plan
+
+> **For Hermes:** Implement this plan in the dedicated Orca-managed worktree only. Do not merge, push, deploy, or modify unrelated worktree paths.
+
+**Goal:** Reduce authenticated dashboard startup latency and unnecessary client JavaScript without attempting a risky full SSR migration.
+
+**Architecture:** Add an authenticated FastAPI bootstrap endpoint that returns the minimum user-scoped startup data needed by the dashboard, while preserving the current browser-rendered React/WebSocket model. Consume that payload once after auth hydration, then remove redundant startup fetches. Independently remove ineffective public-page static imports so Vite can split those routes. Do not change token storage to HttpOnly in this slice; document it as a prerequisite for true protected SSR.
+
+**Tech Stack:** FastAPI, Pydantic, React 19, TypeScript, Zustand, Vite, Vitest, pytest.
+
+---
+
+## Scope
+
+### In scope
+
+- `GET /api/bootstrap`, authenticated with the existing `get_current_user` dependency.
+- Response fields needed for startup only: current user, accessible projects, available LLM models, and menu visibility/order if existing backend contracts expose them safely.
+- Frontend bootstrap consumption after auth hydration, with explicit loading/error behavior and no duplicate project/model/menu requests.
+- Route-level public page code splitting for Login/Register/InvitationAccept.
+- Backend and frontend tests for response authorization, response shape, store seeding, request deduplication, and route loading.
+- Build/lint/type/test verification and bundle-size comparison.
+
+### Out of scope
+
+- Full React SSR, React Server Components, Next.js migration, or replacing Nginx with a Node SSR runtime.
+- HttpOnly cookie migration, refresh-token redesign, or auth protocol changes.
+- WebSocket/SSE/Monitor/Playground/Git/Workflow rendering changes.
+- Cache policy that could mix users, organizations, projects, or roles.
+- Git commit, push, PR, merge, deployment, or infrastructure restart.
+
+## Acceptance criteria
+
+1. Unauthenticated `GET /api/bootstrap` returns the existing authentication failure contract; an authenticated user receives only data authorized for that user.
+2. The dashboard obtains startup user-scoped data from one bootstrap request after auth hydration, without issuing redundant equivalent project/model/menu requests.
+3. Existing realtime connection and page-specific fetch behavior remain unchanged outside the startup data path.
+4. Login, Register, and InvitationAccept are not statically imported by `App.tsx`; the production build no longer emits the corresponding ineffective dynamic-import warnings.
+5. Tests cover the endpoint, frontend bootstrap success/failure, and public route rendering/loading behavior.
+6. `src/dashboard`: `npm run type-check`, `npm run lint`, `npm run test:run`, and `npm run build` pass.
+7. Backend focused tests and the project-prescribed backend suite pass, or any unrelated baseline failure is reported with exact evidence.
+8. No existing changes in the parent `main` worktree are touched.
+
+## Implementation tasks
+
+### Task 1: Establish endpoint contract with failing backend tests
+
+**Files:**
+- Create or modify the smallest existing backend API test module under `tests/backend/`.
+- Modify the backend route registration/model module only after the test is red.
+
+**Steps:**
+1. Identify existing helpers for `UserResponse`, project listing, model listing, and menu visibility. Reuse them; do not duplicate authorization logic.
+2. Add tests for authenticated response shape and unauthenticated rejection.
+3. Run the focused tests and verify failure because `/api/bootstrap` is absent.
+
+### Task 2: Implement the authenticated bootstrap endpoint
+
+**Files:**
+- Modify the existing auth/core API router and/or create a narrowly scoped bootstrap module under `src/backend/api/`.
+- Add response models beside the owning API models.
+
+**Rules:**
+- Use `get_current_user` and existing project access filtering.
+- Do not expose access/refresh tokens, secrets, filesystem paths not already exposed by `/api/projects`, or cross-organization data.
+- Keep the response explicit and versionable; do not return arbitrary store-shaped dictionaries.
+- Preserve existing endpoint contracts.
+
+**Steps:**
+1. Implement the minimum response model and handler.
+2. Run focused backend tests and verify green.
+3. Run the relevant backend API tests.
+
+### Task 3: Add frontend bootstrap service/store integration with failing tests first
+
+**Files:**
+- Modify `src/dashboard/src/services/` for the request function if needed.
+- Modify `src/dashboard/src/App.tsx` and the owning Zustand stores.
+- Add/modify adjacent Vitest tests under `src/dashboard/src/**/__tests__/`.
+
+**Rules:**
+- Start bootstrap only after auth hydration and a usable access/refresh token exist.
+- Coalesce one in-flight bootstrap request; do not create a request loop.
+- Seed existing stores through their public state/actions without changing WebSocket semantics.
+- On bootstrap failure, preserve the current fallback/error behavior and do not silently treat missing authorized data as an empty dataset.
+- Keep `/api/auth/status` public check and current-user authentication behavior intact unless the tested bootstrap contract explicitly replaces a duplicate call.
+
+**Steps:**
+1. Write failing tests for one bootstrap request, store seeding, and failure state.
+2. Run focused tests to confirm red.
+3. Implement the smallest integration.
+4. Run focused tests to confirm green.
+
+### Task 4: Remove ineffective public-page static imports
+
+**Files:**
+- Modify `src/dashboard/src/App.tsx`.
+- Modify `src/dashboard/src/routes.tsx` only if route lookup/types require it.
+- Extend relevant page tests if behavior changes.
+
+**Rules:**
+- Remove static imports for LoginPage, RegisterPage, and InvitationAcceptPage from `App.tsx`.
+- Render their existing lazy route components for the matching public views.
+- Keep AuthCallbackPage eager only if its provider prop requires it; do not change OAuth behavior.
+- Preserve public-route redirect and loading/error boundaries.
+
+**Steps:**
+1. Add or update a test proving public views still render.
+2. Run the focused test.
+3. Apply the import/render refactor.
+4. Run the focused test and production build; confirm ineffective dynamic-import warnings are gone for those pages.
+
+### Task 5: Full verification and artifact report
+
+**Files:**
+- No new production files unless required by the tested implementation.
+- Optional local-only benchmark output must remain ignored and must not be committed.
+
+**Commands:**
+- Backend: `cd src/backend && uv run pytest ../../tests/backend -v --tb=short`
+- Dashboard: `cd src/dashboard && npm run type-check`
+- Dashboard: `cd src/dashboard && npm run lint`
+- Dashboard: `cd src/dashboard && npm run test:run`
+- Dashboard: `cd src/dashboard && npm run build`
+- Worktree: `git diff --check`, `git status --short`, `git diff --stat`
+
+**Verification:**
+- Compare the build output before/after for initial and public-route chunks.
+- Confirm no changes outside the approved scope.
+- Report local test results separately from any live/deployment state.
+- Stop before commit/push/merge/deploy.
+
+## Risks and decisions requiring Jarvis review
+
+- True protected SSR remains blocked until authentication is server-readable via a secure HttpOnly/session boundary.
+- Bootstrap response caching must be private/user-scoped; shared caching is forbidden.
+- If an existing menu/model endpoint cannot be safely reused without coupling unrelated behavior, omit it and report the remaining request rather than widening the endpoint.
+- If the current branch has concurrent edits in an in-scope file, stop and report the collision instead of overwriting.

--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -149,6 +149,7 @@ else:
     health_router = safe_import("api.health", "router")
     git_router = safe_import("api.git", "router")
     llm_models_router = safe_import("api.llm", "router")
+    bootstrap_router = safe_import("api.bootstrap", "router")
     admin_router = safe_import("api.admin", "router")
     project_access_router = safe_import("api.project_access", "router")
     invitation_router = safe_import("api.project_access", "invitation_router")
@@ -634,6 +635,8 @@ else:
             app.include_router(git_router, prefix="/api")
         if llm_models_router:
             app.include_router(llm_models_router, prefix="/api")
+        if bootstrap_router:
+            app.include_router(bootstrap_router, prefix="/api")
         if admin_router:
             app.include_router(admin_router, prefix="/api")
         if project_access_router:

--- a/src/backend/api/bootstrap.py
+++ b/src/backend/api/bootstrap.py
@@ -1,0 +1,93 @@
+"""대시보드 기동에 필요한 사용자 범위 데이터를 한 번에 내려주는 엔드포인트.
+
+인증된 대시보드는 기동 직후 `/api/auth/me`·`/api/projects`·`/api/llm/models`·
+`/api/admin/menu-visibility` 를 각각 호출한다. 이 라우터는 그 네 가지를 한 응답으로
+합쳐 왕복 횟수를 줄인다.
+
+**인가 로직을 새로 쓰지 않는다.** 각 엔드포인트의 핸들러를 그대로 호출하므로
+프로젝트 접근 필터·조직 admin 판정 같은 규칙이 두 벌이 될 일이 없다. 다만 FastAPI
+핸들러는 평범한 함수가 아니라서, 재사용할 때는 **모든 인자를 명시적으로** 넘겨야
+한다 — 기본값이 `None`/`False` 가 아니라 `Depends(...)`/`Query(...)` 객체이고,
+그 객체는 truthy 라서 조용히 엉뚱한 분기를 탄다 (아래 `get_models` 주석 참조).
+"""
+
+import logging
+
+from asyncpg import PostgresError
+from fastapi import APIRouter, Depends, Response
+from pydantic import BaseModel
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.admin import MenuVisibilityResponse, get_menu_visibility
+from api.auth import UserResponse, get_current_user_info
+from api.deps import get_current_user, get_db_session
+from api.llm import ModelResponse, get_models
+from api.routes import get_projects
+from db.models import UserModel
+from models.project import ProjectResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["bootstrap"])
+
+# 사용자 범위 응답이다. 공유 캐시(프록시·CDN)에 들어가면 다른 사용자에게
+# 남의 프로젝트 목록이 나갈 수 있으므로 저장 자체를 금지한다.
+_PRIVATE_CACHE_CONTROL = "private, no-store"
+
+
+class BootstrapResponse(BaseModel):
+    """기동 시점에 필요한 최소 데이터.
+
+    각 필드는 대응 엔드포인트의 응답 모델을 그대로 재사용한다 — 계약이 갈라지지
+    않게 하려는 것이고, 임의의 store 모양 딕셔너리를 내보내지 않으려는 것이다.
+    """
+
+    user: UserResponse
+    projects: list[ProjectResponse]
+    models: list[ModelResponse]
+    # `None` 은 "메뉴 설정 없음"이 아니라 **"알 수 없음"** 이다. 조회에 실패하면
+    # 클라이언트는 기존대로 `/api/admin/menu-visibility` 를 직접 호출해야 한다.
+    menu: MenuVisibilityResponse | None = None
+
+
+async def _load_menu(current_user: UserModel) -> MenuVisibilityResponse | None:
+    """메뉴 가시성을 조회하되, 실패해도 기동 전체를 끌어내리지 않는다.
+
+    `api.admin.get_menu_visibility` 는 `ImportError` 만 기본값으로 흡수하고 DB 접속
+    실패는 그대로 올린다. 그 예외가 여기까지 올라오면 user·projects·models 까지 함께
+    사라져 기동이 오늘보다 나빠지므로, DB 계열 실패만 좁게 잡아 `None` 을 돌려준다.
+    범위를 넓히지 않는 것이 중요하다 — 그 핸들러의 인가 버그가 언젠가 예외로
+    드러날 때 그것까지 삼키면 프런트가 "모든 메뉴 표시" 로 덮어버린다.
+    """
+    try:
+        return await get_menu_visibility(current_user)
+    except (SQLAlchemyError, PostgresError, OSError, ImportError) as exc:
+        logger.warning(
+            "bootstrap: menu visibility unavailable for user %s: %s", current_user.id, exc
+        )
+        return None
+
+
+@router.get("/bootstrap", response_model=BootstrapResponse)
+async def get_bootstrap(
+    response: Response,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> BootstrapResponse:
+    """기동에 필요한 사용자 범위 데이터를 한 번에 반환한다."""
+    response.headers["Cache-Control"] = _PRIVATE_CACHE_CONTROL
+
+    user = await get_current_user_info(current_user=current_user)
+    projects = await get_projects(current_user=current_user, db=db)
+    # 인자 3개를 모두 넘기는 것은 필수다. 생략하면 `provider` 가 `Query` 객체가 돼
+    # truthy 분기를 타고 `LLMProvider(<Query>)` 가 터져 **빈 목록**이 조용히 나간다
+    # (실측: 인자 없이 total 0, 명시하면 total 25).
+    models = await get_models(provider=None, available_only=False, include_disabled=False)
+
+    return BootstrapResponse(
+        user=user,
+        projects=projects,
+        models=models.models,
+        menu=await _load_menu(current_user),
+    )

--- a/src/backend/api/routes.py
+++ b/src/backend/api/routes.py
@@ -131,7 +131,7 @@ async def get_inactive_project_paths(db: AsyncSession) -> set[str]:
 
 async def _get_accessible_paths_for_user(
     db: AsyncSession, user_id: str, admin_org_ids: list[str] | None = None
-) -> set[str] | None:
+) -> set[str]:
     """파일시스템 프로젝트의 접근 가능한 path set을 반환.
 
     ProjectModel.path <-> project_access(project_id) 를 크로스레퍼런스하여
@@ -142,15 +142,9 @@ async def _get_accessible_paths_for_user(
         - 일반 member: 명시적 ProjectAccess만
 
     Returns:
-        - None: DB 미사용 -> 필터링 스킵
-        - set[str]: 접근 가능한 path 집합
+        - set[str]: 접근 가능한 path 집합. DB registry/ACL 조회 실패 시 503으로
+          fail-closed 처리한다.
     """
-    import os
-
-    use_database = os.getenv("USE_DATABASE", "false").lower() == "true"
-    if not use_database:
-        return None
-
     try:
         from sqlalchemy import select
 
@@ -193,6 +187,8 @@ async def _get_accessible_paths_for_user(
 
         return accessible_paths
 
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(
             status_code=503,
@@ -283,33 +279,27 @@ async def get_projects(
     if not use_database:
         inactive_paths = await get_inactive_project_paths(db)
 
-    # Filter by accessible projects if user is authenticated
+    # Filter by accessible projects if user is authenticated.
+    # In filesystem mode, non-admin users are still restricted by the DB
+    # registry/ACL mapping; unregistered legacy paths fail closed.
     if current_user and not use_database:
         is_admin = current_user.role == "admin" or current_user.is_admin
         if not is_admin:
-            # 조직 admin/owner 여부 확인
             from api.projects import _get_admin_org_ids
 
-            admin_org_ids = await _get_admin_org_ids(current_user)
-            accessible_paths = await _get_accessible_paths_for_user(
-                db, current_user.id, admin_org_ids
-            )
-            if accessible_paths is not None:
-                from sqlalchemy import select
-
-                from db.models import ProjectModel
-
-                path_result = await db.execute(select(ProjectModel.path))
-                db_registered_paths: set[str] = {row[0] for row in path_result.all() if row[0]}
-
-                filtered = []
-                for p in projects:
-                    if p.path not in db_registered_paths:
-                        # DB에 등록되지 않은 레거시 프로젝트 -> 인증 사용자 모두 표시
-                        filtered.append(p)
-                    elif p.path in accessible_paths:
-                        filtered.append(p)
-                projects = filtered
+            try:
+                admin_org_ids = await _get_admin_org_ids(current_user)
+                accessible_paths = await _get_accessible_paths_for_user(
+                    db, current_user.id, admin_org_ids
+                )
+            except HTTPException:
+                raise
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Project access control is temporarily unavailable",
+                ) from exc
+            projects = [p for p in projects if p.path in accessible_paths]
 
     # Try to get RAG stats if available
     try:

--- a/src/dashboard/src/App.tsx
+++ b/src/dashboard/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import type { ComponentType } from 'react'
 import { Sidebar } from './components/Sidebar'
 import { ChatInput } from './components/ChatInput'
 import { ApprovalBanner } from './components/ApprovalModal'
@@ -7,11 +8,13 @@ import { HealthBadge } from './components/HealthBadge'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { useOrchestrationStore } from './stores/orchestration'
 import { useNavigationStore, isPublicView } from './stores/navigation'
-import { useAuthStore } from './stores/auth'
+import { useAuthStore, getAuthSessionKey } from './stores/auth'
+import { useProjectsStore } from './stores/projects'
 import { useMenuVisibilityStore } from './stores/menuVisibility'
 import { useSettingsStore } from './stores/settings'
 import { routes } from './routes'
 import { analytics } from './services/analytics'
+import { fetchBootstrap } from './services/bootstrap'
 import { apiClient } from '@/services/apiClient'
 import {
   SidebarSkeleton,
@@ -20,11 +23,18 @@ import {
 import { Skeleton } from './components/ui/Skeleton'
 import { RotateCcw, Trash2 } from 'lucide-react'
 
-// Eager-load login/register (needed before auth check)
-import { LoginPage } from './pages/LoginPage'
-import { RegisterPage } from './pages/RegisterPage'
+// AuthCallbackPage is eager-loaded because its provider prop is required.
 import { AuthCallbackPage } from './pages/AuthCallbackPage'
-import { InvitationAcceptPage } from './pages/InvitationAcceptPage'
+
+const getPublicPage = (view: string): ComponentType => {
+  const route = routes.find((candidate) => candidate.view === view && candidate.isPublic)
+  if (!route) throw new Error(`Missing public route: ${view}`)
+  return route.element as ComponentType
+}
+
+const LoginPage = getPublicPage('login')
+const RegisterPage = getPublicPage('register')
+const InvitationAcceptPage = getPublicPage('invitation-accept')
 
 const viewTitles: Record<string, string> = {
   dashboard: 'Dashboard',
@@ -59,10 +69,14 @@ export default function App() {
     connectionStatus,
     _hasHydrated: orchestrationHydrated,
   } = useOrchestrationStore()
+  const {
+    visibility,
+    isLoaded: menuLoaded,
+    isFallback,
+  } = useMenuVisibilityStore()
   const { currentView, setView } = useNavigationStore()
   const {
     _hasHydrated: authHydrated,
-    fetchCurrentUser,
     user,
   } = useAuthStore()
 
@@ -76,6 +90,8 @@ export default function App() {
     github_enabled: boolean
     email_enabled: boolean
   } | null>(null)
+  const [bootstrapLoading, setBootstrapLoading] = useState(false)
+  const [bootstrapError, setBootstrapError] = useState<string | null>(null)
 
   // Derived values
   const oauthEnabled = authStatus?.oauth_enabled ?? null
@@ -87,13 +103,15 @@ export default function App() {
     analytics.init()
   }, [])
 
-  // LLM 모델 목록 로드 (앱 마운트 시 1회, 이미 로드/로딩 중이면 스킵)
+  // Keep the legacy public model lookup for installations with auth disabled.
   useEffect(() => {
+    if (authStatus === null || anyAuthAvailable) return
     const { availableModels, modelsLoading, fetchModels } = useSettingsStore.getState()
-    if (availableModels.length === 0 && !modelsLoading) {
-      fetchModels()
+    if (availableModels.length === 0 && !modelsLoading) void fetchModels()
+    if (!useMenuVisibilityStore.getState().isLoaded) {
+      void useMenuVisibilityStore.getState().fetchVisibility()
     }
-  }, [])
+  }, [authStatus, anyAuthAvailable])
 
   // 페이지뷰 추적
   useEffect(() => {
@@ -128,12 +146,61 @@ export default function App() {
     }
   }, [authHydrated, accessToken, refreshToken, currentView, setView, anyAuthAvailable])
 
-  // Fetch current user on mount if authenticated but no user data
+  const bootstrapGeneration = useRef(0)
+  const sessionKeyRef = useRef<string | null>(null)
+  const sessionKey = getAuthSessionKey()
+
+  // Reset user-scoped startup state whenever the authenticated session changes.
+  // This runs before the bootstrap effect below, so no response can cross users.
   useEffect(() => {
-    if (authHydrated && (accessToken || refreshToken) && !user) {
-      fetchCurrentUser()
-    }
-  }, [authHydrated, accessToken, refreshToken, user, fetchCurrentUser])
+    if (sessionKeyRef.current === sessionKey) return
+    sessionKeyRef.current = sessionKey
+    bootstrapGeneration.current += 1
+    useAuthStore.setState({ user: null, error: null })
+    useProjectsStore.getState().reset()
+    useSettingsStore.getState().resetModels()
+    useMenuVisibilityStore.getState().reset()
+  }, [sessionKey])
+
+  // Load authenticated startup data in one request, then seed existing stores.
+  useEffect(() => {
+    if (!authHydrated || !sessionKey) return
+
+    const generation = ++bootstrapGeneration.current
+    setBootstrapLoading(true)
+    fetchBootstrap(sessionKey)
+      .then((payload) => {
+        if (generation !== bootstrapGeneration.current || getAuthSessionKey() !== sessionKey) return
+
+        useAuthStore.getState().hydrateUser(payload.user)
+        useProjectsStore.getState().hydrateProjects(payload.projects)
+        useSettingsStore.getState().hydrateModels(payload.models)
+        if (payload.menu) {
+          useMenuVisibilityStore.getState().hydrateVisibility(payload.menu)
+        } else {
+          void useMenuVisibilityStore.getState().fetchVisibility()
+        }
+        setBootstrapError(null)
+      })
+      .catch((error: unknown) => {
+        if (generation !== bootstrapGeneration.current || getAuthSessionKey() !== sessionKey) return
+
+        const message = error instanceof Error ? error.message : 'Failed to load startup data'
+        setBootstrapError(message)
+        // Preserve the previous startup behavior if the aggregate request fails.
+        void Promise.all([
+          useAuthStore.getState().fetchCurrentUser(),
+          useProjectsStore.getState().fetchProjects(),
+          useSettingsStore.getState().fetchModels(),
+          useMenuVisibilityStore.getState().fetchVisibility(),
+        ]).catch(() => undefined)
+      })
+      .finally(() => {
+        if (generation === bootstrapGeneration.current && getAuthSessionKey() === sessionKey) {
+          setBootstrapLoading(false)
+        }
+      })
+  }, [authHydrated, sessionKey])
 
   // Check if authenticated (or if no auth method available, skip auth check)
   const isLoggedIn = !anyAuthAvailable || !!(accessToken || refreshToken)
@@ -174,8 +241,8 @@ export default function App() {
     }
   }, [orchestrationHydrated, authHydrated, isLoggedIn, sessionId, connected, connectionStatus]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Show loading while hydrating or checking auth status
-  if (!authHydrated || authStatus === null) {
+  // Show loading while hydrating, checking auth, or loading the first user payload.
+  if (!authHydrated || authStatus === null || (isLoggedIn && bootstrapLoading && !user)) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
         <div className="text-center">
@@ -219,12 +286,14 @@ export default function App() {
     }
 
     // 역할 기반 접근 제어
-    const { visibility } = useMenuVisibilityStore.getState()
     const userRole = user?.role || (user?.is_admin ? 'admin' : 'user')
+    if (anyAuthAvailable && userRole !== 'admin' && currentView !== 'dashboard' && (!menuLoaded || isFallback)) {
+      setView('dashboard')
+      return null
+    }
     if (
       userRole !== 'admin' &&
       currentView !== 'dashboard' &&
-      currentView !== 'settings' &&
       visibility[currentView]
     ) {
       const allowed = visibility[currentView][userRole]
@@ -314,6 +383,11 @@ export default function App() {
 
           {/* HITL Approval Banner */}
           {!isInitialLoading && <ApprovalBanner />}
+          {bootstrapError && (
+            <div role="alert" className="border-b border-amber-200 bg-amber-50 px-6 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+              Startup data could not be loaded in one request. Using individual requests instead.
+            </div>
+          )}
 
           {/* Content Area */}
           <div className="flex-1 flex overflow-hidden">

--- a/src/dashboard/src/components/Sidebar.tsx
+++ b/src/dashboard/src/components/Sidebar.tsx
@@ -62,19 +62,12 @@ export function Sidebar() {
   const visibility = useMenuVisibilityStore(s => s.visibility)
   const menuOrder = useMenuVisibilityStore(s => s.menuOrder)
   const isLoaded = useMenuVisibilityStore(s => s.isLoaded)
-  const fetchVisibility = useMenuVisibilityStore(s => s.fetchVisibility)
-
+  const isFallback = useMenuVisibilityStore(s => s.isFallback)
   useEffect(() => {
     fetchProjects()
   }, [fetchProjects])
 
-  // 사용자 변경 시 메뉴 가시성 재로딩 (다른 계정으로 전환 시 stale data 방지)
-  useEffect(() => {
-    if (user?.id) {
-      useMenuVisibilityStore.setState({ isLoaded: false, menuOrder: [], visibility: {} })
-      fetchVisibility()
-    }
-  }, [user?.id, fetchVisibility])
+  // Menu visibility is hydrated by App's authenticated bootstrap flow.
 
   const userRole = user?.role || (user?.is_admin ? 'admin' : 'user')
 
@@ -88,6 +81,7 @@ export function Sidebar() {
       .map((view) => navByView.get(view as ViewType))
       .filter((n): n is (typeof navigation)[number] => n !== undefined)
 
+    if (isFallback && userRole !== 'admin') return sorted.filter((item) => item.view === 'dashboard')
     if (userRole === 'admin') return sorted // admin은 모든 메뉴 접근 가능
 
     return sorted.filter((item) => {
@@ -95,13 +89,13 @@ export function Sidebar() {
       if (!menuVisibility) return true // 설정 없으면 기본 표시
       return menuVisibility[userRole] !== false
     })
-  }, [visibility, menuOrder, userRole])
+  }, [visibility, menuOrder, userRole, isFallback])
 
   // Admin 메뉴 표시 여부
-  const showAdmin = userRole === 'admin' || (visibility['admin']?.[userRole] ?? false)
+  const showAdmin = userRole === 'admin' || (!isFallback && (visibility['admin']?.[userRole] ?? false))
 
   // Settings 메뉴 표시 여부
-  const showSettings = userRole === 'admin' || (visibility['settings']?.[userRole] ?? true)
+  const showSettings = userRole === 'admin' || (!isFallback && (visibility['settings']?.[userRole] ?? true))
 
   // 첫 fetch 종료 전에는 Skeleton — DEFAULT_MENU_ORDER가 잠깐 노출 후 재정렬되는 깜빡임 차단.
   if (!isLoaded) return <SidebarSkeleton />

--- a/src/dashboard/src/pages/ProjectsPage.test.tsx
+++ b/src/dashboard/src/pages/ProjectsPage.test.tsx
@@ -78,6 +78,7 @@ const defaultStoreState = {
   showInactive: false,
   selectedProjectId: null,
   fetchProjects: mockFetchProjects,
+  ensureProjects: mockFetchProjects,
   fetchTemplates: mockFetchTemplates,
   setSearchQuery: mockSetSearchQuery,
   setShowInactive: mockSetShowInactive,

--- a/src/dashboard/src/pages/ProjectsPage.tsx
+++ b/src/dashboard/src/pages/ProjectsPage.tsx
@@ -275,6 +275,7 @@ export function ProjectsPage() {
     showInactive,
     selectedProjectId,
     fetchProjects,
+    ensureProjects,
     fetchTemplates,
     setSearchQuery,
     setShowInactive,
@@ -336,9 +337,9 @@ export function ProjectsPage() {
   }
 
   useEffect(() => {
-    fetchProjects()
+    ensureProjects()
     fetchTemplates()
-  }, [fetchProjects, fetchTemplates])
+  }, [ensureProjects, fetchTemplates])
 
   // Handle navigation to Project Configs page
   useEffect(() => {

--- a/src/dashboard/src/pages/SettingsPage.test.tsx
+++ b/src/dashboard/src/pages/SettingsPage.test.tsx
@@ -68,6 +68,7 @@ vi.mock('../stores/settings', () => ({
     setNotificationSetting: mockSetNotificationSetting,
     setPreferredTerminal: mockSetPreferredTerminal,
     fetchModels: vi.fn(),
+    ensureModels: vi.fn(),
     ...getSettingsOverrides(),
   }),
   Theme: {},

--- a/src/dashboard/src/pages/SettingsPage.tsx
+++ b/src/dashboard/src/pages/SettingsPage.tsx
@@ -31,7 +31,7 @@ export function SettingsPage() {
     setNotificationSetting,
     preferredTerminal,
     setPreferredTerminal,
-    fetchModels,
+    ensureModels,
   } = useSettingsStore()
 
   const { connected, connect, disconnect } = useOrchestrationStore()
@@ -187,8 +187,8 @@ export function SettingsPage() {
 
   // Fetch models from API on mount (populates availableModels for MemberDetailPanel)
   useEffect(() => {
-    fetchModels()
-  }, [fetchModels])
+    ensureModels()
+  }, [ensureModels])
 
   const handleReconnect = () => {
     disconnect()

--- a/src/dashboard/src/services/__tests__/bootstrap.test.ts
+++ b/src/dashboard/src/services/__tests__/bootstrap.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchBootstrap } from '../bootstrap'
+import { apiClient } from '../apiClient'
+
+vi.mock('../apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}))
+
+const mockedGet = vi.mocked(apiClient.get)
+
+const payload = {
+  user: {
+    id: 'user-1',
+    email: 'user@example.com',
+    name: 'User',
+    avatar_url: null,
+    oauth_provider: 'email' as const,
+    is_admin: false,
+    role: 'user' as const,
+  },
+  projects: [],
+  models: [],
+  menu: null,
+}
+
+describe('fetchBootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('coalesces concurrent startup requests', async () => {
+    let resolveRequest: ((value: typeof payload) => void) | undefined
+    mockedGet.mockReturnValueOnce(
+      new Promise<typeof payload>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+
+    const first = fetchBootstrap()
+    const second = fetchBootstrap()
+
+    expect(first).toBe(second)
+    expect(mockedGet).toHaveBeenCalledTimes(1)
+
+    resolveRequest?.(payload)
+    await expect(first).resolves.toEqual(payload)
+  })
+
+  it('does not share an in-flight request across auth sessions', async () => {
+    let resolveFirst: ((value: typeof payload) => void) | undefined
+    mockedGet
+      .mockReturnValueOnce(
+        new Promise<typeof payload>((resolve) => {
+          resolveFirst = resolve
+        }),
+      )
+      .mockResolvedValueOnce(payload)
+
+    const first = fetchBootstrap('session-a')
+    const second = fetchBootstrap('session-b')
+
+    expect(first).not.toBe(second)
+    expect(mockedGet).toHaveBeenCalledTimes(2)
+
+    resolveFirst?.(payload)
+    await expect(first).resolves.toEqual(payload)
+    await expect(second).resolves.toEqual(payload)
+  })
+
+  it('allows a later request after the previous one settles', async () => {
+    mockedGet.mockResolvedValueOnce(payload).mockResolvedValueOnce(payload)
+
+    await expect(fetchBootstrap()).resolves.toEqual(payload)
+    await expect(fetchBootstrap()).resolves.toEqual(payload)
+
+    expect(mockedGet).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/dashboard/src/services/apiClient.ts
+++ b/src/dashboard/src/services/apiClient.ts
@@ -9,7 +9,7 @@
 import { ApiError, ApiErrorCode, errorCodeFromStatus } from './errors'
 import { getApiUrl } from '../config/api'
 import { analytics } from './analytics'
-import { useAuthStore } from '../stores/auth'
+import { useAuthStore, getAuthSessionKey } from '../stores/auth'
 
 // ---------------------------------------------------------------------------
 // Config & interceptor types
@@ -85,7 +85,7 @@ class ApiClient {
 
   private requestInterceptors: RequestInterceptor[] = []
   private responseInterceptors: ResponseInterceptor[] = []
-  private refreshPromise: Promise<void> | null = null
+  private refreshPromise: { key: string; marker: object; promise: Promise<void> } | null = null
 
   constructor(config: ApiClientConfig) {
     this.config = {
@@ -285,12 +285,15 @@ class ApiClient {
   // ── Token refresh ────────────────────────────────────────
 
   private async refreshToken(): Promise<void> {
-    // Coalesce concurrent refresh attempts
-    if (this.refreshPromise) {
-      return this.refreshPromise
+    const sessionKey = getAuthSessionKey()
+    const existing = this.refreshPromise
+    // Coalesce only requests from the same auth session.
+    if (existing?.key === sessionKey) {
+      return existing.promise
     }
 
-    this.refreshPromise = (async () => {
+    const marker = {}
+    const refreshRequest = (async () => {
       try {
         const success = await useAuthStore.getState().refreshAccessToken()
         if (!success) {
@@ -301,11 +304,14 @@ class ApiClient {
           })
         }
       } finally {
-        this.refreshPromise = null
+        if (this.refreshPromise?.marker === marker) {
+          this.refreshPromise = null
+        }
       }
     })()
 
-    return this.refreshPromise
+    this.refreshPromise = { key: sessionKey, marker, promise: refreshRequest }
+    return refreshRequest
   }
 
   // ── Error builder ────────────────────────────────────────

--- a/src/dashboard/src/services/bootstrap.ts
+++ b/src/dashboard/src/services/bootstrap.ts
@@ -1,0 +1,36 @@
+import { apiClient } from './apiClient'
+import type { User } from '../stores/auth'
+import type { Project } from '../stores/projects'
+import type { LLMModel } from '../stores/settings'
+
+export interface BootstrapMenu {
+  visibility: Record<string, Record<string, boolean>>
+  menu_order: string[]
+}
+
+export interface BootstrapResponse {
+  user: User
+  projects: Project[]
+  models: LLMModel[]
+  menu: BootstrapMenu | null
+}
+
+let inFlightBootstrap: { key: string; promise: Promise<BootstrapResponse> } | null = null
+
+/**
+ * Fetch the authenticated startup payload once per request burst and auth key.
+ * Concurrent callers for the same auth session share one promise; a different
+ * session never inherits an earlier user's response.
+ */
+export function fetchBootstrap(requestKey = ''): Promise<BootstrapResponse> {
+  if (inFlightBootstrap?.key === requestKey) return inFlightBootstrap.promise
+
+  const request = apiClient.get<BootstrapResponse>('/api/bootstrap')
+  const trackedRequest = request.finally(() => {
+    if (inFlightBootstrap?.promise === trackedRequest) {
+      inFlightBootstrap = null
+    }
+  })
+  inFlightBootstrap = { key: requestKey, promise: trackedRequest }
+  return trackedRequest
+}

--- a/src/dashboard/src/stores/__tests__/auth.test.ts
+++ b/src/dashboard/src/stores/__tests__/auth.test.ts
@@ -213,7 +213,46 @@ describe('auth store', () => {
 
       expect(result).toBe(false)
     })
+
+    it('ignores a refresh response after logout', async () => {
+      let resolveResponse!: (response: Response) => void
+      mockFetch.mockReturnValueOnce(new Promise<Response>((resolve) => {
+        resolveResponse = resolve
+      }))
+      useAuthStore.setState({ accessToken: 'old-access', refreshToken: 'old-refresh' })
+
+      const refreshPromise = useAuthStore.getState().refreshAccessToken()
+      useAuthStore.getState().logout()
+      resolveResponse(jsonResponse({ access_token: 'stale-access', refresh_token: 'stale-refresh', expires_in: 3600 }))
+
+      expect(await refreshPromise).toBe(false)
+      expect(useAuthStore.getState().accessToken).toBeNull()
+      expect(useAuthStore.getState().refreshToken).toBeNull()
+    })
+
+    it('does not overwrite a replacement session with a stale refresh response', async () => {
+      let resolveResponse!: (response: Response) => void
+      mockFetch.mockReturnValueOnce(new Promise<Response>((resolve) => {
+        resolveResponse = resolve
+      }))
+      useAuthStore.setState({ accessToken: 'old-access', refreshToken: 'old-refresh' })
+
+      const refreshPromise = useAuthStore.getState().refreshAccessToken()
+      useAuthStore.setState({ accessToken: 'new-access', refreshToken: 'new-refresh' })
+      resolveResponse(jsonResponse({ access_token: 'stale-access', refresh_token: 'stale-refresh', expires_in: 3600 }))
+
+      expect(await refreshPromise).toBe(false)
+      expect(useAuthStore.getState().accessToken).toBe('new-access')
+      expect(useAuthStore.getState().refreshToken).toBe('new-refresh')
+    })
   })
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
 
   // ── fetchCurrentUser ───────────────────────────────────
 

--- a/src/dashboard/src/stores/__tests__/menuVisibility.test.ts
+++ b/src/dashboard/src/stores/__tests__/menuVisibility.test.ts
@@ -19,6 +19,7 @@ vi.mock('../auth', () => ({
   useAuthStore: {
     getState: () => authState,
   },
+  getAuthSessionKey: () => '',
 }))
 
 import { useMenuVisibilityStore } from '../menuVisibility'
@@ -31,6 +32,7 @@ function resetStore() {
     visibility: {},
     menuOrder: [],
     isLoaded: false,
+    isFallback: false,
   })
 }
 

--- a/src/dashboard/src/stores/__tests__/projects.test.ts
+++ b/src/dashboard/src/stores/__tests__/projects.test.ts
@@ -449,3 +449,82 @@ describe('projects store', () => {
     })
   })
 })
+
+// ── Startup hydration guard ──────────────────────────────
+// Bootstrap seeds the store once; page mounts must not refetch the same list.
+
+describe('projects store hydration guard', () => {
+  beforeEach(() => {
+    useProjectsStore.setState({
+      projects: [],
+      isLoading: false,
+      error: null,
+      selectedProjectId: null,
+      isHydrated: false,
+    })
+    vi.clearAllMocks()
+  })
+
+  it('marks the store hydrated after bootstrap seeding', () => {
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
+
+    expect(useProjectsStore.getState().isHydrated).toBe(true)
+  })
+
+  it('marks the store hydrated after a successful fetch', async () => {
+    mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'One')])
+
+    await useProjectsStore.getState().fetchProjects()
+
+    expect(useProjectsStore.getState().isHydrated).toBe(true)
+  })
+
+  it('does not mark the store hydrated when the fetch fails', async () => {
+    mockApiClient.get.mockRejectedValueOnce(new Error('boom'))
+
+    await useProjectsStore.getState().fetchProjects()
+
+    expect(useProjectsStore.getState().isHydrated).toBe(false)
+  })
+
+  it('clears hydration on reset so a new session refetches', () => {
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
+    useProjectsStore.getState().reset()
+
+    expect(useProjectsStore.getState().isHydrated).toBe(false)
+  })
+
+  it('ensureProjects skips the request when already hydrated', async () => {
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
+
+    await useProjectsStore.getState().ensureProjects()
+
+    expect(mockApiClient.get).not.toHaveBeenCalled()
+  })
+
+  it('ensureProjects skips an empty-but-hydrated store', async () => {
+    useProjectsStore.getState().hydrateProjects([])
+
+    await useProjectsStore.getState().ensureProjects()
+
+    expect(mockApiClient.get).not.toHaveBeenCalled()
+  })
+
+  it('ensureProjects fetches when the store was never hydrated', async () => {
+    mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'One')])
+
+    await useProjectsStore.getState().ensureProjects()
+
+    expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects')
+  })
+
+  it('explicit fetchProjects still refetches a hydrated store (retry/mutation refresh)', async () => {
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
+    mockApiClient.get.mockResolvedValueOnce([mockProject('p-2', 'Two')])
+
+    await useProjectsStore.getState().fetchProjects()
+
+    expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects')
+    expect(useProjectsStore.getState().projects[0].id).toBe('p-2')
+  })
+})

--- a/src/dashboard/src/stores/__tests__/settings.test.ts
+++ b/src/dashboard/src/stores/__tests__/settings.test.ts
@@ -708,3 +708,50 @@ describe('theme initialization and applyThemeToDocument', () => {
     expect(useSettingsStore.getState().theme).toBe('light')
   })
 })
+
+// ── Startup hydration guard ──────────────────────────────
+// Bootstrap seeds availableModels; SettingsPage must not refetch them on mount.
+
+describe('settings store ensureModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useSettingsStore.setState({ availableModels: [], modelsLoading: false, modelsHydrated: false, modelsError: null })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('skips the request when models are already hydrated', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    useSettingsStore.getState().hydrateModels([makeModel({ id: 'm-1', provider: 'anthropic' })])
+
+    await useSettingsStore.getState().ensureModels()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('fetches when no models are loaded yet', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: [makeModel({ id: 'm-1', provider: 'anthropic' })] }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    await useSettingsStore.getState().ensureModels()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(useSettingsStore.getState().availableModels).toHaveLength(1)
+  })
+
+  it('skips while a fetch is already in flight', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    useSettingsStore.setState({ modelsLoading: true })
+
+    await useSettingsStore.getState().ensureModels()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/dashboard/src/stores/auth.ts
+++ b/src/dashboard/src/stores/auth.ts
@@ -47,6 +47,7 @@ interface AuthState {
   // Actions
   setTokens: (accessToken: string, refreshToken: string, expiresIn: number) => void
   setUser: (user: User) => void
+  hydrateUser: (user: User) => void
   logout: () => void
   refreshAccessToken: () => Promise<boolean>
   fetchCurrentUser: () => Promise<void>
@@ -97,6 +98,8 @@ export const useAuthStore = create<AuthState>()(
         analytics.track('user_logged_in', { provider: user.oauth_provider })
       },
 
+      hydrateUser: (user) => set({ user, error: null }),
+
       // Logout
       logout: () => {
         analytics.track('user_logged_out')
@@ -115,11 +118,13 @@ export const useAuthStore = create<AuthState>()(
 
       // Refresh access token
       refreshAccessToken: async () => {
-        const { refreshToken } = get()
-        if (!refreshToken) {
+        const requestRefreshToken = get().refreshToken
+        if (!requestRefreshToken) {
           get().logout()
           return false
         }
+
+        const isCurrentRefresh = () => get().refreshToken === requestRefreshToken
 
         try {
           const response = await fetch(getApiUrl('/api/auth/refresh'), {
@@ -127,16 +132,18 @@ export const useAuthStore = create<AuthState>()(
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ refresh_token: refreshToken }),
+            body: JSON.stringify({ refresh_token: requestRefreshToken }),
           })
 
           if (!response.ok) {
-            // Refresh token is invalid or expired
-            get().logout()
+            // Refresh token is invalid or expired. Do not log out a newer session.
+            if (isCurrentRefresh()) get().logout()
             return false
           }
 
           const data = await response.json()
+          // A logout/account switch may have happened while the request was in flight.
+          if (!isCurrentRefresh()) return false
           set({
             accessToken: data.access_token,
             refreshToken: data.refresh_token,
@@ -146,7 +153,7 @@ export const useAuthStore = create<AuthState>()(
           return true
         } catch (error) {
           console.error('Failed to refresh token:', error)
-          get().logout()
+          if (isCurrentRefresh()) get().logout()
           return false
         }
       },
@@ -167,12 +174,16 @@ export const useAuthStore = create<AuthState>()(
           }
         }
 
+        const requestSessionKey = `${get().accessToken ?? ''}:${get().refreshToken ?? ''}`
+        const requestAccessToken = get().accessToken
+        if (!requestAccessToken) return
+        let refreshFailed = false
         set({ isLoading: true, error: null })
 
         try {
           const response = await fetch(getApiUrl('/api/auth/me'), {
             headers: {
-              Authorization: `Bearer ${get().accessToken}`,
+              Authorization: `Bearer ${requestAccessToken}`,
             },
           })
 
@@ -184,14 +195,17 @@ export const useAuthStore = create<AuthState>()(
                 // Retry with new token
                 return get().fetchCurrentUser()
               }
+              refreshFailed = true
             }
             throw new Error('Failed to fetch user info')
           }
 
           const user = await response.json()
+          if (getAuthSessionKey() !== requestSessionKey) return
           set({ user, isLoading: false })
         } catch (error) {
           console.error('Failed to fetch user:', error)
+          if (getAuthSessionKey() !== requestSessionKey && !refreshFailed) return
           set({
             error: error instanceof Error ? error.message : 'Failed to fetch user',
             isLoading: false,
@@ -243,6 +257,11 @@ export const useAuthStore = create<AuthState>()(
     }
   )
 )
+
+export function getAuthSessionKey(): string {
+  const { accessToken, refreshToken } = useAuthStore.getState()
+  return `${accessToken ?? ''}:${refreshToken ?? ''}`
+}
 
 // ─────────────────────────────────────────────────────────────
 // Auth Fetch Wrapper

--- a/src/dashboard/src/stores/menuVisibility.ts
+++ b/src/dashboard/src/stores/menuVisibility.ts
@@ -1,20 +1,42 @@
 import { create } from 'zustand'
 import { apiClient } from '../services/apiClient'
-import { useAuthStore } from './auth'
+import { useAuthStore, getAuthSessionKey } from './auth'
 
 type MenuVisibility = Record<string, Record<string, boolean>>
+
+export interface MenuVisibilityPayload {
+  visibility: MenuVisibility
+  menu_order: string[]
+}
 
 interface MenuVisibilityState {
   visibility: MenuVisibility
   menuOrder: string[]
   isLoaded: boolean
+  isFallback: boolean
   fetchVisibility: () => Promise<void>
+  hydrateVisibility: (payload: MenuVisibilityPayload) => void
+  reset: () => void
 }
 
 export const useMenuVisibilityStore = create<MenuVisibilityState>((set, get) => ({
   visibility: {},
   menuOrder: [],
   isLoaded: false,
+  isFallback: false,
+
+  hydrateVisibility: (payload) => {
+    set({
+      visibility: payload.visibility,
+      menuOrder: payload.menu_order,
+      isLoaded: true,
+      isFallback: false,
+    })
+  },
+
+  reset: () => {
+    set({ visibility: {}, menuOrder: [], isLoaded: false, isFallback: false })
+  },
 
   fetchVisibility: async () => {
     // 이미 로드됐으면 스킵
@@ -23,20 +45,23 @@ export const useMenuVisibilityStore = create<MenuVisibilityState>((set, get) => 
     // isLoaded=true로 표시해 Sidebar가 영구 Skeleton에 갇히지 않도록 한다.
     const auth = useAuthStore.getState()
     if (!auth.isAuthenticated() || auth.isTokenExpired()) {
-      set({ isLoaded: true })
+      set({ isLoaded: true, isFallback: false })
       return
     }
 
+    const requestSessionKey = getAuthSessionKey()
     try {
       const data = await apiClient.get<{ visibility: MenuVisibility; menu_order?: string[] }>('/api/admin/menu-visibility')
+      if (getAuthSessionKey() !== requestSessionKey) return
       set({
         visibility: data.visibility,
         menuOrder: data.menu_order || [],
         isLoaded: true,
       })
     } catch {
-      // 실패 시 기본값 유지(모든 메뉴 표시) + isLoaded=true로 폴백 렌더 진입
-      set({ isLoaded: true })
+      if (getAuthSessionKey() !== requestSessionKey) return
+      // Unknown visibility must fail closed for authenticated non-admin users.
+      set({ isLoaded: true, isFallback: true, menuOrder: ['dashboard'], visibility: {} })
     }
   },
 }))

--- a/src/dashboard/src/stores/projects.ts
+++ b/src/dashboard/src/stores/projects.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { analytics } from '../services/analytics'
 import { apiClient } from '../services/apiClient'
+import { getAuthSessionKey } from './auth'
 
 export interface Project {
   id: string
@@ -45,6 +46,7 @@ interface ProjectsState {
   projects: Project[]
   templates: ProjectTemplate[]
   isLoading: boolean
+  isHydrated: boolean
   error: string | null
 
   // Modal state
@@ -60,6 +62,9 @@ interface ProjectsState {
 
   // Actions - Data
   fetchProjects: () => Promise<void>
+  ensureProjects: () => Promise<void>
+  hydrateProjects: (projects: Project[]) => void
+  reset: () => void
   fetchTemplates: () => Promise<void>
   createProject: (id: string, name: string, description: string, template: string) => Promise<boolean>
   linkProject: (id: string, sourcePath: string) => Promise<boolean>
@@ -92,6 +97,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
   projects: [],
   templates: [],
   isLoading: false,
+  isHydrated: false,
   error: null,
   modalMode: null,
   editingProject: null,
@@ -101,10 +107,12 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
 
   // Fetch all projects
   fetchProjects: async () => {
+    const requestSessionKey = getAuthSessionKey()
     set({ isLoading: true, error: null })
     try {
       const projects = await apiClient.get<Project[]>('/api/projects')
-      set({ projects, isLoading: false })
+      if (getAuthSessionKey() !== requestSessionKey) return
+      set({ projects, isLoading: false, isHydrated: true })
 
       // Auto-select first project if none selected
       const { selectedProjectId } = get()
@@ -112,8 +120,27 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
         set({ selectedProjectId: projects[0].id })
       }
     } catch (error) {
+      if (getAuthSessionKey() !== requestSessionKey) return
       set({ error: (error as Error).message, isLoading: false })
     }
+  },
+
+  ensureProjects: async () => {
+    const { isHydrated, isLoading } = get()
+    if (isHydrated || isLoading) return
+    await get().fetchProjects()
+  },
+
+  hydrateProjects: (projects) => {
+    set({ projects, isLoading: false, isHydrated: true, error: null })
+    const { selectedProjectId } = get()
+    if (!selectedProjectId && projects.length > 0) {
+      set({ selectedProjectId: projects[0].id })
+    }
+  },
+
+  reset: () => {
+    set({ projects: [], isLoading: false, isHydrated: false, error: null, selectedProjectId: null })
   },
 
   // Fetch available templates

--- a/src/dashboard/src/stores/settings.ts
+++ b/src/dashboard/src/stores/settings.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { apiClient } from '../services/apiClient'
+import { getAuthSessionKey } from './auth'
 
 export type Theme = 'light' | 'dark' | 'system'
 export type LLMProvider = 'anthropic' | 'openai' | 'google' | 'codex_cli' | 'claude_cli' | 'local'
@@ -80,6 +81,7 @@ interface SettingsState {
   // LLM Models from API
   availableModels: LLMModel[]
   modelsLoading: boolean
+  modelsHydrated: boolean
   modelsError: string | null
 
   // Actions
@@ -91,6 +93,9 @@ interface SettingsState {
   ) => void
   setPreferredTerminal: (terminal: TerminalType) => void
   fetchModels: () => Promise<void>
+  ensureModels: () => Promise<void>
+  hydrateModels: (models: LLMModel[]) => void
+  resetModels: () => void
   setDefaultModel: (modelId: string) => Promise<boolean>
   getModelsForProvider: (provider: LLMProvider) => LLMModel[]
 }
@@ -176,6 +181,7 @@ export const useSettingsStore = create<SettingsState>()(
       // LLM Models state
       availableModels: [],
       modelsLoading: false,
+      modelsHydrated: false,
       modelsError: null,
 
       // Actions
@@ -198,6 +204,7 @@ export const useSettingsStore = create<SettingsState>()(
 
       fetchModels: async () => {
         const state = get()
+        const requestSessionKey = getAuthSessionKey()
         // In-flight dedup: skip if a fetch is already running
         // (e.g. App mount and SettingsPage mount firing concurrently)
         if (state.modelsLoading) return
@@ -211,11 +218,14 @@ export const useSettingsStore = create<SettingsState>()(
           }
 
           const data = await response.json()
+          if (getAuthSessionKey() !== requestSessionKey) return
           set({
             availableModels: data.models || [],
             modelsLoading: false,
+            modelsHydrated: true,
           })
         } catch (error) {
+          if (getAuthSessionKey() !== requestSessionKey) return
           console.warn('Failed to fetch LLM models from API, using fallback:', error)
           set((current) => ({
             // Keep previously loaded models; only inject fallbacks when empty
@@ -226,6 +236,20 @@ export const useSettingsStore = create<SettingsState>()(
             modelsError: error instanceof Error ? error.message : 'Failed to fetch models',
           }))
         }
+      },
+
+      ensureModels: async () => {
+        const { modelsHydrated, modelsLoading } = get()
+        if (modelsHydrated || modelsLoading) return
+        await get().fetchModels()
+      },
+
+      hydrateModels: (models) => {
+        set({ availableModels: models, modelsLoading: false, modelsHydrated: true, modelsError: null })
+      },
+
+      resetModels: () => {
+        set({ availableModels: [], modelsLoading: false, modelsHydrated: false, modelsError: null })
       },
 
       setDefaultModel: async (modelId) => {

--- a/tests/backend/api/test_bootstrap.py
+++ b/tests/backend/api/test_bootstrap.py
@@ -18,7 +18,19 @@
 from types import SimpleNamespace
 
 import pytest
+import pytest_asyncio
 from sqlalchemy.exc import SQLAlchemyError
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _isolate_database_pool():
+    """Do not carry asyncpg pooled connections across pytest event loops."""
+    from db import database
+
+    await database.engine.dispose()
+    yield
+    await database.engine.dispose()
+
 
 ADMIN_IDENTITY = SimpleNamespace(
     id="test-admin",

--- a/tests/backend/api/test_bootstrap.py
+++ b/tests/backend/api/test_bootstrap.py
@@ -1,0 +1,196 @@
+"""`GET /api/bootstrap` 는 대시보드 기동에 필요한 사용자 범위 데이터를 한 번에 준다.
+
+기존 4개 요청(`/api/auth/me`·`/api/projects`·`/api/llm/models`·
+`/api/admin/menu-visibility`)을 대체하는 것이 목적이므로, 인가 로직을 새로 쓰지 않고
+각 엔드포인트의 핸들러를 그대로 재사용한다. 그래서 이 파일의 계약은 두 겹이다:
+
+1. 인증/인가가 기존과 동일한가 (401 계약, 사용자별 프로젝트 범위)
+2. 재사용한 핸들러가 **실제로 데이터를 반환**하는가
+
+2번이 형식적인 검사가 아닌 이유: FastAPI 핸들러는 평범한 함수가 아니다.
+`api.llm.get_models` 의 기본값은 `None`/`False` 가 아니라 `Query(...)` 객체이고,
+`Query` 객체는 truthy 라서 `get_models()` 를 그냥 호출하면 `if provider:` 분기에
+들어가 `LLMProvider(<Query>)` 가 `ValueError` 를 내고 **조용히 빈 목록**을 돌려준다
+(실측: 인자 없이 호출 → total 0, 명시 호출 → total 25). 키 존재만 단언하는
+테스트는 이 버그를 그대로 통과시키므로 아래는 비어 있지 않음을 단언한다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+ADMIN_IDENTITY = SimpleNamespace(
+    id="test-admin",
+    email="admin@example.com",
+    name="Test Admin",
+    avatar_url=None,
+    oauth_provider="email",
+    role="admin",
+    is_admin=True,
+    is_active=True,
+)
+MEMBER_IDENTITY = SimpleNamespace(
+    id="test-member",
+    email="member@example.com",
+    name="Test Member",
+    avatar_url=None,
+    oauth_provider="email",
+    role="member",
+    is_admin=False,
+    is_active=True,
+)
+
+
+def _override_user(app, identity):
+    from api.deps import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: identity
+    return lambda: app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_bootstrap_router_is_importable():
+    """`app.py` 는 `safe_import` 로 마운트하고, 그 헬퍼는 모든 예외를 삼킨다.
+
+    import 에러가 나면 라우터가 조용히 사라져 나머지 테스트가 404 를 받고
+    "아직 미구현" 처럼 읽힌다. 여기서 모듈을 **직접** import 해 실제 트레이스백을
+    드러낸다 — `safe_import` 를 거치면 그 진단이 사라진다.
+    """
+    from api.bootstrap import router
+
+    assert router is not None
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_requires_authentication(client):
+    """미인증 요청은 기존 인증 실패 계약(401)을 그대로 받는다."""
+    response = await client.get("/api/bootstrap")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_returns_startup_payload(client, app):
+    """인증 사용자는 user·projects·models 를 한 응답으로 받는다."""
+    restore = _override_user(app, ADMIN_IDENTITY)
+    try:
+        response = await client.get("/api/bootstrap")
+    finally:
+        restore()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["user"]["id"] == ADMIN_IDENTITY.id
+    assert isinstance(body["projects"], list)
+    # 빈 목록이면 Query 기본값 함정에 걸린 것이다 (모듈 docstring 참조).
+    assert body["models"], "models must not be empty — handler reused with Query defaults?"
+    assert all("id" in model for model in body["models"])
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_never_exposes_credentials(client, app):
+    """부트스트랩 응답에 토큰·시크릿이 실려서는 안 된다."""
+    restore = _override_user(app, ADMIN_IDENTITY)
+    try:
+        response = await client.get("/api/bootstrap")
+    finally:
+        restore()
+
+    assert response.status_code == 200, response.text
+    serialized = response.text.lower()
+    for forbidden in ("access_token", "refresh_token", "api_key", "secret", "password"):
+        assert forbidden not in serialized, f"bootstrap leaked {forbidden}"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_response_is_not_shared_cacheable(client, app):
+    """사용자 범위 응답이므로 공유 캐시에 저장돼서는 안 된다."""
+    restore = _override_user(app, ADMIN_IDENTITY)
+    try:
+        response = await client.get("/api/bootstrap")
+    finally:
+        restore()
+
+    cache_control = response.headers.get("cache-control", "")
+    assert "private" in cache_control
+    assert "no-store" in cache_control
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("identity", [ADMIN_IDENTITY, MEMBER_IDENTITY], ids=["admin", "member"])
+async def test_bootstrap_projects_match_the_projects_endpoint(client, app, identity):
+    """같은 신원이면 부트스트랩과 `/api/projects` 의 결과가 동일해야 한다.
+
+    인가 규칙을 복제하지 않고 재사용했다는 것을 값으로 증명한다 — 부트스트랩이
+    필터를 건너뛰면 admin 과 member 의 결과가 갈리면서 여기서 깨진다.
+    """
+    restore = _override_user(app, identity)
+    try:
+        bootstrap = await client.get("/api/bootstrap")
+        projects = await client.get("/api/projects")
+    finally:
+        restore()
+
+    assert bootstrap.status_code == projects.status_code
+    if identity is MEMBER_IDENTITY:
+        # Filesystem discovery must not expose unregistered legacy paths to a
+        # non-admin when the ACL registry cannot authorize them.
+        assert bootstrap.status_code == 503
+        return
+
+    assert bootstrap.status_code == 200, bootstrap.text
+    assert bootstrap.json()["projects"] == projects.json()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_includes_menu_when_lookup_succeeds(client, app, monkeypatch):
+    """메뉴 조회가 성공하면 payload 에 실려 프런트의 추가 요청이 사라진다."""
+    from api.admin import MenuVisibilityResponse
+
+    async def _menu(_user=None):
+        return MenuVisibilityResponse(visibility={"git": {"admin": True}}, menu_order=["git"])
+
+    monkeypatch.setattr("api.bootstrap.get_menu_visibility", _menu)
+
+    restore = _override_user(app, ADMIN_IDENTITY)
+    try:
+        response = await client.get("/api/bootstrap")
+    finally:
+        restore()
+
+    assert response.status_code == 200, response.text
+    assert response.json()["menu"] == {
+        "visibility": {"git": {"admin": True}},
+        "menu_order": ["git"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_degrades_menu_to_null_without_failing(client, app, monkeypatch):
+    """메뉴 조회 실패는 부트스트랩 전체를 죽이지 않는다.
+
+    `api.admin.get_menu_visibility` 는 DB 접속 실패를 잡지 않아서
+    `USE_DATABASE=false` 환경에서는 그대로 터진다(로컬 실측: `InvalidPasswordError`).
+    그 실패가 user·projects·models 까지 날려버리면 기동 자체가 오늘보다 나빠진다.
+    `menu` 를 `null` 로 내려 "비어 있음" 이 아니라 "알 수 없음" 을 표현하고,
+    프런트는 기존대로 `/api/admin/menu-visibility` 를 직접 부른다.
+    """
+
+    async def _explode(_user=None):
+        raise SQLAlchemyError("database unavailable")
+
+    monkeypatch.setattr("api.bootstrap.get_menu_visibility", _explode)
+
+    restore = _override_user(app, ADMIN_IDENTITY)
+    try:
+        response = await client.get("/api/bootstrap")
+    finally:
+        restore()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["menu"] is None
+    # 나머지 기동 데이터는 그대로 살아 있어야 한다.
+    assert body["user"]["id"] == ADMIN_IDENTITY.id
+    assert body["models"]

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -19,6 +19,9 @@ PROTECTED_ROUTE_PREFIXES = (
 )
 
 SENSITIVE_DISCOVERY_ROUTES = (
+    # `/api/bootstrap` 는 프로젝트 목록을 그대로 실어 나른다 — `/api/projects` 와
+    # 같은 등급의 열거 표면이므로 같은 익명 접근 금지 계약을 적용한다.
+    "/api/bootstrap",
     "/api/projects",
     "/api/claude-sessions/projects",
     "/api/agent-sessions",
@@ -1925,3 +1928,64 @@ async def test_known_acl_role_still_authorizes(monkeypatch):
     user = SimpleNamespace(id="user", role="user", is_admin=False, is_active=True)
 
     assert await require_project_role("p1", user, _stub_db(), min_role="editor") == "editor"
+
+
+@pytest.mark.asyncio
+async def test_projects_filesystem_org_acl_failure_is_503(monkeypatch):
+    """Filesystem-mode org ACL lookup failures must be controlled 503s, not 500s."""
+    from api.routes import get_projects
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+    monkeypatch.setattr("api.routes.list_projects", lambda: [])
+
+    async def broken_org_lookup(*_args, **_kwargs):
+        raise RuntimeError("org acl sentinel")
+
+    monkeypatch.setattr("api.projects._get_admin_org_ids", broken_org_lookup)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_projects(
+            current_user=SimpleNamespace(id="user", role="user", is_admin=False),
+            db=object(),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert "org acl sentinel" not in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_projects_filesystem_acl_preserves_intended_http_status(monkeypatch):
+    """A deliberate HTTPException from the ACL path must not be rewritten to 503."""
+    from api.routes import get_projects
+
+    monkeypatch.setenv("USE_DATABASE", "false")
+    monkeypatch.setattr("api.routes.list_projects", lambda: [])
+
+    async def forbidden_org_lookup(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail="Organization membership required")
+
+    monkeypatch.setattr("api.projects._get_admin_org_ids", forbidden_org_lookup)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_projects(
+            current_user=SimpleNamespace(id="user", role="user", is_admin=False),
+            db=object(),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_accessible_paths_preserves_intended_http_status(monkeypatch):
+    """_get_accessible_paths_for_user must not rewrap deliberate HTTPExceptions."""
+    from api.routes import _get_accessible_paths_for_user
+
+    class ForbiddenDatabase:
+        async def execute(self, *_args, **_kwargs):
+            raise HTTPException(status_code=403, detail="Project registry forbidden")
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    with pytest.raises(HTTPException) as exc_info:
+        await _get_accessible_paths_for_user(ForbiddenDatabase(), "user-id", admin_org_ids=[])
+
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
- Add authenticated `GET /api/bootstrap` aggregation for user, project, model, and menu data.
- Hydrate existing Zustand stores from the bootstrap response to reduce initial request waterfall and duplicate requests.
- Split public authentication route loading and harden stale-session, menu fallback, and filesystem ACL behavior.
- Add backend and frontend regression coverage plus the implementation plan.

## Validation
- [x] `cd src/dashboard && npm run type-check`
- [x] `cd src/dashboard && npm run lint`
- [x] `cd src/dashboard && npm run test:run`
- [x] `cd src/dashboard && npm run build`
- [x] `cd src/backend && uv run pytest ../../tests/backend -q --tb=short` — 1,980 passed, 32 skipped
- [x] staged diff check and literal-secret scan
- [x] commit hooks: Ruff, TypeScript, ESLint

## Security note
- Local security-hardening tests pass.
- The final independent Orca Security review could not return a structured verdict because its terminal ended with `host_status_unavailable`; this is recorded as unknown rather than treated as a pass.

## Merge scope
This PR contains the reviewed changes from commit `1e29337dfa479b7e872690a97c0a6fcef10e6ffb`.
