### PR TITLE
feat(git): AI 커밋 초안 생성 버튼 추가

### DIFF
--- a/src/dashboard/src/components/git/WorkingDirectory.tsx
+++ b/src/dashboard/src/components/git/WorkingDirectory.tsx
@@ -255,6 +255,26 @@ export function WorkingDirectory({
               </button>
             </div>
           )}
+          {!is_clean && viewMode === 'list' && (
+            <button
+              onClick={onGenerateDrafts}
+              disabled={isGeneratingDrafts || allFiles.length === 0}
+              className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors disabled:opacity-50"
+              title="Generate commit suggestions with AI"
+            >
+              {isGeneratingDrafts ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Analyzing...
+                </>
+              ) : (
+                <>
+                  <Sparkles className="w-4 h-4" />
+                  {draftCommits.length > 0 ? 'Regenerate' : 'Generate with AI'}
+                </>
+              )}
+            </button>
+          )}
           <button
             onClick={onRefresh}
             disabled={isLoading}

--- a/src/dashboard/src/components/git/__tests__/WorkingDirectory.test.tsx
+++ b/src/dashboard/src/components/git/__tests__/WorkingDirectory.test.tsx
@@ -275,6 +275,34 @@ describe('WorkingDirectory', () => {
     expect(defaultProps.onClearDrafts).toHaveBeenCalledTimes(1)
   })
 
+  it('shows a compact "Generate with AI" action in list view when not clean', () => {
+    render(<WorkingDirectory {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /Generate with AI/ })).toBeInTheDocument()
+  })
+
+  it('calls onGenerateDrafts when the list view AI action is clicked', () => {
+    render(<WorkingDirectory {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /Generate with AI/ }))
+    expect(defaultProps.onGenerateDrafts).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the list view AI action and shows "Analyzing..." while generating', () => {
+    render(<WorkingDirectory {...defaultProps} isGeneratingDrafts={true} />)
+    const button = screen.getByRole('button', { name: /Analyzing/ })
+    expect(screen.getByText('Analyzing...')).toBeInTheDocument()
+    expect(button).toBeDisabled()
+  })
+
+  it('does not show the list view AI action when working directory is clean', () => {
+    const cleanStatus = makeWorkingStatus({
+      is_clean: true,
+      unstaged_files: [],
+      total_changes: 0,
+    })
+    render(<WorkingDirectory {...defaultProps} workingStatus={cleanStatus} />)
+    expect(screen.queryByText('Generate with AI')).not.toBeInTheDocument()
+  })
+
   it('shows "No unstaged changes" when no unstaged files exist', () => {
     const status = makeWorkingStatus({
       unstaged_files: [],


### PR DESCRIPTION
## Summary
- Working Directory 목록(list) 뷰에도 "Generate with AI" 커밋 초안 생성 버튼을 추가했습니다. 기존에는 그룹(grouped) 뷰에서만 노출됐습니다.
- 생성 중에는 스피너 + "Analyzing..." 표시와 함께 버튼을 비활성화하고, 이미 초안이 있으면 라벨을 "Regenerate"로 전환합니다.

## Changes
- `src/dashboard/src/components/git/WorkingDirectory.tsx`
  - `!is_clean && viewMode === 'list'` 조건에서만 렌더되는 컴팩트 액션 버튼 추가
  - `isGeneratingDrafts` 또는 변경 파일 0건이면 `disabled`
  - `draftCommits.length > 0` → `Regenerate`, 아니면 `Generate with AI`
- `src/dashboard/src/components/git/__tests__/WorkingDirectory.test.tsx`
  - 표시 조건 4건 추가: list 뷰 노출 / 클릭 시 `onGenerateDrafts` 호출 / 생성 중 disabled + "Analyzing..." / clean 상태에서 미노출

새 prop 없음 — 그룹 뷰가 이미 쓰던 `onGenerateDrafts` · `isGeneratingDrafts` · `draftCommits`를 그대로 재사용합니다.

## Test Plan
- [x] `npm run type-check` — 에러 0
- [x] `npm run lint` — 에러 0
- [x] `npm run test:coverage` — 전체 통과, vitest.config.ts 임계치 충족 (exit 0)
- [x] `npm run build` — 성공
- [x] Codex 리뷰 (`--scope branch --base b8d1d22`) — 지적 0건
- [ ] 수동 확인: Git 페이지에서 list 뷰 전환 → 버튼 노출 → 클릭 시 초안 생성 → 재클릭 시 "Regenerate"

백엔드 트랙은 SKIP — 변경 파일이 대시보드 2개뿐(`git show --stat`)이라 백엔드 게이트가 이 커밋으로 회귀할 수 없습니다. CI는 PR에서 양쪽 트랙을 모두 실행합니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXxAox1se7ZgEDSRmCRiUR