### PR TITLE
chore: Impeccable 훅 캐시를 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ src/backend/data/
 
 # Cache
 .cache/
+.impeccable/
 *.swp
 
 # Projects (symlinks - managed separately)


### PR DESCRIPTION
## 문제

`src/dashboard/.impeccable/hook.cache.json` 이 gitignore에 없어 매 세션 `git status` 에 untracked로 올라온다. 내용은 Impeccable 훅의 로컬 캐시로, 절대경로(`/Users/.../workspaces/...`)와 세션 UUID를 담고 있어 공유 대상이 아니다.

## 변경

`.gitignore` Cache 섹션에 `.impeccable/` 한 줄 추가. 선행 슬래시가 없어 레포 내 모든 깊이에서 매칭된다.

## 검증

RED → GREEN (`git check-ignore -v src/dashboard/.impeccable/hook.cache.json`):

- 변경 전: 매칭 없음 (exit 1)
- 변경 후: `.gitignore:65:.impeccable/  src/dashboard/.impeccable/hook.cache.json`

기존 추적 파일 영향 없음 — `git ls-files | grep -i impeccable` 결과 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tJd9QYufBsW7CyaYRkNFy