### PR TITLE
fix(rag): DB 레지스트리 프로젝트 지원 + RAG 라우터 인증·인가

### DIFF
--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -136,7 +136,11 @@ else:
     feedback_router = safe_import("api.feedback", "router")
     auth_router = safe_import("api.auth", "router")
     project_configs_router = safe_import("api.project_configs", "router")
-    rag_router = safe_import("api.rag", "router")
+    # RAG is a dashboard feature, not an optional integration.  Import it
+    # directly so a broken dependency fails startup visibly instead of serving
+    # the dashboard with every /api/rag request returning a misleading 404.
+    from api.rag import router as rag_router
+
     audit_router = safe_import("api.audit", "router")
     notifications_router = safe_import("api.notifications", "router")
     analytics_router = safe_import("api.analytics", "router")
@@ -604,8 +608,7 @@ else:
             app.include_router(auth_router, prefix="/api")
         if project_configs_router:
             app.include_router(project_configs_router, prefix="/api")
-        if rag_router:
-            app.include_router(rag_router, prefix="/api")
+        app.include_router(rag_router, prefix="/api")
         if audit_router:
             app.include_router(audit_router, prefix="/api")
         if notifications_router:

--- a/src/backend/api/projects/__init__.py
+++ b/src/backend/api/projects/__init__.py
@@ -14,7 +14,7 @@
 """
 
 from . import members
-from ._shared import _get_admin_org_ids, authorize_db_project
+from ._shared import _get_admin_org_ids, authorize_db_project, authorize_db_projects
 from .registry import router
 
 # 집계 라우터는 `registry` 모듈이 소유한다(그쪽 주석 참조 — 빈 경로 라우트가
@@ -28,5 +28,6 @@ router.include_router(members.router)
 __all__ = [
     "_get_admin_org_ids",
     "authorize_db_project",
+    "authorize_db_projects",
     "router",
 ]

--- a/src/backend/api/projects/__init__.py
+++ b/src/backend/api/projects/__init__.py
@@ -14,7 +14,7 @@
 """
 
 from . import members
-from ._shared import _get_admin_org_ids
+from ._shared import _get_admin_org_ids, authorize_db_project
 from .registry import router
 
 # 집계 라우터는 `registry` 모듈이 소유한다(그쪽 주석 참조 — 빈 경로 라우트가
@@ -27,5 +27,6 @@ router.include_router(members.router)
 
 __all__ = [
     "_get_admin_org_ids",
+    "authorize_db_project",
     "router",
 ]

--- a/src/backend/api/projects/_shared.py
+++ b/src/backend/api/projects/_shared.py
@@ -43,33 +43,35 @@ async def _get_admin_org_ids(user) -> list[str]:
     return db_org_ids
 
 
-async def authorize_db_project(project_id: str, user, session):
-    """유저가 접근 가능한 **활성** DB 레지스트리 프로젝트만 돌려준다.
+async def authorize_db_projects(project_ids: list[str] | None, user, session) -> list:
+    """유저가 접근 가능한 **활성** DB 레지스트리 프로젝트를 돌려준다.
 
     `api/routes.py` 의 `GET /projects` 와 같은 규칙이다:
         - 시스템 admin: 전체
         - 조직 admin/owner: 자기 조직 프로젝트
         - 일반 member: 명시적 `ProjectAccess` 만
 
-    규칙을 두 벌로 두면 인가 검사가 조용히 갈라지므로, 단건 조회가 필요한
-    소비자(`api/rag.py`)는 이 헬퍼를 재사용한다.
+    규칙을 두 벌로 두면 인가 검사가 조용히 갈라지고, 갈라진 쪽이 인가라 티가
+    나지 않는다. 단건·다건 소비자(`api/rag.py`)가 모두 이 하나를 재사용한다.
 
-    접근 불가·미존재를 구분하지 않고 둘 다 `None` 으로 낸다 — 호출자가 404 를
-    내면 존재 자체가 새어나가지 않는다.
+    `project_ids=None` 은 "접근 가능한 전부" 를 뜻한다.
     """
     import os
 
     if os.getenv("USE_DATABASE", "false").lower() != "true":
-        return None
+        return []
 
     from sqlalchemy import or_, select
 
     from db.models import ProjectAccessModel, ProjectModel
 
     query = select(ProjectModel).where(
-        ProjectModel.id == project_id,
         ProjectModel.is_active == True,  # noqa: E712
     )
+    if project_ids is not None:
+        if not project_ids:
+            return []
+        query = query.where(ProjectModel.id.in_(project_ids))
 
     is_admin = getattr(user, "role", None) == "admin" or bool(getattr(user, "is_admin", False))
     if not is_admin:
@@ -85,4 +87,13 @@ async def authorize_db_project(project_id: str, user, session):
         )
 
     result = await session.execute(query)
-    return result.scalar_one_or_none()
+    return list(result.scalars().all())
+
+
+async def authorize_db_project(project_id: str, user, session):
+    """`authorize_db_projects` 의 단건 판. 접근 불가와 미존재를 구분하지 않는다.
+
+    둘 다 `None` 이라, 호출자가 404 를 내면 존재 자체가 새어나가지 않는다.
+    """
+    rows = await authorize_db_projects([project_id], user, session)
+    return rows[0] if rows else None

--- a/src/backend/api/projects/_shared.py
+++ b/src/backend/api/projects/_shared.py
@@ -41,3 +41,48 @@ async def _get_admin_org_ids(user) -> list[str]:
         db_org_ids = [row[0] for row in result.all()]
 
     return db_org_ids
+
+
+async def authorize_db_project(project_id: str, user, session):
+    """유저가 접근 가능한 **활성** DB 레지스트리 프로젝트만 돌려준다.
+
+    `api/routes.py` 의 `GET /projects` 와 같은 규칙이다:
+        - 시스템 admin: 전체
+        - 조직 admin/owner: 자기 조직 프로젝트
+        - 일반 member: 명시적 `ProjectAccess` 만
+
+    규칙을 두 벌로 두면 인가 검사가 조용히 갈라지므로, 단건 조회가 필요한
+    소비자(`api/rag.py`)는 이 헬퍼를 재사용한다.
+
+    접근 불가·미존재를 구분하지 않고 둘 다 `None` 으로 낸다 — 호출자가 404 를
+    내면 존재 자체가 새어나가지 않는다.
+    """
+    import os
+
+    if os.getenv("USE_DATABASE", "false").lower() != "true":
+        return None
+
+    from sqlalchemy import or_, select
+
+    from db.models import ProjectAccessModel, ProjectModel
+
+    query = select(ProjectModel).where(
+        ProjectModel.id == project_id,
+        ProjectModel.is_active == True,  # noqa: E712
+    )
+
+    is_admin = getattr(user, "role", None) == "admin" or bool(getattr(user, "is_admin", False))
+    if not is_admin:
+        admin_org_ids = await _get_admin_org_ids(user)
+        member_subquery = select(ProjectAccessModel.project_id).where(
+            ProjectAccessModel.user_id == user.id
+        )
+        query = query.where(
+            or_(
+                ProjectModel.organization_id.in_(admin_org_ids),
+                ProjectModel.id.in_(member_subquery),
+            )
+        )
+
+    result = await session.execute(query)
+    return result.scalar_one_or_none()

--- a/src/backend/api/projects/_shared.py
+++ b/src/backend/api/projects/_shared.py
@@ -43,7 +43,24 @@ async def _get_admin_org_ids(user) -> list[str]:
     return db_org_ids
 
 
-async def authorize_db_projects(project_ids: list[str] | None, user, session) -> list:
+def _roles_at_or_above(min_role: str) -> list[str]:
+    """`min_role` 이상 등급의 프로젝트 역할 이름들.
+
+    등급표는 `api/deps.py` 가 소유한다 — 여기 숫자를 복제하면 한쪽만 새 역할을
+    알게 되고, 모르는 쪽이 인가라 조용히 헐거워진다.
+    """
+    from api.deps import _PROJECT_ROLE_HIERARCHY
+
+    if min_role not in _PROJECT_ROLE_HIERARCHY:
+        raise ValueError(f"Unknown project role requirement: {min_role!r}")
+
+    threshold = _PROJECT_ROLE_HIERARCHY[min_role]
+    return [role for role, rank in _PROJECT_ROLE_HIERARCHY.items() if rank >= threshold]
+
+
+async def authorize_db_projects(
+    project_ids: list[str] | None, user, session, min_role: str = "viewer"
+) -> list:
     """유저가 접근 가능한 **활성** DB 레지스트리 프로젝트를 돌려준다.
 
     `api/routes.py` 의 `GET /projects` 와 같은 규칙이다:
@@ -55,6 +72,10 @@ async def authorize_db_projects(project_ids: list[str] | None, user, session) ->
     나지 않는다. 단건·다건 소비자(`api/rag.py`)가 모두 이 하나를 재사용한다.
 
     `project_ids=None` 은 "접근 가능한 전부" 를 뜻한다.
+
+    `min_role` 은 명시적 `ProjectAccess` 경로에만 적용된다. viewer 권한으로
+    재인덱싱·컬렉션 삭제가 되면 안 되므로, 변경 라우트는 `editor` 를 요구한다.
+    조직 admin/owner 와 시스템 admin 은 이 하한 위에 있으므로 그대로 통과한다.
     """
     import os
 
@@ -77,7 +98,8 @@ async def authorize_db_projects(project_ids: list[str] | None, user, session) ->
     if not is_admin:
         admin_org_ids = await _get_admin_org_ids(user)
         member_subquery = select(ProjectAccessModel.project_id).where(
-            ProjectAccessModel.user_id == user.id
+            ProjectAccessModel.user_id == user.id,
+            ProjectAccessModel.role.in_(_roles_at_or_above(min_role)),
         )
         query = query.where(
             or_(
@@ -90,10 +112,10 @@ async def authorize_db_projects(project_ids: list[str] | None, user, session) ->
     return list(result.scalars().all())
 
 
-async def authorize_db_project(project_id: str, user, session):
+async def authorize_db_project(project_id: str, user, session, min_role: str = "viewer"):
     """`authorize_db_projects` 의 단건 판. 접근 불가와 미존재를 구분하지 않는다.
 
     둘 다 `None` 이라, 호출자가 404 를 내면 존재 자체가 새어나가지 않는다.
     """
-    rows = await authorize_db_projects([project_id], user, session)
+    rows = await authorize_db_projects([project_id], user, session, min_role=min_role)
     return rows[0] if rows else None

--- a/src/backend/api/rag.py
+++ b/src/backend/api/rag.py
@@ -91,7 +91,9 @@ class StatsResponse(BaseModel):
 _indexing_state: dict[str, dict] = {}
 
 
-async def _get_db_project(project_id: str, user: object, session: AsyncSession) -> Project | None:
+async def _get_db_project(
+    project_id: str, user: object, session: AsyncSession, min_role: str = "viewer"
+) -> Project | None:
     """Resolve an access-authorized DB-registry project as the legacy RAG shape.
 
     인가는 `api/projects` 의 `authorize_db_project` 가 소유한다 — `GET /projects`
@@ -99,7 +101,7 @@ async def _get_db_project(project_id: str, user: object, session: AsyncSession) 
     갈라지고, 갈라진 쪽이 인가 검사라 티가 나지 않는다.
     """
     try:
-        row = await authorize_db_project(project_id, user, session)
+        row = await authorize_db_project(project_id, user, session, min_role=min_role)
     except Exception as exc:
         logger.exception("Failed to resolve RAG project '%s' from the database", project_id)
         raise HTTPException(
@@ -119,7 +121,9 @@ async def _get_db_project(project_id: str, user: object, session: AsyncSession) 
     )
 
 
-async def _resolve_project(project_id: str, user: object, session: AsyncSession) -> Project | None:
+async def _resolve_project(
+    project_id: str, user: object, session: AsyncSession, min_role: str = "viewer"
+) -> Project | None:
     """Resolve legacy filesystem projects first, then DB-registry projects.
 
     DB 레지스트리는 `path` 가 nullable 이다. 빈 경로를 그대로 흘리면
@@ -130,7 +134,7 @@ async def _resolve_project(project_id: str, user: object, session: AsyncSession)
     if legacy:
         return legacy
 
-    db_project = await _get_db_project(project_id, user, session)
+    db_project = await _get_db_project(project_id, user, session, min_role=min_role)
     if db_project is None or not db_project.path.strip():
         return None
     return db_project
@@ -279,7 +283,7 @@ async def index_project(
 
     Indexing runs in the background. Poll GET /status/{project_id} for progress.
     """
-    project = await _resolve_project(project_id, current_user, db)
+    project = await _resolve_project(project_id, current_user, db, min_role="editor")
     if not project:
         raise HTTPException(
             status_code=404, detail=f"Project '{project_id}' not found. Register it first."
@@ -330,12 +334,21 @@ async def query_project(
 
     try:
         store = get_vector_store()
+        # `include_shared` 는 서비스 계층에서 다른 컬렉션을 **전부** 훑는다.
+        # 대상을 호출자의 ACL 로 좁혀 넘기지 않으면 단건 라우트의 인가가
+        # 이 플래그 하나로 우회된다.
+        allowed_shared_ids = (
+            await _authorized_project_ids(None, current_user, db)
+            if request.include_shared
+            else None
+        )
         result = await store.query(
             project_id=project_id,
             query=request.query,
             k=request.k,
             filter_priority=request.filter_priority,
             include_shared=request.include_shared,
+            allowed_shared_project_ids=allowed_shared_ids,
         )
 
         return result
@@ -408,7 +421,7 @@ async def delete_project_index(
     This removes the vector store collection and all associated embeddings.
     """
     # Check if project exists
-    project = await _resolve_project(project_id, current_user, db)
+    project = await _resolve_project(project_id, current_user, db, min_role="editor")
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 

--- a/src/backend/api/rag.py
+++ b/src/backend/api/rag.py
@@ -153,7 +153,15 @@ async def _authorized_project_ids(
     if requested_ids is not None:
         legacy_ids &= set(requested_ids)
 
-    db_rows = await authorize_db_projects(requested_ids, user, session)
+    try:
+        db_rows = await authorize_db_projects(requested_ids, user, session)
+    except Exception as exc:
+        logger.exception("Failed to resolve authorized RAG projects from the database")
+        raise HTTPException(
+            status_code=503,
+            detail="Project registry is temporarily unavailable",
+        ) from exc
+
     return sorted(legacy_ids | {row.id for row in db_rows})
 
 
@@ -504,6 +512,12 @@ async def cross_project_query(
     ACL 을 건 의미가 사라진다.
     """
     allowed_ids = await _authorized_project_ids(request.project_ids, current_user, db)
+    # `query_cross_project` 는 source 목록이 None 일 때만 exclude 를 적용한다.
+    # 인가 필터가 항상 명시 목록을 넘기게 됐으므로 제외를 여기서 미리 뺀다 —
+    # 안 그러면 제외한 프로젝트가 그대로 검색돼 결과에 섞인다.
+    if request.exclude_project_ids:
+        excluded = set(request.exclude_project_ids)
+        allowed_ids = [pid for pid in allowed_ids if pid not in excluded]
     if not allowed_ids:
         return QueryResult(query=request.query, documents=[], total_found=0)
 

--- a/src/backend/api/rag.py
+++ b/src/backend/api/rag.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from pydantic import BaseModel, Field
 
-from models.project import PROJECTS_REGISTRY, get_project
+from models.project import PROJECTS_REGISTRY, Project, get_project
 from services.code_entity_extractor import extract_dependencies, extract_entities
 from services.rag_service import (
     QDRANT_AVAILABLE,
@@ -85,6 +85,51 @@ class StatsResponse(BaseModel):
 # stable number to the UI while a background reindex is mid-flight (the live
 # Qdrant points_count fluctuates as the collection is dropped and refilled).
 _indexing_state: dict[str, dict] = {}
+
+
+async def _get_db_project(project_id: str) -> Project | None:
+    """Resolve an active DB-registry project as the legacy RAG project shape."""
+    import os
+
+    if os.getenv("USE_DATABASE", "false").lower() != "true":
+        return None
+
+    try:
+        from sqlalchemy import select
+
+        from db.database import async_session_factory
+        from db.models import ProjectModel
+
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(ProjectModel).where(
+                    ProjectModel.id == project_id,
+                    ProjectModel.is_active == True,  # noqa: E712
+                )
+            )
+            row = result.scalar_one_or_none()
+    except Exception as exc:
+        logger.exception("Failed to resolve RAG project '%s' from the database", project_id)
+        raise HTTPException(
+            status_code=503,
+            detail="Project registry is temporarily unavailable",
+        ) from exc
+
+    if not row:
+        return None
+
+    return Project(
+        id=row.id,
+        name=row.name,
+        path=row.path or "",
+        description=row.description or "",
+        organization_id=row.organization_id,
+    )
+
+
+async def _resolve_project(project_id: str) -> Project | None:
+    """Resolve legacy filesystem projects first, then DB-registry projects."""
+    return get_project(project_id) or await _get_db_project(project_id)
 
 
 def _get_state(project_id: str) -> dict:
@@ -211,7 +256,7 @@ async def index_project(
 
     Indexing runs in the background. Poll GET /status/{project_id} for progress.
     """
-    project = get_project(project_id)
+    project = await _resolve_project(project_id)
     if not project:
         raise HTTPException(
             status_code=404, detail=f"Project '{project_id}' not found. Register it first."
@@ -246,7 +291,7 @@ async def query_project(
     Returns the most relevant document chunks from the project's indexed files.
     """
     # Check if project exists
-    project = get_project(project_id)
+    project = await _resolve_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
@@ -274,7 +319,7 @@ async def get_project_stats(project_id: str) -> StatsResponse:
     Returns information about the indexed documents and collection status.
     """
     # Check if project exists
-    project = get_project(project_id)
+    project = await _resolve_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
@@ -322,7 +367,7 @@ async def delete_project_index(project_id: str) -> dict:
     This removes the vector store collection and all associated embeddings.
     """
     # Check if project exists
-    project = get_project(project_id)
+    project = await _resolve_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
@@ -449,7 +494,7 @@ async def get_project_entities(
     Scans project files and extracts functions, classes, interfaces, etc.
     Optionally filter by entity_type (function, class, method, interface, etc.).
     """
-    project = get_project(project_id)
+    project = await _resolve_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
 
@@ -516,7 +561,7 @@ async def get_project_dependencies(
     Extracts import and inheritance relationships between code entities.
     Optionally filter by entity_name to see deps for a specific entity.
     """
-    project = get_project(project_id)
+    project = await _resolve_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
 

--- a/src/backend/api/rag.py
+++ b/src/backend/api/rag.py
@@ -2,10 +2,14 @@
 
 import logging
 from datetime import UTC, datetime
+from pathlib import Path
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.deps import get_current_user, get_db_session
+from api.projects import authorize_db_project
 from models.project import PROJECTS_REGISTRY, Project, get_project
 from services.code_entity_extractor import extract_dependencies, extract_entities
 from services.rag_service import (
@@ -87,27 +91,15 @@ class StatsResponse(BaseModel):
 _indexing_state: dict[str, dict] = {}
 
 
-async def _get_db_project(project_id: str) -> Project | None:
-    """Resolve an active DB-registry project as the legacy RAG project shape."""
-    import os
+async def _get_db_project(project_id: str, user: object, session: AsyncSession) -> Project | None:
+    """Resolve an access-authorized DB-registry project as the legacy RAG shape.
 
-    if os.getenv("USE_DATABASE", "false").lower() != "true":
-        return None
-
+    인가는 `api/projects` 의 `authorize_db_project` 가 소유한다 — `GET /projects`
+    와 같은 규칙을 재사용하기 위해서다. 규칙을 여기 복제하면 두 벌이 조용히
+    갈라지고, 갈라진 쪽이 인가 검사라 티가 나지 않는다.
+    """
     try:
-        from sqlalchemy import select
-
-        from db.database import async_session_factory
-        from db.models import ProjectModel
-
-        async with async_session_factory() as session:
-            result = await session.execute(
-                select(ProjectModel).where(
-                    ProjectModel.id == project_id,
-                    ProjectModel.is_active == True,  # noqa: E712
-                )
-            )
-            row = result.scalar_one_or_none()
+        row = await authorize_db_project(project_id, user, session)
     except Exception as exc:
         logger.exception("Failed to resolve RAG project '%s' from the database", project_id)
         raise HTTPException(
@@ -127,9 +119,21 @@ async def _get_db_project(project_id: str) -> Project | None:
     )
 
 
-async def _resolve_project(project_id: str) -> Project | None:
-    """Resolve legacy filesystem projects first, then DB-registry projects."""
-    return get_project(project_id) or await _get_db_project(project_id)
+async def _resolve_project(project_id: str, user: object, session: AsyncSession) -> Project | None:
+    """Resolve legacy filesystem projects first, then DB-registry projects.
+
+    DB 레지스트리는 `path` 가 nullable 이다. 빈 경로를 그대로 흘리면
+    `Path("").resolve()` 가 **서버의 작업 디렉터리**로 해석돼 저장소 전체가 그
+    프로젝트 컬렉션에 인덱싱된다. 그래서 여기서 미등록과 동일하게 취급한다.
+    """
+    legacy = get_project(project_id)
+    if legacy:
+        return legacy
+
+    db_project = await _get_db_project(project_id, user, session)
+    if db_project is None or not db_project.path.strip():
+        return None
+    return db_project
 
 
 def _get_state(project_id: str) -> dict:
@@ -249,6 +253,8 @@ def get_indexing_status_value(project_id: str) -> str:
 async def index_project(
     project_id: str,
     background_tasks: BackgroundTasks,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
     request: IndexRequest | None = None,
 ) -> IndexResponse:
     """
@@ -256,10 +262,18 @@ async def index_project(
 
     Indexing runs in the background. Poll GET /status/{project_id} for progress.
     """
-    project = await _resolve_project(project_id)
+    project = await _resolve_project(project_id, current_user, db)
     if not project:
         raise HTTPException(
             status_code=404, detail=f"Project '{project_id}' not found. Register it first."
+        )
+
+    # 등록된 경로가 실제 디렉터리가 아니면 인덱싱은 조용히 0건을 넣고
+    # `completed` 를 보고한다 — 성공처럼 보이는 실패라, 예약 전에 막는다.
+    if not Path(project.path).is_dir():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Project '{project_id}' has no readable directory at its registered path",
         )
 
     force_reindex = request.force_reindex if request else False
@@ -284,6 +298,8 @@ async def index_project(
 async def query_project(
     project_id: str,
     request: QueryRequest,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
 ) -> QueryResult:
     """
     Query project context using semantic search.
@@ -291,7 +307,7 @@ async def query_project(
     Returns the most relevant document chunks from the project's indexed files.
     """
     # Check if project exists
-    project = await _resolve_project(project_id)
+    project = await _resolve_project(project_id, current_user, db)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
@@ -312,14 +328,18 @@ async def query_project(
 
 
 @router.get("/projects/{project_id}/stats", response_model=StatsResponse)
-async def get_project_stats(project_id: str) -> StatsResponse:
+async def get_project_stats(
+    project_id: str,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> StatsResponse:
     """
     Get vector store statistics for a project.
 
     Returns information about the indexed documents and collection status.
     """
     # Check if project exists
-    project = await _resolve_project(project_id)
+    project = await _resolve_project(project_id, current_user, db)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
@@ -360,14 +380,18 @@ async def get_project_stats(project_id: str) -> StatsResponse:
 
 
 @router.delete("/projects/{project_id}/index")
-async def delete_project_index(project_id: str) -> dict:
+async def delete_project_index(
+    project_id: str,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> dict:
     """
     Delete all indexed data for a project.
 
     This removes the vector store collection and all associated embeddings.
     """
     # Check if project exists
-    project = await _resolve_project(project_id)
+    project = await _resolve_project(project_id, current_user, db)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
@@ -390,13 +414,25 @@ async def delete_project_index(project_id: str) -> dict:
 
 
 @router.get("/status/{project_id}")
-async def get_indexing_status(project_id: str) -> dict:
+async def get_indexing_status(
+    project_id: str,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> dict:
     """Get the current indexing status for a project."""
+    project = await _resolve_project(project_id, current_user, db)
+    if not project:
+        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+
     state = _get_state(project_id)
 
-    indexed = False
     if project_id in PROJECTS_REGISTRY:
         indexed = PROJECTS_REGISTRY[project_id].vector_store_initialized or False
+    else:
+        # DB 레지스트리 프로젝트는 in-memory 플래그가 없다. 그 경우 컬렉션이
+        # 유일한 사실이다 — 안 그러면 인덱싱이 끝나도 영원히 `indexed: false` 라
+        # 대시보드가 "미인덱싱" 으로 계속 표시한다.
+        indexed = _safe_count(project_id) > 0
 
     # Mirror /stats: while indexing, return the last known stable count so
     # the UI never sees the partial mid-reindex value.
@@ -486,6 +522,8 @@ async def list_collections() -> dict:
 @router.get("/projects/{project_id}/entities")
 async def get_project_entities(
     project_id: str,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
     entity_type: str | None = None,
 ) -> dict:
     """
@@ -494,7 +532,7 @@ async def get_project_entities(
     Scans project files and extracts functions, classes, interfaces, etc.
     Optionally filter by entity_type (function, class, method, interface, etc.).
     """
-    project = await _resolve_project(project_id)
+    project = await _resolve_project(project_id, current_user, db)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
 
@@ -553,6 +591,8 @@ async def get_project_entities(
 @router.get("/projects/{project_id}/dependencies")
 async def get_project_dependencies(
     project_id: str,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
     entity_name: str | None = None,
 ) -> dict:
     """
@@ -561,7 +601,7 @@ async def get_project_dependencies(
     Extracts import and inheritance relationships between code entities.
     Optionally filter by entity_name to see deps for a specific entity.
     """
-    project = await _resolve_project(project_id)
+    project = await _resolve_project(project_id, current_user, db)
     if not project:
         raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
 

--- a/src/backend/api/rag.py
+++ b/src/backend/api/rag.py
@@ -332,16 +332,16 @@ async def query_project(
     if not project:
         raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
 
+    # `include_shared` 는 서비스 계층에서 다른 컬렉션을 **전부** 훑는다. 대상을
+    # 호출자의 ACL 로 좁혀 넘기지 않으면 단건 라우트의 인가가 이 플래그 하나로
+    # 우회된다. 이 조회는 try 밖에 둔다 — 레지스트리 장애의 503 이 아래 catch-all
+    # 에 먹히면 내부 예외 문자열이 담긴 500 으로 바뀐다.
+    allowed_shared_ids = (
+        await _authorized_project_ids(None, current_user, db) if request.include_shared else None
+    )
+
     try:
         store = get_vector_store()
-        # `include_shared` 는 서비스 계층에서 다른 컬렉션을 **전부** 훑는다.
-        # 대상을 호출자의 ACL 로 좁혀 넘기지 않으면 단건 라우트의 인가가
-        # 이 플래그 하나로 우회된다.
-        allowed_shared_ids = (
-            await _authorized_project_ids(None, current_user, db)
-            if request.include_shared
-            else None
-        )
         result = await store.query(
             project_id=project_id,
             query=request.query,
@@ -353,6 +353,8 @@ async def query_project(
 
         return result
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Query failed: {str(e)}")
 

--- a/src/backend/api/rag.py
+++ b/src/backend/api/rag.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_current_user, get_db_session
-from api.projects import authorize_db_project
+from api.projects import authorize_db_project, authorize_db_projects
 from models.project import PROJECTS_REGISTRY, Project, get_project
 from services.code_entity_extractor import extract_dependencies, extract_entities
 from services.rag_service import (
@@ -134,6 +134,23 @@ async def _resolve_project(project_id: str, user: object, session: AsyncSession)
     if db_project is None or not db_project.path.strip():
         return None
     return db_project
+
+
+async def _authorized_project_ids(
+    requested_ids: list[str] | None, user: object, session: AsyncSession
+) -> list[str]:
+    """교차 프로젝트 검색이 실제로 훑어도 되는 컬렉션 ID 만 낸다.
+
+    레거시 filesystem 레지스트리에는 per-user ACL 이 아예 없다. 그쪽은 이 변경
+    전과 같은 가시성을 유지하고(인증만 새로 요구한다), DB 레지스트리 프로젝트는
+    단건 라우트와 같은 인가 규칙으로 좁힌다.
+    """
+    legacy_ids = set(PROJECTS_REGISTRY)
+    if requested_ids is not None:
+        legacy_ids &= set(requested_ids)
+
+    db_rows = await authorize_db_projects(requested_ids, user, session)
+    return sorted(legacy_ids | {row.id for row in db_rows})
 
 
 def _get_state(project_id: str) -> dict:
@@ -456,19 +473,31 @@ async def get_indexing_status(
 
 
 @router.post("/query", response_model=QueryResult)
-async def cross_project_query(request: CrossProjectQueryRequest) -> QueryResult:
+async def cross_project_query(
+    request: CrossProjectQueryRequest,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> QueryResult:
     """
     Query across multiple project collections.
 
     Search all indexed projects (or a subset) and return merged results
     ranked by Reciprocal Rank Fusion.
+
+    검색 대상은 **호출자가 접근 가능한 프로젝트로 좁힌다**. 인증만 걸면 member 가
+    남의 project_id 를 지목해 그 청크를 그대로 읽을 수 있다 — 단건 라우트에
+    ACL 을 건 의미가 사라진다.
     """
+    allowed_ids = await _authorized_project_ids(request.project_ids, current_user, db)
+    if not allowed_ids:
+        return QueryResult(query=request.query, documents=[], total_found=0)
+
     try:
         store = get_vector_store()
         result = await store.query_cross_project(
             query=request.query,
             k=request.k,
-            source_project_ids=request.project_ids,
+            source_project_ids=allowed_ids,
             exclude_project_ids=request.exclude_project_ids,
             filter_priority=request.filter_priority,
         )
@@ -538,7 +567,7 @@ async def get_project_entities(
 
     from pathlib import Path
 
-    project_root = Path(project["path"]).resolve()
+    project_root = Path(project.path).resolve()
     if not project_root.is_dir():
         raise HTTPException(status_code=404, detail=f"Project path not found: {project_root}")
 
@@ -607,7 +636,7 @@ async def get_project_dependencies(
 
     from pathlib import Path
 
-    project_root = Path(project["path"]).resolve()
+    project_root = Path(project.path).resolve()
     if not project_root.is_dir():
         raise HTTPException(status_code=404, detail=f"Project path not found: {project_root}")
 

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -1098,6 +1098,7 @@ class ProjectVectorStore:
         k: int = 5,
         filter_priority: str | None = None,
         include_shared: bool = False,
+        allowed_shared_project_ids: list[str] | None = None,
         force_hybrid: bool | None = None,
         force_rerank: bool | None = None,
     ) -> QueryResult:
@@ -1116,6 +1117,10 @@ class ProjectVectorStore:
 
         Args:
             include_shared: If True, also search other project collections
+            allowed_shared_project_ids: When given, the shared search is limited to
+                these project IDs. Callers that serve end users must pass the
+                caller's authorized set — otherwise ``include_shared`` reads every
+                collection in Qdrant and bypasses per-project access control.
                 and merge results (current project gets a boost).
             force_hybrid: Per-call override for ``RAG_ENABLE_HYBRID`` env
                 (``None`` = use env, ``True``/``False`` = force).
@@ -1199,6 +1204,13 @@ class ProjectVectorStore:
         # the prior "insert local twice" boost, which mathematically locked
         # every slot to the current project when k <= len(local_result).
         other_collections = self._get_all_project_collections(exclude_ids=[project_id])
+        if allowed_shared_project_ids is not None:
+            allowed = set(allowed_shared_project_ids)
+            other_collections = [
+                coll
+                for coll in other_collections
+                if self._extract_project_id_from_collection(coll) in allowed
+            ]
 
         all_ranked_lists: list[list[tuple[str, dict[str, Any]]]] = []
 

--- a/src/dashboard/src/components/project-configs/ProjectList.tsx
+++ b/src/dashboard/src/components/project-configs/ProjectList.tsx
@@ -157,8 +157,16 @@ interface ProjectCardProps {
 
 function ProjectCard({ project, isSelected, onClick, onDelete, canDelete }: ProjectCardProps) {
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onClick()
+        }
+      }}
       className={cn(
         'w-full text-left p-3 rounded-lg transition-colors group',
         isSelected
@@ -220,6 +228,6 @@ function ProjectCard({ project, isSelected, onClick, onDelete, canDelete }: Proj
           </button>
         )}
       </div>
-    </button>
+    </div>
   )
 }

--- a/src/dashboard/src/components/project-configs/ProjectList.tsx
+++ b/src/dashboard/src/components/project-configs/ProjectList.tsx
@@ -157,77 +157,80 @@ interface ProjectCardProps {
 
 function ProjectCard({ project, isSelected, onClick, onDelete, canDelete }: ProjectCardProps) {
   return (
+    // 삭제 버튼은 선택 버튼의 **형제**여야 한다. ARIA button 의 자손은 보조기술이
+    // presentational 로 취급해 중첩된 삭제 컨트롤이 읽히지도 도달하지도 않는다.
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onClick()
-        }
-      }}
       className={cn(
-        'w-full text-left p-3 rounded-lg transition-colors group',
+        'relative w-full rounded-lg transition-colors group',
         isSelected
           ? 'bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800'
           : 'hover:bg-gray-100 dark:hover:bg-gray-800 border border-transparent'
       )}
     >
-      <div className="flex items-start gap-3">
-        <div
-          className={cn(
-            'p-2 rounded-lg',
-            isSelected
-              ? 'bg-primary-100 dark:bg-primary-800'
-              : 'bg-gray-100 dark:bg-gray-700'
-          )}
-        >
-          <FolderCode
+      <button
+        type="button"
+        onClick={onClick}
+        aria-current={isSelected}
+        aria-label={`Select ${project.project_name}`}
+        className={cn('w-full text-left p-3', canDelete && 'pr-10')}
+      >
+        <div className="flex items-start gap-3">
+          <div
             className={cn(
-              'w-4 h-4',
+              'p-2 rounded-lg',
               isSelected
-                ? 'text-primary-600 dark:text-primary-400'
-                : 'text-gray-500 dark:text-gray-400'
-            )}
-          />
-        </div>
-        <div className="flex-1 min-w-0">
-          <p
-            className={cn(
-              'text-sm font-medium truncate',
-              isSelected
-                ? 'text-primary-700 dark:text-primary-300'
-                : 'text-gray-900 dark:text-white'
+                ? 'bg-primary-100 dark:bg-primary-800'
+                : 'bg-gray-100 dark:bg-gray-700'
             )}
           >
-            {project.project_name}
-          </p>
-          <div className="flex items-center gap-2 mt-1 text-xs text-gray-500 dark:text-gray-400">
-            {project.skill_count > 0 && (
-              <span>{project.skill_count} skills</span>
-            )}
-            {project.agent_count > 0 && (
-              <span>{project.agent_count} agents</span>
-            )}
-            {project.mcp_server_count > 0 && (
-              <span>{project.mcp_server_count} MCP</span>
-            )}
-            {project.command_count > 0 && (
-              <span>{project.command_count} commands</span>
-            )}
+            <FolderCode
+              className={cn(
+                'w-4 h-4',
+                isSelected
+                  ? 'text-primary-600 dark:text-primary-400'
+                  : 'text-gray-500 dark:text-gray-400'
+              )}
+            />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p
+              className={cn(
+                'text-sm font-medium truncate',
+                isSelected
+                  ? 'text-primary-700 dark:text-primary-300'
+                  : 'text-gray-900 dark:text-white'
+              )}
+            >
+              {project.project_name}
+            </p>
+            <div className="flex items-center gap-2 mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {project.skill_count > 0 && (
+                <span>{project.skill_count} skills</span>
+              )}
+              {project.agent_count > 0 && (
+                <span>{project.agent_count} agents</span>
+              )}
+              {project.mcp_server_count > 0 && (
+                <span>{project.mcp_server_count} MCP</span>
+              )}
+              {project.command_count > 0 && (
+                <span>{project.command_count} commands</span>
+              )}
+            </div>
           </div>
         </div>
-        {canDelete && (
-          <button
-            onClick={onDelete}
-            className="p-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity"
-            title="Remove project"
-          >
-            <Trash2 className="w-3.5 h-3.5" />
-          </button>
-        )}
-      </div>
+      </button>
+      {canDelete && (
+        <button
+          type="button"
+          onClick={onDelete}
+          aria-label={`Remove ${project.project_name}`}
+          className="absolute right-3 top-3 p-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-opacity"
+          title="Remove project"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </button>
+      )}
     </div>
   )
 }

--- a/src/dashboard/src/components/project-configs/__tests__/ProjectList.test.tsx
+++ b/src/dashboard/src/components/project-configs/__tests__/ProjectList.test.tsx
@@ -80,6 +80,16 @@ describe('ProjectList', () => {
     expect(container.querySelector('button button')).not.toBeInTheDocument()
   })
 
+  it('exposes the remove control as a sibling of the selection button', () => {
+    mockStoreState.dbProjects = [{ id: 'db-1', name: 'Project Alpha' }]
+    render(<ProjectList />)
+
+    const select = screen.getByRole('button', { name: /select project alpha/i })
+    const remove = screen.getByRole('button', { name: /remove project alpha/i })
+
+    expect(select).not.toContainElement(remove)
+  })
+
   it('calls selectProject on project click', () => {
     render(<ProjectList />)
     fireEvent.click(screen.getByText('Project Alpha'))

--- a/src/dashboard/src/components/project-configs/__tests__/ProjectList.test.tsx
+++ b/src/dashboard/src/components/project-configs/__tests__/ProjectList.test.tsx
@@ -73,6 +73,13 @@ describe('ProjectList', () => {
     expect(screen.getByText('5 commands')).toBeInTheDocument()
   })
 
+  it('does not nest the remove control inside the project selection button', () => {
+    mockStoreState.dbProjects = [{ id: 'db-1', name: 'Project Alpha' }]
+    const { container } = render(<ProjectList />)
+
+    expect(container.querySelector('button button')).not.toBeInTheDocument()
+  })
+
   it('calls selectProject on project click', () => {
     render(<ProjectList />)
     fireEvent.click(screen.getByText('Project Alpha'))

--- a/src/dashboard/src/pages/SettingsPage.test.tsx
+++ b/src/dashboard/src/pages/SettingsPage.test.tsx
@@ -12,6 +12,7 @@ const {
   mockDisconnect,
   mockRequestPermission,
   mockPlaySound,
+  mockAuthFetch,
   getSettingsOverrides,
   setSettingsOverrides,
   getOrchestrationOverrides,
@@ -28,6 +29,7 @@ const {
     mockDisconnect: vi.fn(),
     mockRequestPermission: vi.fn(),
     mockPlaySound: vi.fn(),
+    mockAuthFetch: vi.fn(),
     getSettingsOverrides: () => _settingsOverrides,
     setSettingsOverrides: (v: Record<string, unknown>) => { _settingsOverrides = v },
     getOrchestrationOverrides: () => _orchestrationOverrides,
@@ -94,6 +96,10 @@ vi.mock('../stores/orchestration', () => ({
   }),
 }))
 
+vi.mock('../stores/auth', () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}))
+
 vi.mock('../lib/utils', () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }))
@@ -132,6 +138,7 @@ describe('SettingsPage', () => {
     setSettingsOverrides({})
     setOrchestrationOverrides({})
     mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    mockAuthFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ terminals: [] }) })
   })
 
   afterEach(() => {
@@ -188,6 +195,14 @@ describe('SettingsPage', () => {
   it('shows connected status for backend', async () => {
     await renderSettingsPage()
     expect(screen.getByText('Connected')).toBeInTheDocument()
+  })
+
+  it('uses the authenticated request helper when loading available terminals', async () => {
+    await renderSettingsPage()
+
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/terminal/available'
+    )
   })
 
   // ---- NEW: Connection Status ----

--- a/src/dashboard/src/pages/SettingsPage.tsx
+++ b/src/dashboard/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useSettingsStore, Theme, TerminalType, TERMINAL_DISPLAY_NAMES } from '../stores/settings'
 import { useOrchestrationStore } from '../stores/orchestration'
+import { authFetch } from '../stores/auth'
 import { notificationService } from '../services/notificationService'
 import { cn } from '../lib/utils'
 import {
@@ -89,7 +90,7 @@ export function SettingsPage() {
     const fetchTerminals = async () => {
       setTerminalsLoading(true)
       try {
-        const response = await fetch(`${backendUrl}/api/terminal/available`)
+        const response = await authFetch(`${backendUrl}/api/terminal/available`)
         if (response.ok) {
           const data = await response.json()
           setAvailableTerminals(data.terminals || [])

--- a/tests/backend/api/test_rag_authorization.py
+++ b/tests/backend/api/test_rag_authorization.py
@@ -313,3 +313,51 @@ async def test_shared_query_propagates_registry_outage_as_503(monkeypatch, tmp_p
         )
 
     assert excinfo.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_cross_project_query_still_honours_exclusions(monkeypatch) -> None:
+    """인가 집합을 명시 목록으로 넘기면서 exclude 가 무시되면 안 된다.
+
+    `query_cross_project` 는 `source_project_ids is None` 일 때만 exclude 를
+    적용한다. 인가 필터가 항상 명시 목록을 넘기게 되었으므로, 제외는 여기서
+    미리 빼야 한다.
+    """
+
+    async def _authorized(requested_ids, user, session):
+        return ["alpha", "beta"]
+
+    monkeypatch.setattr(rag, "_authorized_project_ids", _authorized)
+
+    captured: dict[str, object] = {}
+
+    class _Store:
+        async def query_cross_project(self, **kwargs):
+            captured.update(kwargs)
+            return QueryResult(query=kwargs["query"], documents=[], total_found=0)
+
+    monkeypatch.setattr(rag, "get_vector_store", lambda: _Store())
+
+    await rag.cross_project_query(
+        rag.CrossProjectQueryRequest(query="q", exclude_project_ids=["beta"]),
+        MEMBER,
+        MagicMock(),
+    )
+
+    assert captured["source_project_ids"] == ["alpha"]
+
+
+@pytest.mark.asyncio
+async def test_authorized_project_ids_maps_registry_failure_to_503(monkeypatch) -> None:
+    """ACL 조회가 터지면 500 이 아니라 `_get_db_project` 과 같은 503 이어야 한다."""
+    monkeypatch.setattr(rag, "PROJECTS_REGISTRY", {})
+
+    async def _boom(project_ids, user, session, min_role="viewer"):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(rag, "authorize_db_projects", _boom)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await rag._authorized_project_ids(None, MEMBER, MagicMock())
+
+    assert excinfo.value.status_code == 503

--- a/tests/backend/api/test_rag_authorization.py
+++ b/tests/backend/api/test_rag_authorization.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from api import deps as api_deps
@@ -285,3 +286,30 @@ async def test_shared_query_is_limited_to_authorized_collections(monkeypatch, tm
         DB_PROJECT_ID,
         "another-project-i-can-see",
     ]
+
+
+@pytest.mark.asyncio
+async def test_shared_query_propagates_registry_outage_as_503(monkeypatch, tmp_path) -> None:
+    """ACL 조회 실패가 catch-all 에 먹혀 내부 에러 문자열이 담긴 500 이 되면 안 된다."""
+    project = Project(id=DB_PROJECT_ID, name="Agent System", path=str(tmp_path))
+
+    async def _resolve(project_id, user, session, min_role="viewer"):
+        return project
+
+    monkeypatch.setattr(rag, "_resolve_project", _resolve)
+
+    async def _outage(requested_ids, user, session):
+        raise HTTPException(status_code=503, detail="Project registry is temporarily unavailable")
+
+    monkeypatch.setattr(rag, "_authorized_project_ids", _outage)
+    monkeypatch.setattr(rag, "get_vector_store", lambda: pytest.fail("must not query on outage"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await rag.query_project(
+            DB_PROJECT_ID,
+            rag.QueryRequest(query="secret", include_shared=True),
+            MEMBER,
+            MagicMock(),
+        )
+
+    assert excinfo.value.status_code == 503

--- a/tests/backend/api/test_rag_authorization.py
+++ b/tests/backend/api/test_rag_authorization.py
@@ -26,6 +26,7 @@ from httpx import ASGITransport, AsyncClient
 from api import deps as api_deps
 from api import rag
 from models.project import Project
+from services.rag_service import QueryResult
 
 from .route_table import snapshot
 
@@ -101,7 +102,7 @@ async def test_member_without_access_cannot_resolve_a_db_project(monkeypatch) ->
     """권한 없는 member 에게는 DB 프로젝트가 존재하지 않는 것으로 보인다."""
     monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
 
-    async def _deny(project_id, user, session):
+    async def _deny(project_id, user, session, min_role="viewer"):
         return None
 
     monkeypatch.setattr(rag, "authorize_db_project", _deny)
@@ -119,7 +120,7 @@ async def test_db_project_without_a_path_is_rejected_before_scheduling(monkeypat
     pathless = Project(id=DB_PROJECT_ID, name="Pathless", path="")
     monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
 
-    async def _allow(project_id, user, session):
+    async def _allow(project_id, user, session, min_role="viewer"):
         return pathless
 
     monkeypatch.setattr(rag, "authorize_db_project", _allow)
@@ -141,7 +142,7 @@ async def test_status_reports_indexed_for_a_db_registry_project(monkeypatch) -> 
     db_project = Project(id=DB_PROJECT_ID, name="Agent System", path="/workspace/agent-system")
     monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
 
-    async def _allow(project_id, user, session):
+    async def _allow(project_id, user, session, min_role="viewer"):
         return db_project
 
     monkeypatch.setattr(rag, "authorize_db_project", _allow)
@@ -190,7 +191,7 @@ async def test_code_scanning_routes_do_not_subscript_the_project(
     """
     project = Project(id=DB_PROJECT_ID, name="Agent System", path=str(tmp_path))
 
-    async def _resolve(project_id, user, session):
+    async def _resolve(project_id, user, session, min_role="viewer"):
         return project
 
     monkeypatch.setattr(rag, "_resolve_project", _resolve)
@@ -202,3 +203,85 @@ async def test_code_scanning_routes_do_not_subscript_the_project(
 
     assert isinstance(result, dict)
     assert result["project_id"] == DB_PROJECT_ID
+
+
+@pytest.mark.parametrize(
+    "handler_name, expected_min_role",
+    [
+        ("index_project", "editor"),
+        ("delete_project_index", "editor"),
+        ("get_project_stats", "viewer"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_mutating_rag_routes_demand_editor_access(
+    monkeypatch, tmp_path, handler_name, expected_min_role
+) -> None:
+    """viewer 는 재인덱싱·컬렉션 삭제를 못 한다.
+
+    `ProjectAccess` 를 user_id 로만 거르면 viewer 도 통과해, 비싼 재인덱싱과
+    벡터 컬렉션 전체 삭제가 열린다.
+    """
+    project = Project(id=DB_PROJECT_ID, name="Agent System", path=str(tmp_path))
+    seen: list[str] = []
+
+    async def _record(project_id, user, session, min_role="viewer"):
+        seen.append(min_role)
+        return project
+
+    monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
+    monkeypatch.setattr(rag, "_get_db_project", _record)
+    monkeypatch.setattr(rag, "trigger_background_indexing", lambda **kwargs: True)
+    monkeypatch.setattr(rag, "_safe_count", lambda _project_id: 0)
+
+    handler = getattr(rag, handler_name)
+    args: list[object] = [DB_PROJECT_ID]
+    if handler_name == "index_project":
+        args.append(MagicMock())  # BackgroundTasks
+    args += [MEMBER, MagicMock()]
+
+    try:
+        await handler(*args)
+    except Exception:
+        # 이 테스트가 고정하는 것은 요구 권한 수준뿐이다 — Qdrant 부재 등
+        # 하위 실패는 관심 밖이다.
+        pass
+
+    assert seen == [expected_min_role]
+
+
+@pytest.mark.asyncio
+async def test_shared_query_is_limited_to_authorized_collections(monkeypatch, tmp_path) -> None:
+    """`include_shared` 는 ACL 없이 다른 컬렉션을 전부 훑는다 — 대상을 좁혀 넘긴다."""
+    project = Project(id=DB_PROJECT_ID, name="Agent System", path=str(tmp_path))
+
+    async def _resolve(project_id, user, session, min_role="viewer"):
+        return project
+
+    monkeypatch.setattr(rag, "_resolve_project", _resolve)
+
+    async def _authorized(requested_ids, user, session):
+        return [DB_PROJECT_ID, "another-project-i-can-see"]
+
+    monkeypatch.setattr(rag, "_authorized_project_ids", _authorized)
+
+    captured: dict[str, object] = {}
+
+    class _Store:
+        async def query(self, **kwargs):
+            captured.update(kwargs)
+            return QueryResult(query=kwargs["query"], documents=[], total_found=0)
+
+    monkeypatch.setattr(rag, "get_vector_store", lambda: _Store())
+
+    await rag.query_project(
+        DB_PROJECT_ID,
+        rag.QueryRequest(query="secret", include_shared=True),
+        MEMBER,
+        MagicMock(),
+    )
+
+    assert captured["allowed_shared_project_ids"] == [
+        DB_PROJECT_ID,
+        "another-project-i-can-see",
+    ]

--- a/tests/backend/api/test_rag_authorization.py
+++ b/tests/backend/api/test_rag_authorization.py
@@ -1,0 +1,149 @@
+"""Authorization + resolution contract for the RAG API.
+
+DB 레지스트리 프로젝트를 RAG 가 해석하게 되면서 생긴 노출을 고정한다.
+그 전에는 DB 프로젝트가 전부 404 였으므로 이 계약은 새로 필요해진 것이다.
+
+계약:
+1. 프로젝트 스코프 RAG 라우트는 **전부** 미인증 호출을 401 로 막는다.
+   (`Depends` 를 일곱 중 여섯에만 붙이는 실수를 라우트 표로 잡는다.)
+2. 접근 권한 없는 member 는 DB 프로젝트를 404 로 본다 — 존재를 알리지 않는다.
+3. `path` 가 비어 있는 DB 프로젝트는 404 이며, 인덱싱 작업이 **예약되지 않는다**.
+   (`Path("").resolve()` 는 서버 작업 디렉터리라, 통과하면 그 전체를 인덱싱한다.)
+4. `/rag/status` 는 DB 프로젝트에도 `indexed` 를 사실대로 보고한다.
+
+`POST /api/rag/query`(cross_project_query)는 프로젝트를 해석하지 않아 이 변경의
+범위 밖이므로 여기서 다루지 않는다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from api import deps as api_deps
+from api import rag
+from models.project import Project
+
+from .route_table import snapshot
+
+MEMBER_ID = "11111111-1111-1111-1111-111111111111"
+DB_PROJECT_ID = "05c4302d-9602-4b70-8267-65964f5bed4d"
+
+
+def _make_user(user_id: str, role: str = "member", is_admin: bool = False) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    user.email = f"{role}@example.com"
+    user.name = role
+    user.role = role
+    user.is_admin = is_admin
+    user.is_active = True
+    return user
+
+
+MEMBER = _make_user(MEMBER_ID)
+
+
+@pytest_asyncio.fixture
+async def app(monkeypatch):
+    from api.app import create_app
+
+    # RateLimitService 는 프로세스 전역 싱글턴이라, 여기서 예산을 태우면
+    # 뒤따르는 테스트 모듈이 429 로 죽는다 (순서 의존 실패).
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+
+    test_app = create_app(title="RAG AuthZ Test", debug=True)
+    test_app.dependency_overrides[api_deps.get_db_session] = lambda: MagicMock()
+    yield test_app
+    test_app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _project_scoped_rag_routes(app) -> list[tuple[str, str]]:
+    """`{project_id}` 를 받는 RAG 라우트만 (method, 구체 경로) 로 낸다."""
+    rows = [
+        (method, path)
+        for method, path, _ in snapshot(app.router)
+        if path.startswith("/api/rag/") and "{project_id}" in path
+    ]
+    assert rows, "RAG 라우트가 하나도 안 잡혔다 — 라우터가 안 붙었거나 경로가 바뀌었다"
+    return [(method, path.replace("{project_id}", DB_PROJECT_ID)) for method, path in rows]
+
+
+@pytest.mark.asyncio
+async def test_every_project_scoped_rag_route_requires_authentication(app, client) -> None:
+    """미인증 호출은 전 라우트에서 401 — 한 곳이라도 빠지면 그게 구멍이다."""
+    unprotected: list[tuple[str, str, int]] = []
+    for method, path in _project_scoped_rag_routes(app):
+        response = await client.request(method, path, json={})
+        if response.status_code != 401:
+            unprotected.append((method, path, response.status_code))
+
+    assert not unprotected, f"인증 없이 도달 가능한 RAG 라우트: {unprotected}"
+
+
+@pytest.mark.asyncio
+async def test_member_without_access_cannot_resolve_a_db_project(monkeypatch) -> None:
+    """권한 없는 member 에게는 DB 프로젝트가 존재하지 않는 것으로 보인다."""
+    monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
+
+    async def _deny(project_id, user, session):
+        return None
+
+    monkeypatch.setattr(rag, "authorize_db_project", _deny)
+
+    assert await rag._resolve_project(DB_PROJECT_ID, MEMBER, MagicMock()) is None
+
+
+@pytest.mark.asyncio
+async def test_db_project_without_a_path_is_rejected_before_scheduling(monkeypatch) -> None:
+    """`path` 가 빈 DB 프로젝트는 404 이고, 인덱싱이 예약되지 않아야 한다.
+
+    `Path("").resolve()` 는 서버의 작업 디렉터리다 — 통과하면 저장소 전체가
+    그 프로젝트 컬렉션으로 들어간다.
+    """
+    pathless = Project(id=DB_PROJECT_ID, name="Pathless", path="")
+    monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
+
+    async def _allow(project_id, user, session):
+        return pathless
+
+    monkeypatch.setattr(rag, "authorize_db_project", _allow)
+
+    scheduled: list[str] = []
+    monkeypatch.setattr(
+        rag,
+        "trigger_background_indexing",
+        lambda **kwargs: scheduled.append(kwargs["project_id"]) or True,
+    )
+
+    assert await rag._resolve_project(DB_PROJECT_ID, MEMBER, MagicMock()) is None
+    assert scheduled == [], "해석에 실패했는데 인덱싱이 예약됐다"
+
+
+@pytest.mark.asyncio
+async def test_status_reports_indexed_for_a_db_registry_project(monkeypatch) -> None:
+    """DB 전용 프로젝트도 인덱싱 후 `indexed: true` 로 보고돼야 한다."""
+    db_project = Project(id=DB_PROJECT_ID, name="Agent System", path="/workspace/agent-system")
+    monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
+
+    async def _allow(project_id, user, session):
+        return db_project
+
+    monkeypatch.setattr(rag, "authorize_db_project", _allow)
+    monkeypatch.setattr(rag, "_safe_count", lambda _project_id: 7)
+    monkeypatch.setattr(rag, "_collection_exists", lambda _project_id: True, raising=False)
+
+    result = await rag.get_indexing_status(DB_PROJECT_ID, MEMBER, MagicMock())
+
+    assert result["indexed"] is True
+    assert result["document_count"] == 7

--- a/tests/backend/api/test_rag_authorization.py
+++ b/tests/backend/api/test_rag_authorization.py
@@ -11,8 +11,8 @@ DB 레지스트리 프로젝트를 RAG 가 해석하게 되면서 생긴 노출�
    (`Path("").resolve()` 는 서버 작업 디렉터리라, 통과하면 그 전체를 인덱싱한다.)
 4. `/rag/status` 는 DB 프로젝트에도 `indexed` 를 사실대로 보고한다.
 
-`POST /api/rag/query`(cross_project_query)는 프로젝트를 해석하지 않아 이 변경의
-범위 밖이므로 여기서 다루지 않는다.
+`GET /api/rag/collections` 는 프로젝트 스코프가 아니라 여기서 제외한다 —
+이 변경이 건드리지 않은 기존 표면이다.
 """
 
 from __future__ import annotations
@@ -69,11 +69,16 @@ async def client(app):
 
 
 def _project_scoped_rag_routes(app) -> list[tuple[str, str]]:
-    """`{project_id}` 를 받는 RAG 라우트만 (method, 구체 경로) 로 낸다."""
+    """프로젝트 데이터를 읽거나 바꾸는 RAG 라우트를 (method, 구체 경로) 로 낸다.
+
+    `{project_id}` 라우트에 더해 교차 프로젝트 검색(`POST /api/rag/query`)도
+    포함한다 — 인덱싱된 청크를 그대로 내주므로 같은 경계에 있다.
+    """
     rows = [
         (method, path)
         for method, path, _ in snapshot(app.router)
-        if path.startswith("/api/rag/") and "{project_id}" in path
+        if path.startswith("/api/rag/")
+        and ("{project_id}" in path or path == "/api/rag/query")
     ]
     assert rows, "RAG 라우트가 하나도 안 잡혔다 — 라우터가 안 붙었거나 경로가 바뀌었다"
     return [(method, path.replace("{project_id}", DB_PROJECT_ID)) for method, path in rows]
@@ -147,3 +152,53 @@ async def test_status_reports_indexed_for_a_db_registry_project(monkeypatch) -> 
 
     assert result["indexed"] is True
     assert result["document_count"] == 7
+
+
+@pytest.mark.asyncio
+async def test_cross_project_search_is_narrowed_to_authorized_projects(monkeypatch) -> None:
+    """member 가 남의 project_id 를 지목해도 그 컬렉션은 검색되지 않는다.
+
+    인증만 걸고 대상 집합을 좁히지 않으면 단건 라우트의 ACL 이 무의미해진다.
+    """
+    monkeypatch.setattr(rag, "PROJECTS_REGISTRY", {})
+
+    async def _only_mine(project_ids, user, session):
+        mine = MagicMock()
+        mine.id = DB_PROJECT_ID
+        return [mine] if project_ids is None or DB_PROJECT_ID in project_ids else []
+
+    monkeypatch.setattr(rag, "authorize_db_projects", _only_mine)
+
+    allowed = await rag._authorized_project_ids(
+        [DB_PROJECT_ID, "someone-elses-project"], MEMBER, MagicMock()
+    )
+
+    assert allowed == [DB_PROJECT_ID]
+
+
+@pytest.mark.parametrize(
+    "handler_name, kwargs",
+    [("get_project_entities", {}), ("get_project_dependencies", {})],
+)
+@pytest.mark.asyncio
+async def test_code_scanning_routes_do_not_subscript_the_project(
+    monkeypatch, tmp_path, handler_name, kwargs
+) -> None:
+    """`Project` 는 Pydantic 모델이라 `project["path"]` 는 TypeError → 500 이었다.
+
+    소스 문자열이 아니라 **핸들러를 실제로 호출해서** 고정한다.
+    """
+    project = Project(id=DB_PROJECT_ID, name="Agent System", path=str(tmp_path))
+
+    async def _resolve(project_id, user, session):
+        return project
+
+    monkeypatch.setattr(rag, "_resolve_project", _resolve)
+    monkeypatch.setattr(rag, "extract_entities", lambda *a, **kw: [])
+    monkeypatch.setattr(rag, "extract_dependencies", lambda *a, **kw: [])
+
+    handler = getattr(rag, handler_name)
+    result = await handler(DB_PROJECT_ID, MEMBER, MagicMock(), **kwargs)
+
+    assert isinstance(result, dict)
+    assert result["project_id"] == DB_PROJECT_ID

--- a/tests/backend/api/test_rag_project_resolution.py
+++ b/tests/backend/api/test_rag_project_resolution.py
@@ -1,6 +1,6 @@
 """RAG must resolve projects stored in the database registry."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -19,4 +19,9 @@ async def test_resolve_project_falls_back_to_the_database_registry(monkeypatch) 
     monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
     monkeypatch.setattr(rag, "_get_db_project", AsyncMock(return_value=database_project))
 
-    assert await rag._resolve_project(database_project.id) == database_project
+    user = MagicMock()
+    session = MagicMock()
+
+    resolved = await rag._resolve_project(database_project.id, user, session)
+
+    assert resolved == database_project

--- a/tests/backend/api/test_rag_project_resolution.py
+++ b/tests/backend/api/test_rag_project_resolution.py
@@ -1,27 +1,35 @@
 """RAG must resolve projects stored in the database registry."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from api import rag
-from models.project import Project
 
 
 @pytest.mark.asyncio
 async def test_resolve_project_falls_back_to_the_database_registry(monkeypatch) -> None:
-    """A DB project UUID must work for RAG indexing and queries."""
-    database_project = Project(
-        id="05c4302d-9602-4b70-8267-65964f5bed4d",
-        name="Agent System",
-        path="/workspace/agent-system",
-    )
+    """A DB project UUID must work for RAG indexing and queries.
+
+    `_get_db_project` 이 아니라 그 아래의 `authorize_db_project` 를 갈아끼운다 —
+    `_get_db_project` 를 통째로 스텁하면 `_resolve_project` 가 실제로 하는 일
+    (인가 결과 변환 + 빈 경로 거부)을 전부 건너뛰어 동어반복이 된다.
+    """
+    row = MagicMock()
+    row.id = "05c4302d-9602-4b70-8267-65964f5bed4d"
+    row.name = "Agent System"
+    row.path = "/workspace/agent-system"
+    row.description = None
+    row.organization_id = None
+
+    async def _authorized(project_id, user, session, min_role="viewer"):
+        return row
+
     monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
-    monkeypatch.setattr(rag, "_get_db_project", AsyncMock(return_value=database_project))
+    monkeypatch.setattr(rag, "authorize_db_project", _authorized)
 
-    user = MagicMock()
-    session = MagicMock()
+    resolved = await rag._resolve_project(row.id, MagicMock(), MagicMock())
 
-    resolved = await rag._resolve_project(database_project.id, user, session)
-
-    assert resolved == database_project
+    assert resolved is not None
+    assert resolved.id == row.id
+    assert resolved.path == "/workspace/agent-system"

--- a/tests/backend/api/test_rag_project_resolution.py
+++ b/tests/backend/api/test_rag_project_resolution.py
@@ -1,0 +1,22 @@
+"""RAG must resolve projects stored in the database registry."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api import rag
+from models.project import Project
+
+
+@pytest.mark.asyncio
+async def test_resolve_project_falls_back_to_the_database_registry(monkeypatch) -> None:
+    """A DB project UUID must work for RAG indexing and queries."""
+    database_project = Project(
+        id="05c4302d-9602-4b70-8267-65964f5bed4d",
+        name="Agent System",
+        path="/workspace/agent-system",
+    )
+    monkeypatch.setattr(rag, "get_project", lambda _project_id: None)
+    monkeypatch.setattr(rag, "_get_db_project", AsyncMock(return_value=database_project))
+
+    assert await rag._resolve_project(database_project.id) == database_project

--- a/tests/backend/api/test_rag_registration.py
+++ b/tests/backend/api/test_rag_registration.py
@@ -1,0 +1,14 @@
+"""RAG routes must be mounted in the application served to the dashboard."""
+
+from api.app import create_app
+
+from .route_table import snapshot
+
+
+def test_rag_routes_are_mounted() -> None:
+    """Avoid silently degrading RAG actions into dashboard-side 404s."""
+    app = create_app(title="RAG registration test", debug=True)
+    paths = {path for _, path, _ in snapshot(app.router)}
+
+    assert "/api/rag/projects/{project_id}/index" in paths
+    assert "/api/rag/projects/{project_id}/stats" in paths


### PR DESCRIPTION
## 무엇을

RAG가 DB 레지스트리 프로젝트를 해석하게 만들고, 그 과정에서 드러난 인증·인가 공백을 닫습니다. 대시보드 수정 2건이 함께 있습니다.

원래 작업은 3건이었고, Codex 검증 5라운드에서 나온 지적 반영이 5커밋입니다.

## 왜

`USE_DATABASE=true` 환경에서 DB에 등록된 프로젝트는 filesystem `PROJECTS_REGISTRY`에 없어 모든 `/api/rag/*` 요청이 404였습니다. 그 404를 없애자 **RAG 라우터에 인증 의존성이 하나도 없다는 것**이 문제가 됐습니다 — 전역 auth 미들웨어도 없어(CORS·logging·rate-limit뿐) 프로젝트 UUID만 알면 누구나 인덱싱·조회·삭제·코드 엔티티 열람이 가능해집니다.

## 변경

### 백엔드

| | |
|---|---|
| **라우터 마운트** | `safe_import` 제거. 의존성이 깨지면 startup이 조용히 성공하고 모든 `/api/rag` 요청이 404를 내 원인을 감춥니다. 대시보드 기본 기능이므로 직접 import해 기동 시점에 드러나게 합니다 |
| **인증** | 프로젝트 스코프 7개 라우트 + `/rag/query` 전부 `Depends(get_current_user)` |
| **인가** | `api/projects/_shared.py`에 `authorize_db_projects(project_ids, user, session, min_role)` 신설. `GET /projects`와 **같은 규칙**을 재사용합니다 — 규칙을 두 벌로 두면 갈라지는 쪽이 인가라 티가 나지 않습니다 |
| **역할** | 변경 라우트(`POST`/`DELETE .../index`)는 `editor` 이상 요구. viewer가 비싼 재인덱싱과 벡터 컬렉션 전체 삭제를 못 하게 |
| **빈 경로** | `ProjectModel.path`는 nullable → `path or ""` → `Path("").resolve()` = **서버 작업 디렉터리**. 통과하면 저장소 전체가 그 프로젝트 컬렉션에 들어갑니다. 미등록과 동일 취급하고, 인덱싱 시점엔 실제 디렉터리인지까지 확인 |
| **shared 검색** | `include_shared: true`는 서비스 계층에서 다른 컬렉션을 ACL 없이 전부 훑었습니다. `VectorStore.query`에 `allowed_shared_project_ids`를 추가(기본 `None` = 기존 동작)하고 API 계층이 호출자의 인가 집합만 넘깁니다 |
| **`/rag/status`** | `PROJECTS_REGISTRY`만 봐서 DB 전용 프로젝트는 인덱싱을 마쳐도 영원히 `indexed: false`였습니다 |
| **`project["path"]`** | `Project`는 Pydantic 모델이라 subscript는 `TypeError` → 500. `/entities`·`/dependencies`가 **레거시 프로젝트에서도** 깨져 있었습니다 |

### 프론트엔드

- `ProjectList`: `role="button"` 안에 native button이 남아 있었습니다. ARIA button의 자손은 보조기술이 presentational로 취급해 삭제 컨트롤이 읽히지도 도달하지도 않습니다. 비인터랙티브 wrapper + 형제 버튼 2개로 분리하고 각각 `aria-label`.
- `SettingsPage`: `/api/terminal/available`을 raw `fetch`로 호출해 토큰이 실리지 않았습니다 → `authFetch`.

## 테스트 계획

`tests/backend/api/test_rag_authorization.py` (14건) — 라우트 표 기반이라 `Depends`를 일곱 중 여섯에만 붙이는 실수를 잡습니다.

1. 프로젝트 데이터를 다루는 RAG 라우트 **전수** 익명 요청 → 401
2. 접근 권한 없는 member → 404 (존재를 알리지 않음)
3. 빈 경로 → 404 **이고 인덱싱이 예약되지 않음** (상태 코드만 보면 예약 후 404를 통과시킵니다)
4. `/status`가 DB 프로젝트에 `indexed: true` 보고
5. 변경 라우트의 요구 권한이 `editor`, 조회는 `viewer`
6. `include_shared`가 ACL로 좁힌 집합만 store에 전달
7. `exclude_project_ids` 유지
8. 레지스트리 장애 → 500 아닌 503
9. `/entities`·`/dependencies` 실제 호출(소스 문자열 단언 아님)

**Red-Green 확인:** 한 엔드포인트만 `get_current_user_optional`로 약화 → 라우트 표 테스트가 그 하나를 지목(401 아닌 404). `project.path`를 되돌림 → `TypeError`로 실패. 둘 다 복원 후 통과.

**게이트:** BE `1994 passed / 1 failed` · FE `tsc` + `eslint` + `4502 passed` + `build`

`test_bootstrap_projects_match_the_projects_endpoint[member]` 1건은 **기존 실패**입니다. `app.py`/`rag.py`만 `origin/main` 버전으로 되돌려 같은 디렉터리를 재실행했을 때 동일하게 실패하는 것을 확인했습니다. 로컬 `.env`의 `USE_DATABASE=true` 의존이라 CI에서는 나오지 않습니다.

## 이 PR에서 다루지 않은 것

리뷰어가 물어볼 만한 것을 미리 적습니다.

1. **`GET /api/rag/collections`** — 여전히 미인증입니다. 프로젝트 스코프가 아니고 이 변경이 건드리지 않은 기존 표면이라 남겼습니다.
2. **`rag.py`의 `detail=f"...{str(e)}"`** — 내부 예외 문자열을 응답에 싣는 패턴이 여러 곳에 남아 있습니다. 이번엔 인가 실패가 그 catch-all에 먹히는 경로만 고쳤습니다.
3. **인가 정책이 두 벌** — `api/deps.py:require_project_role`은 "ACL 레코드가 없으면 전원 허용"인 반면, 제가 재사용한 `GET /projects`는 명시적 권한만 인정합니다. 여기서는 **엄격한 쪽**을 골랐습니다 — 대시보드 목록에 안 보이는 프로젝트를 RAG가 UUID만으로 열어주면 두 표면의 가시성이 어긋나기 때문입니다. 어느 쪽이 정본인지는 별도 결정이 필요합니다.

## 검증

`/codex:review` 5라운드. 지적 궤적이 P1×3 → P1×2+P2 → P1×2 → P2×1 → P2×2로 수렴했고, 남은 지적이 전부 이 브랜치가 만든 코드에 대한 오류 매핑 수준이 된 시점에서 멈췄습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gmozo9fDeig9texcdEYpt5