### PR TITLE
refactor(usage): Anthropic 비용표를 클래스 속성으로 승격해 드리프트 불변식에 편입

### DIFF
--- a/.claude/skills/update-llm-models/SKILL.md
+++ b/.claude/skills/update-llm-models/SKILL.md
@@ -83,7 +83,7 @@ prefix 불일치·ID 누락 시 $0 정산 또는 오정산이 조용히 발생�
 
 - `tests/backend/test_llm_model_registry.py`: 신모델 존재·스펙·default 해석, 가격 prefix 매칭(구체 vs generic 순서), `calculate_cost` 정확값.
   - **일부 표는 불변식이 먼저 RED 로 잡아준다** (2026-09-08 추가): `TestCostTableRegistryDrift`(`_MODELS` 전수 ↔ ① llm_proxy `COST_TABLE`, ④ `OpenAIUsageCollector._COST_TABLE`, ③ `claude_session.MODEL_COSTS`. `is_enabled` 무관), `TestCostTablePrefixOrdering`(구체 prefix 가 generic 뒤에 오면 실패), `TestDashboardFallbackMirror`(`settings.ts` 미러 집합 비교), `TestOpenAIStandardTierPricing`(Batch 단가 복귀 감지).
-  - **가드가 없는 표가 하나 남아 있다 — ② `AnthropicUsageCollector` 의 `costs`.** `collect()` **내부 지역 변수**라 import 할 수 없어 자동 검사 대상이 아니다. 즉 Anthropic 신모델을 넣고 이 표만 빠뜨리면 **전 게이트가 초록인데 외부 usage 만 $0** 이 된다 — 2단계에서 손으로 확인하라. (후속: `OpenAIUsageCollector._COST_TABLE` 처럼 클래스 속성으로 승격하면 같은 불변식으로 덮인다.)
+  - **네 표 모두 덮인다** (2026-09-08 기준): ② `AnthropicUsageCollector` 의 표는 `collect()` 내부 지역 변수라 검사할 수 없었는데 `_COST_TABLE` 클래스 속성으로 승격해 같은 불변식에 넣었다. 새 비용표를 만들 때도 **모듈/클래스 레벨 상수로 두어라** — 함수 안에 두면 테스트가 볼 수 없어 조용히 드리프트한다.
   - 새로 단가를 단언할 때 **입력·출력 토큰 수를 다르게 준다**(예: 1000/3000). 같은 수면 비용이 `in+out` 대칭 합이라 두 단가를 뒤바꿔 적은 전치 오류가 그대로 통과한다(실측).
   - **신규 async 테스트는 `@pytest.mark.asyncio` 명시를 관례로 유지하라.** `src/backend/pyproject.toml`에 `asyncio_mode=auto`가 있으나, pytest rootdir이 repo 루트로 해석되는 실행 경로에서는 이 설정이 적용되지 않아 CI "async not supported"로 실패한 실사례가 있다. auto가 적용되는 환경에서도 marker는 무해하므로 항상 붙인다.
 - `src/dashboard/src/stores/__tests__/settings.test.ts`: fallback 목록/default 검증을 갱신.

--- a/src/backend/services/external_usage_service/collectors.py
+++ b/src/backend/services/external_usage_service/collectors.py
@@ -257,8 +257,39 @@ class AnthropicUsageCollector(BaseUsageCollector):
 
     BASE_URL = "https://api.anthropic.com/v1"
 
+    # Per-1K-token USD pricing (input, output), prefix-matched most-specific first.
+    # Mirrors api/llm_proxy.py COST_TABLE; unlisted models fall back to $0 rather
+    # than fabricating a price. Kept as a class attribute (not a local inside
+    # collect()) so tests/backend/test_llm_model_registry.py can assert it against
+    # the _MODELS registry — a local dict here silently drifted in the past.
+    _COST_TABLE: tuple[tuple[str, float, float], ...] = (
+        ("claude-fable-5-1", 0.010, 0.050),
+        ("claude-opus-5", 0.005, 0.025),
+        ("claude-sonnet-5", 0.002, 0.010),
+        ("claude-opus-4-8", 0.005, 0.025),
+        # Opus price cut ($5/$25) applies from Opus 4.5 onward; these specific
+        # prefixes must precede the generic "claude-opus-4" (4-0/4-1 era $15/$75).
+        ("claude-opus-4-7", 0.005, 0.025),
+        ("claude-opus-4-6", 0.005, 0.025),
+        ("claude-opus-4-5", 0.005, 0.025),
+        ("claude-opus-4", 0.015, 0.075),
+        ("claude-sonnet-4", 0.003, 0.015),
+        ("claude-haiku-4-5", 0.001, 0.005),
+        ("claude-haiku-4", 0.00025, 0.00125),
+    )
+
     def __init__(self, admin_key: str) -> None:
         self._admin_key = admin_key
+
+    @classmethod
+    def _calc_cost(cls, model: str | None, input_tokens: int, output_tokens: int) -> float:
+        """Estimate USD cost from the local price table; 0.0 for unlisted models."""
+        if not model:
+            return 0.0
+        for prefix, cost_in, cost_out in cls._COST_TABLE:
+            if model.startswith(prefix):
+                return (input_tokens / 1000) * cost_in + (output_tokens / 1000) * cost_out
+        return 0.0
 
     def get_provider(self) -> ExternalProvider:
         return ExternalProvider.ANTHROPIC
@@ -299,23 +330,6 @@ class AnthropicUsageCollector(BaseUsageCollector):
         """Collect from Anthropic Usage Report API."""
         records: list[UnifiedUsageRecord] = []
 
-        costs: dict[str, tuple[float, float]] = {
-            "claude-fable-5-1": (0.010, 0.050),
-            "claude-opus-5": (0.005, 0.025),
-            "claude-sonnet-5": (0.002, 0.010),
-            "claude-opus-4-8": (0.005, 0.025),
-            # Opus price cut ($5/$25) applies from Opus 4.5 onward; these
-            # specific prefixes must precede the generic "claude-opus-4"
-            # (4-0/4-1 era $15/$75). Dict order == match order (startswith).
-            "claude-opus-4-7": (0.005, 0.025),
-            "claude-opus-4-6": (0.005, 0.025),
-            "claude-opus-4-5": (0.005, 0.025),
-            "claude-opus-4": (0.015, 0.075),
-            "claude-sonnet-4": (0.003, 0.015),
-            "claude-haiku-4-5": (0.001, 0.005),
-            "claude-haiku-4": (0.00025, 0.00125),
-        }
-
         async with httpx.AsyncClient(timeout=30) as client:
             params: dict = {
                 "starting_at": start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -347,11 +361,7 @@ class AnthropicUsageCollector(BaseUsageCollector):
                     model = item.get("model", "unknown")
                     input_tok = item.get("input_tokens", 0)
                     output_tok = item.get("output_tokens", 0)
-                    cost = 0.0
-                    for prefix, (ci, co) in costs.items():
-                        if model.startswith(prefix):
-                            cost = (input_tok / 1000) * ci + (output_tok / 1000) * co
-                            break
+                    cost = self._calc_cost(model, input_tok, output_tok)
                     records.append(
                         UnifiedUsageRecord(
                             provider=ExternalProvider.ANTHROPIC,

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -969,6 +969,22 @@ class TestCostTableRegistryDrift:
 
         assert not mismatched, f"OpenAIUsageCollector._COST_TABLE 미커버/오단가: {mismatched}"
 
+    def test_every_anthropic_registry_model_is_covered_by_usage_collector(self):
+        """AnthropicUsageCollector 의 표는 collect() 지역 변수였다가 클래스 속성으로
+        승격됐다(2026-09-08). 그 전에는 이 불변식을 걸 수 없어 조용히 드리프트했다."""
+        from services.external_usage_service.collectors import AnthropicUsageCollector
+
+        mismatched = []
+        for model in _PRICED_MODELS:
+            if model.provider != LLMProvider.ANTHROPIC:
+                continue
+            expected = _expected_cost(model)
+            actual = AnthropicUsageCollector._calc_cost(model.id, _IN_TOKENS, _OUT_TOKENS)
+            if actual != pytest.approx(expected):
+                mismatched.append((model.id, expected, actual))
+
+        assert not mismatched, f"AnthropicUsageCollector._COST_TABLE 미커버/오단가: {mismatched}"
+
     def test_every_anthropic_registry_model_is_in_claude_session_costs(self):
         """MODEL_COSTS 는 정확-ID 조회라 신규 Anthropic 모델이 빠지면 sonnet 단가로
         폴백해 오집계된다(비싼 모델이면 과소, 싼 모델이면 과대)."""
@@ -1011,10 +1027,17 @@ class TestCostTablePrefixOrdering:
         assert not shadowed, f"COST_TABLE: 구체 prefix 가 generic 뒤에 있어 도달 불가: {shadowed}"
 
     def test_usage_collector_table_has_no_shadowed_row(self):
-        from services.external_usage_service.collectors import OpenAIUsageCollector
+        from services.external_usage_service.collectors import (
+            AnthropicUsageCollector,
+            OpenAIUsageCollector,
+        )
 
-        shadowed = self._shadowed([row[0] for row in OpenAIUsageCollector._COST_TABLE])
-        assert not shadowed, f"_COST_TABLE: 구체 prefix 가 generic 뒤에 있어 도달 불가: {shadowed}"
+        for collector in (OpenAIUsageCollector, AnthropicUsageCollector):
+            shadowed = self._shadowed([row[0] for row in collector._COST_TABLE])
+            assert not shadowed, (
+                f"{collector.__name__}._COST_TABLE: 구체 prefix 가 generic 뒤에 있어 "
+                f"도달 불가: {shadowed}"
+            )
 
     def test_gpt56_variants_are_not_repriced_by_alias_row(self):
         from api.llm_proxy import _calc_cost


### PR DESCRIPTION
## 배경

PR #403에서 남겨둔 마지막 구멍을 닫습니다.

`AnthropicUsageCollector` 의 가격표는 `collect()` **내부 지역 변수**라 import 할 수 없어 드리프트 검사를 걸 수 없었습니다. 즉 Anthropic 신모델을 추가하면서 이 표만 빠뜨리면 **모든 게이트가 초록인데 외부 usage 만 $0** 으로 집계되는 구조였습니다 — PR #402에서 고친 결함과 정확히 같은 유형입니다.

## 변경

- `_COST_TABLE` 클래스 속성 + `_calc_cost` classmethod 로 승격 (`OpenAIUsageCollector` 와 대칭)
- `collect()` 의 인라인 매칭 루프를 `self._calc_cost(...)` 호출로 대체
- 드리프트 불변식과 prefix 그림자 구조 검사를 이 표까지 확장
- 스킬 서술 갱신 + "새 비용표는 모듈/클래스 레벨 상수로 둘 것" 규칙 추가

`dict` 삽입 순서 = 매칭 순서였으므로 `tuple` 로 옮기며 순서가 그대로 보존되고, 미등재 → $0 폴백도 유지됩니다.

## 행동 보존 증명

`grep` 으로 "소비자가 없다"를 확인하는 것은 "동작이 같다"의 근거가 아니므로, **리팩터링 이전 구현을 프로브에 그대로 재현해 전후를 대조**했습니다.

- 대조 대상 26건 = 레지스트리 Anthropic 7종 + 표의 legacy prefix 11종 + 경계 케이스 8종(`claude-opus-4-1`, `claude-3-5-sonnet-20241022`, 미등재 `gpt-4o`, `unknown`, 빈 문자열 등)
- **불일치 0건.** 빈 문자열도 `0.0` 으로 동일
- 기존 `test_external_usage_service.py` **15 passed**

## 가드 RED 확인

| mutation | 결과 |
|---|---|
| `claude-sonnet-5` 행 제거 (신모델 누락 시뮬) | 드리프트 테스트 실패 |
| generic `claude-opus-4` 를 구체 prefix 앞으로 | 그림자 구조 테스트 실패 |

## 검증

- `ruff check` / `ruff format --check` / `mypy` exit 0
- `pytest tests/backend` **2020 passed** (실패 1건은 기존 `test_bootstrap` 크로스모듈 오염 — CI 에서는 통과)
- Codex 리뷰 1라운드 지적 0건 (행동 보존·테스트 가능성·커버리지 확장을 지목)

## 결과

비용표 **4개 전부**가 이제 `_MODELS` 대비 자동 드리프트 검사를 받습니다: ① `llm_proxy.COST_TABLE` ② `AnthropicUsageCollector._COST_TABLE` ③ `claude_session.MODEL_COSTS` ④ `OpenAIUsageCollector._COST_TABLE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019u3XhJ6HHpsBnXieo5xFDY
