### PR TITLE
fix(llm): generic prefix 에 삼켜지던 변종 3종 + gpt-4o 표준가 교정

### DIFF
--- a/src/backend/api/llm_proxy.py
+++ b/src/backend/api/llm_proxy.py
@@ -42,7 +42,12 @@ PROVIDER_BASE_URLS: dict[str, str] = {
 COST_TABLE: list[tuple[str, float, float]] = [
     ("gpt-6-astra", 0.010, 0.050),
     ("gpt-4o-mini", 0.00015, 0.0006),
-    ("gpt-4o", 0.005, 0.015),
+    # gpt-4o 현행 표준가는 $2.50/$10. $5/$15 는 2024-05-13 스냅샷 전용이라
+    # 그 dated id 를 generic 앞에 두어 과거 정산 근거를 보존한다.
+    ("gpt-4o-2024-05-13", 0.005, 0.015),
+    ("gpt-4o", 0.0025, 0.010),
+    # o1-pro 는 $150/$600 — generic "o1"($15/$60) 뒤에 두면 10배 과소 집계된다.
+    ("o1-pro", 0.150, 0.600),
     ("o1-mini", 0.003, 0.012),
     ("o1", 0.015, 0.060),
     # GPT-5.6/5.5/5.4 · o-series: 값은 models/llm_models.py `_MODELS`(SSOT) 그대로.
@@ -88,6 +93,8 @@ COST_TABLE: list[tuple[str, float, float]] = [
     ("gemini-3.1-flash-lite-preview", 0.00025, 0.0015),
     ("gemini-3-flash-preview", 0.0005, 0.003),
     ("gemini-2.5-pro", 0.00125, 0.01),
+    # Flash-Lite($0.10/$0.40)는 generic "gemini-2.5-flash" 뒤에 두면 3~6배 과대 집계된다.
+    ("gemini-2.5-flash-lite", 0.0001, 0.0004),
     ("gemini-2.5-flash", 0.0003, 0.0025),
     ("gemini-2.0-flash", 0.00025, 0.001),
     ("gemini-1.5-pro", 0.00125, 0.005),

--- a/src/backend/models/llm_models.py
+++ b/src/backend/models/llm_models.py
@@ -138,6 +138,9 @@ _MODELS: list[LLMModelConfig] = [
     # Pricing: USD per 1K tokens. Docs: https://ai.google.dev/gemini-api/docs/models
     # ─────────────────────────────────────────────────────────
     # gemini-3.8-flash: official model docs, verified 2026-09-05
+    # 발효일 주의: 공식 가격표가 "$0.75/$3.75 through December 31, 2026,
+    # $1.50/$7.50 starting January 1, 2027" 로 고지한다 (3.7-flash 도 동일).
+    # 2027-01-01 에 이 두 행과 llm_proxy COST_TABLE 을 함께 올려야 한다.
     LLMModelConfig(
         id="gemini-3.8-flash",
         display_name="Gemini 3.8 Flash",
@@ -236,8 +239,10 @@ _MODELS: list[LLMModelConfig] = [
         display_name="GPT-4o",
         provider=LLMProvider.OPENAI,
         context_window=128000,
-        input_price=0.005,  # $5.00/1M tokens
-        output_price=0.015,  # $15.00/1M tokens
+        # 표준 티어 단가. $5.00/$15.00 은 gpt-4o-2024-05-13 스냅샷 가격이라
+        # 현행 gpt-4o 에 쓰면 과대 집계된다 (공식 가격표 대조, 2026-09-08 교정).
+        input_price=0.0025,  # $2.50/1M tokens
+        output_price=0.010,  # $10.00/1M tokens
         is_default=False,
         supports_tools=True,
         supports_vision=True,

--- a/src/backend/services/external_usage_service/collectors.py
+++ b/src/backend/services/external_usage_service/collectors.py
@@ -45,7 +45,11 @@ class OpenAIUsageCollector(BaseUsageCollector):
     _COST_TABLE: tuple[tuple[str, float, float], ...] = (
         ("gpt-6-astra", 0.010, 0.050),
         ("gpt-4o-mini", 0.00015, 0.0006),
-        ("gpt-4o", 0.005, 0.015),
+        # dated 스냅샷은 구 단가($5/$15), 현행 gpt-4o 는 $2.50/$10.
+        ("gpt-4o-2024-05-13", 0.005, 0.015),
+        ("gpt-4o", 0.0025, 0.010),
+        # o1-pro($150/$600)가 generic "o1" 에 삼켜지면 10배 과소 집계.
+        ("o1-pro", 0.150, 0.600),
         ("o1-mini", 0.003, 0.012),
         ("o1", 0.015, 0.060),
         # GPT-5.6/5.5/5.4 · o-series: 값은 models/llm_models.py `_MODELS`(SSOT) 그대로.

--- a/tests/backend/test_external_usage_service.py
+++ b/tests/backend/test_external_usage_service.py
@@ -67,8 +67,9 @@ async def test_openai_collect_computes_cost_for_known_model() -> None:
 
     assert len(records) == 1
     rec = records[0]
-    # gpt-4o: $0.005/1K input + $0.015/1K output → 0.02 for 1K+1K tokens
-    assert rec.cost_usd == pytest.approx(0.02)
+    # gpt-4o: $0.0025/1K input + $0.010/1K output → 0.0125 for 1K+1K tokens
+    # ($5/$15 는 gpt-4o-2024-05-13 스냅샷 전용 단가다)
+    assert rec.cost_usd == pytest.approx(0.0125)
     assert rec.model == "gpt-4o-2024-08-06"
     assert rec.input_tokens == 1000
 

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -1066,6 +1066,27 @@ class TestCostTablePrefixOrdering:
             assert calc("o3-mini", 1000, 3000) == pytest.approx(0.0011 + 3 * 0.0044)
             assert calc("o3", 1000, 3000) == pytest.approx(0.002 + 3 * 0.008)
 
+    def test_swallowed_variants_keep_their_own_price(self):
+        """generic 행이 SSOT 미등재 변종을 삼키던 사례들(2026-09-08 수정).
+        전부 레지스트리 밖 id 라 드리프트 불변식이 보지 못한다."""
+        from api.llm_proxy import _calc_cost
+        from services.external_usage_service.collectors import OpenAIUsageCollector
+
+        for calc in (_calc_cost, OpenAIUsageCollector._calc_cost):
+            # o1-pro $150/$600 vs generic o1 $15/$60 — 삼켜지면 10배 과소 집계
+            assert calc("o1-pro", 1000, 3000) == pytest.approx(0.150 + 3 * 0.600)
+            assert calc("o1", 1000, 3000) == pytest.approx(0.015 + 3 * 0.060)
+            # dated 스냅샷은 구 단가를 유지하고, 현행 gpt-4o 는 표준가를 쓴다
+            assert calc("gpt-4o-2024-05-13", 1000, 3000) == pytest.approx(0.005 + 3 * 0.015)
+            assert calc("gpt-4o", 1000, 3000) == pytest.approx(0.0025 + 3 * 0.010)
+            assert calc("gpt-4o-mini", 1000, 3000) == pytest.approx(0.00015 + 3 * 0.0006)
+
+        # Gemini 는 수집기가 없어 llm_proxy 만 해당
+        assert _calc_cost("gemini-2.5-flash-lite", 1000, 3000) == pytest.approx(
+            0.0001 + 3 * 0.0004
+        )
+        assert _calc_cost("gemini-2.5-flash", 1000, 3000) == pytest.approx(0.0003 + 3 * 0.0025)
+
     def test_usage_collector_keeps_the_same_variant_ordering(self):
         from services.external_usage_service.collectors import OpenAIUsageCollector
 


### PR DESCRIPTION
## 문제

비용표는 `startswith` **선착 매칭**이라 generic 행이 SSOT 미등재 변종까지 삼킵니다. PR #402 본문에 "권위 있는 단가 출처 확보 시 처리"로 남겨둔 항목을 공식 가격표를 확인해 닫습니다.

## 범위 판정 기준

무한정 늘어나지 않도록 **세 조건을 모두 만족할 때만** 행을 추가했습니다.
1. 공식 가격표에 있는 실재 모델
2. 기존 generic prefix 가 삼킴
3. 단가가 그 generic 행과 다름

TTS·transcribe·realtime 계열(`gpt-4o-mini-tts`, `gpt-4o-transcribe`, `gpt-realtime-*`)은 조건 1·2·3을 만족하지만 **도달 불가라 제외**했습니다 — `OpenAIUsageCollector` 가 조회하는 엔드포인트는 `/organization/usage/completions` 뿐이고, `llm_proxy` 는 레지스트리 등재 모델만 라우팅합니다.

## 고친 것

| 모델 | 이전 | 이후 | 영향 |
|---|---|---|---|
| `o1-pro` | generic `o1` 단가 $15/$60 | $150/$600 | **10배 과소** 집계 |
| `gemini-2.5-flash-lite` | generic `gemini-2.5-flash` $0.30/$2.50 | $0.10/$0.40 | 3~6배 과대 집계 |
| `gpt-4o` | $5/$15 | **$2.50/$10** | 2배·1.5배 과대 집계 |
| `gpt-4o-2024-05-13` | (generic 에 흡수) | $5/$15 별도 행 | 과거 정산 근거 보존 |

`gpt-4o` 는 `o4-mini`(PR #404) 와 같은 유형입니다 — 등록된 `$5/$15` 는 현행 단가가 아니라 **2024-05-13 스냅샷** 가격이었습니다. dated id 는 실제로 그 단가이므로 구 단가 행을 generic 앞에 남겨 둘 다 맞게 했습니다.

추가로 `gemini-3.8/3.7-flash` 행에 **발효일 주석**을 달았습니다. 공식 표가 "$0.75/$3.75 through December 31, 2026, $1.50/$7.50 starting January 1, 2027" 로 고지하므로 2027-01-01 에 레지스트리와 COST_TABLE 을 함께 올려야 합니다.

## 가드 (전부 mutation RED 확인)

| mutation | 결과 |
|---|---|
| `o1-pro` 행 제거 | 변종 단가 테스트 실패 |
| `gemini-2.5-flash-lite` 를 generic 뒤로 | 순서·단가 2건 실패 |
| `gpt-4o` 를 옛 단가로 복귀 | 드리프트 포함 2건 실패 |

`gpt-4o` 단가 변경에 딸린 기존 수집기 테스트 기대값(`0.02` → `0.0125`)도 갱신했습니다 — 그 값이 잘못된 단가를 인코딩하고 있었습니다.

## 검증

**격리 워크트리에서 실행했습니다.** 공유 워크트리에 다른 세션의 미커밋 변경(`src/backend/api/routes.py`)이 섞여 있어 그 상태의 게이트 결과는 무효이기 때문입니다.

- `git worktree add --detach` 로 이 커밋만 체크아웃 → `git status` 클린 확인
- `ruff check` / `ruff format --check` / `mypy` **exit 0**
- `pytest tests/backend` **2023 passed, 0 failed**

> 참고: 공유 트리에서는 `test_bootstrap[member]` 1건이 실패하는데, 격리 워크트리에서는 통과합니다. 두 트리의 차이는 gitignore 된 `.env` 뿐이며 별도 이슈로 조사 중입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019u3XhJ6HHpsBnXieo5xFDY
