### PR TITLE
chore(lint): tests/backend 를 ruff 게이트에 편입 (설정 비결정성 제거 포함)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check .
 
+      # tests/backend 는 src/backend 밖이라 위 두 스텝의 범위에 들지 않는다.
+      # 자체 ruff.toml 을 두었으므로 cwd 와 무관하게 같은 규칙이 적용된다.
+      - name: Ruff lint (tests)
+        run: uv run ruff check ../../tests/backend --output-format=github
+
+      - name: Ruff format check (tests)
+        run: uv run ruff format --check ../../tests/backend
+
   backend-typecheck:
     name: Backend Type Check
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "src/backend/**/*.py": [
       "uv run --project src/backend ruff check --fix",
       "uv run --project src/backend ruff format"
+    ],
+    "tests/backend/**/*.py": [
+      "uv run --project src/backend ruff check --fix",
+      "uv run --project src/backend ruff format"
     ]
   }
 }

--- a/tests/backend/api/test_agent_registry.py
+++ b/tests/backend/api/test_agent_registry.py
@@ -10,26 +10,23 @@ import time
 import jwt
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
 
 from api.v1.agent_registry import (
-    router,
+    _seed_default_agents,
     get_cache,
     reset_agent_store,
-    _seed_default_agents,
+    router,
 )
 from api.v1.auth_middleware import (
     JWT_ALGORITHM,
     UserRole,
     create_access_token,
-    create_token_pair,
-    create_refresh_token,
     reset_user_store,
     verify_token,
 )
 from api.v1.rate_limiter import get_rate_limiter
-
 
 # ─────────────────────────────────────────────────────────────
 # Fixtures
@@ -255,7 +252,7 @@ async def test_anonymous_rate_limit(client):
     # Make 10 requests (should all succeed)
     for i in range(10):
         response = await client.get("/api/v1/agents")
-        assert response.status_code == 200, f"Request {i+1} failed unexpectedly"
+        assert response.status_code == 200, f"Request {i + 1} failed unexpectedly"
 
     # 11th request should be rate limited
     response = await client.get("/api/v1/agents")
@@ -272,7 +269,7 @@ async def test_admin_unlimited_rate(client):
     # Make 15 requests (beyond anonymous limit) - all should succeed
     for i in range(15):
         response = await client.get("/api/v1/agents", headers=headers)
-        assert response.status_code == 200, f"Admin request {i+1} failed"
+        assert response.status_code == 200, f"Admin request {i + 1} failed"
 
 
 # ─────────────────────────────────────────────────────────────
@@ -294,9 +291,7 @@ async def test_list_agents_returns_seeded(client):
 @pytest.mark.asyncio
 async def test_get_agent_by_id(client):
     """Test 14: Get a single agent by ID."""
-    response = await client.get(
-        "/api/v1/agents/agent-web-ui", headers=_user_headers()
-    )
+    response = await client.get("/api/v1/agents/agent-web-ui", headers=_user_headers())
 
     assert response.status_code == 200
     data = response.json()
@@ -307,9 +302,7 @@ async def test_get_agent_by_id(client):
 @pytest.mark.asyncio
 async def test_get_agent_not_found(client):
     """Test 15: Get non-existent agent returns 404."""
-    response = await client.get(
-        "/api/v1/agents/nonexistent-agent", headers=_user_headers()
-    )
+    response = await client.get("/api/v1/agents/nonexistent-agent", headers=_user_headers())
 
     assert response.status_code == 404
 
@@ -343,9 +336,7 @@ async def test_filter_by_status(client):
     assert data["total"] == 2  # agent-web-ui and agent-backend
 
     # Filter for multiple statuses
-    response = await client.get(
-        "/api/v1/agents?status=available,busy", headers=headers
-    )
+    response = await client.get("/api/v1/agents?status=available,busy", headers=headers)
     data = response.json()
     assert data["total"] == 3  # available + busy
 
@@ -355,9 +346,7 @@ async def test_filter_by_category(client):
     """Test 18: Filter agents by category."""
     headers = _user_headers()
 
-    response = await client.get(
-        "/api/v1/agents?category=development", headers=headers
-    )
+    response = await client.get("/api/v1/agents?category=development", headers=headers)
     data = response.json()
     assert data["total"] == 2  # agent-web-ui and agent-backend
     for item in data["items"]:
@@ -369,9 +358,7 @@ async def test_filter_by_min_success_rate(client):
     """Test 19: Filter agents by minimum success rate."""
     headers = _user_headers()
 
-    response = await client.get(
-        "/api/v1/agents?min_success_rate=0.95", headers=headers
-    )
+    response = await client.get("/api/v1/agents?min_success_rate=0.95", headers=headers)
     data = response.json()
     # agent-web-ui (0.95) and agent-quality (0.98)
     assert data["total"] == 2
@@ -384,9 +371,7 @@ async def test_search_agents(client):
     """Test 20: Search agents by keyword in name/description."""
     headers = _user_headers()
 
-    response = await client.get(
-        "/api/v1/agents?search=backend", headers=headers
-    )
+    response = await client.get("/api/v1/agents?search=backend", headers=headers)
     data = response.json()
     assert data["total"] == 1
     assert data["items"][0]["id"] == "agent-backend"
@@ -397,9 +382,7 @@ async def test_multi_sort(client):
     """Test 21: Sort agents by multiple fields."""
     headers = _user_headers()
 
-    response = await client.get(
-        "/api/v1/agents?sort=success_rate:desc", headers=headers
-    )
+    response = await client.get("/api/v1/agents?sort=success_rate:desc", headers=headers)
     data = response.json()
 
     rates = [item["success_rate"] for item in data["items"]]
@@ -411,9 +394,7 @@ async def test_offset_pagination(client):
     """Test 22: Offset-based pagination works correctly."""
     headers = _user_headers()
 
-    response = await client.get(
-        "/api/v1/agents?page=1&page_size=2", headers=headers
-    )
+    response = await client.get("/api/v1/agents?page=1&page_size=2", headers=headers)
     data = response.json()
 
     assert len(data["items"]) == 2
@@ -424,9 +405,7 @@ async def test_offset_pagination(client):
     assert data["has_more"] is True
 
     # Page 2
-    response2 = await client.get(
-        "/api/v1/agents?page=2&page_size=2", headers=headers
-    )
+    response2 = await client.get("/api/v1/agents?page=2&page_size=2", headers=headers)
     data2 = response2.json()
     assert len(data2["items"]) == 2
     assert data2["has_more"] is False
@@ -438,24 +417,20 @@ async def test_cursor_pagination(client):
     headers = _user_headers()
 
     # Get first page
-    response = await client.get(
-        "/api/v1/agents?page_size=2&sort=name:asc", headers=headers
-    )
+    response = await client.get("/api/v1/agents?page_size=2&sort=name:asc", headers=headers)
     data = response.json()
     assert len(data["items"]) == 2
-    first_page_ids = [item["id"] for item in data["items"]]
 
     # Use cursor from first page to get next page (if cursor available)
     # Since we didn't use cursor initially, let's build one
     # Get all sorted, then use cursor
-    response_all = await client.get(
-        "/api/v1/agents?sort=name:asc", headers=headers
-    )
+    response_all = await client.get("/api/v1/agents?sort=name:asc", headers=headers)
     all_data = response_all.json()
     all_ids = [item["id"] for item in all_data["items"]]
 
     # Construct cursor from the second item
     import base64
+
     cursor = base64.urlsafe_b64encode(all_ids[1].encode()).decode()
 
     response2 = await client.get(
@@ -761,9 +736,7 @@ def test_env_secret_signs_tokens_after_reload(monkeypatch):
         token = auth_middleware.create_access_token(
             "usr_admin_001", "admin", auth_middleware.UserRole.ADMIN
         )
-        decoded = jwt.decode(
-            token, env_secret, algorithms=[auth_middleware.JWT_ALGORITHM]
-        )
+        decoded = jwt.decode(token, env_secret, algorithms=[auth_middleware.JWT_ALGORITHM])
         assert decoded["sub"] == "usr_admin_001"
         assert decoded["token_type"] == "access"
     finally:
@@ -786,9 +759,7 @@ def test_session_secret_derived_key_after_reload(monkeypatch):
     try:
         importlib.reload(auth_middleware)
 
-        derived = hashlib.sha256(
-            f"agent-registry:{session_secret}".encode()
-        ).hexdigest()
+        derived = hashlib.sha256(f"agent-registry:{session_secret}".encode()).hexdigest()
         # Derived key is stable and NOT the raw session secret (no confusion).
         assert auth_middleware.JWT_SECRET_KEY == derived
         assert auth_middleware.JWT_SECRET_KEY != session_secret
@@ -797,9 +768,7 @@ def test_session_secret_derived_key_after_reload(monkeypatch):
         token = auth_middleware.create_access_token(
             "usr_admin_001", "admin", auth_middleware.UserRole.ADMIN
         )
-        decoded = jwt.decode(
-            token, derived, algorithms=[auth_middleware.JWT_ALGORITHM]
-        )
+        decoded = jwt.decode(token, derived, algorithms=[auth_middleware.JWT_ALGORITHM])
         assert decoded["sub"] == "usr_admin_001"
     finally:
         # Restore original module state to avoid polluting other tests.

--- a/tests/backend/api/test_agents.py
+++ b/tests/backend/api/test_agents.py
@@ -10,13 +10,10 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from api.v1.agents import (
-    AgentCategory,
-    AgentStatus,
     reset_agent_store,
     router,
     seed_default_agents,
 )
-
 
 # ─────────────────────────────────────────────────────────────
 # Fixtures

--- a/tests/backend/api/test_api_git_prune.py
+++ b/tests/backend/api/test_api_git_prune.py
@@ -116,12 +116,8 @@ class TestPruneMergedEndpoint:
         """dry_run=False must call prune_merged_branches and surface deleted list."""
         git_service = MagicMock()
         candidate = _make_candidate("feat/a", pr=1)
-        git_service.find_prune_candidates.return_value = _make_scan_result(
-            candidates=[candidate]
-        )
-        git_service.prune_merged_branches.return_value = _make_execute_result(
-            deleted=["feat/a"]
-        )
+        git_service.find_prune_candidates.return_value = _make_scan_result(candidates=[candidate])
+        git_service.prune_merged_branches.return_value = _make_execute_result(deleted=["feat/a"])
 
         with (
             patch("api.git.branches.get_git_service_for_project", return_value=git_service),
@@ -146,9 +142,7 @@ class TestPruneMergedEndpoint:
             candidates=[_make_candidate("feat/a", pr=1)],
             skipped=skipped,
         )
-        git_service.prune_merged_branches.return_value = _make_execute_result(
-            deleted=["feat/a"]
-        )
+        git_service.prune_merged_branches.return_value = _make_execute_result(deleted=["feat/a"])
 
         with (
             patch("api.git.branches.get_git_service_for_project", return_value=git_service),

--- a/tests/backend/api/test_context_db_mode.py
+++ b/tests/backend/api/test_context_db_mode.py
@@ -206,7 +206,9 @@ async def test_claude_md_reads_the_registered_db_path(db_mode_app):
 
 
 @pytest.mark.asyncio
-async def test_missing_claude_md_is_not_found_not_unavailable(authenticated_app, tmp_path, monkeypatch):
+async def test_missing_claude_md_is_not_found_not_unavailable(
+    authenticated_app, tmp_path, monkeypatch
+):
     """등록 경로는 있는데 CLAUDE.md 만 없으면 404 — 503 이 아니다.
 
     503 은 '검사 가능한 디렉터리가 없음' 하나에만 남겨 둔다. 두 원인을 같은

--- a/tests/backend/api/test_diagnostics_db_mode.py
+++ b/tests/backend/api/test_diagnostics_db_mode.py
@@ -272,9 +272,12 @@ async def test_diagnostics_rejects_project_config_symlink_escape(
             {"fix_action": "enable_mcp_servers", "params": {}},
         )
         assert fix_response.status_code == 400, fix_response.text
-        assert json.loads(outside_config.read_text(encoding="utf-8"))["mcpServers"]["outside"][
-            "disabled"
-        ] is True
+        assert (
+            json.loads(outside_config.read_text(encoding="utf-8"))["mcpServers"]["outside"][
+                "disabled"
+            ]
+            is True
+        )
     finally:
         authenticated_app.dependency_overrides.pop(get_db_session, None)
 

--- a/tests/backend/api/test_git_db_project_resolution.py
+++ b/tests/backend/api/test_git_db_project_resolution.py
@@ -194,9 +194,7 @@ async def test_viewer_can_read_but_not_mutate(db_project_app, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         read = await ac.get(f"/api/git/projects/{DB_UUID}/status")
-        write = await ac.post(
-            f"/api/git/projects/{DB_UUID}/branches", json={"name": "feature/x"}
-        )
+        write = await ac.post(f"/api/git/projects/{DB_UUID}/branches", json={"name": "feature/x"})
 
     assert read.status_code == 200, read.text
     assert write.status_code == 403, write.text

--- a/tests/backend/api/test_llm_models_delete.py
+++ b/tests/backend/api/test_llm_models_delete.py
@@ -10,7 +10,7 @@ The DB session and auth user are injected via FastAPI dependency overrides with
 lightweight fakes (no real DB in the test env).
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -28,7 +28,7 @@ from models.llm_models import LLMModelRegistry
 _ADMIN = SimpleNamespace(id="admin-1", role="admin", is_admin=True, is_active=True)
 _NON_ADMIN = SimpleNamespace(id="user-1", role="user", is_admin=False, is_active=True)
 _INACTIVE_ADMIN = SimpleNamespace(id="admin-2", role="admin", is_admin=True, is_active=False)
-_SUPPRESSED_AT = datetime(2026, 7, 12, 4, 30, tzinfo=timezone.utc)
+_SUPPRESSED_AT = datetime(2026, 7, 12, 4, 30, tzinfo=UTC)
 
 
 def _insert_params(stmt) -> dict:
@@ -142,9 +142,9 @@ async def test_delete_model_success(monkeypatch, make_client):
     )
     db = _FakeDB(
         select_results=[
-            _Result(scalar=db_model),                # SELECT config row (FOR UPDATE)
-            _Result(scalar=suppression),             # read-back suppression
-            _Result(scalars_list=[remaining]),       # load_from_db reload
+            _Result(scalar=db_model),  # SELECT config row (FOR UPDATE)
+            _Result(scalar=suppression),  # read-back suppression
+            _Result(scalars_list=[remaining]),  # load_from_db reload
         ]
     )
     client = await make_client(db, _ADMIN)
@@ -180,9 +180,9 @@ async def test_delete_model_suppression_readback_none_stays_200(monkeypatch, mak
     db_model = SimpleNamespace(id="gpt-5.4-nano", provider="openai", is_default=False)
     db = _FakeDB(
         select_results=[
-            _Result(scalar=db_model),   # SELECT config FOR UPDATE
-            _Result(scalar=None),       # suppression readback → None (raced away)
-            _Result(scalars_list=[]),   # load_from_db
+            _Result(scalar=db_model),  # SELECT config FOR UPDATE
+            _Result(scalar=None),  # suppression readback → None (raced away)
+            _Result(scalars_list=[]),  # load_from_db
         ]
     )
     client = await make_client(db, _ADMIN)
@@ -328,7 +328,7 @@ async def test_patch_model_success_with_row_lock(monkeypatch, make_client):
     )
     db = _FakeDB(
         select_results=[
-            _Result(scalar=db_model),          # SELECT config FOR UPDATE
+            _Result(scalar=db_model),  # SELECT config FOR UPDATE
             _Result(scalars_list=[reloaded]),  # load_from_db reload
         ]
     )

--- a/tests/backend/api/test_project_config_db_identity.py
+++ b/tests/backend/api/test_project_config_db_identity.py
@@ -113,15 +113,15 @@ async def db_mode_app(authenticated_app, tmp_path, monkeypatch, isolated_monitor
         updated_at=None,
     )
 
-    Database = _database_stub(row)
+    database_cls = _database_stub(row)
 
     async def _override():
-        yield Database()
+        yield database_cls()
 
     monkeypatch.setenv("USE_DATABASE", "true")
     # 목록 필터(`_get_db_filtered_projects`)는 주입된 세션이 아니라 자체
     # `async_session_factory()` 를 연다. override 만으로는 실 DB 에 붙는다.
-    monkeypatch.setattr("db.database.async_session_factory", lambda: Database())
+    monkeypatch.setattr("db.database.async_session_factory", lambda: database_cls())
     authenticated_app.dependency_overrides[get_db_session] = _override
     yield authenticated_app, str(project_path)
     authenticated_app.dependency_overrides.pop(get_db_session, None)

--- a/tests/backend/api/test_rag_authorization.py
+++ b/tests/backend/api/test_rag_authorization.py
@@ -79,8 +79,7 @@ def _project_scoped_rag_routes(app) -> list[tuple[str, str]]:
     rows = [
         (method, path)
         for method, path, _ in snapshot(app.router)
-        if path.startswith("/api/rag/")
-        and ("{project_id}" in path or path == "/api/rag/query")
+        if path.startswith("/api/rag/") and ("{project_id}" in path or path == "/api/rag/query")
     ]
     assert rows, "RAG 라우트가 하나도 안 잡혔다 — 라우터가 안 붙었거나 경로가 바뀌었다"
     return [(method, path.replace("{project_id}", DB_PROJECT_ID)) for method, path in rows]

--- a/tests/backend/api/test_stations.py
+++ b/tests/backend/api/test_stations.py
@@ -2,10 +2,10 @@
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
-from api.v1.stations import router, _stations
+from api.v1.stations import _stations, router
 
 
 @pytest.fixture

--- a/tests/backend/api/test_usage_fetch_retry.py
+++ b/tests/backend/api/test_usage_fetch_retry.py
@@ -168,7 +168,9 @@ async def test_retry_budget_stays_under_dashboard_timeout() -> None:
         anthropic_mod.USAGE_FETCH_MAX_ATTEMPTS * anthropic_mod.USAGE_FETCH_TIMEOUT_SECONDS
         + sum(anthropic_mod.USAGE_FETCH_BACKOFF_SECONDS)
     )
-    assert len(anthropic_mod.USAGE_FETCH_BACKOFF_SECONDS) >= anthropic_mod.USAGE_FETCH_MAX_ATTEMPTS - 1
+    assert (
+        len(anthropic_mod.USAGE_FETCH_BACKOFF_SECONDS) >= anthropic_mod.USAGE_FETCH_MAX_ATTEMPTS - 1
+    )
     assert worst_case <= dashboard_timeout_seconds - 5.0, (
         f"retry budget {worst_case}s leaves too little margin under "
         f"{dashboard_timeout_seconds}s dashboard timeout"

--- a/tests/backend/api/test_usage_jsonl.py
+++ b/tests/backend/api/test_usage_jsonl.py
@@ -457,7 +457,9 @@ def test_codex_plan_usage_reads_chatgpt_subscription_limits(
             "rateLimitResetCredits": {"availableCount": 1},
         }
 
-    monkeypatch.setattr(usage_mod.routes, "_read_codex_app_server_rate_limits", _fake_read_rate_limits)
+    monkeypatch.setattr(
+        usage_mod.routes, "_read_codex_app_server_rate_limits", _fake_read_rate_limits
+    )
 
     response = usage_mod.routes.get_codex_plan_usage()
 

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 import pytest_asyncio
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 
 # Add src/backend to path
 backend_path = Path(__file__).parent.parent.parent / "src" / "backend"
@@ -49,7 +49,7 @@ def anyio_backend():
 async def app():
     """Create FastAPI app for testing."""
     from api.app import create_app
-    from api.deps import set_engine, clear_engine
+    from api.deps import clear_engine, set_engine
     from orchestrator import OrchestrationEngine
 
     # Set up engine for tests (simulating lifespan startup)

--- a/tests/backend/ruff.toml
+++ b/tests/backend/ruff.toml
@@ -1,0 +1,30 @@
+# tests/backend 전용 ruff 설정.
+#
+# 왜 별도 파일인가: 이 디렉토리는 src/backend 의 pyproject.toml 바깥이라
+# 어떤 설정도 소유하지 않았고, ruff 는 그럴 때 "실행 시점 cwd 의 설정"을
+# 폴백으로 쓴다. 그래서 같은 파일이 cwd 에 따라 line-length 88/100 으로
+# 다르게 판정되는 상태였다 — 게이트를 걸기 전에 이 비결정성부터 없앤다.
+#
+# 규칙은 src/backend/pyproject.toml 을 미러한다. 갱신 시 양쪽을 함께 고친다.
+line-length = 100
+target-version = "py311"
+# 백엔드 소스 루트를 명시한다. 없으면 isort 가 이 디렉토리를 1st-party 루트로
+# 보고 `models`/`api`/`services` 를 서드파티로 분류해, src/backend 와 정렬
+# 순서가 어긋난다(실측: I001 40 → 113).
+src = ["../../src/backend"]
+
+[lint]
+select = ["E", "F", "I", "N", "W", "B", "UP"]
+ignore = [
+    "E501",   # line-too-long (handled by formatter)
+    "B008",   # function-call-in-default-argument (FastAPI/Pydantic Field patterns)
+    "B904",   # raise-without-from-inside-except
+    "UP042",  # replace-str-enum (StrEnum migration deferred)
+    "N815",   # mixed-case-variable-in-class-scope (API compatibility)
+    "E402",   # module-import-not-at-top (conftest 는 import 전에 env 를 고정해야 한다)
+    "E741",   # ambiguous-variable-name
+    # ── 아래는 tests 고유 ──
+    "B017",   # assert-raises-exception: pytest.raises(Exception) 13곳.
+              # 구체 예외 타입을 고르는 것은 테스트 의미를 바꾸는 판단이라
+              # 게이트 도입 PR 에서 함께 처리하지 않는다 (별도 후속).
+]

--- a/tests/backend/run_e2e_tests.py
+++ b/tests/backend/run_e2e_tests.py
@@ -10,10 +10,10 @@ Usage:
     python ../../tests/backend/run_e2e_tests.py
 """
 
-import sys
 import asyncio
+import sys
+from datetime import UTC, datetime
 from pathlib import Path
-from datetime import datetime, timezone
 
 # Add src/backend to path
 backend_path = Path(__file__).parent.parent.parent / "src" / "backend"
@@ -101,9 +101,10 @@ async def test_api_endpoints():
     """Test FastAPI endpoints."""
     print("\n2. Testing API Endpoints...")
 
-    from httpx import AsyncClient, ASGITransport
+    from httpx import ASGITransport, AsyncClient
+
     from api.app import create_app
-    from api.deps import set_engine, clear_engine
+    from api.deps import clear_engine, set_engine
     from orchestrator import OrchestrationEngine
 
     engine = OrchestrationEngine()
@@ -161,11 +162,12 @@ async def test_hitl_flow():
     """Test HITL (Human-in-the-Loop) flow."""
     print("\n3. Testing HITL Flow...")
 
-    from httpx import AsyncClient, ASGITransport
+    from httpx import ASGITransport, AsyncClient
+
     from api.app import create_app
-    from api.deps import set_engine, clear_engine
-    from orchestrator import OrchestrationEngine
+    from api.deps import clear_engine, set_engine
     from models.hitl import ApprovalStatus
+    from orchestrator import OrchestrationEngine
 
     engine = OrchestrationEngine()
     set_engine(engine)
@@ -189,7 +191,7 @@ async def test_hitl_flow():
                 "risk_level": "HIGH",
                 "risk_description": "Shell command execution",
                 "status": ApprovalStatus.PENDING.value,
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": datetime.now(UTC).isoformat(),
             }
             state["waiting_for_approval"] = True
             engine._sessions[session_id] = state
@@ -223,7 +225,7 @@ async def test_hitl_flow():
                 "risk_level": "HIGH",
                 "risk_description": "Dangerous command",
                 "status": ApprovalStatus.PENDING.value,
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": datetime.now(UTC).isoformat(),
             }
             state2["waiting_for_approval"] = True
             engine._sessions[session_id2] = state2
@@ -246,8 +248,8 @@ async def test_parallel_execution():
     """Test parallel execution capabilities."""
     print("\n4. Testing Parallel Execution...")
 
+    from models.agent_state import TaskNode, TaskStatus, create_initial_state
     from orchestrator import OrchestrationEngine
-    from models.agent_state import TaskStatus, TaskNode, create_initial_state
 
     try:
         engine = OrchestrationEngine()
@@ -296,9 +298,7 @@ async def test_parallel_execution():
                 await asyncio.sleep(0.05)
                 return f"{task_id} done"
 
-        all_results = await asyncio.gather(*[
-            limited_execute(f"task-{i}") for i in range(5)
-        ])
+        all_results = await asyncio.gather(*[limited_execute(f"task-{i}") for i in range(5)])
         assert len(all_results) == 5
         result.add_pass("Semaphore limiting")
 

--- a/tests/backend/test_advanced_matrix.py
+++ b/tests/backend/test_advanced_matrix.py
@@ -1,7 +1,5 @@
 """Tests for advanced matrix features (exclude/include)."""
 
-import pytest
-
 from models.workflow import WorkflowJobDef, WorkflowStepDef
 from services.workflow_engine import WorkflowEngine
 

--- a/tests/backend/test_agent_registry.py
+++ b/tests/backend/test_agent_registry.py
@@ -1,14 +1,12 @@
 """Tests for Agent Registry."""
 
-import pytest
 from services.agent_registry import (
-    AgentRegistry,
-    AgentMetadata,
-    AgentCategory,
-    AgentStatus,
     AgentCapability,
+    AgentCategory,
+    AgentMetadata,
+    AgentRegistry,
+    AgentStatus,
     EffortLevel,
-    get_agent_registry,
 )
 
 
@@ -30,6 +28,7 @@ class TestAgentRegistry:
 
         # 기본 에이전트를 복사해서 등록 (상태 격리)
         from services.agent_registry import _build_default_agents
+
         for agent in _build_default_agents():
             # 깊은 복사를 통해 새 인스턴스 생성
             agent_copy = AgentMetadata(
@@ -222,9 +221,7 @@ class TestAgentMetadata:
                 for model_id in ("claude-sonnet-5", "claude-opus-4-8")
             ]
             monkeypatch.setattr(LLMModelRegistry, "_db_cache", db_models)
-            monkeypatch.setattr(
-                LLMModelRegistry, "_db_index", {m.id: m for m in db_models}
-            )
+            monkeypatch.setattr(LLMModelRegistry, "_db_index", {m.id: m for m in db_models})
 
         # DB-loaded admin default = opus → 빌드 결과에 반영
         _set_db_default("claude-opus-4-8")

--- a/tests/backend/test_analytics_serialization.py
+++ b/tests/backend/test_analytics_serialization.py
@@ -65,6 +65,7 @@ class TestToNaiveUtc:
 
     def test_aware_non_utc_converts_then_strips(self):
         from datetime import timedelta, timezone
+
         kst = timezone(timedelta(hours=9))
         dt = datetime(2026, 5, 2, 3, 0, 0, tzinfo=kst)  # KST 03:00 = UTC 18:00 (전날)
         result = to_naive_utc(dt)

--- a/tests/backend/test_analytics_service.py
+++ b/tests/backend/test_analytics_service.py
@@ -3,8 +3,6 @@
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from utils.time import utcnow
-
 import pytest
 
 from models.analytics import (
@@ -24,7 +22,7 @@ from services.analytics_service import (
     _get_time_delta,
     _normalize_model_name,
 )
-
+from utils.time import utcnow
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -449,10 +447,21 @@ class TestGetOverviewAsync:
     def setup_method(self):
         self.service = AnalyticsService()
 
-    def _make_db(self, session_count=5, active_count=2, total_tasks=10,
-                 completed=8, failed=1, pending=1, tokens=50000, cost=1.5,
-                 avg_duration=4500, approvals_pending=1, approvals_granted=10,
-                 approvals_denied=2):
+    def _make_db(
+        self,
+        session_count=5,
+        active_count=2,
+        total_tasks=10,
+        completed=8,
+        failed=1,
+        pending=1,
+        tokens=50000,
+        cost=1.5,
+        avg_duration=4500,
+        approvals_pending=1,
+        approvals_granted=10,
+        approvals_denied=2,
+    ):
         """Build an AsyncSession mock whose execute() returns canned scalars."""
         db = AsyncMock()
 
@@ -475,17 +484,17 @@ class TestGetOverviewAsync:
             return result
 
         db.execute.side_effect = [
-            _scalar_result(session_count),    # total_sessions
-            _scalar_result(active_count),     # active_sessions
-            _scalar_result(total_tasks),      # total_tasks
-            _scalar_result(completed),        # completed_tasks
-            _scalar_result(failed),           # failed_tasks
-            _scalar_result(pending),          # pending_tasks
-            _row_result(tokens, cost),        # tokens + cost (one row)
-            _scalar_result(avg_duration),     # avg_duration
-            _scalar_result(approvals_pending),   # approvals_pending
-            _scalar_result(approvals_granted),   # approvals_granted
-            _scalar_result(approvals_denied),    # approvals_denied
+            _scalar_result(session_count),  # total_sessions
+            _scalar_result(active_count),  # active_sessions
+            _scalar_result(total_tasks),  # total_tasks
+            _scalar_result(completed),  # completed_tasks
+            _scalar_result(failed),  # failed_tasks
+            _scalar_result(pending),  # pending_tasks
+            _row_result(tokens, cost),  # tokens + cost (one row)
+            _scalar_result(avg_duration),  # avg_duration
+            _scalar_result(approvals_pending),  # approvals_pending
+            _scalar_result(approvals_granted),  # approvals_granted
+            _scalar_result(approvals_denied),  # approvals_denied
         ]
         return db
 

--- a/tests/backend/test_artifact_service.py
+++ b/tests/backend/test_artifact_service.py
@@ -1,14 +1,13 @@
 """Tests for artifact service."""
 
-import pytest
-
-from utils.time import utcnow
 from services.artifact_service import ArtifactService
+from utils.time import utcnow
 
 
 class TestArtifactService:
     def setup_method(self):
         import tempfile
+
         self._tmpdir = tempfile.mkdtemp()
         self.svc = ArtifactService(base_dir=self._tmpdir)
 
@@ -56,6 +55,7 @@ class TestArtifactService:
 
     def test_cleanup_expired(self):
         from datetime import timedelta
+
         artifact = self.svc.create_artifact(
             run_id="run1", name="old.txt", data=b"old", retention_days=0
         )
@@ -67,8 +67,11 @@ class TestArtifactService:
 
     def test_artifact_with_job_and_step(self):
         artifact = self.svc.create_artifact(
-            run_id="run1", name="log.txt", data=b"log",
-            job_id="job1", step_id="step1",
+            run_id="run1",
+            name="log.txt",
+            data=b"log",
+            job_id="job1",
+            step_id="step1",
         )
         assert artifact["job_id"] == "job1"
         assert artifact["step_id"] == "step1"

--- a/tests/backend/test_audit_integrity.py
+++ b/tests/backend/test_audit_integrity.py
@@ -1,9 +1,8 @@
 """Tests for audit integrity service."""
 
-import pytest
-from datetime import datetime, timedelta
+from datetime import timedelta
 
-from utils.time import utcnow
+import pytest
 
 from models.audit import (
     ComplianceAuditEntry,
@@ -11,6 +10,7 @@ from models.audit import (
     RetentionPolicy,
 )
 from services.audit_integrity import AuditIntegrityService
+from utils.time import utcnow
 
 
 @pytest.fixture
@@ -113,7 +113,13 @@ class TestAuditIntegrityService:
     def test_generate_compliance_report(self, integrity_service):
         """Test compliance report generation."""
         # Add entries with various classifications
-        for i, cls in enumerate([DataClassification.PUBLIC, DataClassification.INTERNAL, DataClassification.CONFIDENTIAL]):
+        for i, cls in enumerate(
+            [
+                DataClassification.PUBLIC,
+                DataClassification.INTERNAL,
+                DataClassification.CONFIDENTIAL,
+            ]
+        ):
             entry = ComplianceAuditEntry(
                 id=f"entry-{i}",
                 action="task_created",

--- a/tests/backend/test_auth_service.py
+++ b/tests/backend/test_auth_service.py
@@ -10,10 +10,10 @@ import pytest
 
 from services.auth_service import AuthService, TokenPair, UserInfo
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_settings(
     secret: str = "test-secret-key-32-bytes-long-abc",
@@ -72,6 +72,7 @@ def _make_user_model(
 # ---------------------------------------------------------------------------
 # JWT Token Tests
 # ---------------------------------------------------------------------------
+
 
 class TestJwtTokenCreation:
     """Tests for create_access_token, create_refresh_token, and create_token_pair."""
@@ -149,6 +150,7 @@ class TestJwtTokenCreation:
 # JWT Token Verification Tests
 # ---------------------------------------------------------------------------
 
+
 class TestJwtTokenVerification:
     """Tests for verify_token."""
 
@@ -212,6 +214,7 @@ class TestJwtTokenVerification:
 # ---------------------------------------------------------------------------
 # Password Hashing Tests
 # ---------------------------------------------------------------------------
+
 
 class TestPasswordHashing:
     """Tests for hash_password, verify_password, and verify_and_upgrade_password."""
@@ -279,6 +282,7 @@ class TestPasswordHashing:
 # OAuth URL Generation Tests
 # ---------------------------------------------------------------------------
 
+
 class TestOAuthUrlGeneration:
     """Tests for get_google_auth_url and get_github_auth_url."""
 
@@ -321,6 +325,7 @@ class TestOAuthUrlGeneration:
 # OAuth Code Exchange Tests
 # ---------------------------------------------------------------------------
 
+
 class TestGoogleCodeExchange:
     """Tests for exchange_google_code."""
 
@@ -352,7 +357,9 @@ class TestGoogleCodeExchange:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch("services.auth_service.httpx.AsyncClient", return_value=mock_client):
-            user_info = await self.service.exchange_google_code("auth-code", "https://cb.example.com")
+            user_info = await self.service.exchange_google_code(
+                "auth-code", "https://cb.example.com"
+            )
 
         assert isinstance(user_info, UserInfo)
         assert user_info.id == "goog-123"
@@ -475,6 +482,7 @@ class TestGithubCodeExchange:
 # Email / Password Registration and Login Tests
 # ---------------------------------------------------------------------------
 
+
 class TestEmailPasswordAuth:
     """Tests for register_user and login_user."""
 
@@ -523,7 +531,9 @@ class TestEmailPasswordAuth:
         async def passthrough_sync(user):
             return user
 
-        with patch.object(service, "sync_user_role_from_org", new=AsyncMock(side_effect=passthrough_sync)):
+        with patch.object(
+            service, "sync_user_role_from_org", new=AsyncMock(side_effect=passthrough_sync)
+        ):
             user = await service.register_user("new@example.com", "mypassword", name="Alice")
 
         db.add.assert_called_once()
@@ -616,6 +626,7 @@ class TestEmailPasswordAuth:
 # get_or_create_user Tests
 # ---------------------------------------------------------------------------
 
+
 class TestGetOrCreateUser:
     """Tests for get_or_create_user."""
 
@@ -690,6 +701,7 @@ class TestGetOrCreateUser:
 # ---------------------------------------------------------------------------
 # sync_user_role_from_org Tests
 # ---------------------------------------------------------------------------
+
 
 class TestSyncUserRoleFromOrg:
     """Tests for sync_user_role_from_org."""

--- a/tests/backend/test_automation_loop.py
+++ b/tests/backend/test_automation_loop.py
@@ -11,15 +11,14 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "backend"))
 
 from services.automation_loop_service import (
+    _OPERATORS,
     ActionDef,
     AutomationLoopConfig,
     AutomationLoopService,
     ConditionDef,
     ConditionResult,
     LoopState,
-    _OPERATORS,
 )
-
 
 # ── Fixtures ────────────────────────────────────────────────
 
@@ -62,9 +61,7 @@ def simple_config():
         interval_seconds=0,
         max_iterations=1,
         conditions=[
-            ConditionDef(
-                metric="health.database.latency_ms", operator="gt", threshold=50.0
-            )
+            ConditionDef(metric="health.database.latency_ms", operator="gt", threshold=50.0)
         ],
         actions=[ActionDef(type="log", target="triggered")],
         cooldown_seconds=0,
@@ -78,9 +75,7 @@ class TestModels:
     """Test Pydantic model immutability and validation."""
 
     def test_condition_def_frozen(self):
-        cond = ConditionDef(
-            metric="health.db.latency_ms", operator="gt", threshold=100.0
-        )
+        cond = ConditionDef(metric="health.db.latency_ms", operator="gt", threshold=100.0)
         with pytest.raises(Exception):  # ValidationError for frozen
             cond.metric = "changed"
 
@@ -99,9 +94,7 @@ class TestModels:
             config.name = "changed"
 
     def test_condition_result_frozen(self):
-        result = ConditionResult(
-            metric="test", threshold=1.0, operator="gt", triggered=True
-        )
+        result = ConditionResult(metric="test", threshold=1.0, operator="gt", triggered=True)
         with pytest.raises(Exception):
             result.triggered = False
 
@@ -216,9 +209,7 @@ class TestLifecycle:
     async def test_start_loop(self, service, simple_config):
         loop_id = await service.create_loop(simple_config)
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0):
             await service.start_loop(loop_id)
             # Wait for loop to complete (max_iterations=1)
             await asyncio.sleep(0.1)
@@ -231,9 +222,7 @@ class TestLifecycle:
     async def test_start_already_running(self, service, sample_config):
         loop_id = await service.create_loop(sample_config)
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0):
             await service.start_loop(loop_id)
             with pytest.raises(ValueError, match="already running"):
                 await service.start_loop(loop_id)
@@ -251,18 +240,14 @@ class TestLifecycle:
             interval_seconds=10,  # Long interval
             max_iterations=None,  # Infinite
             conditions=[
-                ConditionDef(
-                    metric="health.database.latency_ms", operator="gt", threshold=100.0
-                )
+                ConditionDef(metric="health.database.latency_ms", operator="gt", threshold=100.0)
             ],
             actions=[ActionDef(type="log", target="triggered")],
             cooldown_seconds=0,
         )
         loop_id = await service.create_loop(config)
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0):
             await service.start_loop(loop_id)
             await asyncio.sleep(0.05)  # Let it run briefly
 
@@ -286,18 +271,14 @@ class TestLifecycle:
             interval_seconds=0,
             max_iterations=3,
             conditions=[
-                ConditionDef(
-                    metric="health.database.latency_ms", operator="gt", threshold=100.0
-                )
+                ConditionDef(metric="health.database.latency_ms", operator="gt", threshold=100.0)
             ],
             actions=[ActionDef(type="log", target="triggered")],
             cooldown_seconds=0,
         )
         loop_id = await service.create_loop(config)
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0):
             await service.start_loop(loop_id)
             await asyncio.sleep(0.2)
 
@@ -314,18 +295,14 @@ class TestLifecycle:
             interval_seconds=10,
             max_iterations=None,
             conditions=[
-                ConditionDef(
-                    metric="health.database.latency_ms", operator="gt", threshold=100.0
-                )
+                ConditionDef(metric="health.database.latency_ms", operator="gt", threshold=100.0)
             ],
             actions=[ActionDef(type="log", target="triggered")],
             cooldown_seconds=0,
         )
         loop_id = await service.create_loop(config)
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0):
             await service.start_loop(loop_id)
             await asyncio.sleep(0.05)
 
@@ -345,14 +322,10 @@ class TestConditionEvaluation:
     @pytest.mark.asyncio
     async def test_condition_triggered(self, service):
         conditions = [
-            ConditionDef(
-                metric="health.database.latency_ms", operator="gt", threshold=100.0
-            )
+            ConditionDef(metric="health.database.latency_ms", operator="gt", threshold=100.0)
         ]
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=150.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=150.0):
             results = await service._evaluate_conditions(conditions)
 
         assert len(results) == 1
@@ -362,14 +335,10 @@ class TestConditionEvaluation:
     @pytest.mark.asyncio
     async def test_condition_not_triggered(self, service):
         conditions = [
-            ConditionDef(
-                metric="health.database.latency_ms", operator="gt", threshold=100.0
-            )
+            ConditionDef(metric="health.database.latency_ms", operator="gt", threshold=100.0)
         ]
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=50.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=50.0):
             results = await service._evaluate_conditions(conditions)
 
         assert len(results) == 1
@@ -377,13 +346,9 @@ class TestConditionEvaluation:
 
     @pytest.mark.asyncio
     async def test_condition_metric_unavailable(self, service):
-        conditions = [
-            ConditionDef(metric="health.unknown.value", operator="gt", threshold=100.0)
-        ]
+        conditions = [ConditionDef(metric="health.unknown.value", operator="gt", threshold=100.0)]
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=None
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=None):
             results = await service._evaluate_conditions(conditions)
 
         assert len(results) == 1
@@ -393,12 +358,8 @@ class TestConditionEvaluation:
     @pytest.mark.asyncio
     async def test_multiple_conditions(self, service):
         conditions = [
-            ConditionDef(
-                metric="health.database.latency_ms", operator="gt", threshold=100.0
-            ),
-            ConditionDef(
-                metric="health.redis.latency_ms", operator="lt", threshold=10.0
-            ),
+            ConditionDef(metric="health.database.latency_ms", operator="gt", threshold=100.0),
+            ConditionDef(metric="health.redis.latency_ms", operator="lt", threshold=10.0),
         ]
 
         async def mock_metric(metric: str):
@@ -533,9 +494,7 @@ class TestLoopIntegration:
         loop_id = await service.create_loop(config)
 
         # Mock metric to return high latency
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=150.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=150.0):
             await service.start_loop(loop_id)
             await asyncio.sleep(0.2)
 
@@ -566,9 +525,7 @@ class TestLoopIntegration:
         loop_id = await service.create_loop(config)
 
         # Mock metric to return low latency
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=50.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=50.0):
             await service.start_loop(loop_id)
             await asyncio.sleep(0.2)
 
@@ -597,9 +554,7 @@ class TestLoopIntegration:
 
         loop_id = await service.create_loop(config)
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=150.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=150.0):
             await service.start_loop(loop_id)
             await asyncio.sleep(0.3)
 
@@ -614,9 +569,7 @@ class TestLoopIntegration:
         """Task reference should be cleaned up after loop completes."""
         loop_id = await service.create_loop(simple_config)
 
-        with patch.object(
-            service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0
-        ):
+        with patch.object(service, "_get_metric_value", new_callable=AsyncMock, return_value=10.0):
             await service.start_loop(loop_id)
             await asyncio.sleep(0.2)
 

--- a/tests/backend/test_claude_cli_chat_model.py
+++ b/tests/backend/test_claude_cli_chat_model.py
@@ -52,9 +52,7 @@ def test_message_role_maps_known_types() -> None:
 
 
 def test_format_messages_includes_roles_and_trailing_assistant() -> None:
-    prompt = _format_messages(
-        [SystemMessage(content="be terse"), HumanMessage(content="hi")]
-    )
+    prompt = _format_messages([SystemMessage(content="be terse"), HumanMessage(content="hi")])
     assert "## System\nbe terse" in prompt
     assert "## User\nhi" in prompt
     # Must end by cueing the assistant turn so Claude completes the response.
@@ -65,15 +63,15 @@ def test_format_messages_includes_roles_and_trailing_assistant() -> None:
 
 
 def test_call_reads_answer_from_stdout() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(stdout="claude answer")):
+    with patch(f"{MODULE}.subprocess.run", side_effect=_run_side_effect(stdout="claude answer")):
         out = _model()._call([HumanMessage(content="q")])
     assert out == "claude answer"
 
 
 def test_call_strips_stdout_whitespace() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(stdout="  spaced answer \n")):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=_run_side_effect(stdout="  spaced answer \n")
+    ):
         out = _model()._call([HumanMessage(content="q")])
     assert out == "spaced answer"
 
@@ -110,8 +108,9 @@ def test_call_detaches_stdin_to_avoid_interactive_hang() -> None:
 
 
 def test_call_raises_on_nonzero_exit(caplog: pytest.LogCaptureFixture) -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(returncode=1, stderr="boom")):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=_run_side_effect(returncode=1, stderr="boom")
+    ):
         with caplog.at_level("WARNING", logger=MODULE):
             with pytest.raises(RuntimeError, match="boom"):
                 _model()._call([HumanMessage(content="q")])
@@ -129,8 +128,9 @@ def test_call_raises_when_command_not_found() -> None:
 def test_call_raises_on_timeout() -> None:
     import subprocess
 
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1)):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1)
+    ):
         with pytest.raises(RuntimeError, match="timed out"):
             _model()._call([HumanMessage(content="q")])
 
@@ -155,8 +155,10 @@ class _Plan(BaseModel):
 
 @pytest.mark.asyncio
 async def test_structured_output_parses_pydantic() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(stdout='{"title": "x", "steps": 3}')):
+    with patch(
+        f"{MODULE}.subprocess.run",
+        side_effect=_run_side_effect(stdout='{"title": "x", "steps": 3}'),
+    ):
         runnable = _model().with_structured_output(_Plan)
         result = await runnable.ainvoke([HumanMessage(content="plan it")])
     assert isinstance(result, _Plan)
@@ -166,9 +168,8 @@ async def test_structured_output_parses_pydantic() -> None:
 
 @pytest.mark.asyncio
 async def test_structured_output_strips_surrounding_markdown() -> None:
-    fenced = "Here you go:\n```json\n{\"title\": \"y\", \"steps\": 1}\n```\nThanks!"
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(stdout=fenced)):
+    fenced = 'Here you go:\n```json\n{"title": "y", "steps": 1}\n```\nThanks!'
+    with patch(f"{MODULE}.subprocess.run", side_effect=_run_side_effect(stdout=fenced)):
         runnable = _model().with_structured_output(_Plan)
         result = await runnable.ainvoke([HumanMessage(content="plan it")])
     assert result == _Plan(title="y", steps=1)
@@ -176,8 +177,7 @@ async def test_structured_output_strips_surrounding_markdown() -> None:
 
 @pytest.mark.asyncio
 async def test_structured_output_raises_without_json() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(stdout="no json here")):
+    with patch(f"{MODULE}.subprocess.run", side_effect=_run_side_effect(stdout="no json here")):
         runnable = _model().with_structured_output(_Plan)
         with pytest.raises(ValueError, match="did not contain a JSON object"):
             await runnable.ainvoke([HumanMessage(content="plan it")])
@@ -193,8 +193,7 @@ def test_structured_output_include_raw_unsupported() -> None:
 
 @pytest.mark.asyncio
 async def test_acall_delegates_to_call() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(stdout="async answer")):
+    with patch(f"{MODULE}.subprocess.run", side_effect=_run_side_effect(stdout="async answer")):
         out = await _model()._acall([HumanMessage(content="q")])
     assert out == "async answer"
 

--- a/tests/backend/test_code_entity_extractor.py
+++ b/tests/backend/test_code_entity_extractor.py
@@ -3,8 +3,6 @@
 import pytest
 
 from services.code_entity_extractor import (
-    CodeDependency,
-    CodeEntity,
     CodeEntityType,
     PythonEntityExtractor,
     TypeScriptEntityExtractor,
@@ -69,13 +67,13 @@ class MyService(BaseService):
         assert methods[1].name == "async_method"
 
     def test_import_extraction(self, extractor):
-        source = '''
+        source = """
 import os
 import json
 from pathlib import Path
 from typing import Any, Optional
 from ..models import TaskNode
-'''
+"""
         entities = extractor.extract(source, "test.py")
         imports = [e for e in entities if e.entity_type == CodeEntityType.IMPORT]
 
@@ -87,12 +85,12 @@ from ..models import TaskNode
         assert "Any" in names
 
     def test_variable_extraction(self, extractor):
-        source = '''
+        source = """
 MAX_RETRIES = 3
 DEFAULT_TIMEOUT = 30
 _private = "hidden"
 simple = 42
-'''
+"""
         entities = extractor.extract(source, "test.py")
         vars_ = [e for e in entities if e.entity_type == CodeEntityType.VARIABLE]
 
@@ -102,12 +100,12 @@ simple = 42
         assert "DEFAULT_TIMEOUT" in names
 
     def test_decorator_extraction(self, extractor):
-        source = '''
+        source = """
 @app.route("/api")
 @require_auth
 def endpoint():
     pass
-'''
+"""
         entities = extractor.extract(source, "test.py")
         funcs = [e for e in entities if e.entity_type == CodeEntityType.FUNCTION]
 
@@ -121,14 +119,14 @@ def endpoint():
         assert entities == []
 
     def test_dependency_extraction(self, extractor):
-        source = '''
+        source = """
 import os
 from pathlib import Path
 from models.base import BaseModel
 
 class Child(BaseModel):
     pass
-'''
+"""
         deps = extractor.extract_dependencies(source, "test.py")
 
         import_deps = [d for d in deps if d.dependency_type == "imports"]
@@ -147,7 +145,7 @@ class TestTypeScriptEntityExtractor:
         return TypeScriptEntityExtractor()
 
     def test_function_extraction(self, extractor):
-        source = '''
+        source = """
 export function fetchData(url: string): Promise<Data> {
   return fetch(url);
 }
@@ -155,7 +153,7 @@ export function fetchData(url: string): Promise<Data> {
 export async function processItems(items: Item[]): Promise<void> {
   // process
 }
-'''
+"""
         entities = extractor.extract(source, "test.ts")
         funcs = [e for e in entities if e.entity_type == CodeEntityType.FUNCTION]
 
@@ -165,7 +163,7 @@ export async function processItems(items: Item[]): Promise<void> {
         assert "processItems" in names
 
     def test_class_extraction(self, extractor):
-        source = '''
+        source = """
 export class UserService {
   async getUser(id: string) { }
 }
@@ -173,7 +171,7 @@ export class UserService {
 export default class AppController {
   start() { }
 }
-'''
+"""
         entities = extractor.extract(source, "test.ts")
         classes = [e for e in entities if e.entity_type == CodeEntityType.CLASS]
 
@@ -183,7 +181,7 @@ export default class AppController {
         assert "AppController" in names
 
     def test_interface_extraction(self, extractor):
-        source = '''
+        source = """
 export interface UserProps {
   name: string;
   age: number;
@@ -192,7 +190,7 @@ export interface UserProps {
 export default interface Config {
   apiUrl: string;
 }
-'''
+"""
         entities = extractor.extract(source, "test.ts")
         interfaces = [e for e in entities if e.entity_type == CodeEntityType.INTERFACE]
 
@@ -202,11 +200,11 @@ export default interface Config {
         assert "Config" in names
 
     def test_type_alias_extraction(self, extractor):
-        source = '''
+        source = """
 export type UserId = string;
 export type Status = 'active' | 'inactive';
 export type Result<T> = { data: T; error: string | null };
-'''
+"""
         entities = extractor.extract(source, "test.ts")
         types = [e for e in entities if e.entity_type == CodeEntityType.TYPE_ALIAS]
 
@@ -217,7 +215,7 @@ export type Result<T> = { data: T; error: string | null };
         assert "Result" in names
 
     def test_enum_extraction(self, extractor):
-        source = '''
+        source = """
 export enum Direction {
   Up = "UP",
   Down = "DOWN",
@@ -227,7 +225,7 @@ export const enum Color {
   Red,
   Blue,
 }
-'''
+"""
         entities = extractor.extract(source, "test.ts")
         enums = [e for e in entities if e.entity_type == CodeEntityType.ENUM]
 
@@ -237,12 +235,12 @@ export const enum Color {
         assert "Color" in names
 
     def test_import_extraction(self, extractor):
-        source = '''
+        source = """
 import { useState, useEffect } from 'react';
 import type { FC } from 'react';
 import axios from 'axios';
 import * as utils from './utils';
-'''
+"""
         entities = extractor.extract(source, "test.ts")
         imports = [e for e in entities if e.entity_type == CodeEntityType.IMPORT]
 
@@ -252,10 +250,10 @@ import * as utils from './utils';
         assert "axios" in import_paths
 
     def test_dependency_extraction(self, extractor):
-        source = '''
+        source = """
 import { api } from './api';
 import { User } from '../types';
-'''
+"""
         deps = extractor.extract_dependencies(source, "test.ts")
 
         assert len(deps) == 2

--- a/tests/backend/test_codex_cli_chat_model.py
+++ b/tests/backend/test_codex_cli_chat_model.py
@@ -22,8 +22,9 @@ from services.codex_cli_chat_model import (
 MODULE = "services.codex_cli_chat_model"
 
 
-def _run_side_effect(*, last_message: str | None = None, returncode: int = 0,
-                     stdout: str = "", stderr: str = ""):
+def _run_side_effect(
+    *, last_message: str | None = None, returncode: int = 0, stdout: str = "", stderr: str = ""
+):
     """Build a subprocess.run replacement that emulates Codex CLI behaviour.
 
     If ``last_message`` is given, it is written to the path that follows
@@ -57,9 +58,7 @@ def test_message_role_maps_known_types() -> None:
 
 
 def test_format_messages_includes_roles_and_trailing_assistant() -> None:
-    prompt = _format_messages(
-        [SystemMessage(content="be terse"), HumanMessage(content="hi")]
-    )
+    prompt = _format_messages([SystemMessage(content="be terse"), HumanMessage(content="hi")])
     assert "## System\nbe terse" in prompt
     assert "## User\nhi" in prompt
     # Must end by cueing the assistant turn so Codex completes the response.
@@ -70,16 +69,19 @@ def test_format_messages_includes_roles_and_trailing_assistant() -> None:
 
 
 def test_call_reads_output_last_message_file() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(last_message="codex answer")):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=_run_side_effect(last_message="codex answer")
+    ):
         out = _model()._call([HumanMessage(content="q")])
     assert out == "codex answer"
 
 
 def test_call_falls_back_to_stdout_when_file_empty() -> None:
     # Codex wrote nothing to the file; stdout carries the answer instead.
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(last_message="", stdout="stdout answer")):
+    with patch(
+        f"{MODULE}.subprocess.run",
+        side_effect=_run_side_effect(last_message="", stdout="stdout answer"),
+    ):
         out = _model()._call([HumanMessage(content="q")])
     assert out == "stdout answer"
 
@@ -119,8 +121,9 @@ def test_call_detaches_stdin_to_avoid_interactive_hang() -> None:
 
 
 def test_call_raises_on_nonzero_exit(caplog: pytest.LogCaptureFixture) -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(returncode=1, stderr="boom")):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=_run_side_effect(returncode=1, stderr="boom")
+    ):
         with caplog.at_level("WARNING", logger=MODULE):
             with pytest.raises(RuntimeError, match="boom"):
                 _model()._call([HumanMessage(content="q")])
@@ -138,8 +141,9 @@ def test_call_raises_when_command_not_found() -> None:
 def test_call_raises_on_timeout() -> None:
     import subprocess
 
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=subprocess.TimeoutExpired(cmd="codex", timeout=1)):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="codex", timeout=1)
+    ):
         with pytest.raises(RuntimeError, match="timed out"):
             _model()._call([HumanMessage(content="q")])
 
@@ -164,8 +168,10 @@ class _Plan(BaseModel):
 
 @pytest.mark.asyncio
 async def test_structured_output_parses_pydantic() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(last_message='{"title": "x", "steps": 3}')):
+    with patch(
+        f"{MODULE}.subprocess.run",
+        side_effect=_run_side_effect(last_message='{"title": "x", "steps": 3}'),
+    ):
         runnable = _model().with_structured_output(_Plan)
         result = await runnable.ainvoke([HumanMessage(content="plan it")])
     assert isinstance(result, _Plan)
@@ -175,9 +181,8 @@ async def test_structured_output_parses_pydantic() -> None:
 
 @pytest.mark.asyncio
 async def test_structured_output_strips_surrounding_markdown() -> None:
-    fenced = "Here you go:\n```json\n{\"title\": \"y\", \"steps\": 1}\n```\nThanks!"
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(last_message=fenced)):
+    fenced = 'Here you go:\n```json\n{"title": "y", "steps": 1}\n```\nThanks!'
+    with patch(f"{MODULE}.subprocess.run", side_effect=_run_side_effect(last_message=fenced)):
         runnable = _model().with_structured_output(_Plan)
         result = await runnable.ainvoke([HumanMessage(content="plan it")])
     assert result == _Plan(title="y", steps=1)
@@ -185,8 +190,9 @@ async def test_structured_output_strips_surrounding_markdown() -> None:
 
 @pytest.mark.asyncio
 async def test_structured_output_raises_without_json() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(last_message="no json here")):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=_run_side_effect(last_message="no json here")
+    ):
         runnable = _model().with_structured_output(_Plan)
         with pytest.raises(ValueError, match="did not contain a JSON object"):
             await runnable.ainvoke([HumanMessage(content="plan it")])
@@ -202,7 +208,8 @@ def test_structured_output_include_raw_unsupported() -> None:
 
 @pytest.mark.asyncio
 async def test_acall_delegates_to_call() -> None:
-    with patch(f"{MODULE}.subprocess.run",
-               side_effect=_run_side_effect(last_message="async answer")):
+    with patch(
+        f"{MODULE}.subprocess.run", side_effect=_run_side_effect(last_message="async answer")
+    ):
         out = await _model()._acall([HumanMessage(content="q")])
     assert out == "async answer"

--- a/tests/backend/test_e2e_api.py
+++ b/tests/backend/test_e2e_api.py
@@ -154,9 +154,7 @@ class TestApprovalAPI:
         session_id = create_resp.json()["session_id"]
 
         try:
-            response = await client.post(
-                f"/api/sessions/{session_id}/approve/nonexistent-approval"
-            )
+            response = await client.post(f"/api/sessions/{session_id}/approve/nonexistent-approval")
         finally:
             app.dependency_overrides.pop(get_current_user, None)
 

--- a/tests/backend/test_e2e_hitl.py
+++ b/tests/backend/test_e2e_hitl.py
@@ -1,11 +1,12 @@
 """E2E HITL (Human-in-the-Loop) tests."""
 
-import pytest
 from datetime import datetime
 from types import SimpleNamespace
 
+import pytest
+
 from models.agent_state import TaskNode
-from models.hitl import ApprovalStatus, RiskLevel, TOOL_RISK_CONFIG
+from models.hitl import TOOL_RISK_CONFIG, ApprovalStatus, RiskLevel
 
 
 @pytest.mark.asyncio
@@ -20,9 +21,7 @@ class TestHITLConfiguration:
     async def test_high_risk_tools_defined(self):
         """Test high risk tools are properly defined."""
         high_risk_tools = [
-            tool
-            for tool, config in TOOL_RISK_CONFIG.items()
-            if config.risk_level == RiskLevel.HIGH
+            tool for tool, config in TOOL_RISK_CONFIG.items() if config.risk_level == RiskLevel.HIGH
         ]
 
         # At least execute_bash should be high risk
@@ -93,9 +92,7 @@ class TestHITLState:
         state["waiting_for_approval"] = True
 
         # Approve
-        state["pending_approvals"][approval_id]["status"] = (
-            ApprovalStatus.APPROVED.value
-        )
+        state["pending_approvals"][approval_id]["status"] = ApprovalStatus.APPROVED.value
         state["waiting_for_approval"] = False
         engine._sessions[session_id] = state
 
@@ -130,10 +127,7 @@ class TestHITLState:
         # Verify
         updated_state = await engine.get_session(session_id)
         assert updated_state["pending_approvals"][approval_id]["status"] == "denied"
-        assert (
-            "Too dangerous"
-            in updated_state["pending_approvals"][approval_id]["resolver_note"]
-        )
+        assert "Too dangerous" in updated_state["pending_approvals"][approval_id]["resolver_note"]
 
 
 @pytest.mark.asyncio
@@ -171,9 +165,7 @@ class TestHITLAPIIntegration:
         session_id = create_resp.json()["session_id"]
 
         try:
-            response = await client.post(
-                f"/api/sessions/{session_id}/approve/nonexistent"
-            )
+            response = await client.post(f"/api/sessions/{session_id}/approve/nonexistent")
         finally:
             app.dependency_overrides.pop(get_current_user, None)
 
@@ -191,9 +183,7 @@ class TestHITLAPIIntegration:
         session_id = create_resp.json()["session_id"]
 
         try:
-            response = await client.post(
-                f"/api/sessions/{session_id}/deny/nonexistent"
-            )
+            response = await client.post(f"/api/sessions/{session_id}/deny/nonexistent")
         finally:
             app.dependency_overrides.pop(get_current_user, None)
 

--- a/tests/backend/test_e2e_orchestration.py
+++ b/tests/backend/test_e2e_orchestration.py
@@ -1,9 +1,8 @@
 """E2E orchestration integration tests."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
-from models.agent_state import TaskStatus, TaskNode
+from models.agent_state import TaskNode
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_e2e_parallel.py
+++ b/tests/backend/test_e2e_parallel.py
@@ -1,10 +1,10 @@
 """E2E parallel execution tests."""
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 import asyncio
 
-from models.agent_state import TaskStatus, TaskNode, create_initial_state
+import pytest
+
+from models.agent_state import TaskNode, TaskStatus, create_initial_state
 
 
 @pytest.mark.asyncio
@@ -98,10 +98,7 @@ class TestConcurrentTaskExecution:
             )
             state["tasks"][f"task-{i}"] = task
 
-        pending_count = sum(
-            1 for t in state["tasks"].values()
-            if t.status == TaskStatus.PENDING
-        )
+        pending_count = sum(1 for t in state["tasks"].values() if t.status == TaskStatus.PENDING)
         assert pending_count == 5
 
     async def test_tasks_can_be_marked_in_progress(self):
@@ -122,8 +119,7 @@ class TestConcurrentTaskExecution:
             state["tasks"][tid].status = TaskStatus.IN_PROGRESS
 
         in_progress_count = sum(
-            1 for t in state["tasks"].values()
-            if t.status == TaskStatus.IN_PROGRESS
+            1 for t in state["tasks"].values() if t.status == TaskStatus.IN_PROGRESS
         )
         assert in_progress_count == 3
 

--- a/tests/backend/test_executor_token_accumulation.py
+++ b/tests/backend/test_executor_token_accumulation.py
@@ -91,9 +91,7 @@ async def test_executor_accumulates_token_usage_across_iterations(
 
 
 @pytest.mark.asyncio
-async def test_executor_total_cost_matches_ledger_sum(
-    monkeypatch, executor_state, usage_recorder
-):
+async def test_executor_total_cost_matches_ledger_sum(monkeypatch, executor_state, usage_recorder):
     """state 의 total_cost 는 원장에 기록된 회차별 비용의 합과 일치해야 한다."""
     node = _build_node(
         monkeypatch,

--- a/tests/backend/test_gemini_review_fixes.py
+++ b/tests/backend/test_gemini_review_fixes.py
@@ -10,7 +10,7 @@ Covers:
 import os
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -20,7 +20,6 @@ from agents.lead_orchestrator import (
     _safe_execution_strategy,
 )
 from services.agent_registry import EffortLevel
-
 
 # ─────────────────────────────────────────────────────────────
 # 1. project_path "." should be validated too
@@ -46,7 +45,7 @@ class TestProjectPathValidation:
 
     def test_validate_project_path_accepts_allowed_root(self):
         """허용된 workspace 내 경로를 수락해야 한다."""
-        from api.agents import ALLOWED_WORKSPACE_ROOTS, _validate_project_path
+        from api.agents import _validate_project_path
 
         # Create a temp dir under the first allowed root for testing
         # Just test that the function exists and has the right signature
@@ -58,8 +57,12 @@ class TestProjectPathValidation:
 
         # "." resolves to CWD - if CWD is not in allowed roots, should raise
         cwd = Path.cwd().resolve()
-        allowed_roots = [Path.home() / "Work", Path.home() / "Projects",
-                         Path.home() / "Developer", Path("/tmp/aos-workspaces")]
+        allowed_roots = [
+            Path.home() / "Work",
+            Path.home() / "Projects",
+            Path.home() / "Developer",
+            Path("/tmp/aos-workspaces"),
+        ]
 
         cwd_is_allowed = any(
             cwd == root.resolve() or str(cwd).startswith(str(root.resolve()) + "/")

--- a/tests/backend/test_git_service.py
+++ b/tests/backend/test_git_service.py
@@ -1,8 +1,9 @@
 """Tests for GitService."""
 
-import pytest
-from unittest.mock import MagicMock, patch
 from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestGitService:

--- a/tests/backend/test_git_service_prune.py
+++ b/tests/backend/test_git_service_prune.py
@@ -235,9 +235,7 @@ class TestFindPruneCandidates:
 
     @patch("services.git_service.Repo")
     @patch("services.git_service.GIT_AVAILABLE", True)
-    def test_unpushed_commits_skipped(
-        self, mock_repo_class, mock_github_service, tmp_path
-    ):
+    def test_unpushed_commits_skipped(self, mock_repo_class, mock_github_service, tmp_path):
         """Branch with ahead>0 vs origin → skipped with 'unpushed_commits'."""
         repo = MagicMock()
         repo.is_dirty.return_value = False
@@ -580,9 +578,7 @@ class TestScanErrorSurfacing:
 class TestHasUnpushedCommitsFallback:
     @patch("services.git_service.Repo")
     @patch("services.git_service.GIT_AVAILABLE", True)
-    def test_untracked_branch_with_remote_ref_not_unpushed(
-        self, mock_repo_class, tmp_path
-    ):
+    def test_untracked_branch_with_remote_ref_not_unpushed(self, mock_repo_class, tmp_path):
         """No upstream config but origin/<name> exists at same tip → not unpushed."""
         repo = MagicMock()
         branch = _make_branch("feat/pushed", tracking_ref=None, ahead=0)
@@ -605,9 +601,7 @@ class TestHasUnpushedCommitsFallback:
 
     @patch("services.git_service.Repo")
     @patch("services.git_service.GIT_AVAILABLE", True)
-    def test_untracked_branch_without_remote_ref_is_unpushed(
-        self, mock_repo_class, tmp_path
-    ):
+    def test_untracked_branch_without_remote_ref_is_unpushed(self, mock_repo_class, tmp_path):
         """Genuinely-local branch (no upstream, no origin/<name>) stays protected."""
         repo = MagicMock()
         branch = _make_branch("wip/local-only", tracking_ref=None, ahead=0)

--- a/tests/backend/test_github_service_list_prs.py
+++ b/tests/backend/test_github_service_list_prs.py
@@ -83,8 +83,15 @@ def _list_payload_pr():
     pr.closed_at = now
     # These are NOT in the PR list payload — accessing them triggers a per-PR
     # API round-trip. The lite path must never touch them.
-    for attr in ("mergeable", "mergeable_state", "commits", "additions",
-                 "deletions", "changed_files", "review_comments"):
+    for attr in (
+        "mergeable",
+        "mergeable_state",
+        "commits",
+        "additions",
+        "deletions",
+        "changed_files",
+        "review_comments",
+    ):
         setattr(type(pr), attr, PropertyMock(side_effect=AssertionError(f"{attr} fetched!")))
     return pr
 

--- a/tests/backend/test_hitl_approval_resume.py
+++ b/tests/backend/test_hitl_approval_resume.py
@@ -177,9 +177,7 @@ class TestApprovalResumeEndToEnd:
     """compiled graph 를 실제로 통과하는 승인 왕복."""
 
     @pytest.mark.asyncio
-    async def test_approved_tool_runs_exactly_once_and_task_completes(
-        self, monkeypatch, graph_env
-    ):
+    async def test_approved_tool_runs_exactly_once_and_task_completes(self, monkeypatch, graph_env):
         """승인 생성 → 승인 → 도구가 정확히 한 번 실행 → task COMPLETED."""
         compiled, execute_tool = _build_graph(
             monkeypatch,

--- a/tests/backend/test_integration_automation.py
+++ b/tests/backend/test_integration_automation.py
@@ -20,7 +20,6 @@ from services.automation_loop_service import (
 from services.pipeline.models import PipelineConfig, StageConfig
 from services.pipeline.pipeline_service import PipelineService
 
-
 # ── Fixtures ────────────────────────────────────────────────
 
 
@@ -326,9 +325,7 @@ class TestScenario3AutomationTriggersPipeline:
     """
 
     @pytest.mark.asyncio
-    async def test_automation_loop_triggers_pipeline(
-        self, automation_service, pipeline_service
-    ):
+    async def test_automation_loop_triggers_pipeline(self, automation_service, pipeline_service):
         """자동화 루프가 조건 충족 시 파이프라인을 트리거해야 한다."""
         # 1. Create pipeline first
         pipeline_config = PipelineConfig(
@@ -404,9 +401,7 @@ class TestScenario3AutomationTriggersPipeline:
         assert triggered[0].run_count == 1
 
     @pytest.mark.asyncio
-    async def test_pipeline_action_failure_handled(
-        self, automation_service, pipeline_service
-    ):
+    async def test_pipeline_action_failure_handled(self, automation_service, pipeline_service):
         """존재하지 않는 파이프라인 트리거 시 에러가 적절히 처리되어야 한다."""
         loop_config = AutomationLoopConfig(
             name="bad-pipeline-loop",

--- a/tests/backend/test_lead_orchestrator.py
+++ b/tests/backend/test_lead_orchestrator.py
@@ -1,15 +1,15 @@
 """Tests for Lead Orchestrator Agent."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
 
 from agents.lead_orchestrator import (
-    LeadOrchestratorAgent,
-    TaskAnalysis,
-    SubtaskPlan,
-    ExecutionStrategy,
     EffortLevel,
-    get_lead_orchestrator,
+    ExecutionStrategy,
+    LeadOrchestratorAgent,
+    SubtaskPlan,
+    TaskAnalysis,
 )
 
 
@@ -30,7 +30,7 @@ class TestLeadOrchestratorAgent:
     async def test_execute_simple_task(self):
         """간단한 태스크 실행 테스트."""
         # LLM 응답 모킹
-        mock_response = '''```json
+        mock_response = """```json
 {
   "analysis": {
     "complexity_score": 3,
@@ -52,9 +52,9 @@ class TestLeadOrchestratorAgent:
   "execution_strategy": "sequential",
   "reasoning": "Simple task, no decomposition needed"
 }
-```'''
+```"""
 
-        with patch.object(self.orchestrator, '_invoke_llm', new_callable=AsyncMock) as mock_llm:
+        with patch.object(self.orchestrator, "_invoke_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = mock_response
 
             result = await self.orchestrator.execute("Create a button component")
@@ -66,7 +66,7 @@ class TestLeadOrchestratorAgent:
     @pytest.mark.asyncio
     async def test_execute_complex_task(self):
         """복잡한 태스크 실행 테스트 (분해 필요)."""
-        mock_response = '''```json
+        mock_response = """```json
 {
   "analysis": {
     "complexity_score": 8,
@@ -104,9 +104,9 @@ class TestLeadOrchestratorAgent:
   "execution_strategy": "mixed",
   "reasoning": "Complex feature requires multiple specialists"
 }
-```'''
+```"""
 
-        with patch.object(self.orchestrator, '_invoke_llm', new_callable=AsyncMock) as mock_llm:
+        with patch.object(self.orchestrator, "_invoke_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = mock_response
 
             result = await self.orchestrator.execute("Implement user login with Firebase")
@@ -119,9 +119,19 @@ class TestLeadOrchestratorAgent:
         """위상 정렬 테스트."""
         subtasks = [
             SubtaskPlan(id="st-1", title="Task 1", description="First", priority=10),
-            SubtaskPlan(id="st-2", title="Task 2", description="Second", dependencies=["st-1"], priority=5),
-            SubtaskPlan(id="st-3", title="Task 3", description="Third", dependencies=["st-1"], priority=8),
-            SubtaskPlan(id="st-4", title="Task 4", description="Fourth", dependencies=["st-2", "st-3"], priority=1),
+            SubtaskPlan(
+                id="st-2", title="Task 2", description="Second", dependencies=["st-1"], priority=5
+            ),
+            SubtaskPlan(
+                id="st-3", title="Task 3", description="Third", dependencies=["st-1"], priority=8
+            ),
+            SubtaskPlan(
+                id="st-4",
+                title="Task 4",
+                description="Fourth",
+                dependencies=["st-2", "st-3"],
+                priority=1,
+            ),
         ]
 
         order = self.orchestrator._topological_sort(subtasks)
@@ -292,7 +302,7 @@ class TestAnalyzeTaskParsing:
     @pytest.mark.asyncio
     async def test_parse_new_fields(self):
         """safety_flags, dependency_rationale, task_boundaries 파싱 테스트."""
-        mock_response = '''```json
+        mock_response = """```json
 {
   "analysis": {
     "complexity_score": 7,
@@ -334,9 +344,9 @@ class TestAnalyzeTaskParsing:
   "execution_strategy": "sequential",
   "reasoning": "API 먼저 구현 후 UI 연동"
 }
-```'''
+```"""
 
-        with patch.object(self.orchestrator, '_invoke_llm', new_callable=AsyncMock) as mock_llm:
+        with patch.object(self.orchestrator, "_invoke_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = mock_response
 
             result = await self.orchestrator.execute("API와 UI 기능 구현")
@@ -356,7 +366,7 @@ class TestAnalyzeTaskParsing:
     @pytest.mark.asyncio
     async def test_parse_without_new_fields_backward_compat(self):
         """새 필드 없는 기존 응답도 정상 파싱 (하위 호환)."""
-        mock_response = '''```json
+        mock_response = """```json
 {
   "analysis": {
     "complexity_score": 3,
@@ -378,9 +388,9 @@ class TestAnalyzeTaskParsing:
   "execution_strategy": "sequential",
   "reasoning": "간단한 작업"
 }
-```'''
+```"""
 
-        with patch.object(self.orchestrator, '_invoke_llm', new_callable=AsyncMock) as mock_llm:
+        with patch.object(self.orchestrator, "_invoke_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = mock_response
 
             result = await self.orchestrator.execute("버튼 추가")

--- a/tests/backend/test_llm_access_service.py
+++ b/tests/backend/test_llm_access_service.py
@@ -220,10 +220,12 @@ class _FakeSequenceDb:
 async def test_delete_cli_profile_removes_profile_and_unassigns_entitlements() -> None:
     profile = SimpleNamespace(id="profile-1")
     entitlement = SimpleNamespace(cli_profile_id="profile-1", updated_at=None)
-    db = _FakeSequenceDb([
-        _FakeScalarResult(profile),
-        _FakeListResult([entitlement]),
-    ])
+    db = _FakeSequenceDb(
+        [
+            _FakeScalarResult(profile),
+            _FakeListResult([entitlement]),
+        ]
+    )
 
     deleted = await delete_cli_profile(db, "profile-1")
 

--- a/tests/backend/test_llm_model_registry.py
+++ b/tests/backend/test_llm_model_registry.py
@@ -47,11 +47,7 @@ class TestSonnet5RegistryEntry:
         assert LLMModelRegistry.get_default("anthropic") == "claude-sonnet-5"
 
     def test_anthropic_has_exactly_one_code_default(self):
-        defaults = [
-            m.id
-            for m in _MODELS
-            if m.provider == LLMProvider.ANTHROPIC and m.is_default
-        ]
+        defaults = [m.id for m in _MODELS if m.provider == LLMProvider.ANTHROPIC and m.is_default]
         assert defaults == ["claude-sonnet-5"]
 
 
@@ -134,11 +130,7 @@ class TestGpt56RegistryEntry:
         assert LLMModelRegistry.get_default("openai") == "gpt-5.6"
 
     def test_openai_has_exactly_one_code_default(self):
-        defaults = [
-            m.id
-            for m in _MODELS
-            if m.provider == LLMProvider.OPENAI and m.is_default
-        ]
+        defaults = [m.id for m in _MODELS if m.provider == LLMProvider.OPENAI and m.is_default]
         assert defaults == ["gpt-5.6"]
 
     @pytest.mark.parametrize(
@@ -176,11 +168,7 @@ class TestGemini37FlashRegistryEntry:
         assert LLMModelRegistry.get_default("google") == "gemini-3.7-flash"
 
     def test_google_has_exactly_one_code_default(self):
-        defaults = [
-            m.id
-            for m in _MODELS
-            if m.provider == LLMProvider.GOOGLE and m.is_default
-        ]
+        defaults = [m.id for m in _MODELS if m.provider == LLMProvider.GOOGLE and m.is_default]
         assert defaults == ["gemini-3.7-flash"]
 
 
@@ -280,12 +268,8 @@ class TestGetDefaultSelectionPolicy:
         providers = {m.provider for m in _MODELS}
         for provider in providers:
             defaults = [m for m in _MODELS if m.provider == provider and m.is_default]
-            assert len(defaults) == 1, (
-                f"{provider.value}: defaults={[m.id for m in defaults]}"
-            )
-            assert defaults[0].is_enabled, (
-                f"{provider.value}: default {defaults[0].id} is disabled"
-            )
+            assert len(defaults) == 1, f"{provider.value}: defaults={[m.id for m in defaults]}"
+            assert defaults[0].is_enabled, f"{provider.value}: default {defaults[0].id} is disabled"
 
     def test_no_enabled_default_falls_back_to_cheapest_deterministically(self, caplog):
         """default 가 disabled 된 provider: 목록 순서(첫 요소)가 아니라
@@ -409,11 +393,7 @@ class TestClaudeCliRegistryEntry:
         assert LLMModelRegistry.get_default("claude_cli") == "claude-cli"
 
     def test_claude_cli_provider_has_exactly_one_code_default(self):
-        defaults = [
-            m.id
-            for m in _MODELS
-            if m.provider == LLMProvider.CLAUDE_CLI and m.is_default
-        ]
+        defaults = [m.id for m in _MODELS if m.provider == LLMProvider.CLAUDE_CLI and m.is_default]
         assert defaults == ["claude-cli"]
 
     def test_claude_cli_is_always_available(self):
@@ -577,9 +557,7 @@ async def test_sync_to_db_new_default_demoted_when_prior_default_is_disabled():
 
     params = _insert_params(_find_insert(session, "claude-sonnet-5"))
     assert params["is_default"] is False
-    assert session.updates == [], (
-        "sync must not clear/override admin flags on existing rows"
-    )
+    assert session.updates == [], "sync must not clear/override admin flags on existing rows"
 
 
 @pytest.mark.asyncio
@@ -845,9 +823,7 @@ class TestLLMProxyCostTable:
         from api.llm_proxy import _calc_cost
 
         # Must hit the claude-haiku-4-5 row ($1/$5), not claude-haiku-4
-        assert _calc_cost("claude-haiku-4-5-20251001", 1000, 1000) == pytest.approx(
-            0.001 + 0.005
-        )
+        assert _calc_cost("claude-haiku-4-5-20251001", 1000, 1000) == pytest.approx(0.001 + 0.005)
 
     def test_opus_4_5_and_later_match_post_price_cut_rows(self):
         """Opus price cut ($5/$25) applies from 4.5 onward: the specific
@@ -1082,9 +1058,7 @@ class TestCostTablePrefixOrdering:
             assert calc("gpt-4o-mini", 1000, 3000) == pytest.approx(0.00015 + 3 * 0.0006)
 
         # Gemini 는 수집기가 없어 llm_proxy 만 해당
-        assert _calc_cost("gemini-2.5-flash-lite", 1000, 3000) == pytest.approx(
-            0.0001 + 3 * 0.0004
-        )
+        assert _calc_cost("gemini-2.5-flash-lite", 1000, 3000) == pytest.approx(0.0001 + 3 * 0.0004)
         assert _calc_cost("gemini-2.5-flash", 1000, 3000) == pytest.approx(0.0003 + 3 * 0.0025)
 
     def test_usage_collector_keeps_the_same_variant_ordering(self):

--- a/tests/backend/test_llm_runtime_resolver.py
+++ b/tests/backend/test_llm_runtime_resolver.py
@@ -291,9 +291,7 @@ def test_resolve_fails_closed_when_entitled_provider_has_no_enabled_models(
         user_id="user-1",
         api_fallback_enabled=False,
         profiles=[],
-        entitlements=[
-            _entitlement(provider="ollama", mode="local", cli_profile_id=None)
-        ],
+        entitlements=[_entitlement(provider="ollama", mode="local", cli_profile_id=None)],
     )
 
     with pytest.raises(LLMRuntimeResolutionError, match="ollama"):

--- a/tests/backend/test_llm_usage_instrumentation.py
+++ b/tests/backend/test_llm_usage_instrumentation.py
@@ -518,8 +518,12 @@ async def test_task_analyzer_ocr_records_allowed_api_fallback_usage(monkeypatch)
     preflight = AsyncMock()
 
     monkeypatch.setattr("api.agents.ocr.get_access_for_user", AsyncMock(return_value=access))
-    monkeypatch.setattr("api.agents.ocr.LLMModelRegistry.get_enabled", MagicMock(return_value=[model]))
-    monkeypatch.setattr("api.agents.ocr.LLMModelRegistry.is_available", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        "api.agents.ocr.LLMModelRegistry.get_enabled", MagicMock(return_value=[model])
+    )
+    monkeypatch.setattr(
+        "api.agents.ocr.LLMModelRegistry.is_available", MagicMock(return_value=True)
+    )
     monkeypatch.setattr("api.agents.ocr.LLMService._get_llm", MagicMock(return_value=fake_llm))
     monkeypatch.setattr("api.agents.ocr.record_usage_best_effort", recorder)
     monkeypatch.setattr(

--- a/tests/backend/test_llm_usage_ledger_service.py
+++ b/tests/backend/test_llm_usage_ledger_service.py
@@ -142,9 +142,7 @@ async def test_record_usage_resolves_unique_user_org_and_updates_quota_counter()
         add=MagicMock(),
         flush=AsyncMock(side_effect=flush_side_effect),
         execute=AsyncMock(
-            return_value=_FakeResult(
-                [SimpleNamespace(organization_id="org-1", is_active=True)]
-            )
+            return_value=_FakeResult([SimpleNamespace(organization_id="org-1", is_active=True)])
         ),
     )
     data = LLMUsageRecordCreate(
@@ -235,9 +233,7 @@ async def test_record_usage_accepts_explicit_org_scope_for_active_member() -> No
         add=MagicMock(),
         flush=AsyncMock(side_effect=flush_side_effect),
         execute=AsyncMock(
-            return_value=_FakeResult(
-                [SimpleNamespace(organization_id="org-2", is_active=True)]
-            )
+            return_value=_FakeResult([SimpleNamespace(organization_id="org-2", is_active=True)])
         ),
     )
     data = LLMUsageRecordCreate(
@@ -303,9 +299,7 @@ async def test_record_usage_rejects_explicit_org_scope_for_non_member() -> None:
 async def test_enforce_usage_quota_preflight_allows_with_remaining_quota() -> None:
     db = SimpleNamespace(
         execute=AsyncMock(
-            return_value=_FakeResult(
-                [SimpleNamespace(organization_id="org-1", is_active=True)]
-            )
+            return_value=_FakeResult([SimpleNamespace(organization_id="org-1", is_active=True)])
         ),
     )
     org = SimpleNamespace(
@@ -333,9 +327,7 @@ async def test_enforce_usage_quota_preflight_allows_with_remaining_quota() -> No
 async def test_enforce_usage_quota_preflight_raises_when_quota_exceeded() -> None:
     db = SimpleNamespace(
         execute=AsyncMock(
-            return_value=_FakeResult(
-                [SimpleNamespace(organization_id="org-1", is_active=True)]
-            )
+            return_value=_FakeResult([SimpleNamespace(organization_id="org-1", is_active=True)])
         ),
     )
     org = SimpleNamespace(

--- a/tests/backend/test_mcp_service.py
+++ b/tests/backend/test_mcp_service.py
@@ -1,10 +1,11 @@
 """Tests for MCPService (MCP protocol handler)."""
 
 import json
+
 import pytest
 
 from models.mcp import MCPRequest, MCPToolResult
-from services.mcp_service import MCPService, get_mcp_service
+from services.mcp_service import MCPService
 
 
 @pytest.fixture
@@ -50,7 +51,9 @@ class TestHandleRequest:
         assert mcp_service._initialized is True
 
     @pytest.mark.asyncio
-    async def test_unknown_method_returns_method_not_found_error(self, mcp_service: MCPService) -> None:
+    async def test_unknown_method_returns_method_not_found_error(
+        self, mcp_service: MCPService
+    ) -> None:
         req = MCPRequest(id=2, method="unknown/method", params={})
 
         resp = await mcp_service.handle_request(req)
@@ -61,7 +64,9 @@ class TestHandleRequest:
         assert "Method not found" in resp.error["message"]
 
     @pytest.mark.asyncio
-    async def test_internal_error_is_wrapped(self, mcp_service: MCPService, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_internal_error_is_wrapped(
+        self, mcp_service: MCPService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Force _handle_initialize to raise to exercise the generic error handler
         def boom(_params: dict):  # type: ignore[override]
             raise RuntimeError("boom")
@@ -108,7 +113,9 @@ class TestExecuteToolDispatch:
         assert any("Unknown tool" in c.get("text", "") for c in result.content)
 
     @pytest.mark.asyncio
-    async def test_execute_tool_wraps_exceptions(self, mcp_service: MCPService, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_execute_tool_wraps_exceptions(
+        self, mcp_service: MCPService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         async def boom(_args: dict):  # type: ignore[override]
             raise RuntimeError("tool failed")
 
@@ -159,7 +166,9 @@ class TestCreateTaskAndStatusTools:
 
         # Patch project lookup/registry
         monkeypatch.setattr("services.mcp_service.get_project", lambda _pid: dummy_project)
-        monkeypatch.setattr("services.mcp_service.PROJECTS_REGISTRY", {"demo": dummy_project}, raising=False)
+        monkeypatch.setattr(
+            "services.mcp_service.PROJECTS_REGISTRY", {"demo": dummy_project}, raising=False
+        )
 
         # Create task
         create_result = await mcp_service._tool_create_task(
@@ -265,7 +274,9 @@ class TestRunCheckTool:
         # Patch get_runner so we don't touch the real filesystem when constructing ProjectRunner
         monkeypatch.setattr("services.mcp_service.get_runner", lambda _path: DummyRunner())
 
-        result = await mcp_service._tool_run_check({"project_id": "demo", "check_type": "not-a-check"})
+        result = await mcp_service._tool_run_check(
+            {"project_id": "demo", "check_type": "not-a-check"}
+        )
 
         assert result.isError is True
         text = "\n".join(c.get("text", "") for c in result.content)
@@ -335,7 +346,11 @@ class TestRunCheckTool:
                 return type(
                     "R",
                     (),
-                    {"status": status, "duration_ms": 50, "stderr": "boom" if status != "success" else ""},
+                    {
+                        "status": status,
+                        "duration_ms": 50,
+                        "stderr": "boom" if status != "success" else "",
+                    },
                 )()
 
         monkeypatch.setattr("services.mcp_service.get_runner", lambda _path: DummyRunner())

--- a/tests/backend/test_model_update_suppression.py
+++ b/tests/backend/test_model_update_suppression.py
@@ -128,6 +128,4 @@ async def test_apply_changes_self_heals_suppressed_config_rows(monkeypatch):
     sql = str(compiled)
     assert "DELETE FROM llm_model_configs" in sql
     assert "llm_model_suppressions" in sql
-    assert (
-        session.deletes[0].get_execution_options().get("synchronize_session") is False
-    )
+    assert session.deletes[0].get_execution_options().get("synchronize_session") is False

--- a/tests/backend/test_notification_service.py
+++ b/tests/backend/test_notification_service.py
@@ -1,10 +1,9 @@
 """Unit tests for notification_service.py."""
 
-import pytest
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from utils.time import utcnow
+import pytest
 
 from models.notification import (
     ChannelConfig,
@@ -22,16 +21,17 @@ from services.notification_service import (
     NotificationService,
     SlackAdapter,
     WebhookAdapter,
-    _rules,
     _notification_history,
+    _rules,
     notify_task_completed,
     notify_task_failed,
 )
-
+from utils.time import utcnow
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_rule_create(
     name: str = "Test Rule",
@@ -72,6 +72,7 @@ def _make_channel_config(
 # ---------------------------------------------------------------------------
 # CRUD – In-memory
 # ---------------------------------------------------------------------------
+
 
 class TestNotificationServiceCRUD:
     """Tests for in-memory CRUD operations."""
@@ -189,6 +190,7 @@ class TestNotificationServiceCRUD:
 # Condition / Project filter checks
 # ---------------------------------------------------------------------------
 
+
 class TestCheckConditions:
     """Tests for _check_conditions."""
 
@@ -212,81 +214,81 @@ class TestCheckConditions:
 
     def test_equals_operator_match(self):
         """equals condition passes when field value is equal."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="status", operator="equals", value="done")
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="status", operator="equals", value="done")]
+        )
         assert NotificationService._check_conditions(rule, {"status": "done"}) is True
 
     def test_equals_operator_no_match(self):
         """equals condition fails when field value differs."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="status", operator="equals", value="done")
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="status", operator="equals", value="done")]
+        )
         assert NotificationService._check_conditions(rule, {"status": "pending"}) is False
 
     def test_contains_operator_match(self):
         """contains condition passes when substring is found."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="message", operator="contains", value="error")
-        ])
-        assert NotificationService._check_conditions(rule, {"message": "fatal error occurred"}) is True
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="message", operator="contains", value="error")]
+        )
+        assert (
+            NotificationService._check_conditions(rule, {"message": "fatal error occurred"}) is True
+        )
 
     def test_contains_operator_no_match(self):
         """contains condition fails when substring is absent."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="message", operator="contains", value="error")
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="message", operator="contains", value="error")]
+        )
         assert NotificationService._check_conditions(rule, {"message": "all good"}) is False
 
     def test_greater_than_operator_match(self):
         """greater_than condition passes when value is larger."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="cost", operator="greater_than", value=10.0)
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="cost", operator="greater_than", value=10.0)]
+        )
         assert NotificationService._check_conditions(rule, {"cost": 15.0}) is True
 
     def test_greater_than_operator_no_match(self):
         """greater_than condition fails when value is smaller or equal."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="cost", operator="greater_than", value=10.0)
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="cost", operator="greater_than", value=10.0)]
+        )
         assert NotificationService._check_conditions(rule, {"cost": 5.0}) is False
         assert NotificationService._check_conditions(rule, {"cost": 10.0}) is False
 
     def test_less_than_operator_match(self):
         """less_than condition passes when value is smaller."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="score", operator="less_than", value=50)
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="score", operator="less_than", value=50)]
+        )
         assert NotificationService._check_conditions(rule, {"score": 30}) is True
 
     def test_less_than_operator_no_match(self):
         """less_than condition fails when value is equal or larger."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="score", operator="less_than", value=50)
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="score", operator="less_than", value=50)]
+        )
         assert NotificationService._check_conditions(rule, {"score": 50}) is False
         assert NotificationService._check_conditions(rule, {"score": 70}) is False
 
     def test_missing_field_fails(self):
         """A condition whose field is absent in data returns False."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="missing_key", operator="equals", value="x")
-        ])
+        rule = self._rule_with_conditions(
+            [NotificationCondition(field="missing_key", operator="equals", value="x")]
+        )
         assert NotificationService._check_conditions(rule, {}) is False
 
     def test_multiple_conditions_all_must_pass(self):
         """All conditions must be satisfied for the overall check to pass."""
-        rule = self._rule_with_conditions([
-            NotificationCondition(field="status", operator="equals", value="done"),
-            NotificationCondition(field="cost", operator="greater_than", value=5.0),
-        ])
-        assert NotificationService._check_conditions(
-            rule, {"status": "done", "cost": 10.0}
-        ) is True
-        assert NotificationService._check_conditions(
-            rule, {"status": "done", "cost": 1.0}
-        ) is False
+        rule = self._rule_with_conditions(
+            [
+                NotificationCondition(field="status", operator="equals", value="done"),
+                NotificationCondition(field="cost", operator="greater_than", value=5.0),
+            ]
+        )
+        assert NotificationService._check_conditions(rule, {"status": "done", "cost": 10.0}) is True
+        assert NotificationService._check_conditions(rule, {"status": "done", "cost": 1.0}) is False
 
 
 class TestCheckRateLimit:
@@ -363,6 +365,7 @@ class TestCheckProjectFilter:
 # Adapters
 # ---------------------------------------------------------------------------
 
+
 class TestSlackAdapter:
     """Tests for SlackAdapter.send."""
 
@@ -404,7 +407,9 @@ class TestSlackAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client
+        ):
             success, error = await adapter.send(message, config)
 
         assert success is True
@@ -430,7 +435,9 @@ class TestSlackAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client
+        ):
             success, error = await adapter.send(message, config)
 
         assert success is False
@@ -453,7 +460,9 @@ class TestSlackAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client
+        ):
             success, error = await adapter.send(message, config)
 
         assert success is False
@@ -503,7 +512,9 @@ class TestDiscordAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client
+        ):
             success, error = await adapter.send(message, config)
 
         assert success is True
@@ -532,7 +543,9 @@ class TestDiscordAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client
+        ):
             success, error = await adapter.send(message, config)
 
         assert success is False
@@ -582,7 +595,9 @@ class TestWebhookAdapter:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client
+        ):
             success, error = await adapter.send(message, config)
 
         assert success is True
@@ -592,6 +607,7 @@ class TestWebhookAdapter:
 # ---------------------------------------------------------------------------
 # send_notification (in-memory rules path)
 # ---------------------------------------------------------------------------
+
 
 class TestSendNotification:
     """Tests for NotificationService.send_notification (in-memory)."""
@@ -627,10 +643,15 @@ class TestSendNotification:
             webhook_url="https://hooks.slack.com/test",
         )
 
-        with patch(
-            "services.notification_service.NotificationService.get_channel_config",
-            return_value=slack_config,
-        ), patch("services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client):
+        with (
+            patch(
+                "services.notification_service.NotificationService.get_channel_config",
+                return_value=slack_config,
+            ),
+            patch(
+                "services.notification_service.adapters.httpx.AsyncClient", return_value=mock_client
+            ),
+        ):
             msg = await NotificationService.send_notification(
                 NotificationEventType.TASK_COMPLETED,
                 {"task_title": "My Task"},
@@ -750,6 +771,7 @@ class TestSendNotification:
 # Convenience functions
 # ---------------------------------------------------------------------------
 
+
 class TestConvenienceFunctions:
     """Tests for notify_task_completed and notify_task_failed."""
 
@@ -807,6 +829,7 @@ class TestConvenienceFunctions:
 # ---------------------------------------------------------------------------
 # Notification history helpers
 # ---------------------------------------------------------------------------
+
 
 class TestNotificationHistory:
     """Tests for get_history and clear_history."""

--- a/tests/backend/test_organization_service.py
+++ b/tests/backend/test_organization_service.py
@@ -78,8 +78,10 @@ def _create_org(
 ) -> Organization:
     """Create an org through the service (with file I/O patched out)."""
     data = _make_org_create(name=name, slug=slug, plan=plan)
-    with patch("services.organization_service._save_organizations"), \
-         patch("services.organization_service._save_members"):
+    with (
+        patch("services.organization_service._save_organizations"),
+        patch("services.organization_service._save_members"),
+    ):
         return OrganizationService.create_organization(
             data=data,
             owner_user_id=owner_id,
@@ -91,6 +93,7 @@ def _create_org(
 # ---------------------------------------------------------------------------
 # Test Class
 # ---------------------------------------------------------------------------
+
 
 class TestOrganizationService:
     """Unit tests for OrganizationService (in-memory mode)."""
@@ -105,8 +108,10 @@ class TestOrganizationService:
 
     def test_create_organization_success(self):
         """Creating an org stores it and adds an OWNER member."""
-        with patch("services.organization_service._save_organizations"), \
-             patch("services.organization_service._save_members"):
+        with (
+            patch("services.organization_service._save_organizations"),
+            patch("services.organization_service._save_members"),
+        ):
             org = OrganizationService.create_organization(
                 data=_make_org_create(),
                 owner_user_id="user-1",
@@ -134,8 +139,10 @@ class TestOrganizationService:
 
     def test_create_organization_applies_plan_limits(self):
         """Plan limits are applied to max_members etc. at creation time."""
-        with patch("services.organization_service._save_organizations"), \
-             patch("services.organization_service._save_members"):
+        with (
+            patch("services.organization_service._save_organizations"),
+            patch("services.organization_service._save_members"),
+        ):
             org = OrganizationService.create_organization(
                 data=_make_org_create(slug="starter-org", plan=OrganizationPlan.STARTER),
                 owner_user_id="u1",
@@ -153,8 +160,10 @@ class TestOrganizationService:
         _create_org(slug="dup-slug")
 
         with pytest.raises(ValueError, match="already taken"):
-            with patch("services.organization_service._save_organizations"), \
-                 patch("services.organization_service._save_members"):
+            with (
+                patch("services.organization_service._save_organizations"),
+                patch("services.organization_service._save_members"),
+            ):
                 OrganizationService.create_organization(
                     data=_make_org_create(slug="dup-slug"),
                     owner_user_id="u2",
@@ -258,9 +267,7 @@ class TestOrganizationService:
 
     def test_update_organization_not_found_returns_none(self):
         """update_organization returns None for unknown org_id."""
-        result = OrganizationService.update_organization(
-            "bad-id", OrganizationUpdate(name="X")
-        )
+        result = OrganizationService.update_organization("bad-id", OrganizationUpdate(name="X"))
         assert result is None
 
     # -----------------------------------------------------------------------
@@ -289,8 +296,10 @@ class TestOrganizationService:
             )
 
         # Create new org with same slug - should not raise
-        with patch("services.organization_service._save_organizations"), \
-             patch("services.organization_service._save_members"):
+        with (
+            patch("services.organization_service._save_organizations"),
+            patch("services.organization_service._save_members"),
+        ):
             new_org = OrganizationService.create_organization(
                 data=_make_org_create(slug="reusable-slug"),
                 owner_user_id="u2",
@@ -328,9 +337,12 @@ class TestOrganizationService:
         mock_quota = MagicMock()
         mock_quota.allowed = True
 
-        with patch("services.quota_service.QuotaService.check_member_quota",
-                   return_value=mock_quota), \
-             patch("services.organization_service._save_invitations"):
+        with (
+            patch(
+                "services.quota_service.QuotaService.check_member_quota", return_value=mock_quota
+            ),
+            patch("services.organization_service._save_invitations"),
+        ):
             inv = OrganizationService.invite_member(
                 org_id=org.id,
                 request=InviteMemberRequest(email="newmember@example.com", role=MemberRole.MEMBER),
@@ -352,8 +364,9 @@ class TestOrganizationService:
         mock_quota.allowed = False
         mock_quota.message = "Member limit reached (5)"
 
-        with patch("services.quota_service.QuotaService.check_member_quota",
-                   return_value=mock_quota):
+        with patch(
+            "services.quota_service.QuotaService.check_member_quota", return_value=mock_quota
+        ):
             with pytest.raises(ValueError, match="Member limit reached"):
                 OrganizationService.invite_member(
                     org_id=org.id,
@@ -368,8 +381,9 @@ class TestOrganizationService:
         mock_quota = MagicMock()
         mock_quota.allowed = True
 
-        with patch("services.quota_service.QuotaService.check_member_quota",
-                   return_value=mock_quota):
+        with patch(
+            "services.quota_service.QuotaService.check_member_quota", return_value=mock_quota
+        ):
             with pytest.raises(ValueError, match="already a member"):
                 OrganizationService.invite_member(
                     org_id=org.id,
@@ -385,9 +399,12 @@ class TestOrganizationService:
         mock_quota.allowed = True
 
         # First invite
-        with patch("services.quota_service.QuotaService.check_member_quota",
-                   return_value=mock_quota), \
-             patch("services.organization_service._save_invitations"):
+        with (
+            patch(
+                "services.quota_service.QuotaService.check_member_quota", return_value=mock_quota
+            ),
+            patch("services.organization_service._save_invitations"),
+        ):
             OrganizationService.invite_member(
                 org_id=org.id,
                 request=InviteMemberRequest(email="new@example.com"),
@@ -395,8 +412,9 @@ class TestOrganizationService:
             )
 
         # Second invite for same email
-        with patch("services.quota_service.QuotaService.check_member_quota",
-                   return_value=mock_quota):
+        with patch(
+            "services.quota_service.QuotaService.check_member_quota", return_value=mock_quota
+        ):
             with pytest.raises(ValueError, match="already pending"):
                 OrganizationService.invite_member(
                     org_id=org.id,
@@ -418,9 +436,11 @@ class TestOrganizationService:
         )
         org_module._invitations[inv.id] = inv
 
-        with patch("services.organization_service._save_members"), \
-             patch("services.organization_service._save_invitations"), \
-             patch("services.organization_service._save_organizations"):
+        with (
+            patch("services.organization_service._save_members"),
+            patch("services.organization_service._save_invitations"),
+            patch("services.organization_service._save_organizations"),
+        ):
             member = OrganizationService.accept_invitation(
                 token=inv.token,
                 user_id="user-invited",
@@ -512,8 +532,10 @@ class TestOrganizationService:
         org.current_members = 2
         org_module._user_orgs.setdefault("user-2", []).append(org.id)
 
-        with patch("services.organization_service._save_members"), \
-             patch("services.organization_service._save_organizations"):
+        with (
+            patch("services.organization_service._save_members"),
+            patch("services.organization_service._save_organizations"),
+        ):
             result = OrganizationService.remove_member(second.id)
 
         assert result is True
@@ -682,9 +704,10 @@ class TestOrganizationService:
         mock_quota = MagicMock()
         mock_quota.allowed = True
 
-        with patch("services.quota_service.QuotaService.check_token_quota",
-                   return_value=mock_quota), \
-             patch("services.organization_service._save_organizations"):
+        with (
+            patch("services.quota_service.QuotaService.check_token_quota", return_value=mock_quota),
+            patch("services.organization_service._save_organizations"),
+        ):
             success = OrganizationService.track_token_usage(org.id, 500)
 
         assert success is True
@@ -697,8 +720,9 @@ class TestOrganizationService:
         mock_quota = MagicMock()
         mock_quota.allowed = False
 
-        with patch("services.quota_service.QuotaService.check_token_quota",
-                   return_value=mock_quota):
+        with patch(
+            "services.quota_service.QuotaService.check_token_quota", return_value=mock_quota
+        ):
             result = OrganizationService.track_token_usage(org.id, 99999)
 
         assert result is False
@@ -709,7 +733,9 @@ class TestOrganizationService:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_track_token_usage_async_can_skip_quota_and_commit_for_ledger_post_processing(self):
+    async def test_track_token_usage_async_can_skip_quota_and_commit_for_ledger_post_processing(
+        self,
+    ):
         """Ledger post-processing updates counters inside the caller transaction."""
         org = SimpleNamespace(id="org-1", tokens_used_this_month=100)
         db = SimpleNamespace(
@@ -772,9 +798,7 @@ class TestOrganizationService:
         assert response.total_tokens == 300
         assert len(response.members) >= 1
 
-        owner_summary = next(
-            (m for m in response.members if m.user_id == "uid-usage"), None
-        )
+        owner_summary = next((m for m in response.members if m.user_id == "uid-usage"), None)
         assert owner_summary is not None
         assert owner_summary.tokens_used_this_month == 300
 

--- a/tests/backend/test_password_upgrade.py
+++ b/tests/backend/test_password_upgrade.py
@@ -3,8 +3,6 @@
 import hashlib
 import secrets
 
-import pytest
-
 from services.auth_service import AuthService
 
 

--- a/tests/backend/test_phase_runner_checkbox_sync.py
+++ b/tests/backend/test_phase_runner_checkbox_sync.py
@@ -28,9 +28,7 @@ class TestStatusToCheckbox:
 class TestIdFormats:
     def test_bold_id_with_colon(self):
         body = "- [ ] **migrate_button**: do stuff\n"
-        out = sync_checkboxes(
-            body, _spec(Task(id="migrate_button", status="done"))
-        )
+        out = sync_checkboxes(body, _spec(Task(id="migrate_button", status="done")))
         assert "[x]" in out
 
     def test_plain_id_with_colon(self):
@@ -56,10 +54,7 @@ class TestSelectivity:
         assert out == body
 
     def test_does_not_touch_other_checkboxes(self):
-        body = (
-            "- [ ] **W0-1**: managed\n"
-            "- [ ] **UNKNOWN**: manual item user added\n"
-        )
+        body = "- [ ] **W0-1**: managed\n- [ ] **UNKNOWN**: manual item user added\n"
         out = sync_checkboxes(body, _spec(Task(id="W0-1", status="done")))
         assert "- [x] **W0-1**" in out
         assert "- [ ] **UNKNOWN**" in out

--- a/tests/backend/test_phase_runner_migrate.py
+++ b/tests/backend/test_phase_runner_migrate.py
@@ -7,7 +7,6 @@ import pytest
 from phase_runner.migrate import infer_frontmatter, migrate_file
 from phase_runner.schema import PhaseSpec
 
-
 SAMPLE_BODY = """# React 19 Migration — Tasks
 
 ## Wave 0 — 사전 조사

--- a/tests/backend/test_pipeline.py
+++ b/tests/backend/test_pipeline.py
@@ -17,7 +17,6 @@ from services.pipeline.stages.collect_stage import CollectStage
 from services.pipeline.stages.output_stage import OutputStage
 from services.pipeline.stages.transform_stage import TransformStage
 
-
 # ── Fixtures ────────────────────────────────────────────────
 
 
@@ -224,9 +223,7 @@ class TestTransformStage:
 
     @pytest.mark.asyncio
     async def test_filter_list_by_value(self):
-        stage = TransformStage(
-            {"operation": "filter", "field": "status", "value": "active"}
-        )
+        stage = TransformStage({"operation": "filter", "field": "status", "value": "active"})
         ctx = PipelineContext()
         ctx.set(
             "collected",
@@ -241,9 +238,7 @@ class TestTransformStage:
 
     @pytest.mark.asyncio
     async def test_map_fields(self):
-        stage = TransformStage(
-            {"operation": "map", "field_map": {"old_name": "new_name"}}
-        )
+        stage = TransformStage({"operation": "map", "field_map": {"old_name": "new_name"}})
         ctx = PipelineContext()
         ctx.set("collected", {"old_name": "value", "keep": True})
         result = await stage.execute(ctx)
@@ -401,9 +396,7 @@ class TestOutputStage:
     @pytest.mark.asyncio
     async def test_file_output_path_traversal_blocked(self):
         """Path traversal should be blocked on write."""
-        stage = OutputStage(
-            {"output_type": "file", "file_path": "/tmp/evil/output.json"}
-        )
+        stage = OutputStage({"output_type": "file", "file_path": "/tmp/evil/output.json"})
         ctx = PipelineContext()
         ctx.set("collected", {"x": 1})
         result = await stage.execute(ctx)
@@ -422,12 +415,8 @@ class TestOutputStage:
     async def test_summary_output(self):
         stage = OutputStage({"output_type": "summary"})
         ctx = PipelineContext()
-        ctx.add_result(
-            StageResult(stage_name="collect", status="success", duration_ms=10)
-        )
-        ctx.add_result(
-            StageResult(stage_name="transform", status="success", duration_ms=5)
-        )
+        ctx.add_result(StageResult(stage_name="collect", status="success", duration_ms=10))
+        ctx.add_result(StageResult(stage_name="transform", status="success", duration_ms=5))
         result = await stage.execute(ctx)
         assert result.status == "success"
         assert result.data["output"]["total_stages"] == 2
@@ -484,9 +473,7 @@ class TestPipelineCRUD:
                 pass
 
             async def execute(self, context: PipelineContext) -> StageResult:
-                return StageResult(
-                    stage_name=self.name, status="success", data={"custom": True}
-                )
+                return StageResult(stage_name=self.name, status="success", data={"custom": True})
 
         service.register_stage("custom", CustomStage)
         assert "custom" in service.get_registered_stages()
@@ -524,9 +511,7 @@ class TestPipelineExecution:
             ],
         )
         pid = await service.create_pipeline(config)
-        result = await service.execute_pipeline(
-            pid, initial_data={"collected": [1, 2, 3]}
-        )
+        result = await service.execute_pipeline(pid, initial_data={"collected": [1, 2, 3]})
         assert result.status == "success"
 
     @pytest.mark.asyncio

--- a/tests/backend/test_playground_context.py
+++ b/tests/backend/test_playground_context.py
@@ -15,7 +15,6 @@ from models.playground import PlaygroundSession
 from models.project_config import MemoryConfig, RuleConfig
 from services.playground_context import build_effective_system_prompt
 
-
 # ─────────────────────────────────────────────────────────────
 # Stub config source
 # ─────────────────────────────────────────────────────────────
@@ -211,9 +210,7 @@ def test_budget_truncates_longest_entry_first() -> None:
 
 
 def test_zero_budget_returns_base_prompt() -> None:
-    session = _session(
-        rules_mode="global", memory_mode="off", context_budget_tokens=500
-    )
+    session = _session(rules_mode="global", memory_mode="off", context_budget_tokens=500)
     # With empty rules, nothing to inject — should fall through to base.
     stub = _Stub()
     result = build_effective_system_prompt(session, source=stub)

--- a/tests/backend/test_playground_model_policy_followup.py
+++ b/tests/backend/test_playground_model_policy_followup.py
@@ -37,9 +37,7 @@ def _isolated_sessions(monkeypatch):
     playground_service._sessions.clear()
     monkeypatch.setattr(playground_service.service, "_load_sessions", lambda: None)
     monkeypatch.setattr(playground_service.service, "_save_sessions", lambda: None)
-    monkeypatch.setattr(
-        playground_service.service, "_fire_and_forget", lambda coro: coro.close()
-    )
+    monkeypatch.setattr(playground_service.service, "_fire_and_forget", lambda coro: coro.close())
     yield
     playground_service._sessions.clear()
 
@@ -87,15 +85,11 @@ async def test_create_route_still_creates_with_enabled_model() -> None:
 
 @pytest.mark.asyncio
 async def test_update_route_maps_invalid_model_to_400() -> None:
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
     data = playground_api.SessionSettingsUpdate(model="gpt-5.4", name="renamed")
 
     with pytest.raises(HTTPException) as exc_info:
-        await playground_api.update_session_settings(
-            session.id, data, BackgroundTasks()
-        )
+        await playground_api.update_session_settings(session.id, data, BackgroundTasks())
 
     assert exc_info.value.status_code == 400
     # 원자성: 같은 요청의 다른 필드도 반영되지 않는다.
@@ -105,13 +99,9 @@ async def test_update_route_maps_invalid_model_to_400() -> None:
 
 @pytest.mark.asyncio
 async def test_update_route_still_updates_with_enabled_model() -> None:
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
     data = playground_api.SessionSettingsUpdate(model="claude-sonnet-5")
 
-    updated = await playground_api.update_session_settings(
-        session.id, data, BackgroundTasks()
-    )
+    updated = await playground_api.update_session_settings(session.id, data, BackgroundTasks())
 
     assert updated.model == "claude-sonnet-5"

--- a/tests/backend/test_playground_service.py
+++ b/tests/backend/test_playground_service.py
@@ -128,12 +128,8 @@ def _isolate_sessions(monkeypatch) -> list[bool]:
     playground_service._sessions.clear()
     saves: list[bool] = []
     monkeypatch.setattr(playground_service.service, "_load_sessions", lambda: None)
-    monkeypatch.setattr(
-        playground_service.service, "_save_sessions", lambda: saves.append(True)
-    )
-    monkeypatch.setattr(
-        playground_service.service, "_fire_and_forget", lambda coro: coro.close()
-    )
+    monkeypatch.setattr(playground_service.service, "_save_sessions", lambda: saves.append(True))
+    monkeypatch.setattr(playground_service.service, "_fire_and_forget", lambda coro: coro.close())
     return saves
 
 
@@ -146,9 +142,7 @@ def test_create_session_rejects_unknown_model(monkeypatch) -> None:
     """Registry 에 없는 모델은 세션 생성(영속화) 전에 거부된다."""
     saves = _isolate_sessions(monkeypatch)
     with pytest.raises(ValueError, match="Unknown model"):
-        PlaygroundService.create_session(
-            PlaygroundSessionCreate(name="bad", model="no-such-model")
-        )
+        PlaygroundService.create_session(PlaygroundSessionCreate(name="bad", model="no-such-model"))
     assert playground_service._sessions == {}
     assert saves == []
 
@@ -157,9 +151,7 @@ def test_create_session_rejects_disabled_model(monkeypatch) -> None:
     """gpt-5.4 는 registry 에 있으나 disabled — 저장 전에 거부되어야 한다."""
     saves = _isolate_sessions(monkeypatch)
     with pytest.raises(ValueError, match="Model disabled"):
-        PlaygroundService.create_session(
-            PlaygroundSessionCreate(name="bad", model="gpt-5.4")
-        )
+        PlaygroundService.create_session(PlaygroundSessionCreate(name="bad", model="gpt-5.4"))
     assert playground_service._sessions == {}
     assert saves == []
 
@@ -197,9 +189,7 @@ def test_update_settings_rejects_invalid_model_atomically(monkeypatch) -> None:
 
 def test_update_settings_rejects_disabled_model(monkeypatch) -> None:
     _isolate_sessions(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
     with pytest.raises(ValueError, match="Model disabled"):
         PlaygroundService.update_session_settings(session.id, model="gpt-5.4")
     assert session.model == "codex-cli"
@@ -207,12 +197,8 @@ def test_update_settings_rejects_disabled_model(monkeypatch) -> None:
 
 def test_update_settings_accepts_enabled_model(monkeypatch) -> None:
     _isolate_sessions(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
-    updated = PlaygroundService.update_session_settings(
-        session.id, model="claude-sonnet-5"
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
+    updated = PlaygroundService.update_session_settings(session.id, model="claude-sonnet-5")
     assert updated is not None
     assert updated.model == "claude-sonnet-5"
 
@@ -825,9 +811,7 @@ async def test_stream_client_disconnect_finalizes_execution_as_cancelled(
     monkeypatch.setattr(
         playground_service.service, "_save_sessions", lambda: save_calls.append(True)
     )
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
     save_calls.clear()
 
     def fake_stream(**kwargs):
@@ -840,9 +824,7 @@ async def test_stream_client_disconnect_finalizes_execution_as_cancelled(
 
     monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
 
-    stream = PlaygroundService.execute_stream(
-        session.id, PlaygroundExecuteRequest(prompt="hi")
-    )
+    stream = PlaygroundService.execute_stream(session.id, PlaygroundExecuteRequest(prompt="hi"))
     assert await stream.__anext__() == "chunk-1 "
     await stream.aclose()
 
@@ -864,9 +846,7 @@ async def test_stream_task_cancellation_finalizes_execution_as_cancelled(
     import asyncio
 
     _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
 
     def fake_stream(**kwargs):
         async def gen():
@@ -877,9 +857,7 @@ async def test_stream_task_cancellation_finalizes_execution_as_cancelled(
 
     monkeypatch.setattr(LLMService, "stream_with_tokens", fake_stream)
 
-    stream = PlaygroundService.execute_stream(
-        session.id, PlaygroundExecuteRequest(prompt="hi")
-    )
+    stream = PlaygroundService.execute_stream(session.id, PlaygroundExecuteRequest(prompt="hi"))
     assert await stream.__anext__() == "chunk-1 "
     with pytest.raises(asyncio.CancelledError):
         await stream.athrow(asyncio.CancelledError)
@@ -897,9 +875,7 @@ async def test_stream_init_exception_does_not_leave_running_execution(
     """LLM 루프 진입 전(history/RAG 준비 단계) 예외도 RUNNING execution 을
     남기지 않고 FAILED 로 마감한 뒤 in-band [Error] 청크로 표면화한다."""
     _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
 
     def boom(_msgs):
         raise RuntimeError("history exploded")
@@ -940,18 +916,14 @@ async def test_execute_stamps_registry_revision(monkeypatch) -> None:
     from models.llm_models import LLMModelRegistry
 
     _isolate_sessions(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
 
     async def fake_invoke(**kwargs):
         return LLMResponse(content="ok", model=kwargs["model_id"], provider="codex_cli")
 
     monkeypatch.setattr(LLMService, "invoke", fake_invoke)
 
-    execution = await PlaygroundService.execute(
-        session.id, PlaygroundExecuteRequest(prompt="hi")
-    )
+    execution = await PlaygroundService.execute(session.id, PlaygroundExecuteRequest(prompt="hi"))
 
     assert execution.registry_revision == LLMModelRegistry.get_revision()
     # 기존 DB JSON 직렬화 경로에도 자동 포함된다 (model_dump 전량 직렬화).
@@ -964,9 +936,7 @@ async def test_stream_stamps_registry_revision(monkeypatch) -> None:
     from models.llm_models import LLMModelRegistry
 
     _patch_stream_env(monkeypatch)
-    session = PlaygroundService.create_session(
-        PlaygroundSessionCreate(name="s", model="codex-cli")
-    )
+    session = PlaygroundService.create_session(PlaygroundSessionCreate(name="s", model="codex-cli"))
 
     def fake_stream(**kwargs):
         async def gen():

--- a/tests/backend/test_project_access_api.py
+++ b/tests/backend/test_project_access_api.py
@@ -80,9 +80,9 @@ class TestGetMyAccess:
                     __import__(
                         "api.deps", fromlist=["get_current_user"]
                     ).get_current_user: lambda: admin_user,
-                    __import__(
-                        "api.deps", fromlist=["get_db_session"]
-                    ).get_db_session: lambda: AsyncMock(),
+                    __import__("api.deps", fromlist=["get_db_session"]).get_db_session: lambda: (
+                        AsyncMock()
+                    ),
                 }
 
                 # Admin bypass is handled in the endpoint itself

--- a/tests/backend/test_project_access_api.py
+++ b/tests/backend/test_project_access_api.py
@@ -5,10 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
 from api.project_access import router
-
 
 # ─────────────────────────────────────────────────────────────
 # Test Setup
@@ -77,11 +75,14 @@ class TestGetMyAccess:
         with patch("api.project_access.get_current_user", return_value=admin_user):
             with patch("api.project_access.get_db_session") as mock_db:
                 mock_db.return_value = AsyncMock()
-                client = TestClient(app)
                 # Override dependencies
                 app.dependency_overrides = {
-                    __import__("api.deps", fromlist=["get_current_user"]).get_current_user: lambda: admin_user,
-                    __import__("api.deps", fromlist=["get_db_session"]).get_db_session: lambda: AsyncMock(),
+                    __import__(
+                        "api.deps", fromlist=["get_current_user"]
+                    ).get_current_user: lambda: admin_user,
+                    __import__(
+                        "api.deps", fromlist=["get_db_session"]
+                    ).get_db_session: lambda: AsyncMock(),
                 }
 
                 # Admin bypass is handled in the endpoint itself

--- a/tests/backend/test_project_access_service.py
+++ b/tests/backend/test_project_access_service.py
@@ -32,9 +32,7 @@ class TestGrantAccess:
     async def test_grant_access_new_user(self, mock_db, project_id, user_id):
         """Should create a new access record for a user."""
         # Mock check_access to return None (no existing access)
-        with patch.object(
-            ProjectAccessService, "check_access", return_value=None
-        ):
+        with patch.object(ProjectAccessService, "check_access", return_value=None):
             mock_db.flush = AsyncMock()
 
             result = await ProjectAccessService.grant_access(
@@ -54,9 +52,7 @@ class TestGrantAccess:
     @pytest.mark.asyncio
     async def test_grant_access_existing_user_raises(self, mock_db, project_id, user_id):
         """Should raise ValueError when user already has access."""
-        with patch.object(
-            ProjectAccessService, "check_access", return_value="viewer"
-        ):
+        with patch.object(ProjectAccessService, "check_access", return_value="viewer"):
             with pytest.raises(ValueError, match="already has"):
                 await ProjectAccessService.grant_access(
                     db=mock_db,

--- a/tests/backend/test_project_active_filter.py
+++ b/tests/backend/test_project_active_filter.py
@@ -1,6 +1,8 @@
 """Tests for project active filter based on project-registry is_active."""
-import pytest
+
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 # USE_DATABASE=true로 설정해야 get_inactive_project_paths가 DB 조회를 수행함
 _USE_DB_ENV = {"USE_DATABASE": "true"}

--- a/tests/backend/test_project_invitation_model.py
+++ b/tests/backend/test_project_invitation_model.py
@@ -1,6 +1,7 @@
-import pytest
 from datetime import datetime, timedelta
+
 from db.models import ProjectInvitationModel
+
 
 def test_invitation_model_fields():
     inv = ProjectInvitationModel(

--- a/tests/backend/test_project_invitation_service.py
+++ b/tests/backend/test_project_invitation_service.py
@@ -1,11 +1,13 @@
 """Tests for ProjectInvitationService."""
+
+import sys
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from utils.time import utcnow
-import sys
-from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "backend"))
 

--- a/tests/backend/test_rag_service.py
+++ b/tests/backend/test_rag_service.py
@@ -1,6 +1,6 @@
 """Tests for RAG service: chunking, hybrid search, BM25, reranking."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -128,7 +128,8 @@ class TestChunkDocument:
 
         monkeypatch.setattr(rag_mod, "RAG_FULL_CONTEXT_THRESHOLD", 100)
 
-        python_content = '''
+        python_content = (
+            '''
 class MyClass:
     """A class."""
 
@@ -144,7 +145,9 @@ class AnotherClass:
 
     def another_method(self):
         return 3
-''' * 5  # Repeat to ensure it's large enough
+'''
+            * 5
+        )  # Repeat to ensure it's large enough
 
         chunks = vector_store._chunk_document(python_content, "module.py", chunk_size=200)
         assert len(chunks) > 1
@@ -383,9 +386,7 @@ class TestQueryPaths:
         mock_doc.metadata = {"source": "test.py", "chunk_index": 0, "priority": "normal"}
         mock_collection.similarity_search_with_score.return_value = [(mock_doc, 0.8)]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
         result = await vector_store.query("proj1", "test query", k=5)
 
@@ -410,9 +411,7 @@ class TestQueryPaths:
         mock_doc.metadata = {"source": "sem.py", "chunk_index": 0, "priority": "normal"}
         mock_collection.similarity_search_with_score.return_value = [(mock_doc, 0.9)]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
         # Build BM25 index
         vector_store._build_bm25_index(
@@ -493,11 +492,21 @@ class TestCrossProjectQuery:
         # Mock vector stores for each project
         doc_a = MagicMock()
         doc_a.page_content = "alpha content about auth"
-        doc_a.metadata = {"source": "auth.py", "chunk_index": 0, "priority": "high", "project_id": "alpha"}
+        doc_a.metadata = {
+            "source": "auth.py",
+            "chunk_index": 0,
+            "priority": "high",
+            "project_id": "alpha",
+        }
 
         doc_b = MagicMock()
         doc_b.page_content = "beta content about auth"
-        doc_b.metadata = {"source": "login.py", "chunk_index": 0, "priority": "normal", "project_id": "beta"}
+        doc_b.metadata = {
+            "source": "login.py",
+            "chunk_index": 0,
+            "priority": "normal",
+            "project_id": "beta",
+        }
 
         mock_vs_alpha = MagicMock()
         mock_vs_alpha.similarity_search_with_score.return_value = [(doc_a, 0.9)]
@@ -505,7 +514,6 @@ class TestCrossProjectQuery:
         mock_vs_beta.similarity_search_with_score.return_value = [(doc_b, 0.85)]
 
         call_count = {"n": 0}
-        original_get_or_create = vector_store._get_or_create_collection
 
         def fake_get_or_create(pid):
             call_count["n"] += 1
@@ -530,16 +538,19 @@ class TestCrossProjectQuery:
 
         doc = MagicMock()
         doc.page_content = "only alpha content"
-        doc.metadata = {"source": "a.py", "chunk_index": 0, "priority": "normal", "project_id": "alpha"}
+        doc.metadata = {
+            "source": "a.py",
+            "chunk_index": 0,
+            "priority": "normal",
+            "project_id": "alpha",
+        }
 
         mock_vs = MagicMock()
         mock_vs.similarity_search_with_score.return_value = [(doc, 0.8)]
 
         monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_vs)
 
-        result = await vector_store.query_cross_project(
-            "query", k=5, source_project_ids=["alpha"]
-        )
+        result = await vector_store.query_cross_project("query", k=5, source_project_ids=["alpha"])
 
         assert result.total_found == 1
         assert result.documents[0]["project_id"] == "alpha"
@@ -562,11 +573,21 @@ class TestCrossProjectQuery:
 
         local_doc = MagicMock()
         local_doc.page_content = "local result"
-        local_doc.metadata = {"source": "main.py", "chunk_index": 0, "priority": "normal", "project_id": "main"}
+        local_doc.metadata = {
+            "source": "main.py",
+            "chunk_index": 0,
+            "priority": "normal",
+            "project_id": "main",
+        }
 
         other_doc = MagicMock()
         other_doc.page_content = "other project result"
-        other_doc.metadata = {"source": "lib.py", "chunk_index": 0, "priority": "normal", "project_id": "other"}
+        other_doc.metadata = {
+            "source": "lib.py",
+            "chunk_index": 0,
+            "priority": "normal",
+            "project_id": "other",
+        }
 
         mock_local_vs = MagicMock()
         mock_local_vs.similarity_search_with_score.return_value = [(local_doc, 0.9)]
@@ -600,9 +621,7 @@ class TestCrossProjectQuery:
         mock_doc.metadata = {"source": "test.py", "chunk_index": 0, "priority": "normal"}
         mock_collection.similarity_search_with_score.return_value = [(mock_doc, 0.8)]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
         result = await vector_store.query("proj1", "test query", k=5, include_shared=False)
 
@@ -626,7 +645,12 @@ class TestCrossProjectQuery:
 
         doc = MagicMock()
         doc.page_content = "alpha content"
-        doc.metadata = {"source": "a.py", "chunk_index": 0, "priority": "normal", "project_id": "alpha"}
+        doc.metadata = {
+            "source": "a.py",
+            "chunk_index": 0,
+            "priority": "normal",
+            "project_id": "alpha",
+        }
 
         mock_vs = MagicMock()
         mock_vs.similarity_search_with_score.return_value = [(doc, 0.85)]

--- a/tests/backend/test_rag_verification.py
+++ b/tests/backend/test_rag_verification.py
@@ -10,13 +10,9 @@
   - 거리 계산 방식(Metric) 설정 오류
 """
 
-import hashlib
-import os
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-
 
 # ── Test Helpers ─────────────────────────────────────────────────────────────
 
@@ -139,7 +135,6 @@ class TestStage1Ingestion:
         priority_files = ["CLAUDE.md", "README.md", "package.json", "pyproject.toml"]
 
         # 실제 인덱싱에서 priority_files 목록이 코드와 일치하는지 확인
-        import services.rag_service as rag_mod
 
         # index_project 메서드 내의 priority_files 목록 참조
         # 코드에서 하드코딩된 목록과 일치하는지 검증
@@ -204,9 +199,7 @@ class TestStage2Retrieval:
             (irrelevant_doc, 0.31),
         ]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
         result = await vector_store.query("proj1", "재택근무 규정은?", k=5)
 
@@ -228,9 +221,7 @@ class TestStage2Retrieval:
         mock_doc.metadata = {"source": "test.py", "chunk_index": 0, "priority": "normal"}
         mock_collection.similarity_search_with_score.return_value = [(mock_doc, 0.75)]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
         result = await vector_store.query("proj1", "test", k=5)
 
@@ -254,12 +245,10 @@ class TestStage2Retrieval:
 
         mock_collection.similarity_search_with_score.return_value = [
             (doc1, -0.1),  # 음수
-            (doc2, 1.5),   # 1 초과
+            (doc2, 1.5),  # 1 초과
         ]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
         result = await vector_store.query("proj1", "test", k=5)
 
@@ -329,11 +318,9 @@ class TestStage2Retrieval:
         mock_doc.metadata = {"source": "CLAUDE.md", "chunk_index": 0, "priority": "high"}
         mock_collection.similarity_search_with_score.return_value = [(mock_doc, 0.9)]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
-        result = await vector_store.query("proj1", "query", k=5, filter_priority="high")
+        await vector_store.query("proj1", "query", k=5, filter_priority="high")
 
         # Qdrant 필터가 첫 호출에 적용되었는지 확인.
         # (sparse-result fallback 발동 시 후속 호출은 filter=None로 재시도하므로
@@ -367,9 +354,7 @@ class TestStage3Generation:
         }
         mock_collection.similarity_search_with_score.return_value = [(mock_doc, 0.88)]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
 
         # 전역 인스턴스 모킹
         monkeypatch.setattr(rag_mod, "_vector_store", vector_store)
@@ -409,9 +394,7 @@ class TestStage3Generation:
             (doc2, 0.7),
         ]
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
         monkeypatch.setattr(rag_mod, "_vector_store", vector_store)
 
         context = await rag_mod.get_project_context("proj1", "query", k=2)
@@ -431,9 +414,7 @@ class TestStage3Generation:
         mock_collection = MagicMock()
         mock_collection.similarity_search_with_score.return_value = []
 
-        monkeypatch.setattr(
-            vector_store, "_get_or_create_collection", lambda pid: mock_collection
-        )
+        monkeypatch.setattr(vector_store, "_get_or_create_collection", lambda pid: mock_collection)
         monkeypatch.setattr(rag_mod, "_vector_store", vector_store)
 
         context = await rag_mod.get_project_context("proj1", "존재하지 않는 내용")
@@ -490,11 +471,11 @@ class TestTroubleshooting:
 
     def test_distance_metric_is_cosine(self):
         """거리 계산 방식이 Cosine으로 올바르게 설정되어 있는지."""
-        import services.rag_service as rag_mod
-
         # 코드에서 Distance.COSINE을 사용하는지 확인
         # _ensure_collection_exists 메서드에서 Distance.COSINE 설정
         import inspect
+
+        import services.rag_service as rag_mod
 
         source = inspect.getsource(rag_mod.ProjectVectorStore._ensure_collection_exists)
         assert "Distance.COSINE" in source
@@ -589,7 +570,8 @@ class TestEdgeCases:
         """오버랩이 청크 크기 이상일 때 무한 루프 방지."""
         # overlap >= chunk_size인 경우
         chunks = vector_store._chunk_document_manual(
-            "A" * 300, "test.txt",
+            "A" * 300,
+            "test.txt",
             chunk_size=100,
             chunk_overlap=100,  # overlap == size
         )

--- a/tests/backend/test_rate_limit_service.py
+++ b/tests/backend/test_rate_limit_service.py
@@ -1,10 +1,8 @@
 """Tests for rate limit service."""
 
 import pytest
-import asyncio
-from datetime import datetime
 
-from models.rate_limit import RateLimitTier, RATE_LIMIT_TIERS
+from models.rate_limit import RATE_LIMIT_TIERS, RateLimitTier
 from services.rate_limit_service import RateLimitService
 
 
@@ -55,7 +53,7 @@ class TestRateLimitService:
                 identifier=identifier,
                 tier=RateLimitTier.FREE.value,
             )
-            assert result.allowed is True, f"Request {i+1} should be allowed"
+            assert result.allowed is True, f"Request {i + 1} should be allowed"
 
         # Next request should be blocked
         result = await rate_limit_service.check_rate_limit(
@@ -80,7 +78,10 @@ class TestRateLimitService:
 
         assert status.identifier == identifier
         assert status.minute_count == 5
-        assert status.minute_remaining == RATE_LIMIT_TIERS[RateLimitTier.FREE.value].requests_per_minute - 5
+        assert (
+            status.minute_remaining
+            == RATE_LIMIT_TIERS[RateLimitTier.FREE.value].requests_per_minute - 5
+        )
 
     @pytest.mark.asyncio
     async def test_reset_limits(self, rate_limit_service):
@@ -155,7 +156,7 @@ class TestRateLimitTierConfig:
 
     def test_all_tiers_have_required_fields(self):
         """Test that all tiers have required configuration."""
-        for tier_name, config in RATE_LIMIT_TIERS.items():
+        for _tier_name, config in RATE_LIMIT_TIERS.items():
             assert config.name is not None
             assert config.requests_per_minute is not None
             assert config.requests_per_hour is not None

--- a/tests/backend/test_scheduler_service.py
+++ b/tests/backend/test_scheduler_service.py
@@ -1,7 +1,6 @@
 """Tests for scheduler service."""
 
 import pytest
-from unittest.mock import patch, AsyncMock
 
 from services.scheduler_service import SchedulerService
 

--- a/tests/backend/test_secret_service.py
+++ b/tests/backend/test_secret_service.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -61,7 +61,9 @@ class TestSecretService:
         self.db.flush = AsyncMock()
 
         result = await self.svc.create_secret(
-            SecretCreate(name="API_KEY", value="secret123", scope=SecretScope.WORKFLOW, scope_id="wf1"),
+            SecretCreate(
+                name="API_KEY", value="secret123", scope=SecretScope.WORKFLOW, scope_id="wf1"
+            ),
             user_id="user-1",
         )
         assert result["name"] == "API_KEY"

--- a/tests/backend/test_self_correction_categories.py
+++ b/tests/backend/test_self_correction_categories.py
@@ -6,7 +6,6 @@ without LLM analysis for PERMANENT, TRANSIENT, and RESOURCE errors.
 
 from __future__ import annotations
 
-from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -206,7 +205,7 @@ class TestLogicError:
         mock_llm.with_structured_output.return_value = MagicMock()
         mock_llm.with_structured_output.return_value.ainvoke = structured_llm
 
-        result = await node.run(state)
+        await node.run(state)
 
         # LLM SHOULD be called (unlike TRANSIENT/PERMANENT)
         assert mock_llm.with_structured_output.called or mock_llm.ainvoke.called
@@ -267,7 +266,7 @@ class TestNoStructuredError:
         mock_llm.with_structured_output.return_value = MagicMock()
         mock_llm.with_structured_output.return_value.ainvoke = structured_llm
 
-        result = await node.run(state)
+        await node.run(state)
 
         # LLM should be called since no structured error for fast path
         assert mock_llm.with_structured_output.called or mock_llm.ainvoke.called

--- a/tests/backend/test_session_conflict_response.py
+++ b/tests/backend/test_session_conflict_response.py
@@ -65,9 +65,7 @@ async def test_ping_survives_ttl_refresh_contention(monkeypatch):
         async def refresh_session(self, session_id):
             raise SessionVersionConflictError(session_id)
 
-    monkeypatch.setattr(
-        "services.session_service.get_session_service", lambda: _AlwaysConflicts()
-    )
+    monkeypatch.setattr("services.session_service.get_session_service", lambda: _AlwaysConflicts())
 
     engine = OrchestrationEngine()
     await engine.create_session(session_id="s-292", user_id="test-admin")

--- a/tests/backend/test_session_service.py
+++ b/tests/backend/test_session_service.py
@@ -1,10 +1,10 @@
 """Tests for session service."""
 
-import pytest
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from utils.time import utcnow
+import pytest
+
 from db.repository import serialize_state
 from models.agent_state import (
     AgentInfo,
@@ -22,7 +22,7 @@ from services.session_service import (
     get_session_service,
     set_session_service,
 )
-
+from utils.time import utcnow
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -363,9 +363,7 @@ class TestSessionServiceExpiration:
         sid2 = await self.service.create_session()
 
         # Expire sid1
-        self.service._session_metadata[sid1].expires_at = (
-            utcnow() - timedelta(seconds=1)
-        )
+        self.service._session_metadata[sid1].expires_at = utcnow() - timedelta(seconds=1)
 
         cleaned = await self.service.cleanup_expired_sessions()
         assert cleaned >= 1
@@ -376,9 +374,7 @@ class TestSessionServiceExpiration:
     async def test_cleanup_inactive_sessions(self):
         sid = await self.service.create_session()
         # Age the last_activity well beyond any reasonable threshold
-        self.service._session_metadata[sid].last_activity = (
-            utcnow() - timedelta(hours=72)
-        )
+        self.service._session_metadata[sid].last_activity = utcnow() - timedelta(hours=72)
 
         cleaned = await self.service.cleanup_expired_sessions()
         assert cleaned >= 1
@@ -570,14 +566,12 @@ class TestSessionServiceQuota:
         mock_check.message = "Daily session quota exceeded"
         mock_quota_module.QuotaService.check_session_quota.return_value = mock_check
 
-        with (
-            patch.dict(
-                sys.modules,
-                {
-                    "services.organization_service": mock_org_module,
-                    "services.quota_service": mock_quota_module,
-                },
-            )
+        with patch.dict(
+            sys.modules,
+            {
+                "services.organization_service": mock_org_module,
+                "services.quota_service": mock_quota_module,
+            },
         ):
             with pytest.raises(ValueError, match="quota"):
                 await self.service.create_session(organization_id="org-1")
@@ -597,14 +591,12 @@ class TestSessionServiceQuota:
         mock_check.allowed = True
         mock_quota_module.QuotaService.check_session_quota.return_value = mock_check
 
-        with (
-            patch.dict(
-                sys.modules,
-                {
-                    "services.organization_service": mock_org_module,
-                    "services.quota_service": mock_quota_module,
-                },
-            )
+        with patch.dict(
+            sys.modules,
+            {
+                "services.organization_service": mock_org_module,
+                "services.quota_service": mock_quota_module,
+            },
         ):
             sid = await self.service.create_session(organization_id="org-2")
             assert isinstance(sid, str)

--- a/tests/backend/test_step_retry.py
+++ b/tests/backend/test_step_retry.py
@@ -76,11 +76,7 @@ class TestStepRetry:
         """Test normal step execution without retry."""
         definition = WorkflowDefinitionSchema(
             name="normal",
-            jobs={
-                "test": WorkflowJobDef(
-                    steps=[WorkflowStepDef(name="ok", run="echo hi")]
-                )
-            },
+            jobs={"test": WorkflowJobDef(steps=[WorkflowStepDef(name="ok", run="echo hi")])},
         )
         result = await self.engine.execute_run(
             run_id="retry-3",

--- a/tests/backend/test_structured_error.py
+++ b/tests/backend/test_structured_error.py
@@ -1,7 +1,5 @@
 """Tests for StructuredError model and exception classification."""
 
-import pytest
-
 from models.errors import (
     ErrorCategory,
     ErrorSeverity,
@@ -90,15 +88,22 @@ class TestClassifyException:
 
     def test_httpx_timeout_by_class_name(self):
         """Test classification by exception class name (for httpx/aiohttp)."""
-        class TimeoutException(Exception):
+
+        # 이름이 부하를 진다: models/errors.py `_classify_exception` 이
+        # `type(exc).__name__ in ("TimeoutException", ...)` 로 정확 매칭하므로
+        # 개명하면 이 테스트가 겨냥한 분기가 조용히 죽는다.
+        class TimeoutException(Exception):  # noqa: N818
             pass
+
         cat, sev = _classify_exception(TimeoutException("read timeout"))
         assert cat == ErrorCategory.TRANSIENT
 
     def test_rate_limit_error_by_class_name(self):
         """Test classification by class name for RateLimitError."""
+
         class RateLimitError(Exception):
             pass
+
         cat, sev = _classify_exception(RateLimitError("Too many requests"))
         assert cat == ErrorCategory.LLM_ERROR
 

--- a/tests/backend/test_template_service.py
+++ b/tests/backend/test_template_service.py
@@ -47,9 +47,7 @@ class TestTemplateService:
 
     def test_create_template_invalid_yaml(self):
         with pytest.raises(ValueError):
-            self.svc.create_template(
-                TemplateCreate(name="Bad", yaml_content="invalid yaml: [")
-            )
+            self.svc.create_template(TemplateCreate(name="Bad", yaml_content="invalid yaml: ["))
 
     def test_update_template(self):
         templates = self.svc.list_templates()

--- a/tests/backend/test_terminal_service_orca.py
+++ b/tests/backend/test_terminal_service_orca.py
@@ -15,8 +15,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from services.terminal_service import (
-    OrcaAdapter,
     TERMINAL_INFO,
+    OrcaAdapter,
     TerminalService,
     TerminalType,
     _resolve_orca_command,
@@ -52,9 +52,7 @@ def _ok_json() -> str:
 
 
 def _err_json(code: str, message: str | None = None) -> str:
-    return json.dumps(
-        {"id": "x", "ok": False, "error": {"code": code, "message": message or code}}
-    )
+    return json.dumps({"id": "x", "ok": False, "error": {"code": code, "message": message or code}})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_time_timestamptz.py
+++ b/tests/backend/test_time_timestamptz.py
@@ -32,8 +32,8 @@ from db.models.base import Base
 from db.models.session import SessionModel
 from db.repository import SessionRepository
 from models.config_version import ConfigVersion
-from models.organization import MemberUsageRecord, OrganizationInvitation
 from models.feedback import DatasetExportOptions, FeedbackQueryParams
+from models.organization import MemberUsageRecord, OrganizationInvitation
 from models.playground import PlaygroundMessage, PlaygroundSession
 from models.rate_limit import RateLimitOverride
 from services.session_service import SessionMetadata
@@ -132,8 +132,12 @@ def test_legacy_json_records_normalize_to_aware():
     legacy = "2026-01-01T00:00:00"  # offset suffix 없음
 
     invitation = OrganizationInvitation(
-        id="i", organization_id="o", email="a@b.co", invited_by="u",
-        expires_at="2099-01-01T00:00:00", created_at=legacy,
+        id="i",
+        organization_id="o",
+        email="a@b.co",
+        invited_by="u",
+        expires_at="2099-01-01T00:00:00",
+        created_at=legacy,
     )
     assert invitation.expires_at.tzinfo is not None
     assert invitation.expires_at > utcnow()  # 비교가 TypeError 없이 성립한다
@@ -168,8 +172,9 @@ def test_playground_session_sorts_legacy_and_new_together():
     정렬이 TypeError 로 죽고 목록이 통째로 안 나온다.
     """
     legacy = PlaygroundSession(
-        name="legacy", user_id="u",
-        created_at="2026-02-05T00:59:49.044250",   # offset 없음 = 구버전 형식
+        name="legacy",
+        user_id="u",
+        created_at="2026-02-05T00:59:49.044250",  # offset 없음 = 구버전 형식
         updated_at="2026-04-23T13:42:57.712906",
     )
     assert legacy.updated_at.tzinfo is not None
@@ -186,9 +191,17 @@ JSON_PERSISTED_MODELS = [
     (PlaygroundSession, {"name": "n", "user_id": "u"}, "updated_at"),
     (PlaygroundMessage, {"role": "user", "content": "c"}, "timestamp"),
     (MemberUsageRecord, {"organization_id": "o", "user_id": "u"}, "timestamp"),
-    (OrganizationInvitation,
-     {"id": "i", "organization_id": "o", "email": "a@b.co", "invited_by": "u",
-      "expires_at": "2099-01-01T00:00:00"}, "created_at"),
+    (
+        OrganizationInvitation,
+        {
+            "id": "i",
+            "organization_id": "o",
+            "email": "a@b.co",
+            "invited_by": "u",
+            "expires_at": "2099-01-01T00:00:00",
+        },
+        "created_at",
+    ),
     (RateLimitOverride, {"identifier": "u"}, "created_at"),
     # 날짜 필터 모델. DB 경로에서는 예외 없이 **조용히** 조회 구간이 밀리므로
     # 메모리 경로 테스트만으로는 회귀를 잡지 못한다.
@@ -415,8 +428,7 @@ async def test_utcnow_roundtrips_through_timestamptz(db_factory):
     # 저장된 값은 aware 로 돌아온다. 같은 순간이면 차이가 0 이다.
     skew = abs((stored - _as_aware(written)).total_seconds())
     assert skew < 1, (
-        f"timestamptz 왕복에서 {skew}초 어긋났다 "
-        f"(프로세스 TZ 오프셋 {OFFSET_SECONDS}초와 비교하라)"
+        f"timestamptz 왕복에서 {skew}초 어긋났다 (프로세스 TZ 오프셋 {OFFSET_SECONDS}초와 비교하라)"
     )
 
 

--- a/tests/backend/test_variable_expander.py
+++ b/tests/backend/test_variable_expander.py
@@ -1,7 +1,5 @@
 """Tests for variable expander."""
 
-import pytest
-
 from services.variable_expander import expand_variables, mask_secrets, parse_step_outputs
 
 

--- a/tests/backend/test_webhook_service.py
+++ b/tests/backend/test_webhook_service.py
@@ -45,9 +45,9 @@ class TestWebhookService:
     def test_verify_signature_valid(self):
         webhook = self.svc.create_webhook("wf1")
         payload = b'{"ref":"refs/heads/main"}'
-        expected = "sha256=" + hmac.new(
-            webhook["secret"].encode(), payload, hashlib.sha256
-        ).hexdigest()
+        expected = (
+            "sha256=" + hmac.new(webhook["secret"].encode(), payload, hashlib.sha256).hexdigest()
+        )
         assert self.svc.verify_signature(webhook["id"], payload, expected) is True
 
     def test_verify_signature_invalid(self):

--- a/tests/backend/test_workflow.py
+++ b/tests/backend/test_workflow.py
@@ -5,9 +5,6 @@ import asyncio
 import pytest
 
 from models.workflow import (
-    JobStatus,
-    RunnerType,
-    StepStatus,
     TriggerType,
     WorkflowCreate,
     WorkflowDefinitionSchema,
@@ -21,7 +18,6 @@ from models.workflow import (
 from services.workflow_engine import WorkflowEngine
 from services.workflow_service import WorkflowService
 from services.workflow_yaml_parser import parse_workflow_yaml, workflow_to_yaml
-
 
 # ── YAML Parser Tests ──────────────────────────────────────
 
@@ -70,9 +66,7 @@ jobs:
 
     def test_step_without_run_or_uses_raises(self):
         with pytest.raises(ValueError, match="run.*uses"):
-            parse_workflow_yaml(
-                "name: test\njobs:\n  test:\n    steps:\n      - name: bad step"
-            )
+            parse_workflow_yaml("name: test\njobs:\n  test:\n    steps:\n      - name: bad step")
 
     def test_trigger_normalization_string(self):
         result = parse_workflow_yaml(
@@ -213,11 +207,7 @@ class TestWorkflowEngine:
     async def test_execute_simple_run(self):
         definition = WorkflowDefinitionSchema(
             name="test",
-            jobs={
-                "echo": WorkflowJobDef(
-                    steps=[WorkflowStepDef(name="hello", run="echo hello")]
-                )
-            },
+            jobs={"echo": WorkflowJobDef(steps=[WorkflowStepDef(name="hello", run="echo hello")])},
         )
         result = await self.engine.execute_run(
             run_id="test-run-1",
@@ -231,11 +221,7 @@ class TestWorkflowEngine:
     async def test_execute_failing_run(self):
         definition = WorkflowDefinitionSchema(
             name="fail",
-            jobs={
-                "fail": WorkflowJobDef(
-                    steps=[WorkflowStepDef(name="fail", run="exit 1")]
-                )
-            },
+            jobs={"fail": WorkflowJobDef(steps=[WorkflowStepDef(name="fail", run="exit 1")])},
         )
         result = await self.engine.execute_run(
             run_id="test-fail-1",
@@ -271,9 +257,7 @@ class TestWorkflowEngine:
         definition = WorkflowDefinitionSchema(
             name="skip",
             jobs={
-                "fail": WorkflowJobDef(
-                    steps=[WorkflowStepDef(name="fail", run="exit 1")]
-                ),
+                "fail": WorkflowJobDef(steps=[WorkflowStepDef(name="fail", run="exit 1")]),
                 "should-skip": WorkflowJobDef(
                     needs=["fail"],
                     steps=[WorkflowStepDef(name="skip", run="echo skip")],
@@ -292,11 +276,7 @@ class TestWorkflowEngine:
     async def test_logs_are_emitted(self):
         definition = WorkflowDefinitionSchema(
             name="logs",
-            jobs={
-                "test": WorkflowJobDef(
-                    steps=[WorkflowStepDef(name="log", run="echo logtest")]
-                )
-            },
+            jobs={"test": WorkflowJobDef(steps=[WorkflowStepDef(name="log", run="echo logtest")])},
         )
         await self.engine.execute_run(
             run_id="test-logs-1",
@@ -336,20 +316,14 @@ jobs:
             self.svc.delete_workflow(wf["id"])
 
     def test_create_workflow(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Test", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Test", yaml_content=self.SAMPLE_YAML))
         assert wf["name"] == "Test"
         assert wf["status"] == WorkflowStatus.ACTIVE
         assert wf["version"] == 1
 
     def test_list_workflows(self):
-        self.svc.create_workflow(
-            WorkflowCreate(name="A", yaml_content=self.SAMPLE_YAML)
-        )
-        self.svc.create_workflow(
-            WorkflowCreate(name="B", yaml_content=self.SAMPLE_YAML)
-        )
+        self.svc.create_workflow(WorkflowCreate(name="A", yaml_content=self.SAMPLE_YAML))
+        self.svc.create_workflow(WorkflowCreate(name="B", yaml_content=self.SAMPLE_YAML))
         assert len(self.svc.list_workflows()) == 2
 
     def test_list_workflows_project_filter(self):
@@ -362,9 +336,7 @@ jobs:
         assert len(self.svc.list_workflows(project_id="p1")) == 1
 
     def test_get_workflow(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Get", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Get", yaml_content=self.SAMPLE_YAML))
         fetched = self.svc.get_workflow(wf["id"])
         assert fetched is not None
         assert fetched["name"] == "Get"
@@ -373,28 +345,18 @@ jobs:
         assert self.svc.get_workflow("nonexistent") is None
 
     def test_update_workflow(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Upd", yaml_content=self.SAMPLE_YAML)
-        )
-        updated = self.svc.update_workflow(
-            wf["id"], WorkflowUpdate(description="new desc")
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Upd", yaml_content=self.SAMPLE_YAML))
+        updated = self.svc.update_workflow(wf["id"], WorkflowUpdate(description="new desc"))
         assert updated["description"] == "new desc"
 
     def test_update_yaml_increments_version(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Ver", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Ver", yaml_content=self.SAMPLE_YAML))
         assert wf["version"] == 1
-        updated = self.svc.update_workflow(
-            wf["id"], WorkflowUpdate(yaml_content=self.SAMPLE_YAML)
-        )
+        updated = self.svc.update_workflow(wf["id"], WorkflowUpdate(yaml_content=self.SAMPLE_YAML))
         assert updated["version"] == 2
 
     def test_delete_workflow(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Del", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Del", yaml_content=self.SAMPLE_YAML))
         assert self.svc.delete_workflow(wf["id"]) is True
         assert self.svc.get_workflow(wf["id"]) is None
 
@@ -407,9 +369,7 @@ jobs:
 
     @pytest.mark.asyncio
     async def test_trigger_and_complete_run(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Run", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Run", yaml_content=self.SAMPLE_YAML))
         run = await self.svc.trigger_run(wf["id"], WorkflowRunTrigger())
 
         # Wait for completion
@@ -427,27 +387,21 @@ jobs:
 
     @pytest.mark.asyncio
     async def test_trigger_inactive_workflow_raises(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Inact", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Inact", yaml_content=self.SAMPLE_YAML))
         self.svc.update_workflow(wf["id"], WorkflowUpdate(status=WorkflowStatus.INACTIVE))
         with pytest.raises(ValueError, match="not active"):
             await self.svc.trigger_run(wf["id"], WorkflowRunTrigger())
 
     @pytest.mark.asyncio
     async def test_list_runs(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Runs", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Runs", yaml_content=self.SAMPLE_YAML))
         await self.svc.trigger_run(wf["id"], WorkflowRunTrigger())
         runs = self.svc.list_runs(workflow_id=wf["id"])
         assert len(runs) == 1
 
     @pytest.mark.asyncio
     async def test_cancel_run(self):
-        wf = self.svc.create_workflow(
-            WorkflowCreate(name="Cancel", yaml_content=self.SAMPLE_YAML)
-        )
+        wf = self.svc.create_workflow(WorkflowCreate(name="Cancel", yaml_content=self.SAMPLE_YAML))
         run = await self.svc.trigger_run(wf["id"], WorkflowRunTrigger())
         cancelled = self.svc.cancel_run(run["id"])
         assert cancelled is not None
@@ -467,9 +421,10 @@ class TestWorkflowAPI:
         """Create async httpx test client with an explicit privileged test user."""
         from types import SimpleNamespace
 
+        from httpx import ASGITransport, AsyncClient
+
         from api.app import app
         from api.deps import get_current_user
-        from httpx import ASGITransport, AsyncClient
 
         app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
             id="test-admin",


### PR DESCRIPTION
## 배경

`tests/backend` 는 두 게이트 **모두의 범위 밖**이었습니다.
- pre-commit: `lint-staged` glob 이 `src/backend/**/*.py`
- CI: `backend-lint` 잡의 `working-directory` 가 `src/backend`

그래서 이 디렉토리는 한 번도 린트·포맷 검사를 받은 적이 없습니다.

## 먼저 고친 것: 설정의 비결정성

이 디렉토리는 어떤 ruff 설정도 소유하지 않아, ruff 가 **실행 시점 cwd 의 설정**을 폴백으로 썼습니다. 같은 파일이 cwd 에 따라 line-length 88/100 으로 다르게 판정되던 상태입니다 — 게이트를 걸기 전에 이것부터 없애야 CI 와 로컬이 같은 답을 냅니다.

`tests/backend/ruff.toml` 을 추가하고 cwd 3곳(`src/backend`, repo 루트, `/tmp`)에서 결과가 **169 → 동일**함을 확인했습니다.

`src = ["../../src/backend"]` 도 함께 지정했습니다. 없으면 isort 가 이 디렉토리를 1st-party 루트로 보고 `models`/`api`/`services` 를 서드파티로 분류해 `src/backend` 와 정렬 순서가 어긋납니다 (실측: I001 **40 → 113**).

## 정리 내역

| 종류 | 건수 | 처리 |
|---|---|---|
| `ruff format` | 62파일 | 자동 |
| I001 / F401 / UP017 등 | 92 | `ruff check --fix` |
| F841 | 6 | 죽은 바인딩만 제거, **호출은 유지** |
| B007 | 1 | 미사용 루프 변수 `_` 접두 |
| N806 | 1 | `Database` → `database_cls` (같은 파일의 실제 클래스 정의는 그대로) |

## 의도적으로 고치지 않은 것

- **B017 13건** (`pytest.raises(Exception)`): `ruff.toml` 에서 무시했습니다. 구체 예외 타입을 고르는 것은 **테스트 의미를 바꾸는 판단**이라 게이트 도입 PR 에 섞지 않습니다. 후속 별건.
- **N818 1건**: 개명 대신 `# noqa` + 근거 주석입니다. `models/errors.py` 의 `_classify_exception` 이
  ```python
  type(exc).__name__ in ("TimeoutException", "ReadTimeout", "ConnectTimeout", ...)
  ```
  로 **정확 이름 매칭**을 합니다. 테스트가 그 분기를 겨냥해 일부러 `TimeoutException` 이라 이름 지은 것이라, 린트를 만족시키려 개명하면 검증 대상 분기가 조용히 죽습니다.

## 게이트 배선

- CI `backend-lint` 에 `ruff check ../../tests/backend --output-format=github` + `ruff format --check ../../tests/backend`
- `lint-staged` 에 `tests/backend/**/*.py` glob (이 커밋에서 실제로 74파일에 발동해 통과 확인)

## 발견한 잠재 결함 (이 PR 에서 고치지 않음)

정리 중 **단언이 없는 테스트** 2건을 발견했습니다. 삭제한 것은 죽은 바인딩뿐이고 테스트 동작은 그대로 두었습니다.
1. `tests/backend/api/test_agent_registry.py` — 첫 페이지 id 를 계산만 하고 끝까지 비교하지 않습니다(페이지네이션 검증 공백).
2. `tests/backend/test_project_access_api.py::test_admin_gets_owner_access` — `TestClient` 를 만들고 dependency override 만 설정한 뒤 **단언이 하나도 없습니다**("This is a structural test" 주석으로 끝남).

## 검증

- `ruff check` / `ruff format --check` on `tests/backend` **exit 0**, cwd 무관
- `src/backend` 게이트 3종(`ruff check`/`format --check`/`mypy`) **exit 0**
- `pytest tests/backend` **2021 passed** — 74파일이 바뀌었고 F401 44건을 제거했으나 **신규 실패 0건**
- 기존 실패 1건(`test_bootstrap[member]`)은 이 PR 과 무관하며 별도 브랜치에서 처리 중입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019u3XhJ6HHpsBnXieo5xFDY
