### PR TITLE
fix(test): DATABASE_URL 을 conftest 에서 고정해 스위트를 hermetic 하게

### DIFF
--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -17,6 +17,27 @@ os.environ["USE_DATABASE"] = "false"
 os.environ["LLM_PROVIDER"] = "ollama"
 os.environ["OLLAMA_MODEL"] = "qwen2.5:7b"
 
+# db.database builds its module-global engine from DATABASE_URL at *import*
+# time, so there is no per-test state to reset — whichever value os.environ
+# holds when that import first happens is baked in for the whole session. That
+# makes reachability of the developer's real Postgres a function of import
+# order: api/app.py calls load_dotenv(PROJECT_ROOT_ENV), so a module that
+# touches api.app before db.database gets the repo-root .env credentials,
+# while one that imports db.database first gets the unreachable default.
+# tests/backend/api/test_bootstrap.py hit exactly that split — its autouse
+# pool-disposal fixture imports db.database before the app fixture, so alone
+# the ACL registry was unreachable (fail-closed 503, as asserted) and after any
+# earlier api.app importer it was live with 9 rows (200). Pinning the value
+# here, before any backend import, removes the ordering dependency and stops
+# the suite from reading and writing a real development database.
+# setdefault (not a plain assignment) preserves CI, which exports its own
+# DATABASE_URL for the ephemeral aos_test service container, and keeps the
+# escape hatch open: DATABASE_URL=... pytest ...
+# Port 1 on the loopback address is refused immediately and needs no DNS; the
+# opt-in real-database suites are unaffected because they read their own
+# AOS_TEST_DATABASE_URL.
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://aos:aos@127.0.0.1:1/aos_unreachable")
+
 # RateLimitService is a process-global singleton keyed by client IP, and every
 # suite here shares the one TestClient IP. A request-heavy module therefore
 # drains the shared free-tier budget (60 req/min) and whichever module runs


### PR DESCRIPTION
## 문제

`test_bootstrap_projects_match_the_projects_endpoint[member]` 이 **로컬 전체 실행에서만** 깨졌습니다. 단독 실행은 통과, CI 도 통과 — 전형적인 순서 의존 오염처럼 보였지만 원인은 다른 층위였습니다.

```
>  assert bootstrap.status_code == 503
E  assert 200 == 503
```

## 근본 원인: import 순서에 따라 갈리는 `DATABASE_URL`

`db/database.py` 가 **import 시점에** `DATABASE_URL` 을 읽어 모듈 전역 `engine` 을 만듭니다. 그 값이 `api/app.py` 의 `load_dotenv()` 보다 먼저 읽히느냐 나중이냐로 결과가 갈립니다.

| 실행 | import 순서 | DB | 결과 |
|---|---|---|---|
| 단독 | `db.database` → `api.app` | dotenv 미적용 → 기본 URL 접속 실패 | ACL fail-closed **503** → 통과 |
| 전체 | `api.app` → `db.database` | `.env` 자격증명 → **실 Postgres 접속, 레지스트리 9행** | **200** → 실패 |

`builtins.__import__` 후킹으로 순서를 직접 계측하고, 디버그 프린트로 양방향(`InvalidPasswordError` vs `path_map 9`)을 확증했습니다. 오염원은 특정 테스트가 아니라 **`api.app` 을 먼저 import 하는 아무 테스트나** 입니다.

> **부수 발견 (더 중요할 수 있음)**: 이 스위트는 그동안 **개발자의 실 개발 DB 를 읽고 있었습니다.** 이번 실패는 그 증상 하나였을 뿐입니다.

## 범인 확정: `.env` 단일 키 ablation

최소 재현은 100초 전체 실행이 아니라 **8초 페어**로 줄였습니다:
```bash
pytest tests/backend/api/test_api_health.py::test_nonexistent_endpoint \
       tests/backend/api/test_bootstrap.py -q -p no:randomly
```

| `.env` 변형 | 결과 |
|---|---|
| 없음 (baseline) | 10 passed |
| 전체 | **1 failed** |
| `-DATABASE_URL` | **10 passed** ← 범인 |
| `-USE_DATABASE` | 1 failed ← 무죄 |
| `-RATE_LIMIT_ENABLED` | 1 failed ← 무죄 |

뒤 두 키는 **구조적으로도** 무죄입니다: conftest 가 `load_dotenv` 보다 먼저 두 키를 설정하고 `load_dotenv` 는 `override=False` 가 기본이라 `.env` 가 덮을 수 없습니다. **`DATABASE_URL` 만 conftest 에 항목이 없었고, 그 구멍이 곧 버그였습니다.**

## 수정

이웃 두 선례(`USE_DATABASE`, `RATE_LIMIT_ENABLED`)와 **같은 관용구**로 구멍을 메웁니다 (+21줄, 1파일).

```python
os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://aos:aos@127.0.0.1:1/aos_unreachable")
```

- **`setdefault`**: CI 는 자기 `DATABASE_URL` 을 export 하므로 완전 no-op — CI 동작 무변경이 설계 의도이고 로컬만 결정론적으로 만듭니다. 개발자 탈출구(`DATABASE_URL=... pytest`)도 유지됩니다.
- **루프백 포트 1**: 즉시 refused, DNS 조회 불필요(가짜 호스트명은 DNS 에서 멈출 수 있음).
- **autouse fixture 로는 불가능합니다**: `engine` 은 import 한 번에 만들어져 되돌릴 per-test 상태가 없습니다. import 이전 시점의 env 고정이 같은 범주의 유일한 적용 지점입니다.
- `_isolate_database_pool` 은 의도적으로 미변경 — 제거하면 오염이 "가끔"에서 "항상"으로 뒤집힙니다.

## 검증

- **Red-Green 3회**: RED(1 failed) → GREEN(10 passed) → 수정 되돌림 RED(1 failed). 리뷰어와 별개로 리드가 직접 재현했습니다.
- **전체 스위트 2022 passed / 0 failed** — 이 레포 로컬 실행이 처음으로 완전히 초록입니다.
- **skip 33 → 33 불변**: `AOS_TEST_DATABASE_URL` 로 게이트되는 실 DB 스위트 5종(`test_session_concurrency_db`, `test_session_sweep_db`, `test_hitl_cross_process_atomicity`, `test_init_db_schema_convergence`, `test_time_timestamptz`)은 별도 변수를 쓰므로 영향 없습니다.
- ruff **0.16.6(CI 와 동일 버전)** check·format, mypy 전부 exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019u3XhJ6HHpsBnXieo5xFDY
