### PR TITLE
security: harden agent execution boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,7 +123,10 @@ USE_DATABASE=true
 # Server Configuration
 # =============================================================================
 
-HOST=0.0.0.0
+# Bind address. Default is loopback — the backend is reachable only from this
+# machine. Set 0.0.0.0 ONLY for a deployment that is meant to serve other hosts
+# (and put it behind a reverse proxy / firewall).
+HOST=127.0.0.1
 PORT=8000
 # API docs are enabled for development and should be disabled in production.
 ENABLE_API_DOCS=false

--- a/infra/scripts/start-all.sh
+++ b/infra/scripts/start-all.sh
@@ -127,8 +127,19 @@ export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$PROJECT_ROOT/.env" | cut -d'=' -f2
 export GOOGLE_API_KEY=$(grep "^GOOGLE_API_KEY=" "$PROJECT_ROOT/.env" | cut -d'=' -f2-)
 export ANTHROPIC_API_KEY=$(grep "^ANTHROPIC_API_KEY=" "$PROJECT_ROOT/.env" | cut -d'=' -f2-)
 
-# Start backend in background
-USE_DATABASE=true nohup uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload \
+# Start backend in background.
+#
+# 바인드 기본값은 루프백이다. 와일드카드 바인드는 개발 노트북을 켜 두는 것만으로
+# 백엔드를 같은 네트워크(카페 Wi-Fi, 공유 오피스)에 노출하며, AOS 는 로컬 파일
+# 시스템·터미널·MCP 서버를 조작하는 표면이라 노출 비용이 크다.
+#
+# 이 스크립트는 uvicorn 에 --host 를 직접 넘기므로 config.Settings 의 안전한
+# 기본값(127.0.0.1)을 거치지 않는다 — 그래서 여기서도 같은 기본값을 명시한다.
+#
+# 배포·원격 접근이 필요하면 호출자가 명시적으로 덮어쓴다:
+#   HOST=0.0.0.0 ./infra/scripts/start-all.sh
+BACKEND_HOST="${HOST:-127.0.0.1}"
+USE_DATABASE=true nohup uvicorn api.app:app --host "$BACKEND_HOST" --port 8000 --reload \
     --reload-exclude ".claude/*" --reload-exclude ".temp/*" --reload-exclude "*.json" \
     --reload-exclude "logs/*" --reload-exclude "node_modules/*" \
     > "$PROJECT_ROOT/logs/backend.log" 2>&1 &

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -42,7 +42,11 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379/0"
 
     # Server
-    host: str = "0.0.0.0"
+    # 기본은 루프백이다. 와일드카드 바인드는 개발 노트북을 켜 두는 것만으로
+    # 백엔드를 같은 네트워크에 노출하며, AOS 는 로컬 파일 시스템·터미널·MCP
+    # 서버를 조작하는 표면이라 노출 비용이 크다.
+    # 배포에서 외부 인터페이스가 필요하면 HOST 환경변수로 명시 지정한다.
+    host: str = "127.0.0.1"
     port: int = 8000
     debug: bool = False
     log_level: str = "INFO"

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -2,15 +2,23 @@
 
 import uvicorn
 
+from config import get_settings
+
 
 def main():
-    """Run the FastAPI server."""
+    """Run the FastAPI server.
+
+    바인드 주소·포트를 하드코딩하지 않는다 — `config.Settings` 가 정본이고
+    `HOST`/`PORT` 환경변수가 그 위에 얹힌다. 하드코딩된 `0.0.0.0` 은 설정의
+    안전한 기본값을 무력화한다.
+    """
+    settings = get_settings()
     uvicorn.run(
         "api.app:app",
-        host="0.0.0.0",
-        port=8000,
+        host=settings.host,
+        port=settings.port,
         reload=True,
-        log_level="info",
+        log_level=settings.log_level.lower(),
     )
 
 

--- a/src/backend/models/hitl.py
+++ b/src/backend/models/hitl.py
@@ -141,6 +141,22 @@ DEFAULT_RISK = OperationRisk(
     description="Unknown operation",
 )
 
+# `orchestrator/tools.py:create_mcp_tool` 이 MCP 서버의 도구를
+# `mcp_<server_id>_<tool_name>` 이름으로 **런타임에** 만든다. 어떤 서버가 무엇을
+# 노출할지는 붙어 봐야 알기 때문에 이 이름들은 정의상 TOOL_RISK_CONFIG 에 없고,
+# 그래서 전부 DEFAULT_RISK(LOW·승인 불필요)로 떨어졌다 — 외부 프로세스가 노출한
+# 임의의 능력이 HITL 을 통과하지 않고 실행된다는 뜻이다.
+#
+# 접두사로 판정한다. 세그먼트 개수(`mcp_<server>_<tool>` = 3토막)로 좁히면
+# server_id 와 tool 이름 양쪽에 밑줄이 들어가는 실제 사례(claude_ai_Figma 등)를
+# 놓친다. 넓게 잡는 쪽이 fail-closed 이고, 명시 등록된 이름은 위 조회가 먼저
+# 가로채므로 기존 정책은 그대로다.
+MCP_TOOL_NAME_PREFIX = "mcp_"
+
+MCP_DYNAMIC_TOOL_RISK_DESCRIPTION = (
+    "Dynamic MCP tool from an external server - capability not reviewed by the risk registry"
+)
+
 
 def is_task_resumable_after_approval(
     task: TaskNode,
@@ -194,8 +210,27 @@ def is_task_orphaned_by_consumed_approval(
 
 
 def get_tool_risk(tool_name: str) -> OperationRisk:
-    """Get risk configuration for a tool."""
-    return TOOL_RISK_CONFIG.get(tool_name, DEFAULT_RISK)
+    """Get risk configuration for a tool.
+
+    명시 등록 > 동적 MCP fail-closed > 기본값 순으로 판정한다. 반환은 매번
+    새 객체이며 DEFAULT_RISK·TOOL_RISK_CONFIG 항목을 변형하지 않는다(싱글턴).
+    """
+    configured = TOOL_RISK_CONFIG.get(tool_name)
+    if configured is not None:
+        return configured
+
+    if tool_name.startswith(MCP_TOOL_NAME_PREFIX):
+        return OperationRisk(
+            tool_name=tool_name,
+            risk_level=RiskLevel.HIGH,
+            requires_approval=True,
+            description=MCP_DYNAMIC_TOOL_RISK_DESCRIPTION,
+            # 비워 둔다 — assess_operation_risk 의 패턴 승격 루프가 무동작이 되어
+            # HIGH·승인필요가 인자 내용과 무관하게 그대로 흘러간다.
+            patterns=[],
+        )
+
+    return DEFAULT_RISK
 
 
 def assess_operation_risk(

--- a/src/backend/tools/bash_tools.py
+++ b/src/backend/tools/bash_tools.py
@@ -9,6 +9,37 @@ from langchain_core.tools import tool
 
 from services.sandbox_manager import execute_sandboxed, get_sandbox_manager
 
+# 호스트 쉘 실행 opt-in 스위치.
+#
+# `execute_bash` / `execute_bash_async` 는 샌드박스 없이 호스트에서 임의 명령을
+# 돌린다. 아래의 위험 패턴 목록은 문자열 부분일치라 우회가 쉬워(`rm -r -f /`,
+# 변수 치환, base64 디코드 등) 경계로 쓸 수 없는 완화책일 뿐이다.
+# 실제 경계는 "명시적으로 켜지 않으면 subprocess 를 만들지 않는다"이며,
+# 이 파일의 두 함수는 그 판정을 **첫 문장에서** 수행한다.
+#
+# 샌드박스 경로(`execute_bash_sandboxed`)는 이 스위치의 대상이 아니다 —
+# Docker 격리·네트워크 차단·non-root 로 실행되어 위협 모델이 다르다.
+HOST_SHELL_ENV_VAR = "AOS_ALLOW_HOST_SHELL"
+
+# 화이트리스트로 판정한다. `if os.getenv(VAR):` 는 "false"·"0" 같은 비어 있지
+# 않은 문자열도 참이라 조용히 fail-open 된다.
+_HOST_SHELL_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+HOST_SHELL_DISABLED_MESSAGE = (
+    "Error: host shell execution is disabled. "
+    f"Set {HOST_SHELL_ENV_VAR}=true to opt in for approved local development, "
+    "or use execute_bash_sandboxed for isolated execution."
+)
+
+
+def is_host_shell_execution_enabled() -> bool:
+    """호스트 쉘 실행이 명시적으로 승인됐는가.
+
+    호출 시점에 환경변수를 읽는다 — 모듈 로드 시점에 고정하면 런타임 토글도,
+    테스트의 monkeypatch 도 반영되지 않는다.
+    """
+    return os.getenv(HOST_SHELL_ENV_VAR, "").strip().lower() in _HOST_SHELL_TRUTHY_VALUES
+
 
 @tool
 def execute_bash(
@@ -27,6 +58,10 @@ def execute_bash(
     Returns:
         명령어 출력 또는 오류 메시지
     """
+    # Fail closed before anything else: 켜져 있지 않으면 subprocess 를 만들지 않는다.
+    if not is_host_shell_execution_enabled():
+        return HOST_SHELL_DISABLED_MESSAGE
+
     # Security check - block dangerous commands
     dangerous_patterns = [
         "rm -rf /",
@@ -101,6 +136,10 @@ async def execute_bash_async(
     Returns:
         명령어 출력 또는 오류 메시지
     """
+    # Fail closed before anything else: 켜져 있지 않으면 subprocess 를 만들지 않는다.
+    if not is_host_shell_execution_enabled():
+        return HOST_SHELL_DISABLED_MESSAGE
+
     # Security check
     dangerous_patterns = [
         "rm -rf /",

--- a/tests/backend/test_bind_host_default.py
+++ b/tests/backend/test_bind_host_default.py
@@ -1,0 +1,85 @@
+"""기본 바인드 주소는 루프백이어야 한다.
+
+`0.0.0.0` 기본값은 개발 노트북을 켜 두는 것만으로 백엔드를 같은 네트워크
+(카페 Wi-Fi, 공유 오피스)에 노출한다. AOS 는 로컬 파일 시스템·터미널·MCP 서버를
+조작하는 표면이라 노출 비용이 크다.
+
+기본값은 `127.0.0.1`, 배포에서의 와일드카드 바인드는 `HOST` 환경변수로 명시
+지정한다 — 기본을 안전하게 하되 탈출구는 남긴다.
+
+`Settings` 는 저장소 루트 `.env` 를 읽으므로(`PROJECT_ROOT_ENV`), 기본값 단언은
+`_env_file=None` + `HOST` 삭제로 격리한다. 그러지 않으면 개발자 `.env` 값에
+따라 로컬/CI 판정이 갈린다.
+"""
+
+import pytest
+
+from config import Settings
+
+LOOPBACK = "127.0.0.1"
+WILDCARD = "0.0.0.0"
+
+
+@pytest.fixture
+def isolated_env(monkeypatch):
+    """프로세스 환경의 HOST 를 제거해 코드 기본값만 남긴다."""
+    monkeypatch.delenv("HOST", raising=False)
+
+
+def test_default_host_is_loopback(isolated_env):
+    """어떤 오버라이드도 없을 때 기본 바인드는 루프백이다."""
+    settings = Settings(_env_file=None)
+
+    assert settings.host == LOOPBACK
+
+
+def test_explicit_deployment_host_override_still_works(monkeypatch):
+    """배포용 와일드카드 바인드는 HOST 환경변수로 여전히 가능하다."""
+    monkeypatch.setenv("HOST", WILDCARD)
+
+    settings = Settings(_env_file=None)
+
+    assert settings.host == WILDCARD
+
+
+def test_arbitrary_host_override_is_honored(monkeypatch):
+    """특정 인터페이스 지정도 그대로 통과한다."""
+    monkeypatch.setenv("HOST", "10.0.0.5")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.host == "10.0.0.5"
+
+
+@pytest.mark.parametrize(
+    ("host_env", "expected"),
+    [(None, LOOPBACK), ("10.0.0.5", "10.0.0.5"), (WILDCARD, WILDCARD)],
+)
+def test_main_binds_to_configured_host(monkeypatch, host_env, expected):
+    """엔트리포인트가 설정값을 실제로 uvicorn 에 넘긴다 (하드코딩 금지).
+
+    `get_settings` 는 lru_cache 라 테스트마다 비워야 환경변수가 반영된다.
+    """
+    import config
+    import main as backend_main
+
+    if host_env is None:
+        monkeypatch.delenv("HOST", raising=False)
+    else:
+        monkeypatch.setenv("HOST", host_env)
+
+    captured: dict[str, object] = {}
+
+    def fake_run(app, **kwargs):
+        captured["app"] = app
+        captured.update(kwargs)
+
+    monkeypatch.setattr(backend_main.uvicorn, "run", fake_run)
+
+    config.get_settings.cache_clear()
+    try:
+        backend_main.main()
+    finally:
+        config.get_settings.cache_clear()
+
+    assert captured["host"] == expected

--- a/tests/backend/test_host_shell_optin.py
+++ b/tests/backend/test_host_shell_optin.py
@@ -1,0 +1,99 @@
+"""호스트 쉘 실행은 opt-in 이어야 한다 — 기본값은 차단.
+
+`tools/bash_tools.py` 의 `execute_bash` / `execute_bash_async` 는 샌드박스 없이
+호스트에서 임의 명령을 돌린다. 위험 패턴 블랙리스트는 우회 가능한 완화책일 뿐
+경계가 아니다 — 경계는 "명시적으로 켜지 않으면 subprocess 자체를 만들지 않는다"다.
+
+단언의 핵심은 **반환 문자열이 아니라 subprocess 미호출**이다. 에러 문자열만
+확인하면 가드가 subprocess 호출 *뒤에* 있어도 통과한다(= 이미 실행된 뒤 거절).
+그래서 `subprocess.run` 과 `asyncio.create_subprocess_shell` 을 감시하고
+호출 횟수 0 을 단언한다.
+"""
+
+import asyncio
+import subprocess
+
+import pytest
+
+from tools import bash_tools
+
+HOST_SHELL_ENV_VAR = "AOS_ALLOW_HOST_SHELL"
+
+# 켜졌다고 오해될 수 있으나 켜지면 안 되는 값들 — "false" 는 truthy 문자열이라
+# `if os.getenv(...)` 형태의 순진한 가드에서 조용히 fail-open 된다.
+FALSY_VALUES = ("", "false", "False", "0", "no", "off")
+
+
+@pytest.fixture
+def spies(monkeypatch):
+    """subprocess 생성 경로 두 곳을 감시한다 (호출되면 즉시 실패)."""
+    calls: list[str] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append("subprocess.run")
+        raise AssertionError("subprocess.run 이 호출됐다 — fail-closed 가 아니다")
+
+    async def fake_create_subprocess_shell(*args, **kwargs):
+        calls.append("asyncio.create_subprocess_shell")
+        raise AssertionError("create_subprocess_shell 이 호출됐다 — fail-closed 가 아니다")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", fake_create_subprocess_shell)
+    return calls
+
+
+def test_execute_bash_disabled_by_default(monkeypatch, spies):
+    """환경변수 미설정이면 호스트 쉘은 실행되지 않는다."""
+    monkeypatch.delenv(HOST_SHELL_ENV_VAR, raising=False)
+
+    result = execute_bash_result("echo hello")
+
+    assert spies == [], f"subprocess 가 호출됐다: {spies}"
+    assert "disabled" in result.lower() or "비활성" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_bash_async_disabled_by_default(monkeypatch, spies):
+    """비동기 경로도 같은 계약을 따른다."""
+    monkeypatch.delenv(HOST_SHELL_ENV_VAR, raising=False)
+
+    result = await bash_tools.execute_bash_async("echo hello")
+
+    assert spies == [], f"subprocess 가 호출됐다: {spies}"
+    assert "disabled" in result.lower() or "비활성" in result
+
+
+@pytest.mark.parametrize("value", FALSY_VALUES)
+def test_falsy_env_values_do_not_enable(monkeypatch, spies, value):
+    """'false'·'0' 같은 값으로는 절대 열리지 않는다 (truthy-string 함정)."""
+    monkeypatch.setenv(HOST_SHELL_ENV_VAR, value)
+
+    result = execute_bash_result("echo hello")
+
+    assert spies == [], f"{value!r} 로 호스트 쉘이 열렸다: {spies}"
+    assert "disabled" in result.lower() or "비활성" in result
+
+
+@pytest.mark.parametrize("value", ("1", "true", "TRUE", "yes", "on"))
+def test_escape_hatch_enables_execution(monkeypatch, value):
+    """명시적 승인 값이면 실제로 실행된다 — 탈출구가 살아 있어야 한다."""
+    monkeypatch.setenv(HOST_SHELL_ENV_VAR, value)
+
+    result = execute_bash_result("echo aos-optin-marker")
+
+    assert "aos-optin-marker" in result
+
+
+@pytest.mark.asyncio
+async def test_escape_hatch_enables_async_execution(monkeypatch):
+    """비동기 경로 탈출구."""
+    monkeypatch.setenv(HOST_SHELL_ENV_VAR, "true")
+
+    result = await bash_tools.execute_bash_async("echo aos-optin-async-marker")
+
+    assert "aos-optin-async-marker" in result
+
+
+def execute_bash_result(command: str) -> str:
+    """`@tool` 로 감싸인 execute_bash 를 호출한다."""
+    return bash_tools.execute_bash.invoke({"command": command})

--- a/tests/backend/test_mcp_tool_risk_failclosed.py
+++ b/tests/backend/test_mcp_tool_risk_failclosed.py
@@ -1,0 +1,120 @@
+"""동적 MCP 도구는 위험도 판정에서 fail-closed 여야 한다.
+
+`orchestrator/tools.py:create_mcp_tool` 은 MCP 서버의 도구를
+`mcp_<server_id>_<tool_name>` 이름으로 런타임에 만들어 executor 에 넘긴다.
+이 이름들은 `TOOL_RISK_CONFIG` 에 존재할 수 없다(서버가 붙어야 알 수 있다).
+
+그런데 `get_tool_risk` 는 미등록 이름에 `DEFAULT_RISK`(LOW, 승인 불필요)를
+돌려준다 — 즉 외부 MCP 서버가 노출한 임의의 도구가 **HITL 승인 없이** 실행된다.
+경계는 "모르는 MCP 도구 = HIGH + 승인 필요"다.
+
+기존 명시 정책(execute_bash / write_file / edit_file / 비-MCP 미등록 도구)은
+그대로 유지돼야 한다 — 이 파일이 그 회귀도 함께 잠근다.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from models.hitl import (
+    DEFAULT_RISK,
+    TOOL_RISK_CONFIG,
+    RiskLevel,
+    assess_operation_risk,
+    get_tool_risk,
+    is_approval_required,
+)
+from orchestrator.nodes.executor import ExecutorNode
+
+# create_mcp_tool 이 실제로 만들어내는 이름 형태들.
+# server_id 에 밑줄이 들어가는 경우(claude_ai_Figma)와 tool 이름에 밑줄이
+# 들어가는 경우 모두 실재하므로, 세그먼트 개수로 판정하면 새어 나간다.
+DYNAMIC_MCP_TOOL_NAMES = (
+    "mcp_github_create_issue",
+    "mcp_filesystem_write_file",
+    "mcp_claude_ai_Figma_create_new_file",
+    "mcp_tavily_search",
+    # 밑줄이 하나뿐인 형태도 MCP 표면이므로 함께 닫는다.
+    # (`TOOL_PERMISSION_MAP` 의 mcp_call 이 여기 해당 — 의도적 확대)
+    "mcp_call",
+)
+
+
+@pytest.mark.parametrize("tool_name", DYNAMIC_MCP_TOOL_NAMES)
+def test_dynamic_mcp_tool_is_high_risk(tool_name):
+    """미등록 MCP 도구는 HIGH 로 판정된다."""
+    risk = get_tool_risk(tool_name)
+
+    assert risk.risk_level is RiskLevel.HIGH, f"{tool_name} 가 {risk.risk_level} 로 샜다"
+    assert risk.requires_approval is True
+
+
+@pytest.mark.parametrize("tool_name", DYNAMIC_MCP_TOOL_NAMES)
+def test_dynamic_mcp_tool_requires_approval(tool_name):
+    """인자 내용과 무관하게 승인이 필요하다 (패턴 매칭에 기대지 않는다)."""
+    risk_level, requires_approval, _ = assess_operation_risk(tool_name, {"arguments": {}})
+
+    assert risk_level is RiskLevel.HIGH
+    assert requires_approval is True
+    assert is_approval_required(tool_name, {"arguments": {}}) is True
+
+
+def test_executor_creates_high_risk_approval_request_for_mcp_tool():
+    """executor 경로가 실제로 PENDING 승인 요청을 만든다 (계약의 종착점)."""
+    node = ExecutorNode(llm=MagicMock(), tools=[])
+
+    requires_approval, request = node._check_approval_required(
+        tool_name="mcp_github_create_issue",
+        tool_args={"arguments": {"title": "hello"}},
+        task_id="task-1",
+        session_id="session-1",
+    )
+
+    assert requires_approval is True
+    assert request is not None
+    assert request["risk_level"] == RiskLevel.HIGH.value
+    assert request["tool_name"] == "mcp_github_create_issue"
+    assert request["status"] == "pending"
+
+
+def test_default_risk_singleton_is_not_mutated():
+    """MCP 판정이 모듈 싱글턴 DEFAULT_RISK 를 오염시키지 않는다."""
+    get_tool_risk("mcp_github_create_issue")
+
+    assert DEFAULT_RISK.risk_level is RiskLevel.LOW
+    assert DEFAULT_RISK.requires_approval is False
+    assert DEFAULT_RISK.tool_name == "unknown"
+
+
+@pytest.mark.parametrize("tool_name", ("read_file", "list_directory", "totally_unknown_tool"))
+def test_non_mcp_unknown_tools_keep_default_policy(tool_name):
+    """비-MCP 미등록 도구의 기존 동작은 바뀌지 않는다."""
+    risk = get_tool_risk(tool_name)
+
+    assert risk.risk_level is RiskLevel.LOW
+    assert risk.requires_approval is False
+
+
+@pytest.mark.parametrize("tool_name", sorted(TOOL_RISK_CONFIG))
+def test_explicitly_configured_tools_keep_exact_policy(tool_name):
+    """명시 등록된 도구는 등록된 설정 객체를 그대로 돌려준다."""
+    assert get_tool_risk(tool_name) is TOOL_RISK_CONFIG[tool_name]
+
+
+def test_execute_bash_policy_unchanged():
+    """execute_bash 의 기존 판정(HIGH + 승인)은 그대로다."""
+    risk_level, requires_approval, _ = assess_operation_risk("execute_bash", {"command": "ls -la"})
+
+    assert risk_level is RiskLevel.HIGH
+    assert requires_approval is True
+
+
+def test_write_file_policy_unchanged():
+    """write_file 은 평범한 경로면 MEDIUM·승인 불필요, .env 면 HIGH·승인 필요."""
+    plain_level, plain_approval, _ = assess_operation_risk("write_file", {"path": "/tmp/notes.txt"})
+    assert plain_level is RiskLevel.MEDIUM
+    assert plain_approval is False
+
+    env_level, env_approval, _ = assess_operation_risk("write_file", {"path": "/app/.env"})
+    assert env_level is RiskLevel.HIGH
+    assert env_approval is True

--- a/tests/backend/test_start_all_bind_host.py
+++ b/tests/backend/test_start_all_bind_host.py
@@ -1,0 +1,150 @@
+"""`infra/scripts/start-all.sh` 의 백엔드 바인드 주소 회귀 테스트.
+
+이 스크립트는 uvicorn 에 `--host` 를 CLI 인자로 직접 넘긴다 — 즉
+`config.Settings.host` 의 안전한 기본값(127.0.0.1)을 **거치지 않는다**.
+로컬 기동 경로에서 와일드카드 바인드가 되살아나도 파이썬 쪽 테스트는 전부
+초록이므로, 그 구멍은 여기서만 잡을 수 있다.
+
+grep 으로 문자열을 확인하지 않는다. 스크립트에서 uvicorn 호출 블록을 **그대로
+꺼내 bash 로 실행**하고, `uvicorn` 을 argv 기록 함수로 바꿔치기해 실제로 어떤
+`--host` 가 만들어지는지 관측한다. 프로세스도 네트워크도 뜨지 않는다:
+`nohup`·`uvicorn` 둘 다 셸 함수로 가려지고, 표준 출력 리다이렉트는 임시
+디렉토리로 향한다.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+START_ALL = REPO_ROOT / "infra" / "scripts" / "start-all.sh"
+
+LOOPBACK = "127.0.0.1"
+WILDCARD = "0.0.0.0"
+
+# uvicorn 호출 블록을 감싼 bash 하네스.
+#   - nohup: 그대로 통과시켜 뒤따르는 명령이 실행되게 한다
+#   - uvicorn: 실행 대신 argv 를 파일에 기록한다 (스텁)
+# 스크립트가 `> "$PROJECT_ROOT/logs/backend.log"` 로 stdout 을 돌리므로
+# 스텁은 stdout 이 아니라 $ARGV_OUT 경로에 직접 쓴다.
+HARNESS = """
+set -e
+nohup() { "$@"; }
+uvicorn() { printf '%s\\n' "$@" >> "$ARGV_OUT"; }
+. "$BLOCK"
+wait
+"""
+
+
+def _extract_uvicorn_block() -> str:
+    """`BACKEND_HOST=` 부터 백그라운드 실행(`2>&1 &`)까지를 원문 그대로 꺼낸다."""
+    lines = START_ALL.read_text(encoding="utf-8").splitlines()
+
+    starts = [i for i, line in enumerate(lines) if line.startswith("BACKEND_HOST=")]
+    assert len(starts) == 1, f"BACKEND_HOST 할당이 {len(starts)}건 — 1건이어야 한다"
+    start = starts[0]
+
+    end = next(
+        (i for i in range(start, len(lines)) if lines[i].rstrip().endswith("2>&1 &")),
+        None,
+    )
+    assert end is not None, "uvicorn 백그라운드 실행 라인을 찾지 못했다"
+
+    return "\n".join(lines[start : end + 1]) + "\n"
+
+
+def _uvicorn_argv(tmp_path: Path, host_env: str | None) -> list[str]:
+    """스크립트 블록을 실행해 uvicorn 이 받았을 argv 를 돌려준다."""
+    project_root = tmp_path / "root"
+    (project_root / "logs").mkdir(parents=True)
+
+    block = tmp_path / "block.sh"
+    block.write_text(_extract_uvicorn_block(), encoding="utf-8")
+
+    argv_out = tmp_path / "argv.txt"
+
+    # 상속 환경을 쓰지 않는다 — 실행 환경의 HOST 가 판정을 오염시키면 안 된다.
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "PROJECT_ROOT": str(project_root),
+        "ARGV_OUT": str(argv_out),
+        "BLOCK": str(block),
+    }
+    if host_env is not None:
+        env["HOST"] = host_env
+
+    result = subprocess.run(
+        ["bash", "-c", HARNESS],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"하네스 실패: {result.stderr}"
+
+    return argv_out.read_text(encoding="utf-8").split()
+
+
+def _host_arg(argv: list[str]) -> str:
+    assert "--host" in argv, f"--host 가 없다: {argv}"
+    return argv[argv.index("--host") + 1]
+
+
+def test_script_is_syntactically_valid():
+    """수정된 스크립트가 bash 문법 검사를 통과한다."""
+    result = subprocess.run(
+        ["bash", "-n", str(START_ALL)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_default_bind_is_loopback(tmp_path):
+    """HOST 미설정이면 루프백으로 바인드한다."""
+    argv = _uvicorn_argv(tmp_path, host_env=None)
+
+    assert _host_arg(argv) == LOOPBACK
+
+
+def test_explicit_wildcard_override_is_honored(tmp_path):
+    """배포용 와일드카드 바인드는 HOST 로 여전히 가능하다."""
+    argv = _uvicorn_argv(tmp_path, host_env=WILDCARD)
+
+    assert _host_arg(argv) == WILDCARD
+
+
+@pytest.mark.parametrize("host_env", ["10.0.0.5", "192.168.1.20", "::1"])
+def test_arbitrary_interface_override_is_honored(tmp_path, host_env):
+    """특정 인터페이스 지정도 그대로 전달된다."""
+    argv = _uvicorn_argv(tmp_path, host_env=host_env)
+
+    assert _host_arg(argv) == host_env
+
+
+def test_empty_host_falls_back_to_loopback(tmp_path):
+    """HOST="" 는 미설정과 같게 취급한다 (`:-` 이므로 빈 값도 폴백)."""
+    argv = _uvicorn_argv(tmp_path, host_env="")
+
+    assert _host_arg(argv) == LOOPBACK
+
+
+def test_other_uvicorn_arguments_are_unchanged(tmp_path):
+    """--host 외 인자는 건드리지 않았다."""
+    argv = _uvicorn_argv(tmp_path, host_env=None)
+
+    assert argv[0] == "api.app:app"
+    assert "--port" in argv and argv[argv.index("--port") + 1] == "8000"
+    assert "--reload" in argv
+    assert argv.count("--reload-exclude") == 5
+
+
+def test_block_does_not_hardcode_a_bind_address():
+    """호출 블록에 리터럴 주소가 되살아나지 않았다 (재도입 방지 핀)."""
+    block = _extract_uvicorn_block()
+
+    assert f"--host {WILDCARD}" not in block
+    assert f"--host {LOOPBACK}" not in block


### PR DESCRIPTION
## Summary
- Default API and local starter binding to loopback; explicit host override remains possible.
- Make host shell execution explicit opt-in.
- Treat dynamic MCP tools as high-risk, approval-required by default.

## Verification
- `uv run pytest tests/backend -q` → 420 passed
- Focused start script: 9 passed
- `ruff format --check`, `ruff check`, `mypy` passed
- Security review: PASS-WITH-NONBLOCKING; safe to commit.