### PR TITLE
fix(projects): DB 모드에서 link/create/reorder 복구 + 터미널 DB 프로젝트 해석

### DIFF
--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -81,6 +81,38 @@ id 는 `projects/<id>` 경로 세그먼트로 그대로 쓰여 심볼릭 링크�
 
 > 회귀 테스트: `tests/backend/test_project_id_path_traversal.py`
 
+### DB 모드(`USE_DATABASE=true`)에서의 쓰기 동작
+
+`.env.example` 기본값이 DB 모드이고 대시보드(`stores/projects.ts`)는 아래 세 경로를 호출하므로,
+세 핸들러는 `PUT /api/projects/{id}` 와 같은 방식으로 **DB 인지형 분기**를 가진다
+(`api/routes.py`). `/api/project-registry` 는 대체가 아니다 — 사용자가 고른 id 를 버리고
+UUID 를 찍으며 템플릿 스캐폴딩·정렬 엔드포인트가 없다.
+
+| 경로 | 파일시스템 모드 | DB 모드 |
+|------|----------------|---------|
+| `POST /api/projects/link` | `projects/<id>` 심볼릭 링크 + 메모리 레지스트리 | `ProjectModel(id=요청 id, path=source_path)` 행 + 등록자 `owner` 접근권. **심볼릭 링크 없음** |
+| `POST /api/projects/create` | 템플릿 스캐폴딩 + 메모리 레지스트리 | 중복 검사 → 템플릿 스캐폴딩 → `ProjectModel` 행 (검사가 먼저라 409 가 고아 디렉터리를 남기지 않음) |
+| `POST /api/projects/reorder` | `.aos-project.json` 의 `sort_order` | `ProjectModel.settings["sort_order"]`. 응답은 `GET /api/projects` 와 같은 **전체** 목록 |
+| `POST /api/projects` | 경로 등록 + 백그라운드 인덱싱 | 503 (대시보드 미사용, 미전환) |
+| `DELETE /api/projects/{id}` | cascade 삭제 | 503 (미전환 — `reject_legacy_project_operation_in_database_mode`) |
+
+- `link` 요청 본문에 선택 필드 `name`·`description` 이 추가됐다. DB 모드는 그대로 행에 쓰고
+  (`name` 생략 시 디렉터리명), 파일시스템 모드는 무시한다.
+- 중복 `id`·`name` 은 **409** 다. slug 만 겹치면 `/api/project-registry` 와 같은 규칙으로
+  `-{id[:8]}` 접미사를 붙인다(모달은 slug 를 보여주지 않아 slug 409 는 해석 불가).
+  DB 오류는 503 `Project registry is temporarily unavailable`.
+- `GET /api/projects` 의 DB 분기는 `(settings.sort_order, name)` 순으로 정렬하고, 행의 `path` 에서
+  CLAUDE.md 를 읽어 `has_claude_md` 를 채운다 — reorder 결과가 새로고침 뒤에도 유지되고, 템플릿이 만든
+  CLAUDE.md 가 카드에 '없음'으로 보이지 않는 근거.
+- `create` 는 스캐폴딩 뒤 DB 등록이 실패하면(사전 검사 뒤 경쟁 INSERT·commit 실패) 스캐폴드를 지우고
+  503 을 돌려준다 — 남기면 재시도가 `Path already exists` 로 막힌다.
+- `POST /api/terminal/execute`·`POST /api/warp/open` 은 `api/git/_shared.resolve_project` 로 프로젝트를
+  해석한다(DB 모드는 `ProjectModel` 행만, 파일시스템 모드는 레거시 레지스트리). 심링크 없이 등록된
+  DB 모드 프로젝트도 터미널에서 열 수 있어야 하기 때문이다.
+
+> 회귀 테스트: `tests/backend/api/test_projects_db_mode_writes.py`,
+> `tests/backend/api/test_terminal_db_project_resolution.py`
+
 ---
 
 ## Project Configs

--- a/src/backend/api/routes.py
+++ b/src/backend/api/routes.py
@@ -17,6 +17,10 @@ so that ``app.py`` can keep a single ``include_router(router, prefix="/api")``.
 """
 
 import os
+import re
+import shutil
+import uuid
+from pathlib import Path
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -259,11 +263,18 @@ async def get_projects(
                     name=p.name,
                     path=p.path or "",
                     description=p.description or "",
+                    # `has_claude_md` 의 근거. 비워 두면 DB 모드 카드가 항상 '없음'이라
+                    # Claude 설정 액션이 숨는다 — `Project.from_path` 와 같은 소스.
+                    claude_md=_read_claude_md(p.path),
                     sort_order=(p.settings or {}).get("sort_order", 0),
                     organization_id=p.organization_id,
                 )
                 for p in visible_projects
             ]
+            # 위 쿼리는 name 순이다. `POST /projects/reorder` 가 기록한
+            # settings.sort_order 를 여기서 적용하지 않으면 새로고침 한 번에
+            # 드래그 정렬이 풀린다 — 파일시스템 모드의 `list_projects()` 와 같은 키.
+            projects.sort(key=lambda p: (p.sort_order, p.name.lower()))
         except HTTPException:
             raise
         except Exception as exc:
@@ -335,19 +346,171 @@ async def get_projects(
     return result
 
 
+# ─────────────────────────────────────────────────────────────
+# DB-mode project writes (USE_DATABASE=true)
+# ─────────────────────────────────────────────────────────────
+#
+# PR #318 은 link/create/reorder 를 DB 모드에서 503 으로 잠갔다. 그러나 대시보드
+# (`stores/projects.ts`)는 이 세 경로를 계속 호출하고 `.env` 기본값은 DB 모드라,
+# 기본 설치에서 Link Existing / Create New / 드래그 정렬이 전부 실패했다.
+# `/api/project-registry` 로 옮기는 것은 답이 아니다 — 그 API 는 사용자가 고른 id 를
+# 버리고 UUID 를 찍으며(기존 행은 slug id), 템플릿 스캐폴딩과 정렬이 없다. 그래서
+# `PUT /projects/{project_id}` 와 같은 방식으로 핸들러 안에 DB 분기를 둔다.
+#
+# `services.project_sync_service.sync_project_to_db` 를 쓰지 않는다: 이름 기준
+# upsert 인 데다 모든 예외를 warning 으로 삼켜 INSERT 가 실패해도 200 이 돌아간다.
+
+
+def _use_database() -> bool:
+    return os.getenv("USE_DATABASE", "false").lower() == "true"
+
+
+def _read_claude_md(path: str | None) -> str | None:
+    """`Project.from_path` 가 하는 것과 같은 CLAUDE.md 읽기. 없거나 못 읽으면 None."""
+    if not path:
+        return None
+    claude_md = Path(path) / "CLAUDE.md"
+    try:
+        return claude_md.read_text(encoding="utf-8") if claude_md.is_file() else None
+    except OSError:
+        return None
+
+
+def _db_slug(name: str, fallback: str) -> str:
+    """`project_sync_service._slugify` 와 같은 규칙. 비면 id 로 대체한다."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or fallback
+
+
+async def _resolve_free_slug(db: AsyncSession, *, project_id: str, name: str) -> str:
+    """id·name·slug 셋 다 unique 컬럼이다. 미리 검사해 id·name 충돌은 409 로 답한다.
+
+    안 하면 IntegrityError 가 일반 503 으로 새어 사용자는 원인을 모른다. create 는
+    이 검사를 스캐폴딩보다 **먼저** 불러야 409 가 고아 디렉터리를 남기지 않는다.
+
+    slug 만 겹치면 409 가 아니라 `api/projects/registry.py::create_project` 와 같은
+    `-{id[:8]}` 접미사로 피한다 — 모달은 slug 를 보여주지 않아 slug 409 는 사용자가
+    해석할 수 없다. 반환값이 실제로 쓸 slug 다.
+    """
+    from sqlalchemy import or_, select
+
+    from db.models import ProjectModel
+
+    slug = _db_slug(name, project_id)
+    result = await db.execute(
+        select(ProjectModel).where(
+            or_(
+                ProjectModel.id == project_id,
+                ProjectModel.name == name,
+                ProjectModel.slug == slug,
+            )
+        )
+    )
+    slug_taken = False
+    for existing in result.scalars().all():
+        if existing.id == project_id:
+            raise HTTPException(status_code=409, detail=f"Project ID '{project_id}' already exists")
+        if existing.name == name:
+            raise HTTPException(status_code=409, detail=f"Project '{name}' already exists")
+        slug_taken = True
+    return f"{slug}-{project_id[:8]}" if slug_taken else slug
+
+
+async def _insert_db_project(
+    db: AsyncSession,
+    *,
+    project_id: str,
+    name: str,
+    slug: str,
+    description: str | None,
+    path: str,
+    current_user,
+) -> ProjectResponse:
+    """`ProjectModel` 행 + 등록자 owner 접근권 한 쌍을 커밋한다 (registry 와 동일)."""
+    from db.models import ProjectAccessModel, ProjectModel
+
+    project = ProjectModel(
+        id=project_id,
+        name=name,
+        slug=slug,
+        description=description or "",
+        path=path,
+        is_active=True,
+        settings={},
+        organization_id=None,
+        created_by=current_user.id,
+    )
+    db.add(project)
+    db.add(
+        ProjectAccessModel(
+            id=str(uuid.uuid4()),
+            project_id=project_id,
+            user_id=current_user.id,
+            role="owner",
+            granted_by=current_user.id,
+        )
+    )
+    await db.commit()
+    await db.refresh(project)
+
+    return ProjectResponse(
+        id=project.id,
+        name=project.name,
+        path=project.path or "",
+        description=project.description or "",
+        has_claude_md=(Path(path) / "CLAUDE.md").is_file(),
+        is_active=True,
+    )
+
+
+def _registry_unavailable() -> HTTPException:
+    return HTTPException(status_code=503, detail="Project registry is temporarily unavailable")
+
+
 @router.post("/projects/reorder", response_model=list[ProjectResponse])
 async def reorder_projects_endpoint(
     request: ProjectReorderRequest,
     _admin=Depends(get_current_admin_or_manager_user),
+    db: AsyncSession = Depends(get_db_session),
 ):
     """
     Reorder projects by providing a list of project IDs in the desired order.
 
     This updates the sort_order field for each project and persists it
-    to the .aos-project.json metadata file.
+    to the .aos-project.json metadata file (filesystem mode) or to
+    ``ProjectModel.settings["sort_order"]`` (DB mode).
     """
-    if os.getenv("USE_DATABASE", "false").lower() == "true":
-        raise HTTPException(status_code=503, detail="Use the database project registry")
+    if _use_database():
+        from sqlalchemy import select
+
+        from db.models import ProjectModel
+
+        try:
+            result = await db.execute(
+                select(ProjectModel).where(ProjectModel.id.in_(request.project_ids))
+            )
+            rows = {p.id: p for p in result.scalars().all()}
+        except Exception as exc:
+            raise _registry_unavailable() from exc
+
+        missing = [pid for pid in request.project_ids if pid not in rows]
+        if missing:
+            raise HTTPException(status_code=404, detail=f"Project '{missing[0]}' not found")
+
+        for index, pid in enumerate(request.project_ids):
+            row = rows[pid]
+            # JSONB 제자리 변경은 SQLAlchemy 가 dirty 로 잡지 않는다 — 새 dict 재할당.
+            row.settings = {**(row.settings or {}), "sort_order": index}
+
+        try:
+            await db.commit()
+        except Exception as exc:
+            raise _registry_unavailable() from exc
+
+        # store 는 응답을 `projects` 전체로 덮어쓴다 — 요청에 없던(필터로 가려진)
+        # 프로젝트가 화면에서 사라지지 않도록 GET 과 같은 전체 목록을 돌려준다.
+        return await get_projects(current_user=_admin, db=db)
+
     # Validate all project IDs exist
     for project_id in request.project_ids:
         if not get_project(project_id):
@@ -400,17 +563,17 @@ async def list_templates(_current_user=Depends(get_current_user)):
 @router.post("/projects/link", response_model=ProjectResponse)
 async def link_project(
     request: ProjectLinkRequest,
-    _admin=Depends(get_current_admin_or_manager_user),
+    current_user=Depends(get_current_admin_or_manager_user),
+    db: AsyncSession = Depends(get_db_session),
 ):
     """
-    Link an external project by creating a symlink.
+    Link an external project.
 
-    Creates a symbolic link in the projects/ directory pointing to the source.
+    Filesystem mode: creates a symbolic link in the projects/ directory pointing
+    to the source. DB mode: registers a ``ProjectModel`` row with the requested
+    id and path — no symlink (that filesystem side effect is what the DB-mode
+    gate protects against).
     """
-    if os.getenv("USE_DATABASE", "false").lower() == "true":
-        raise HTTPException(status_code=503, detail="Use the database project registry")
-    from pathlib import Path
-
     # Normalize path to remove shell escape characters (e.g., "Mobile\ Documents" -> "Mobile Documents")
     normalized_path = normalize_path(request.source_path)
     source_path = Path(normalized_path)
@@ -425,6 +588,24 @@ async def link_project(
             raise HTTPException(
                 status_code=400, detail=f"Source path is not a directory: {request.source_path}"
             )
+
+    if _use_database():
+        name = request.name or source_path.name
+        try:
+            slug = await _resolve_free_slug(db, project_id=request.id, name=name)
+            return await _insert_db_project(
+                db,
+                project_id=request.id,
+                name=name,
+                slug=slug,
+                description=request.description,
+                path=normalized_path,
+                current_user=current_user,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise _registry_unavailable() from exc
 
     # Check if project ID already exists
     if get_project(request.id):
@@ -461,7 +642,8 @@ async def link_project(
 @router.post("/projects/create", response_model=ProjectResponse)
 async def create_project_from_template(
     request: ProjectCreateFromTemplate,
-    _admin=Depends(get_current_admin_or_manager_user),
+    current_user=Depends(get_current_admin_or_manager_user),
+    db: AsyncSession = Depends(get_db_session),
 ):
     """
     Create a new project from a template.
@@ -471,10 +653,10 @@ async def create_project_from_template(
     - react-native: React Native Expo project
     - python: Python package with pyproject.toml
     - fastapi: FastAPI service
-    """
-    if os.getenv("USE_DATABASE", "false").lower() == "true":
-        raise HTTPException(status_code=503, detail="Use the database project registry")
 
+    In DB mode the scaffolded directory is registered as a ``ProjectModel``
+    row (id = request id) instead of the in-memory filesystem registry.
+    """
     from services.project_template_service import (
         create_project_from_template as create_from_template,
     )
@@ -485,8 +667,19 @@ async def create_project_from_template(
     if not template:
         raise HTTPException(status_code=400, detail=f"Unknown template: {request.template}")
 
-    # Check if project ID already exists
-    if get_project(request.id):
+    use_database = _use_database()
+    slug = ""
+
+    # Check if project ID already exists — DB 모드는 스캐폴딩보다 먼저 검사해야
+    # 409 가 projects/ 아래에 고아 디렉터리를 남기지 않는다.
+    if use_database:
+        try:
+            slug = await _resolve_free_slug(db, project_id=request.id, name=request.name)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise _registry_unavailable() from exc
+    elif get_project(request.id):
         raise HTTPException(status_code=400, detail=f"Project ID '{request.id}' already exists")
 
     # Create project in projects/ directory
@@ -509,6 +702,25 @@ async def create_project_from_template(
 
     if not success:
         raise HTTPException(status_code=500, detail="Failed to create project from template")
+
+    if use_database:
+        try:
+            return await _insert_db_project(
+                db,
+                project_id=request.id,
+                name=request.name,
+                slug=slug,
+                description=request.description,
+                path=str(project_path),
+                current_user=current_user,
+            )
+        except Exception as exc:
+            # 사전 검사 뒤 경쟁 INSERT·commit 실패. 스캐폴드를 남기면 재시도가
+            # `Path already exists` 로 영영 막히고 등록 안 된 고아 디렉터리가 남는다.
+            shutil.rmtree(project_path, ignore_errors=True)
+            if isinstance(exc, HTTPException):
+                raise
+            raise _registry_unavailable() from exc
 
     # Register the project
     project = register_project(request.id, str(project_path))

--- a/src/backend/api/terminal.py
+++ b/src/backend/api/terminal.py
@@ -12,8 +12,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
 from api.deps import get_current_admin_or_manager_user, get_current_user
+from api.git._shared import resolve_project
 from db.models import UserModel
-from models.project import get_project
 from services.audit_service import AuditAction, AuditService, ResourceType
 from services.terminal_service import (
     TERMINAL_INFO,
@@ -132,10 +132,9 @@ async def execute_in_terminal(
             detail=f"Unknown terminal type: {request.terminal}",
         )
 
-    # Resolve project path
-    project = get_project(request.project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    # Resolve project path — DB 모드는 `ProjectModel` 행이 유일한 권위다. 레거시
+    # `get_project()` 만 보면 DB 모드에서 link/create 한 프로젝트(심링크 없음)가 404 다.
+    project = await resolve_project(request.project_id)
 
     try:
         service = get_terminal_service()

--- a/src/backend/api/warp.py
+++ b/src/backend/api/warp.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
 from api.deps import get_current_admin_or_manager_user
+from api.git._shared import resolve_project
 from models.llm_usage import (
     LLMRuntimeMode,
     LLMUsageMeasurementMethod,
@@ -19,7 +20,6 @@ from models.llm_usage import (
     LLMUsageSource,
     LLMUsageStatus,
 )
-from models.project import get_project
 from services.llm_usage_ledger_service import (
     LLMUsageQuotaExceededError,
     enforce_usage_quota_preflight_best_effort,
@@ -152,10 +152,8 @@ async def open_in_warp(request: WarpOpenRequest):
     If a command is provided without use_claude_cli, it will be executed directly.
     Without any command, Warp will simply open a new window/tab at the project path.
     """
-    # Get project
-    project = get_project(request.project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail=f"Project '{request.project_id}' not found")
+    # Get project — DB 모드는 `ProjectModel` 행이 유일한 권위다 (api/terminal.py 와 동일).
+    project = await resolve_project(request.project_id)
 
     warp = get_warp_service()
 

--- a/src/backend/models/project.py
+++ b/src/backend/models/project.py
@@ -162,6 +162,11 @@ class ProjectLinkRequest(BaseModel):
         description="Unique project identifier (slug; used as a path segment)",
     )
     source_path: str = Field(..., description="Absolute path to source project")
+    # DB 모드(`USE_DATABASE=true`)에서 `ProjectModel` 행에 그대로 들어간다. 대시보드
+    # 모달은 둘 다 입력받지만 파일시스템 모드는 디렉터리명·.aos-project.json 에서
+    # 파생하므로 선택 필드로 둔다 — 기존 호출자(id+source_path)는 그대로 유효하다.
+    name: str | None = Field(None, max_length=255, description="Display name (DB mode)")
+    description: str | None = Field(None, description="Project description (DB mode)")
 
 
 class ProjectCreateFromTemplate(BaseModel):

--- a/src/dashboard/src/components/ProjectFormModal.tsx
+++ b/src/dashboard/src/components/ProjectFormModal.tsx
@@ -68,7 +68,7 @@ export function ProjectFormModal() {
         await createProject(id, name, description, template)
         break
       case 'link':
-        await linkProject(id, sourcePath)
+        await linkProject(id, sourcePath, name, description)
         break
       case 'edit': {
         // 경로가 변경되었는지 확인하고 전달

--- a/src/dashboard/src/components/__tests__/ProjectFormModal.test.tsx
+++ b/src/dashboard/src/components/__tests__/ProjectFormModal.test.tsx
@@ -1,20 +1,24 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
   X: (props: Record<string, unknown>) => <span data-testid="icon-x" {...props} />,
   Loader2: (props: Record<string, unknown>) => <span data-testid="icon-loader" {...props} />,
-  FolderPlus: (props: Record<string, unknown>) => <span data-testid="icon-folder-plus" {...props} />,
+  FolderPlus: (props: Record<string, unknown>) => (
+    <span data-testid="icon-folder-plus" {...props} />
+  ),
   Link: (props: Record<string, unknown>) => <span data-testid="icon-link" {...props} />,
   Pencil: (props: Record<string, unknown>) => <span data-testid="icon-pencil" {...props} />,
-  FolderOpen: (props: Record<string, unknown>) => <span data-testid="icon-folder-open" {...props} />,
-}))
+  FolderOpen: (props: Record<string, unknown>) => (
+    <span data-testid="icon-folder-open" {...props} />
+  ),
+}));
 
-const mockCloseModal = vi.fn()
-const mockCreateProject = vi.fn()
-const mockLinkProject = vi.fn()
-const mockUpdateProject = vi.fn()
+const mockCloseModal = vi.fn();
+const mockCreateProject = vi.fn();
+const mockLinkProject = vi.fn();
+const mockUpdateProject = vi.fn();
 
 let storeState: Record<string, unknown> = {
   modalMode: null,
@@ -29,17 +33,17 @@ let storeState: Record<string, unknown> = {
   createProject: mockCreateProject,
   linkProject: mockLinkProject,
   updateProject: mockUpdateProject,
-}
+};
 
 vi.mock('../../stores/projects', () => ({
   useProjectsStore: vi.fn(() => storeState),
-}))
+}));
 
-import { ProjectFormModal } from '../ProjectFormModal'
+import { ProjectFormModal } from '../ProjectFormModal';
 
 describe('ProjectFormModal', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
     storeState = {
       modalMode: null,
       editingProject: null,
@@ -53,179 +57,201 @@ describe('ProjectFormModal', () => {
       createProject: mockCreateProject,
       linkProject: mockLinkProject,
       updateProject: mockUpdateProject,
-    }
-  })
+    };
+  });
 
   it('returns null when modalMode is null', () => {
-    const { container } = render(<ProjectFormModal />)
-    expect(container.firstChild).toBeNull()
-  })
+    const { container } = render(<ProjectFormModal />);
+    expect(container.firstChild).toBeNull();
+  });
 
   it('renders create modal with title', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Create New Project')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Create New Project')).toBeInTheDocument();
+  });
 
   it('renders link modal with title', () => {
-    storeState.modalMode = 'link'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Link Existing Project')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'link';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Link Existing Project')).toBeInTheDocument();
+  });
 
   it('renders edit modal with title', () => {
-    storeState.modalMode = 'edit'
-    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' }
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Edit Project')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'edit';
+    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' };
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Edit Project')).toBeInTheDocument();
+  });
 
   it('shows template selector in create mode', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Template')).toBeInTheDocument()
-    expect(screen.getByText('Default project template')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Template')).toBeInTheDocument();
+    expect(screen.getByText('Default project template')).toBeInTheDocument();
+  });
 
   it('does not show template selector in link mode', () => {
-    storeState.modalMode = 'link'
-    render(<ProjectFormModal />)
-    expect(screen.queryByText('Template')).not.toBeInTheDocument()
-  })
+    storeState.modalMode = 'link';
+    render(<ProjectFormModal />);
+    expect(screen.queryByText('Template')).not.toBeInTheDocument();
+  });
 
   it('shows source path field in link mode', () => {
-    storeState.modalMode = 'link'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Source Path *')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('/absolute/path/to/project')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'link';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Source Path *')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('/absolute/path/to/project')).toBeInTheDocument();
+  });
 
   it('does not show source path in create mode', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.queryByText('Source Path *')).not.toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.queryByText('Source Path *')).not.toBeInTheDocument();
+  });
 
   it('shows project name field', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Project Name *')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('My Project')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Project Name *')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('My Project')).toBeInTheDocument();
+  });
 
   it('shows project ID field in create mode', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Project ID *')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Project ID *')).toBeInTheDocument();
+  });
 
   it('does not show project ID field in edit mode', () => {
-    storeState.modalMode = 'edit'
-    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' }
-    render(<ProjectFormModal />)
-    expect(screen.queryByText('Project ID *')).not.toBeInTheDocument()
-  })
+    storeState.modalMode = 'edit';
+    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' };
+    render(<ProjectFormModal />);
+    expect(screen.queryByText('Project ID *')).not.toBeInTheDocument();
+  });
 
   it('shows project path field in edit mode', () => {
-    storeState.modalMode = 'edit'
-    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' }
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Project Path')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'edit';
+    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' };
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Project Path')).toBeInTheDocument();
+  });
 
   it('shows description field', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Description')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Description')).toBeInTheDocument();
+  });
 
   it('shows cancel button', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Cancel')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
 
   it('calls closeModal when cancel is clicked', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    fireEvent.click(screen.getByText('Cancel'))
-    expect(mockCloseModal).toHaveBeenCalled()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockCloseModal).toHaveBeenCalled();
+  });
 
   it('shows "Create Project" submit button in create mode', () => {
-    storeState.modalMode = 'create'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Create Project')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Create Project')).toBeInTheDocument();
+  });
 
   it('shows "Link Project" submit button in link mode', () => {
-    storeState.modalMode = 'link'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Link Project')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'link';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Link Project')).toBeInTheDocument();
+  });
 
   it('shows "Save Changes" submit button in edit mode', () => {
-    storeState.modalMode = 'edit'
-    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' }
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Save Changes')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'edit';
+    storeState.editingProject = { id: 'test', name: 'Test', path: '/path', description: 'Desc' };
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Save Changes')).toBeInTheDocument();
+  });
 
   it('shows error message when error is set', () => {
-    storeState.modalMode = 'create'
-    storeState.error = 'Project already exists'
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Project already exists')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    storeState.error = 'Project already exists';
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Project already exists')).toBeInTheDocument();
+  });
 
   it('disables submit button when loading', () => {
-    storeState.modalMode = 'create'
-    storeState.isLoading = true
-    render(<ProjectFormModal />)
-    expect(screen.getByText('Create Project').closest('button')).toBeDisabled()
-  })
+    storeState.modalMode = 'create';
+    storeState.isLoading = true;
+    render(<ProjectFormModal />);
+    expect(screen.getByText('Create Project').closest('button')).toBeDisabled();
+  });
 
   it('shows loader icon when loading', () => {
-    storeState.modalMode = 'create'
-    storeState.isLoading = true
-    render(<ProjectFormModal />)
-    expect(screen.getByTestId('icon-loader')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'create';
+    storeState.isLoading = true;
+    render(<ProjectFormModal />);
+    expect(screen.getByTestId('icon-loader')).toBeInTheDocument();
+  });
 
   it('populates form fields in edit mode', () => {
-    storeState.modalMode = 'edit'
-    storeState.editingProject = { id: 'my-proj', name: 'My Project', path: '/my/path', description: 'Some desc' }
-    render(<ProjectFormModal />)
-    expect(screen.getByDisplayValue('My Project')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('Some desc')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('/my/path')).toBeInTheDocument()
-  })
+    storeState.modalMode = 'edit';
+    storeState.editingProject = {
+      id: 'my-proj',
+      name: 'My Project',
+      path: '/my/path',
+      description: 'Some desc',
+    };
+    render(<ProjectFormModal />);
+    expect(screen.getByDisplayValue('My Project')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Some desc')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('/my/path')).toBeInTheDocument();
+  });
 
   // 백엔드 계약(models/project.py: PROJECT_ID_PATTERN / PROJECT_ID_MAX_LENGTH=36)과
   // 폼 제약이 어긋나면 제출 후 422 로만 드러난다. 아래 3건이 그 간극을 잡는다.
   describe('project ID constraints mirror the backend contract', () => {
-    const getIdInput = () => screen.getByPlaceholderText('my-project') as HTMLInputElement
+    const getIdInput = () => screen.getByPlaceholderText('my-project') as HTMLInputElement;
 
     it('caps the ID input at the backend max length', () => {
-      storeState.modalMode = 'create'
-      render(<ProjectFormModal />)
-      expect(getIdInput().maxLength).toBe(36)
-    })
+      storeState.modalMode = 'create';
+      render(<ProjectFormModal />);
+      expect(getIdInput().maxLength).toBe(36);
+    });
 
     it('requires the ID to start with an alphanumeric character', () => {
-      storeState.modalMode = 'create'
-      render(<ProjectFormModal />)
+      storeState.modalMode = 'create';
+      render(<ProjectFormModal />);
       // 선행 하이픈은 백엔드가 거부하므로 폼 pattern 도 허용하면 안 된다
-      expect(new RegExp(`^(?:${getIdInput().pattern})$`).test('-leading')).toBe(false)
-      expect(new RegExp(`^(?:${getIdInput().pattern})$`).test('my-project')).toBe(true)
-    })
+      expect(new RegExp(`^(?:${getIdInput().pattern})$`).test('-leading')).toBe(false);
+      expect(new RegExp(`^(?:${getIdInput().pattern})$`).test('my-project')).toBe(true);
+    });
 
     it('truncates the auto-generated ID from a long project name', () => {
-      storeState.modalMode = 'create'
-      render(<ProjectFormModal />)
-      const longName = 'A'.repeat(80)
-      fireEvent.change(screen.getByPlaceholderText('My Project'), { target: { value: longName } })
-      expect(getIdInput().value.length).toBeLessThanOrEqual(36)
-    })
-  })
-})
+      storeState.modalMode = 'create';
+      render(<ProjectFormModal />);
+      const longName = 'A'.repeat(80);
+      fireEvent.change(screen.getByPlaceholderText('My Project'), { target: { value: longName } });
+      expect(getIdInput().value.length).toBeLessThanOrEqual(36);
+    });
+  });
+
+  it('submits name and description along with id and source path in link mode', () => {
+    storeState.modalMode = 'link';
+    mockLinkProject.mockResolvedValue(true);
+    render(<ProjectFormModal />);
+
+    fireEvent.change(screen.getByPlaceholderText('/absolute/path/to/project'), {
+      target: { value: '/work/KVCA' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('My Project'), { target: { value: 'KVCA' } });
+    fireEvent.change(screen.getByPlaceholderText('Brief description of the project...'), {
+      target: { value: 'Venture capital' },
+    });
+    fireEvent.submit(screen.getByRole('button', { name: 'Link Project' }).closest('form')!);
+
+    expect(mockLinkProject).toHaveBeenCalledWith('kvca', '/work/KVCA', 'KVCA', 'Venture capital');
+  });
+});

--- a/src/dashboard/src/stores/__tests__/projects.test.ts
+++ b/src/dashboard/src/stores/__tests__/projects.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 vi.mock('../../services/apiClient', () => ({
   apiClient: {
@@ -9,12 +9,12 @@ vi.mock('../../services/apiClient', () => ({
     patch: vi.fn(),
     delete: vi.fn(),
   },
-}))
+}));
 
-import { useProjectsStore } from '../projects'
-import { apiClient } from '../../services/apiClient'
+import { useProjectsStore } from '../projects';
+import { apiClient } from '../../services/apiClient';
 
-const mockApiClient = vi.mocked(apiClient)
+const mockApiClient = vi.mocked(apiClient);
 
 function resetStore() {
   useProjectsStore.setState({
@@ -26,7 +26,7 @@ function resetStore() {
     editingProject: null,
     searchQuery: '',
     selectedProjectId: null,
-  })
+  });
 }
 
 const mockProject = (id: string, name: string) => ({
@@ -40,90 +40,90 @@ const mockProject = (id: string, name: string) => ({
   git_path: null,
   git_enabled: false,
   sort_order: 0,
-})
+});
 
 describe('projects store', () => {
   beforeEach(() => {
-    resetStore()
-    vi.clearAllMocks()
-  })
+    resetStore();
+    vi.clearAllMocks();
+  });
 
   // ── Initial State ──────────────────────────────────────
 
   describe('initial state', () => {
     it('has empty projects', () => {
-      expect(useProjectsStore.getState().projects).toEqual([])
-    })
+      expect(useProjectsStore.getState().projects).toEqual([]);
+    });
 
     it('has no modal open', () => {
-      expect(useProjectsStore.getState().modalMode).toBeNull()
-    })
+      expect(useProjectsStore.getState().modalMode).toBeNull();
+    });
 
     it('has empty search query', () => {
-      expect(useProjectsStore.getState().searchQuery).toBe('')
-    })
+      expect(useProjectsStore.getState().searchQuery).toBe('');
+    });
 
     it('has no selected project', () => {
-      expect(useProjectsStore.getState().selectedProjectId).toBeNull()
-    })
-  })
+      expect(useProjectsStore.getState().selectedProjectId).toBeNull();
+    });
+  });
 
   // ── Modal Actions ──────────────────────────────────────
 
   describe('modal actions', () => {
     it('openCreateModal sets create mode', () => {
-      useProjectsStore.getState().openCreateModal()
-      expect(useProjectsStore.getState().modalMode).toBe('create')
-      expect(useProjectsStore.getState().editingProject).toBeNull()
-    })
+      useProjectsStore.getState().openCreateModal();
+      expect(useProjectsStore.getState().modalMode).toBe('create');
+      expect(useProjectsStore.getState().editingProject).toBeNull();
+    });
 
     it('openLinkModal sets link mode', () => {
-      useProjectsStore.getState().openLinkModal()
-      expect(useProjectsStore.getState().modalMode).toBe('link')
-    })
+      useProjectsStore.getState().openLinkModal();
+      expect(useProjectsStore.getState().modalMode).toBe('link');
+    });
 
     it('openEditModal sets edit mode with project', () => {
-      const project = mockProject('p-1', 'Test')
-      useProjectsStore.getState().openEditModal(project as any)
-      expect(useProjectsStore.getState().modalMode).toBe('edit')
-      expect(useProjectsStore.getState().editingProject).toEqual(project)
-    })
+      const project = mockProject('p-1', 'Test');
+      useProjectsStore.getState().openEditModal(project as any);
+      expect(useProjectsStore.getState().modalMode).toBe('edit');
+      expect(useProjectsStore.getState().editingProject).toEqual(project);
+    });
 
     it('closeModal clears modal state', () => {
       useProjectsStore.setState({
         modalMode: 'edit',
         editingProject: mockProject('p-1', 'Test') as any,
         error: 'some error',
-      })
+      });
 
-      useProjectsStore.getState().closeModal()
+      useProjectsStore.getState().closeModal();
 
-      const state = useProjectsStore.getState()
-      expect(state.modalMode).toBeNull()
-      expect(state.editingProject).toBeNull()
-      expect(state.error).toBeNull()
-    })
-  })
+      const state = useProjectsStore.getState();
+      expect(state.modalMode).toBeNull();
+      expect(state.editingProject).toBeNull();
+      expect(state.error).toBeNull();
+    });
+  });
 
   // ── Search & Selection ─────────────────────────────────
 
   describe('search and selection', () => {
     it('setSearchQuery updates query', () => {
-      useProjectsStore.getState().setSearchQuery('test')
-      expect(useProjectsStore.getState().searchQuery).toBe('test')
-    })
+      useProjectsStore.getState().setSearchQuery('test');
+      expect(useProjectsStore.getState().searchQuery).toBe('test');
+    });
 
     it('selectProject sets selectedProjectId', () => {
-      useProjectsStore.getState().selectProject('p-1')
-      expect(useProjectsStore.getState().selectedProjectId).toBe('p-1')
-    })
+      useProjectsStore.getState().selectProject('p-1');
+      expect(useProjectsStore.getState().selectedProjectId).toBe('p-1');
+    });
 
     it('selectProject with null clears selection', () => {
-      useProjectsStore.setState({ selectedProjectId: 'p-1' })
-      useProjectsStore.getState().selectProject(null)
-      expect(useProjectsStore.getState().selectedProjectId).toBeNull()
-    })
-  })
+      useProjectsStore.setState({ selectedProjectId: 'p-1' });
+      useProjectsStore.getState().selectProject(null);
+      expect(useProjectsStore.getState().selectedProjectId).toBeNull();
+    });
+  });
 
   // ── filteredProjects ───────────────────────────────────
 
@@ -135,42 +135,42 @@ describe('projects store', () => {
           mockProject('web-app', 'Web Application'),
           mockProject('cli-tool', 'CLI Tool'),
         ] as any[],
-      })
-    })
+      });
+    });
 
     it('returns all projects when no search query', () => {
-      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(3)
-    })
+      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(3);
+    });
 
     it('filters by name', () => {
-      useProjectsStore.setState({ searchQuery: 'agent' })
-      const filtered = useProjectsStore.getState().filteredProjects()
-      expect(filtered).toHaveLength(1)
-      expect(filtered[0].id).toBe('agent-system')
-    })
+      useProjectsStore.setState({ searchQuery: 'agent' });
+      const filtered = useProjectsStore.getState().filteredProjects();
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].id).toBe('agent-system');
+    });
 
     it('filters by id', () => {
-      useProjectsStore.setState({ searchQuery: 'cli' })
-      const filtered = useProjectsStore.getState().filteredProjects()
-      expect(filtered).toHaveLength(1)
-      expect(filtered[0].id).toBe('cli-tool')
-    })
+      useProjectsStore.setState({ searchQuery: 'cli' });
+      const filtered = useProjectsStore.getState().filteredProjects();
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].id).toBe('cli-tool');
+    });
 
     it('filters case-insensitively', () => {
-      useProjectsStore.setState({ searchQuery: 'WEB' })
-      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(1)
-    })
+      useProjectsStore.setState({ searchQuery: 'WEB' });
+      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(1);
+    });
 
     it('filters by description', () => {
-      useProjectsStore.setState({ searchQuery: 'project' })
-      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(3)
-    })
+      useProjectsStore.setState({ searchQuery: 'project' });
+      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(3);
+    });
 
     it('returns empty for no match', () => {
-      useProjectsStore.setState({ searchQuery: 'nonexistent' })
-      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(0)
-    })
-  })
+      useProjectsStore.setState({ searchQuery: 'nonexistent' });
+      expect(useProjectsStore.getState().filteredProjects()).toHaveLength(0);
+    });
+  });
 
   // ── getSelectedProject ─────────────────────────────────
 
@@ -179,260 +179,285 @@ describe('projects store', () => {
       useProjectsStore.setState({
         projects: [mockProject('p-1', 'Test')] as any[],
         selectedProjectId: 'p-1',
-      })
+      });
 
-      expect(useProjectsStore.getState().getSelectedProject()?.id).toBe('p-1')
-    })
+      expect(useProjectsStore.getState().getSelectedProject()?.id).toBe('p-1');
+    });
 
     it('returns null when no selection', () => {
-      expect(useProjectsStore.getState().getSelectedProject()).toBeNull()
-    })
+      expect(useProjectsStore.getState().getSelectedProject()).toBeNull();
+    });
 
     it('returns null when selected project not found', () => {
       useProjectsStore.setState({
         projects: [mockProject('p-1', 'Test')] as any[],
         selectedProjectId: 'p-nonexistent',
-      })
+      });
 
-      expect(useProjectsStore.getState().getSelectedProject()).toBeNull()
-    })
-  })
+      expect(useProjectsStore.getState().getSelectedProject()).toBeNull();
+    });
+  });
 
   // ── fetchProjects ──────────────────────────────────────
 
   describe('fetchProjects', () => {
     it('fetches and stores projects', async () => {
-      const projects = [mockProject('p-1', 'Test')]
-      mockApiClient.get.mockResolvedValueOnce(projects)
+      const projects = [mockProject('p-1', 'Test')];
+      mockApiClient.get.mockResolvedValueOnce(projects);
 
-      await useProjectsStore.getState().fetchProjects()
+      await useProjectsStore.getState().fetchProjects();
 
-      const state = useProjectsStore.getState()
-      expect(state.projects).toEqual(projects)
-      expect(state.isLoading).toBe(false)
-    })
+      const state = useProjectsStore.getState();
+      expect(state.projects).toEqual(projects);
+      expect(state.isLoading).toBe(false);
+    });
 
     it('auto-selects first project if none selected', async () => {
-      mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'Test')])
+      mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'Test')]);
 
-      await useProjectsStore.getState().fetchProjects()
+      await useProjectsStore.getState().fetchProjects();
 
-      expect(useProjectsStore.getState().selectedProjectId).toBe('p-1')
-    })
+      expect(useProjectsStore.getState().selectedProjectId).toBe('p-1');
+    });
 
     it('preserves existing selection', async () => {
-      useProjectsStore.setState({ selectedProjectId: 'p-2' })
-      mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'Test'), mockProject('p-2', 'Other')])
+      useProjectsStore.setState({ selectedProjectId: 'p-2' });
+      mockApiClient.get.mockResolvedValueOnce([
+        mockProject('p-1', 'Test'),
+        mockProject('p-2', 'Other'),
+      ]);
 
-      await useProjectsStore.getState().fetchProjects()
+      await useProjectsStore.getState().fetchProjects();
 
-      expect(useProjectsStore.getState().selectedProjectId).toBe('p-2')
-    })
+      expect(useProjectsStore.getState().selectedProjectId).toBe('p-2');
+    });
 
     it('sets error on fetch failure', async () => {
-      mockApiClient.get.mockRejectedValueOnce(new Error('Failed to fetch projects'))
+      mockApiClient.get.mockRejectedValueOnce(new Error('Failed to fetch projects'));
 
-      await useProjectsStore.getState().fetchProjects()
+      await useProjectsStore.getState().fetchProjects();
 
-      expect(useProjectsStore.getState().error).toContain('Failed to fetch projects')
-    })
-  })
+      expect(useProjectsStore.getState().error).toContain('Failed to fetch projects');
+    });
+  });
 
   // ── createProject ──────────────────────────────────────
 
   describe('createProject', () => {
     it('creates project and refreshes list', async () => {
       // First call: post (create). Second call: get (fetchProjects)
-      mockApiClient.post.mockResolvedValueOnce({ id: 'new-proj' })
-      mockApiClient.get.mockResolvedValueOnce([mockProject('new-proj', 'New')])
+      mockApiClient.post.mockResolvedValueOnce({ id: 'new-proj' });
+      mockApiClient.get.mockResolvedValueOnce([mockProject('new-proj', 'New')]);
 
-      const result = await useProjectsStore.getState().createProject(
-        'new-proj', 'New', 'desc', 'default'
-      )
+      const result = await useProjectsStore
+        .getState()
+        .createProject('new-proj', 'New', 'desc', 'default');
 
-      expect(result).toBe(true)
-      expect(useProjectsStore.getState().modalMode).toBeNull()
-    })
+      expect(result).toBe(true);
+      expect(useProjectsStore.getState().modalMode).toBeNull();
+    });
 
     it('returns false on error', async () => {
-      mockApiClient.post.mockRejectedValueOnce(new Error('Project already exists'))
+      mockApiClient.post.mockRejectedValueOnce(new Error('Project already exists'));
 
-      const result = await useProjectsStore.getState().createProject(
-        'dup', 'Dup', 'desc', 'default'
-      )
+      const result = await useProjectsStore
+        .getState()
+        .createProject('dup', 'Dup', 'desc', 'default');
 
-      expect(result).toBe(false)
-      expect(useProjectsStore.getState().error).toBe('Project already exists')
-    })
-  })
+      expect(result).toBe(false);
+      expect(useProjectsStore.getState().error).toBe('Project already exists');
+    });
+  });
 
   // ── deleteProject ──────────────────────────────────────
 
   describe('deleteProject', () => {
     it('deletes project and refreshes list', async () => {
-      mockApiClient.delete.mockResolvedValueOnce(undefined)
-      mockApiClient.get.mockResolvedValueOnce([])
+      mockApiClient.delete.mockResolvedValueOnce(undefined);
+      mockApiClient.get.mockResolvedValueOnce([]);
 
-      const result = await useProjectsStore.getState().deleteProject('p-1')
+      const result = await useProjectsStore.getState().deleteProject('p-1');
 
-      expect(result).toBe(true)
-    })
+      expect(result).toBe(true);
+    });
 
     it('returns false on error', async () => {
-      mockApiClient.delete.mockRejectedValueOnce(new Error('Not found'))
+      mockApiClient.delete.mockRejectedValueOnce(new Error('Not found'));
 
-      const result = await useProjectsStore.getState().deleteProject('p-x')
+      const result = await useProjectsStore.getState().deleteProject('p-x');
 
-      expect(result).toBe(false)
-      expect(useProjectsStore.getState().error).toBe('Not found')
-    })
-  })
+      expect(result).toBe(false);
+      expect(useProjectsStore.getState().error).toBe('Not found');
+    });
+  });
 
   // ── reorderProjects ────────────────────────────────────
 
   describe('reorderProjects', () => {
     it('reorders and updates projects list', async () => {
-      const reordered = [mockProject('p-2', 'B'), mockProject('p-1', 'A')]
-      mockApiClient.post.mockResolvedValueOnce(reordered)
+      const reordered = [mockProject('p-2', 'B'), mockProject('p-1', 'A')];
+      mockApiClient.post.mockResolvedValueOnce(reordered);
 
-      const result = await useProjectsStore.getState().reorderProjects(['p-2', 'p-1'])
+      const result = await useProjectsStore.getState().reorderProjects(['p-2', 'p-1']);
 
-      expect(result).toBe(true)
-      expect(useProjectsStore.getState().projects).toEqual(reordered)
-    })
+      expect(result).toBe(true);
+      expect(useProjectsStore.getState().projects).toEqual(reordered);
+    });
 
     it('returns false and sets error on failure', async () => {
-      mockApiClient.post.mockRejectedValueOnce(new Error('Reorder failed'))
+      mockApiClient.post.mockRejectedValueOnce(new Error('Reorder failed'));
 
-      const result = await useProjectsStore.getState().reorderProjects(['p-1', 'p-2'])
+      const result = await useProjectsStore.getState().reorderProjects(['p-1', 'p-2']);
 
-      expect(result).toBe(false)
-      expect(useProjectsStore.getState().error).toBeTruthy()
-    })
-  })
+      expect(result).toBe(false);
+      expect(useProjectsStore.getState().error).toBeTruthy();
+    });
+  });
 
   // ── fetchTemplates ─────────────────────────────────────
 
   describe('fetchTemplates', () => {
     it('fetches and stores templates', async () => {
-      const templates = [{ id: 't-1', name: 'Python', description: 'Python project' }]
-      mockApiClient.get.mockResolvedValueOnce(templates)
+      const templates = [{ id: 't-1', name: 'Python', description: 'Python project' }];
+      mockApiClient.get.mockResolvedValueOnce(templates);
 
-      await useProjectsStore.getState().fetchTemplates()
+      await useProjectsStore.getState().fetchTemplates();
 
-      expect(useProjectsStore.getState().templates).toEqual(templates)
-    })
+      expect(useProjectsStore.getState().templates).toEqual(templates);
+    });
 
     it('handles fetch failure gracefully', async () => {
-      mockApiClient.get.mockRejectedValueOnce(new Error('Network error'))
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockApiClient.get.mockRejectedValueOnce(new Error('Network error'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-      await useProjectsStore.getState().fetchTemplates()
+      await useProjectsStore.getState().fetchTemplates();
 
-      expect(consoleSpy).toHaveBeenCalled()
-      consoleSpy.mockRestore()
-    })
-  })
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
 
   // ── linkProject ────────────────────────────────────────
 
   describe('linkProject', () => {
     it('links project and refreshes list', async () => {
-      mockApiClient.post.mockResolvedValueOnce({})
-      mockApiClient.get.mockResolvedValueOnce([])
+      mockApiClient.post.mockResolvedValueOnce({});
+      mockApiClient.get.mockResolvedValueOnce([]);
 
-      const result = await useProjectsStore.getState().linkProject('p-link', '/path/to/project')
+      const result = await useProjectsStore.getState().linkProject('p-link', '/path/to/project');
 
-      expect(result).toBe(true)
-    })
+      expect(result).toBe(true);
+    });
+
+    // DB 모드(USE_DATABASE=true)의 백엔드는 name/description 을 그대로 ProjectModel 행에
+    // 쓴다. 모달이 입력받은 값을 여기서 떨어뜨리면 DB 에는 디렉터리명만 남는다.
+    it('sends name and description with the link request', async () => {
+      mockApiClient.post.mockResolvedValueOnce({});
+      mockApiClient.get.mockResolvedValueOnce([]);
+
+      await useProjectsStore
+        .getState()
+        .linkProject('kvca', '/work/KVCA', 'KVCA', 'Venture capital');
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/api/projects/link', {
+        id: 'kvca',
+        source_path: '/work/KVCA',
+        name: 'KVCA',
+        description: 'Venture capital',
+      });
+    });
 
     it('returns false on error', async () => {
-      mockApiClient.post.mockRejectedValueOnce(new Error('Path not found'))
+      mockApiClient.post.mockRejectedValueOnce(new Error('Path not found'));
 
-      const result = await useProjectsStore.getState().linkProject('p-link', '/bad/path')
+      const result = await useProjectsStore.getState().linkProject('p-link', '/bad/path');
 
-      expect(result).toBe(false)
-      expect(useProjectsStore.getState().error).toBeTruthy()
-    })
-  })
+      expect(result).toBe(false);
+      expect(useProjectsStore.getState().error).toBeTruthy();
+    });
+  });
 
   // ── updateProject ──────────────────────────────────────
 
   describe('updateProject', () => {
     it('updates project and refreshes list', async () => {
-      mockApiClient.put.mockResolvedValueOnce({})
-      mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'Updated')])
+      mockApiClient.put.mockResolvedValueOnce({});
+      mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'Updated')]);
 
-      const result = await useProjectsStore.getState().updateProject('p-1', 'Updated', 'New desc', '/new/path')
+      const result = await useProjectsStore
+        .getState()
+        .updateProject('p-1', 'Updated', 'New desc', '/new/path');
 
-      expect(result).toBe(true)
-      expect(useProjectsStore.getState().modalMode).toBeNull()
-    })
+      expect(result).toBe(true);
+      expect(useProjectsStore.getState().modalMode).toBeNull();
+    });
 
     it('returns false on error', async () => {
-      mockApiClient.put.mockRejectedValueOnce(new Error('Not found'))
+      mockApiClient.put.mockRejectedValueOnce(new Error('Not found'));
 
-      const result = await useProjectsStore.getState().updateProject('p-1', 'Name', 'Desc', '/path')
+      const result = await useProjectsStore
+        .getState()
+        .updateProject('p-1', 'Name', 'Desc', '/path');
 
-      expect(result).toBe(false)
-    })
-  })
+      expect(result).toBe(false);
+    });
+  });
 
   // ── indexProject ───────────────────────────────────────
 
   describe('indexProject', () => {
     it('indexes project and refreshes list', async () => {
-      mockApiClient.post.mockResolvedValueOnce({})
-      mockApiClient.get.mockResolvedValueOnce([])
+      mockApiClient.post.mockResolvedValueOnce({});
+      mockApiClient.get.mockResolvedValueOnce([]);
 
-      const result = await useProjectsStore.getState().indexProject('p-1')
+      const result = await useProjectsStore.getState().indexProject('p-1');
 
-      expect(result).toBe(true)
-    })
+      expect(result).toBe(true);
+    });
 
     it('returns false on error', async () => {
-      mockApiClient.post.mockRejectedValueOnce(new Error('Index failed'))
+      mockApiClient.post.mockRejectedValueOnce(new Error('Index failed'));
 
-      const result = await useProjectsStore.getState().indexProject('p-1')
+      const result = await useProjectsStore.getState().indexProject('p-1');
 
-      expect(result).toBe(false)
-    })
-  })
+      expect(result).toBe(false);
+    });
+  });
 
   // ── fetchDeletionPreview ───────────────────────────────
 
   describe('fetchDeletionPreview', () => {
     it('returns deletion preview data', async () => {
-      const preview = { tasks_count: 5, agents_count: 2 }
-      mockApiClient.get.mockResolvedValueOnce(preview)
+      const preview = { tasks_count: 5, agents_count: 2 };
+      mockApiClient.get.mockResolvedValueOnce(preview);
 
-      const result = await useProjectsStore.getState().fetchDeletionPreview('p-1')
+      const result = await useProjectsStore.getState().fetchDeletionPreview('p-1');
 
-      expect(result).toEqual(preview)
-    })
+      expect(result).toEqual(preview);
+    });
 
     it('returns null on error', async () => {
-      mockApiClient.get.mockRejectedValueOnce(new Error('Not found'))
+      mockApiClient.get.mockRejectedValueOnce(new Error('Not found'));
 
-      const result = await useProjectsStore.getState().fetchDeletionPreview('p-1')
+      const result = await useProjectsStore.getState().fetchDeletionPreview('p-1');
 
-      expect(result).toBeNull()
-    })
-  })
+      expect(result).toBeNull();
+    });
+  });
 
   // ── setShowInactive ────────────────────────────────────
 
   describe('setShowInactive', () => {
     it('sets showInactive to false', () => {
-      useProjectsStore.getState().setShowInactive(false)
-      expect(useProjectsStore.getState().showInactive).toBe(false)
-    })
+      useProjectsStore.getState().setShowInactive(false);
+      expect(useProjectsStore.getState().showInactive).toBe(false);
+    });
 
     it('sets showInactive to true', () => {
-      useProjectsStore.setState({ showInactive: false })
-      useProjectsStore.getState().setShowInactive(true)
-      expect(useProjectsStore.getState().showInactive).toBe(true)
-    })
+      useProjectsStore.setState({ showInactive: false });
+      useProjectsStore.getState().setShowInactive(true);
+      expect(useProjectsStore.getState().showInactive).toBe(true);
+    });
 
     it('filteredProjects respects showInactive=false', () => {
       useProjectsStore.setState({
@@ -442,13 +467,13 @@ describe('projects store', () => {
         ],
         showInactive: false,
         searchQuery: '',
-      })
-      const result = useProjectsStore.getState().filteredProjects()
-      expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('p-1')
-    })
-  })
-})
+      });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('p-1');
+    });
+  });
+});
 
 // ── Startup hydration guard ──────────────────────────────
 // Bootstrap seeds the store once; page mounts must not refetch the same list.
@@ -461,70 +486,70 @@ describe('projects store hydration guard', () => {
       error: null,
       selectedProjectId: null,
       isHydrated: false,
-    })
-    vi.clearAllMocks()
-  })
+    });
+    vi.clearAllMocks();
+  });
 
   it('marks the store hydrated after bootstrap seeding', () => {
-    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any);
 
-    expect(useProjectsStore.getState().isHydrated).toBe(true)
-  })
+    expect(useProjectsStore.getState().isHydrated).toBe(true);
+  });
 
   it('marks the store hydrated after a successful fetch', async () => {
-    mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'One')])
+    mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'One')]);
 
-    await useProjectsStore.getState().fetchProjects()
+    await useProjectsStore.getState().fetchProjects();
 
-    expect(useProjectsStore.getState().isHydrated).toBe(true)
-  })
+    expect(useProjectsStore.getState().isHydrated).toBe(true);
+  });
 
   it('does not mark the store hydrated when the fetch fails', async () => {
-    mockApiClient.get.mockRejectedValueOnce(new Error('boom'))
+    mockApiClient.get.mockRejectedValueOnce(new Error('boom'));
 
-    await useProjectsStore.getState().fetchProjects()
+    await useProjectsStore.getState().fetchProjects();
 
-    expect(useProjectsStore.getState().isHydrated).toBe(false)
-  })
+    expect(useProjectsStore.getState().isHydrated).toBe(false);
+  });
 
   it('clears hydration on reset so a new session refetches', () => {
-    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
-    useProjectsStore.getState().reset()
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any);
+    useProjectsStore.getState().reset();
 
-    expect(useProjectsStore.getState().isHydrated).toBe(false)
-  })
+    expect(useProjectsStore.getState().isHydrated).toBe(false);
+  });
 
   it('ensureProjects skips the request when already hydrated', async () => {
-    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any);
 
-    await useProjectsStore.getState().ensureProjects()
+    await useProjectsStore.getState().ensureProjects();
 
-    expect(mockApiClient.get).not.toHaveBeenCalled()
-  })
+    expect(mockApiClient.get).not.toHaveBeenCalled();
+  });
 
   it('ensureProjects skips an empty-but-hydrated store', async () => {
-    useProjectsStore.getState().hydrateProjects([])
+    useProjectsStore.getState().hydrateProjects([]);
 
-    await useProjectsStore.getState().ensureProjects()
+    await useProjectsStore.getState().ensureProjects();
 
-    expect(mockApiClient.get).not.toHaveBeenCalled()
-  })
+    expect(mockApiClient.get).not.toHaveBeenCalled();
+  });
 
   it('ensureProjects fetches when the store was never hydrated', async () => {
-    mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'One')])
+    mockApiClient.get.mockResolvedValueOnce([mockProject('p-1', 'One')]);
 
-    await useProjectsStore.getState().ensureProjects()
+    await useProjectsStore.getState().ensureProjects();
 
-    expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects')
-  })
+    expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects');
+  });
 
   it('explicit fetchProjects still refetches a hydrated store (retry/mutation refresh)', async () => {
-    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any)
-    mockApiClient.get.mockResolvedValueOnce([mockProject('p-2', 'Two')])
+    useProjectsStore.getState().hydrateProjects([mockProject('p-1', 'One')] as any);
+    mockApiClient.get.mockResolvedValueOnce([mockProject('p-2', 'Two')]);
 
-    await useProjectsStore.getState().fetchProjects()
+    await useProjectsStore.getState().fetchProjects();
 
-    expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects')
-    expect(useProjectsStore.getState().projects[0].id).toBe('p-2')
-  })
-})
+    expect(mockApiClient.get).toHaveBeenCalledWith('/api/projects');
+    expect(useProjectsStore.getState().projects[0].id).toBe('p-2');
+  });
+});

--- a/src/dashboard/src/stores/projects.ts
+++ b/src/dashboard/src/stores/projects.ts
@@ -67,7 +67,7 @@ interface ProjectsState {
   reset: () => void
   fetchTemplates: () => Promise<void>
   createProject: (id: string, name: string, description: string, template: string) => Promise<boolean>
-  linkProject: (id: string, sourcePath: string) => Promise<boolean>
+  linkProject: (id: string, sourcePath: string, name?: string, description?: string) => Promise<boolean>
   updateProject: (id: string, name?: string, description?: string, path?: string) => Promise<boolean>
   deleteProject: (id: string) => Promise<boolean>
   indexProject: (id: string) => Promise<boolean>
@@ -168,11 +168,13 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
     }
   },
 
-  // Link an external project
-  linkProject: async (id, sourcePath) => {
+  // Link an external project.
+  // name/description: DB 모드(USE_DATABASE=true)의 백엔드가 ProjectModel 행에 그대로
+  // 쓴다. 파일시스템 모드는 무시하고 디렉터리명·.aos-project.json 에서 파생한다.
+  linkProject: async (id, sourcePath, name, description) => {
     set({ isLoading: true, error: null })
     try {
-      await apiClient.post('/api/projects/link', { id, source_path: sourcePath })
+      await apiClient.post('/api/projects/link', { id, source_path: sourcePath, name, description })
       await get().fetchProjects()
       set({ isLoading: false, modalMode: null })
       return true

--- a/tests/backend/api/test_projects_db_mode_writes.py
+++ b/tests/backend/api/test_projects_db_mode_writes.py
@@ -1,0 +1,400 @@
+"""DB 모드(`USE_DATABASE=true`)에서 대시보드의 프로젝트 쓰기 3종이 동작해야 한다.
+
+PR #318 이 `POST /api/projects/link`·`/create`·`/reorder` 를 DB 모드에서
+503 "Use the database project registry" 로 잠갔지만, 대시보드 store
+(`stores/projects.ts`)는 여전히 이 세 경로를 호출한다. 그리고 `.env`/`.env.example`
+기본값이 `USE_DATABASE=true` 라서 기본 설치에서 Link Existing / Create New /
+드래그 정렬이 전부 실패한다.
+
+`/api/project-registry` 로 프론트를 옮기는 것은 답이 아니다 — 그 API 는 사용자가
+고른 id 를 버리고 UUID 를 찍으며(기존 행은 slug id: apfs·kiips·vcs), 템플릿
+스캐폴딩과 정렬 엔드포인트가 없다. 대신 같은 파일의 `PUT /api/projects/{id}` 가
+이미 하듯 DB 인지형 분기를 둔다.
+
+여기서 고정하는 계약:
+  1. 세 경로는 DB 모드에서 503 이 아니다.
+  2. link/create 는 요청 `id` 를 그대로 `ProjectModel.id` 로 쓰고 심볼릭 링크를
+     만들지 않는다(그 파일시스템 부작용이 게이트가 막던 것이다).
+  3. 중복 id/name 은 409 — `IntegrityError` 가 일반 503 으로 새지 않는다.
+  4. reorder 는 `settings["sort_order"]` 를 **새 dict 재할당**으로 기록하고
+     (JSONB 제자리 변경은 SQLAlchemy 가 추적하지 않는다), GET 과 같은 모양의
+     전체 목록을 `sort_order` 순으로 돌려준다.
+  5. GET `/api/projects` 의 DB 분기도 `sort_order` 로 정렬한다 — 아니면 새로고침
+     한 번에 정렬이 풀린다.
+
+라우터 전체를 지나가게 한다(핸들러 직접 호출 금지) — 인가 의존성과 응답 모델
+직렬화까지 계약이다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+def _row(project_id: str, name: str, *, sort_order: int = 0, path: str = "/tmp/x"):
+    return SimpleNamespace(
+        id=project_id,
+        name=name,
+        slug=project_id,
+        description="",
+        path=path,
+        is_active=True,
+        settings={"sort_order": sort_order},
+        organization_id=None,
+        created_at=None,
+        updated_at=None,
+        created_by=None,
+    )
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return SimpleNamespace(all=lambda: list(self._rows))
+
+    def all(self):
+        return [(r.id, r.path, r.organization_id) for r in self._rows]
+
+
+class FakeSession:
+    """`ProjectModel` 행 몇 개를 든 세션 스텁.
+
+    쿼리 문자열을 파싱하지 않는다. 컴파일된 바인드 값에 id/name/slug 가 걸리는
+    행만 돌려주고, 바인드가 없으면(목록 조회) 전부 돌려준다. `add()` 는 기록만
+    한다 — 핸들러가 무엇을 INSERT 하려 했는지 테스트가 들여다본다.
+    """
+
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.added = []
+        self.commits = 0
+
+    async def execute(self, stmt, *_args, **_kwargs):
+        params = stmt.compile().params
+        bound = set()
+        for value in params.values():
+            if isinstance(value, (list, tuple, set)):
+                bound.update(value)
+            else:
+                bound.add(value)
+        if not bound:
+            return _Result(self.rows)
+        hits = [r for r in self.rows if {r.id, r.name, r.slug} & bound]
+        return _Result(hits)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        return None
+
+    async def commit(self):
+        self.commits += 1
+
+    async def refresh(self, _obj):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+@pytest_asyncio.fixture
+async def db_mode(authenticated_app, monkeypatch, tmp_path):
+    """DB 모드 + 가짜 세션 + RAG 비활성 + 스캐폴딩 대상 디렉터리를 tmp 로 격리."""
+    from api.deps import get_db_session
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+
+    session = FakeSession(
+        [_row("apfs", "APFS", sort_order=0), _row("kiips", "KiiPS", sort_order=1)]
+    )
+
+    async def _override():
+        yield session
+
+    authenticated_app.dependency_overrides[get_db_session] = _override
+
+    # GET /api/projects 는 Qdrant 통계를 붙이려 한다 — 테스트에서 네트워크 금지.
+    import services.rag_service as rag_service
+
+    def _no_store():
+        raise ValueError("rag disabled in test")
+
+    monkeypatch.setattr(rag_service, "get_vector_store", _no_store)
+
+    # create 는 리포지토리 루트의 projects/ 아래에 스캐폴딩한다 — 잔여물 금지.
+    projects_dir = tmp_path / "projects"
+    monkeypatch.setattr("api.routes.get_projects_dir", lambda: projects_dir)
+
+    try:
+        yield authenticated_app, session, tmp_path, projects_dir
+    finally:
+        authenticated_app.dependency_overrides.pop(get_db_session, None)
+
+
+async def _post(app, url, body):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.post(url, json=body)
+
+
+async def _get(app, url):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get(url)
+
+
+# ── link ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_link_registers_db_row_with_requested_id_and_no_symlink(db_mode):
+    app, session, tmp_path, projects_dir = db_mode
+    source = tmp_path / "KVCA"
+    source.mkdir()
+
+    resp = await _post(
+        app,
+        "/api/projects/link",
+        {"id": "kvca", "source_path": str(source), "name": "KVCA", "description": "벤처"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == "kvca"
+    assert body["name"] == "KVCA"
+    assert body["path"] == str(source)
+
+    from db.models import ProjectAccessModel, ProjectModel
+
+    inserted = [o for o in session.added if isinstance(o, ProjectModel)]
+    assert len(inserted) == 1
+    assert inserted[0].id == "kvca"
+    assert inserted[0].name == "KVCA"
+    assert inserted[0].description == "벤처"
+    assert inserted[0].path == str(source)
+    owner = [o for o in session.added if isinstance(o, ProjectAccessModel)]
+    assert len(owner) == 1 and owner[0].role == "owner" and owner[0].project_id == "kvca"
+    assert session.commits == 1
+    assert not (projects_dir / "kvca").exists(), "DB 모드에서는 심볼릭 링크를 만들지 않는다"
+
+
+@pytest.mark.asyncio
+async def test_link_name_falls_back_to_directory_name(db_mode):
+    app, session, tmp_path, _ = db_mode
+    source = tmp_path / "My-Repo"
+    source.mkdir()
+
+    resp = await _post(app, "/api/projects/link", {"id": "my-repo", "source_path": str(source)})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "My-Repo"
+
+
+@pytest.mark.asyncio
+async def test_link_duplicate_id_is_409(db_mode):
+    app, session, tmp_path, _ = db_mode
+    source = tmp_path / "dup"
+    source.mkdir()
+
+    resp = await _post(
+        app, "/api/projects/link", {"id": "apfs", "source_path": str(source), "name": "New"}
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert session.added == []
+
+
+@pytest.mark.asyncio
+async def test_link_duplicate_name_is_409(db_mode):
+    app, session, tmp_path, _ = db_mode
+    source = tmp_path / "dup"
+    source.mkdir()
+
+    resp = await _post(
+        app, "/api/projects/link", {"id": "fresh", "source_path": str(source), "name": "APFS"}
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert session.added == []
+
+
+@pytest.mark.asyncio
+async def test_link_slug_only_collision_gets_suffixed_like_registry(db_mode):
+    """slug 만 겹치면(id·name 은 새것) 409 가 아니라 registry 와 같은 `-{id[:8]}` 접미사.
+
+    모달은 slug 를 보여주지 않으므로 slug 409 는 사용자가 해석할 수 없다.
+    `api/projects/registry.py::create_project` 와 규칙을 맞춘다.
+    """
+    app, session, tmp_path, _ = db_mode
+    source = tmp_path / "apfs-two"
+    source.mkdir()
+
+    # name "apfs" → slug "apfs" 는 기존 행(id=apfs, name=APFS)과 slug 만 겹친다
+    resp = await _post(
+        app, "/api/projects/link", {"id": "apfs2", "source_path": str(source), "name": "apfs"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    from db.models import ProjectModel
+
+    inserted = [o for o in session.added if isinstance(o, ProjectModel)]
+    assert len(inserted) == 1
+    assert inserted[0].slug == "apfs-apfs2"
+
+
+@pytest.mark.asyncio
+async def test_link_missing_source_path_is_400(db_mode):
+    app, _, tmp_path, _ = db_mode
+
+    resp = await _post(
+        app, "/api/projects/link", {"id": "ghost", "source_path": str(tmp_path / "nope")}
+    )
+
+    assert resp.status_code == 400, resp.text
+
+
+# ── create ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_scaffolds_template_and_registers_db_row(db_mode):
+    app, session, _, projects_dir = db_mode
+
+    resp = await _post(
+        app,
+        "/api/projects/create",
+        {"id": "newproj", "name": "New Proj", "description": "d", "template": "default"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == "newproj"
+    assert body["path"] == str(projects_dir / "newproj")
+    assert (projects_dir / "newproj").is_dir()
+
+    from db.models import ProjectModel
+
+    inserted = [o for o in session.added if isinstance(o, ProjectModel)]
+    assert len(inserted) == 1
+    assert inserted[0].id == "newproj"
+    assert inserted[0].path == str(projects_dir / "newproj")
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_id_is_409_and_leaves_no_directory(db_mode):
+    app, session, _, projects_dir = db_mode
+
+    resp = await _post(
+        app,
+        "/api/projects/create",
+        {"id": "apfs", "name": "Other", "description": "", "template": "default"},
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert session.added == []
+    assert not (projects_dir / "apfs").exists(), "중복 검사는 스캐폴딩보다 먼저"
+
+
+@pytest.mark.asyncio
+async def test_create_removes_scaffold_when_db_registration_fails(db_mode):
+    """사전 검사 뒤 경쟁 INSERT·commit 실패가 나면 503 이지만, 스캐폴드는 남기지 않는다.
+
+    남기면 다음 재시도가 `Path already exists` 로 영영 막히고, 등록 안 된 디렉터리가
+    projects/ 에 고아로 남는다.
+    """
+    app, session, _, projects_dir = db_mode
+
+    async def _boom():
+        raise RuntimeError("unique violation after pre-check")
+
+    session.commit = _boom  # type: ignore[method-assign]
+
+    resp = await _post(
+        app,
+        "/api/projects/create",
+        {"id": "flaky", "name": "Flaky", "description": "", "template": "default"},
+    )
+
+    assert resp.status_code == 503, resp.text
+    assert not (projects_dir / "flaky").exists()
+
+
+# ── reorder ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reorder_persists_sort_order_and_returns_full_list_in_order(db_mode):
+    app, session, _, _ = db_mode
+    kiips = next(r for r in session.rows if r.id == "kiips")
+    original_settings = kiips.settings
+
+    resp = await _post(app, "/api/projects/reorder", {"project_ids": ["kiips", "apfs"]})
+
+    assert resp.status_code == 200, resp.text
+    assert [p["id"] for p in resp.json()] == ["kiips", "apfs"]
+    assert [p["sort_order"] for p in resp.json()] == [0, 1]
+    assert kiips.settings["sort_order"] == 0
+    assert kiips.settings is not original_settings, "JSONB 는 새 dict 로 재할당해야 dirty 로 잡힌다"
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_reorder_unknown_id_is_404(db_mode):
+    app, session, _, _ = db_mode
+
+    resp = await _post(app, "/api/projects/reorder", {"project_ids": ["kiips", "ghost"]})
+
+    assert resp.status_code == 404, resp.text
+    assert session.commits == 0
+
+
+# ── GET ordering ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_projects_db_mode_orders_by_sort_order_then_name(db_mode):
+    app, session, _, _ = db_mode
+    session.rows = [
+        _row("apfs", "APFS", sort_order=2),
+        _row("kiips", "KiiPS", sort_order=0),
+        _row("vcs", "VCS", sort_order=0),
+    ]
+
+    resp = await _get(app, "/api/projects")
+
+    assert resp.status_code == 200, resp.text
+    assert [p["id"] for p in resp.json()] == ["kiips", "vcs", "apfs"]
+
+
+@pytest.mark.asyncio
+async def test_get_projects_db_mode_reports_claude_md_presence(db_mode):
+    """DB 분기는 `Project` 를 손으로 조립해 `claude_md` 가 항상 None 이었다.
+
+    기본 템플릿은 CLAUDE.md 를 만들지만 카드에는 '없음'으로 보여 Claude 설정 액션이
+    숨는다(`ProjectsPage.tsx`). store 는 link/create 응답을 버리고 GET 을 다시 부르므로
+    목록 응답에서 존재 여부를 계산해야 한다.
+    """
+    app, session, tmp_path, _ = db_mode
+    with_md = tmp_path / "with-md"
+    with_md.mkdir()
+    (with_md / "CLAUDE.md").write_text("# hi\n", encoding="utf-8")
+    without_md = tmp_path / "without-md"
+    without_md.mkdir()
+    session.rows = [
+        _row("a", "A", path=str(with_md)),
+        _row("b", "B", path=str(without_md)),
+    ]
+
+    resp = await _get(app, "/api/projects")
+
+    assert resp.status_code == 200, resp.text
+    assert {p["id"]: p["has_claude_md"] for p in resp.json()} == {"a": True, "b": False}

--- a/tests/backend/api/test_terminal_db_project_resolution.py
+++ b/tests/backend/api/test_terminal_db_project_resolution.py
@@ -1,0 +1,124 @@
+"""DB 모드에서 터미널 런처(`/api/terminal/execute`·`/api/warp/open`)는 `ProjectModel.id` 를 해석해야 한다.
+
+DB 모드의 link/create 는 `ProjectModel` 행만 만들고 in-memory `PROJECTS_REGISTRY`
+(`projects/<심링크명>` 기준)는 채우지 않는다 — 심링크 생성이 바로 DB 모드 게이트가
+막던 파일시스템 부작용이기 때문이다. 그런데 두 런처는 레거시 `get_project()` 만 봐서,
+방금 등록한 프로젝트를 대시보드(`stores/agents.ts` Task Analyzer, orchestration
+store 의 Warp 열기)에서 고르면 404 가 난다.
+
+git API 가 이미 같은 문제를 `api/git/_shared.resolve_project` 로 풀었다(DB 모드는
+DB 행만, 파일시스템 모드는 레거시 레지스트리). 두 런처도 그 해석기를 쓴다.
+
+라우트 전체를 지나가게 한다 — 인가 의존성과 응답 직렬화까지 계약이다.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from models.project import PROJECTS_REGISTRY
+
+DB_ID = "kvca"
+
+
+@pytest.fixture
+def empty_registry():
+    """레거시 레지스트리가 비어 있어도 DB 행만으로 해석돼야 한다."""
+    snapshot = dict(PROJECTS_REGISTRY)
+    PROJECTS_REGISTRY.clear()
+    yield PROJECTS_REGISTRY
+    PROJECTS_REGISTRY.clear()
+    PROJECTS_REGISTRY.update(snapshot)
+
+
+@pytest_asyncio.fixture
+async def db_project_app(authenticated_app, tmp_path, monkeypatch, empty_registry):
+    """DB 에 slug id 프로젝트 1건만 있고 레거시 레지스트리는 빈 앱."""
+    project_path = tmp_path / "KVCA"
+    project_path.mkdir()
+
+    row = SimpleNamespace(
+        id=DB_ID,
+        name="KVCA",
+        slug="kvca",
+        description="",
+        path=str(project_path),
+        is_active=True,
+        settings={},
+        organization_id=None,
+    )
+
+    class Result:
+        def scalar_one_or_none(self):
+            return row
+
+    class Database:
+        async def execute(self, *_args, **_kwargs):
+            return Result()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    monkeypatch.setenv("USE_DATABASE", "true")
+    # `resolve_project` 는 주입 세션이 아니라 자체 세션을 연다 — 여기서 갈아끼운다.
+    monkeypatch.setattr("db.database.async_session_factory", lambda: Database())
+    yield authenticated_app, str(project_path)
+
+
+async def _post(app, url, body):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.post(url, json=body)
+
+
+@pytest.mark.asyncio
+async def test_terminal_execute_resolves_database_project(db_project_app, monkeypatch):
+    app, project_path = db_project_app
+    launched: dict = {}
+
+    class Adapter:
+        async def is_available(self):
+            return True
+
+        async def execute(self, **kwargs):
+            launched.update(kwargs)
+            return {"success": True, "terminal": "orca", "message": "started"}
+
+    class Service:
+        def get_adapter(self, _terminal_type):
+            return Adapter()
+
+    monkeypatch.setattr("api.terminal.get_terminal_service", lambda: Service())
+
+    resp = await _post(
+        app,
+        "/api/terminal/execute",
+        {"terminal": "orca", "project_id": DB_ID, "command": "echo hi"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+    assert launched["project_path"] == project_path
+
+
+@pytest.mark.asyncio
+async def test_warp_open_resolves_database_project(db_project_app, monkeypatch):
+    app, _ = db_project_app
+
+    class Warp:
+        def is_warp_installed(self):
+            return False
+
+    monkeypatch.setattr("api.warp.get_warp_service", lambda: Warp())
+
+    resp = await _post(app, "/api/warp/open", {"project_id": DB_ID})
+
+    # 해석이 됐으면 404 가 아니라 "Warp 미설치" 응답(200, success=False)까지 간다.
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is False
+    assert "not installed" in resp.json()["error"]

--- a/tests/backend/test_llm_usage_instrumentation.py
+++ b/tests/backend/test_llm_usage_instrumentation.py
@@ -734,7 +734,7 @@ async def test_warp_open_claude_launch_records_usage_intent(monkeypatch, tmp_pat
     recorder = AsyncMock()
     preflight = AsyncMock()
 
-    monkeypatch.setattr("api.warp.get_project", MagicMock(return_value=project))
+    monkeypatch.setattr("api.git._shared.get_project", MagicMock(return_value=project))
     monkeypatch.setattr("api.warp.get_warp_service", MagicMock(return_value=fake_warp))
     monkeypatch.setattr("api.warp.record_usage_best_effort", recorder)
     monkeypatch.setattr(
@@ -796,7 +796,7 @@ async def test_warp_open_claude_launch_preflight_quota_blocks_launch(
         )
     )
 
-    monkeypatch.setattr("api.warp.get_project", MagicMock(return_value=project))
+    monkeypatch.setattr("api.git._shared.get_project", MagicMock(return_value=project))
     monkeypatch.setattr("api.warp.get_warp_service", MagicMock(return_value=fake_warp))
     monkeypatch.setattr("api.warp.record_usage_best_effort", recorder)
     monkeypatch.setattr(

--- a/tests/backend/test_security_hardening.py
+++ b/tests/backend/test_security_hardening.py
@@ -313,7 +313,7 @@ async def test_terminal_execution_writes_audit_event(client, app, monkeypatch):
         id="operator-user", role="admin", is_admin=True, is_active=True
     )
     monkeypatch.setattr(
-        "api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
+        "api.git._shared.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
     )
     monkeypatch.setattr("api.terminal.get_terminal_service", lambda: Service())
     try:
@@ -420,7 +420,7 @@ async def test_terminal_resolution_failure_is_audited(client, app, monkeypatch):
         id="operator", role="admin", is_admin=True, is_active=True
     )
     monkeypatch.setattr(
-        "api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
+        "api.git._shared.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
     )
     monkeypatch.setattr(
         "api.terminal.get_terminal_service",
@@ -464,7 +464,7 @@ async def test_terminal_malformed_result_is_audited(client, app, monkeypatch):
         id="operator", role="admin", is_admin=True, is_active=True
     )
     monkeypatch.setattr(
-        "api.terminal.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
+        "api.git._shared.get_project", lambda _project_id: SimpleNamespace(path="/tmp")
     )
     monkeypatch.setattr("api.terminal.get_terminal_service", lambda: Service())
     before = len(_audit_logs)


### PR DESCRIPTION
## Summary

`USE_DATABASE=true`(`.env` 기본값)에서 대시보드의 Link Existing / Create New / 드래그 정렬이 전부 503 `Use the database project registry` 로 실패하던 문제를 고친다. PR #318 이 파일 기반 `POST /api/projects/link`·`/create`·`/reorder` 를 DB 모드에서 잠갔지만 대시보드 store 는 그 세 경로를 계속 호출하고 있었다. `/api/project-registry` 는 사용자가 고른 id 를 버리고 UUID 를 찍으며 템플릿 스캐폴딩·정렬 엔드포인트가 없어 대체가 못 되므로, 같은 파일의 `PUT /api/projects/{id}` 와 같은 방식으로 세 핸들러에 DB 인지형 분기를 둔다.

## Changes

**Backend**
- `link`: `ProjectModel(id=요청 id, path=source_path)` 행 + 등록자 owner 접근권. 심링크는 만들지 않는다(그 파일시스템 부작용이 게이트가 막던 것). 요청 본문에 선택 필드 `name`/`description` 추가
- `create`: 중복 검사 → 템플릿 스캐폴딩 → 행 삽입. DB 등록 실패 시 스캐폴드를 지워 재시도가 `Path already exists` 로 막히지 않게 함
- `reorder`: `settings["sort_order"]` 를 새 dict 재할당으로 기록(JSONB 제자리 변경은 SQLAlchemy 가 추적 안 함), GET 과 같은 전체 목록 반환
- `GET /api/projects` DB 분기: `(sort_order, name)` 정렬 + 행 path 의 CLAUDE.md 로 `has_claude_md` 계산
- 중복 `id`/`name` 은 409, slug 만 겹치면 registry 와 같은 `-{id[:8]}` 접미사
- `/api/terminal/execute`·`/api/warp/open`: `api/git/_shared.resolve_project` 로 해석해 DB 모드에서 심링크 없이 등록된 프로젝트도 터미널에서 열 수 있게 함

**Frontend**
- `stores/projects.ts` `linkProject(id, sourcePath, name?, description?)` — 모달이 입력받던 name/description 을 실제로 전송

**Docs**
- `docs/api/projects.md` 에 DB 모드 쓰기 동작 절 추가

## Files Changed

| 파일 | 변경 |
|---|---|
| `src/backend/api/routes.py` | Modified — DB 분기 + 헬퍼 |
| `src/backend/api/terminal.py`, `src/backend/api/warp.py` | Modified — `resolve_project` 사용 |
| `src/backend/models/project.py` | Modified — `ProjectLinkRequest.name/description` |
| `src/dashboard/src/stores/projects.ts`, `components/ProjectFormModal.tsx` | Modified |
| `tests/backend/api/test_projects_db_mode_writes.py` | Added (12 tests) |
| `tests/backend/api/test_terminal_db_project_resolution.py` | Added (2 tests) |
| `tests/backend/test_security_hardening.py`, `test_llm_usage_instrumentation.py` | Modified — monkeypatch 대상을 `api.git._shared.get_project` 로 |
| `src/dashboard/src/**/__tests__/*` | Modified — 테스트 2건 추가 (+ 포매터 재정렬) |
| `docs/api/projects.md` | Modified |

## Testing

- 새 백엔드 테스트 14건은 503/404/잔여 디렉터리로 먼저 실패하는 것을 확인한 뒤 통과 (TDD)
- 백엔드 전체 `pytest ../../tests/backend`: 2087 passed. `test_bind_host_default.py::test_main_binds_to_configured_host[None-127.0.0.1]` 1건은 로컬 `.env` 의 `HOST=0.0.0.0` 때문에 깨끗한 트리(HEAD `abcf7cc`)에서도 실패 — 이 PR 과 무관, CI(.env 없음)에서는 통과 예상
- 대시보드 `tsc` / `eslint` / `vitest run` 4504 passed / `build` 통과
- Codex 리뷰 1차 지적 3건(터미널 해석·스캐폴드 정리·has_claude_md) 반영. 수정본 재리뷰는 미실행

## Notes

- `resolve_project` 는 DB 모드에서 파일시스템 폴백이 없고 비활성 프로젝트를 거른다. 심링크만 있고 DB 미등록인 프로젝트, 비활성 프로젝트는 터미널·Warp 에서 404 — `GET /api/projects`·git API 와 같은 규칙
- `DELETE /api/projects/{id}` 와 `POST /api/projects` 는 여전히 DB 모드에서 503 (범위 밖)

## Related Issues

Relates to #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5cztH68UNcHwGagBRhga8
